### PR TITLE
fix(anki,dict,video): 四条已合入 PR 的事后审查补修（AnkiMobile 三态 / Lapis vendored CSS / 词典展开 memo / 错 BUG 号）

### DIFF
--- a/fushi/ios/Runner/AppDelegate.swift
+++ b/fushi/ios/Runner/AppDelegate.swift
@@ -258,8 +258,13 @@ import Flutter
   /// 用户看到的却是「剪贴板上没有 AnkiMobile 配置」——一句与事实无关的错误。
   ///
   /// 非 active 时挂一次性 `didBecomeActiveNotification` 观察者，等真正活跃后再读；
-  /// 万一始终等不到（用户又切走了），超时后仍尽力读一次并如实报告看到的状态，而不是
+  /// 万一始终等不到（用户又切走了），超时后**不读**、如实报 `notActive`，而不是
   /// 无限挂起让 Dart 侧的 Future 永不完成。
+  ///
+  /// 超时后不能"尽力读一次"：非 active 下 `data(forPasteboardType:)` 必然返回 nil，
+  /// 而 `contains(pasteboardTypes:)` 仍看得见类型（只查元数据），于是三态判定会落到
+  /// `denied` —— 把「app 还没回到前台」谎报成「iOS 拒绝了粘贴」，用户被指去改一个
+  /// 根本没出问题的权限。这正是 BUG-2150 要消灭的那类误导诊断。
   private static func consumeAnkiMobilePasteboard(result: @escaping FlutterResult) {
     if UIApplication.shared.applicationState == .active {
       result(readAnkiMobilePasteboard())
@@ -270,12 +275,18 @@ import Flutter
     var timeout: DispatchWorkItem? = nil
     var finished = false
     // FlutterResult 必须恰好回调一次：两条路径（变 active / 超时）共用这道闸门。
-    let finish = {
+    // `becameActive` 决定读不读剪贴板——超时那条路径下 app 仍非 active，读出来的
+    // 三态没有意义（必落 denied），只能如实报 notActive。
+    let finish = { (becameActive: Bool) in
       guard !finished else { return }
       finished = true
       timeout?.cancel()
       if let observer = observer {
         NotificationCenter.default.removeObserver(observer)
+      }
+      guard becameActive else {
+        result(["status": "notActive"])
+        return
       }
       result(readAnkiMobilePasteboard())
     }
@@ -284,9 +295,9 @@ import Flutter
       forName: UIApplication.didBecomeActiveNotification,
       object: nil,
       queue: .main
-    ) { _ in finish() }
+    ) { _ in finish(true) }
 
-    let work = DispatchWorkItem { finish() }
+    let work = DispatchWorkItem { finish(false) }
     timeout = work
     DispatchQueue.main.asyncAfter(
       deadline: .now() + ankiMobilePasteboardActiveTimeout,

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 72148 (4244 per locale)
+/// Strings: 72182 (4246 per locale)
 ///
-/// Built on 2026-09-05 at 15:36 UTC
+/// Built on 2026-09-05 at 17:12 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5834,6 +5834,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_error_ankimobile_unavailable =>
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -15738,6 +15741,11 @@ class _StringsAr extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -25869,6 +25877,11 @@ class _StringsDe extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -36053,6 +36066,11 @@ class _StringsEs extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -46271,6 +46289,11 @@ class _StringsFr extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -56293,6 +56316,11 @@ class _StringsId extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -66407,6 +66435,11 @@ class _StringsIt extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -75908,6 +75941,11 @@ class _StringsJa extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -85419,6 +85457,11 @@ class _StringsKo extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -95488,6 +95531,11 @@ class _StringsNl extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -105611,6 +105659,11 @@ class _StringsPtBr extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -115712,6 +115765,11 @@ class _StringsRu extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -125612,6 +125670,11 @@ class _StringsTh extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -135629,6 +135692,11 @@ class _StringsTr extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -145617,6 +145685,11 @@ class _StringsVi extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 // Path: <root>
@@ -154796,6 +154869,11 @@ class _StringsZhCn extends _StringsEn {
       '无法打开 AnkiMobile。请先安装 AnkiMobile 再试。';
   @override
   String get dictionary_collapse_follow_global => '跟随全局设置';
+  @override
+  String get anki_ankimobile_imported => '已导入 AnkiMobile 配置。';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi 没能及时回到前台，剪贴板还没被读取。回到 Fushi 后重试即可。';
 }
 
 // Path: <root>
@@ -163990,6 +164068,11 @@ class _StringsZhHk extends _StringsEn {
       'Could not open AnkiMobile. Install AnkiMobile and try again.';
   @override
   String get dictionary_collapse_follow_global => 'Follow global setting';
+  @override
+  String get anki_ankimobile_imported => 'AnkiMobile configuration imported.';
+  @override
+  String get anki_error_ankimobile_not_active =>
+      'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -172696,6 +172779,10 @@ extension on _StringsEn {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -181397,6 +181484,10 @@ extension on _StringsAr {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -190143,6 +190234,10 @@ extension on _StringsDe {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -198880,6 +198975,10 @@ extension on _StringsEs {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -207626,6 +207725,10 @@ extension on _StringsFr {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -216343,6 +216446,10 @@ extension on _StringsId {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -225082,6 +225189,10 @@ extension on _StringsIt {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -233748,6 +233859,10 @@ extension on _StringsJa {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -242418,6 +242533,10 @@ extension on _StringsKo {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -251150,6 +251269,10 @@ extension on _StringsNl {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -259877,6 +260000,10 @@ extension on _StringsPtBr {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -268611,6 +268738,10 @@ extension on _StringsRu {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -277317,6 +277448,10 @@ extension on _StringsTh {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -286038,6 +286173,10 @@ extension on _StringsTr {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -294753,6 +294892,10 @@ extension on _StringsVi {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }
@@ -303394,6 +303537,10 @@ extension on _StringsZhCn {
         return '无法打开 AnkiMobile。请先安装 AnkiMobile 再试。';
       case 'dictionary_collapse_follow_global':
         return '跟随全局设置';
+      case 'anki_ankimobile_imported':
+        return '已导入 AnkiMobile 配置。';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi 没能及时回到前台，剪贴板还没被读取。回到 Fushi 后重试即可。';
       default:
         return null;
     }
@@ -312038,6 +312185,10 @@ extension on _StringsZhHk {
         return 'Could not open AnkiMobile. Install AnkiMobile and try again.';
       case 'dictionary_collapse_follow_global':
         return 'Follow global setting';
+      case 'anki_ankimobile_imported':
+        return 'AnkiMobile configuration imported.';
+      case 'anki_error_ankimobile_not_active':
+        return 'Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS 阻止了读取剪贴板。返回 Fushi 时请在系统提示里选「允许粘贴」，然后重试。",
   "anki_error_ankimobile_no_decks": "AnkiMobile 没有回传任何牌组或笔记类型。",
   "anki_error_ankimobile_unavailable": "无法打开 AnkiMobile。请先安装 AnkiMobile 再试。",
-  "dictionary_collapse_follow_global": "跟随全局设置"
+  "dictionary_collapse_follow_global": "跟随全局设置",
+  "anki_ankimobile_imported": "已导入 AnkiMobile 配置。",
+  "anki_error_ankimobile_not_active": "Fushi 没能及时回到前台，剪贴板还没被读取。回到 Fushi 后重试即可。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4242,5 +4242,7 @@
   "anki_error_ankimobile_pasteboard_denied": "iOS blocked reading the clipboard. Choose Allow Paste when returning to Fushi, then try again.",
   "anki_error_ankimobile_no_decks": "AnkiMobile returned no decks or note types.",
   "anki_error_ankimobile_unavailable": "Could not open AnkiMobile. Install AnkiMobile and try again.",
-  "dictionary_collapse_follow_global": "Follow global setting"
+  "dictionary_collapse_follow_global": "Follow global setting",
+  "anki_ankimobile_imported": "AnkiMobile configuration imported.",
+  "anki_error_ankimobile_not_active": "Fushi did not come back to the foreground in time, so the clipboard could not be read. Return to Fushi and try again."
 }

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -1076,10 +1076,15 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
             .read(ankiViewModelProvider.notifier)
             .applyFetchedConfiguration();
         FushiToast.show(
-          msg: 'AnkiMobile configuration imported.',
+          msg: t.anki_ankimobile_imported,
           severity: ToastSeverity.success,
         );
       case AnkiFetchError(:final message, :final code):
+        // toast 几秒即逝，设置页那行错误才是用户真正盯着的：真结果必须覆盖
+        // fetchConfiguration 留下的「去 AnkiMobile 点同意」中间态（BUG-2150）。
+        ref
+            .read(ankiViewModelProvider.notifier)
+            .applyFetchedFailure(message, code);
         FushiToast.show(
           msg: AnkiViewModel.localizeAnkiFetchError(message, code),
           severity: ToastSeverity.error,

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -83,6 +83,18 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
     );
   }
 
+  /// 回调带回的是**失败**时的对偶动作（BUG-2150 补修）：中间态「已跳转 AnkiMobile，
+  /// 去那边点同意」是 [fetchConfiguration] 写进 [AnkiUiState.errorMessage] 的，
+  /// 此前只有成功侧清了它。失败侧只弹一条几秒即逝的 toast，设置页那行红字仍旧说
+  /// 「去 AnkiMobile 点同意」——用户于是反复回 AnkiMobile 同意，永远看不到真正
+  /// 卡住的原因（例如系统「允许粘贴」被拒）。真结果必须覆盖中间态。
+  void applyFetchedFailure(String message, String? code) {
+    state = state.copyWith(
+      isFetching: false,
+      errorMessage: localizeAnkiFetchError(message, code),
+    );
+  }
+
   Future<void> fetchConfiguration() async {
     state = state.copyWith(isFetching: true, clearError: true);
     final result = await _repository.fetchConfiguration();
@@ -119,6 +131,8 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
         return t.anki_error_ankimobile_pasteboard_empty;
       case AnkiErrorCode.ankiMobilePasteboardDenied:
         return t.anki_error_ankimobile_pasteboard_denied;
+      case AnkiErrorCode.ankiMobileNotActive:
+        return t.anki_error_ankimobile_not_active;
       case AnkiErrorCode.ankiMobileNoDecks:
         return t.anki_error_ankimobile_no_decks;
     }

--- a/fushi/lib/src/anki/ankimobile_repository.dart
+++ b/fushi/lib/src/anki/ankimobile_repository.dart
@@ -35,6 +35,11 @@ enum AnkiMobilePasteboardStatus {
   /// 数据在，但系统不让读：用户在 iOS 的「允许粘贴」提示里选了不允许，或此刻
   /// 根本弹不出那个提示。
   denied,
+
+  /// app 一直没回到前台，剪贴板**压根没被读过**（原生侧等 active 超时）。
+  /// 与 [denied] 必须分开：非 active 时读出来的三态恒为 denied（内容读不到、
+  /// 类型元数据却看得见），合并会把「没回前台」谎报成「权限被拒」。
+  notActive,
 }
 
 /// 一次剪贴板读取的结果。[json] 仅在 [status] == [AnkiMobilePasteboardStatus.ok]
@@ -50,6 +55,9 @@ class AnkiMobilePasteboardRead {
 
   const AnkiMobilePasteboardRead.denied()
       : this(AnkiMobilePasteboardStatus.denied);
+
+  const AnkiMobilePasteboardRead.notActive()
+      : this(AnkiMobilePasteboardStatus.notActive);
 
   final AnkiMobilePasteboardStatus status;
   final String? json;
@@ -131,6 +139,8 @@ class AnkiMobileRepository extends BaseAnkiRepository {
         return AnkiMobilePasteboardRead.ok(json);
       case 'denied':
         return const AnkiMobilePasteboardRead.denied();
+      case 'notActive':
+        return const AnkiMobilePasteboardRead.notActive();
       default:
         return const AnkiMobilePasteboardRead.empty();
     }
@@ -186,6 +196,13 @@ class AnkiMobileRepository extends BaseAnkiRepository {
   Future<AnkiFetchResult> consumeInfoForAddingPasteboard() async {
     final read = await _readInfoForAddingJson();
     final String? raw = read.json;
+    if (read.status == AnkiMobilePasteboardStatus.notActive) {
+      return const AnkiFetchResult.error(
+        'Fushi did not come back to the foreground in time, so the clipboard '
+        'was never read. Return to Fushi and try again.',
+        code: AnkiErrorCode.ankiMobileNotActive,
+      );
+    }
     if (read.status == AnkiMobilePasteboardStatus.denied) {
       return const AnkiFetchResult.error(
         'iOS blocked reading the clipboard. Choose Allow Paste when returning '

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -2533,7 +2533,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// respectAssStyle 关 = **纯字幕模式**（BUG-915/1264）：**颜色语义整体归零**——行内 `\c`
   /// / `\1c` 主色与 `\3c` 描边色（[_resolveStroke]）、`\1a` 填充透明度、cueStyle 主色、`\t`
   /// 颜色动画、卡拉 OK SecondaryColour（[_applyDynamicFill]）同源门控，一律回落用户
-  /// textColor；行内 `\fs` 字号同样门控（BUG-2149，此前按裸像素放行、架空用户字号
+  /// textColor；行内 `\fs` 字号同样门控（BUG-2157，此前按裸像素放行、架空用户字号
   /// 滑块）。只保留行内 `\i \b \u \s` 这些**文本语义**；字体 / 字号 / 颜色的基线恒为
   /// 用户统一样式。
   /// respectAssStyle 开：字体名 / 主色 / 字号 / 粗斜下删线优先取 .ass 值（行内 span >
@@ -2665,7 +2665,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
           ? span.letterSpacingPx! * assFontScale
           : null,
       // 行内字号（respect 时）同按 ASS 缩放 + cell/em 校准。
-      // respect 关 = 纯字幕模式：**字号与兄弟属性同源门控**（BUG-2149）。曾按「历史
+      // respect 关 = 纯字幕模式：**字号与兄弟属性同源门控**（BUG-2157）。曾按「历史
       // 裸像素」放行 `span.fontSizePx`，那是最后一条穿透的外观通道——`\c` 主色
       // （BUG-1285）、`\3c` 描边色、`\1a` 填充透明度、`\fsp` 字距、`\shad` 阴影、
       // `\fscx/\fscy` 缩放早已全部门控，唯独它把作者字号直接写进 TextStyle，且写的是

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -608,6 +608,7 @@ class _PopupStaticSettingsMemo {
     required this.collapseDictionaries,
     required this.autoExpandRows,
     required this.collapsedNames,
+    required this.expandedNames,
     required this.hiddenNames,
     required this.stylesJson,
     required this.globalDictCSS,
@@ -632,6 +633,7 @@ class _PopupStaticSettingsMemo {
   final bool collapseDictionaries;
   final int autoExpandRows;
   final String collapsedNames;
+  final String expandedNames;
   final String hiddenNames;
   final String stylesJson;
   final String globalDictCSS;
@@ -745,6 +747,12 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
       cached.collapseDictionaries == appModel.collapseDictionaries &&
       cached.autoExpandRows == appModel.popupAutoExpandDictionaries &&
       cached.collapsedNames == collapsedNames &&
+      // BUG-2158 补修：命中判据必须是产物**全部输入**的廉价投影（本类文档写死的
+      // 契约）。漏掉它时「继承 → 显式展开」这一档转移不改 collapsedNames，命中判据
+      // 全等 → memo 命中 → 用户点『展开』毫无反应。今天没中招只是因为
+      // persistDictionary 顺带让 stylesJson 换了新实例（每次点击整个重载 native
+      // 词典引擎），一旦那条被优化掉就静默失效。
+      cached.expandedNames == expandedNames &&
       cached.hiddenNames == hiddenNames &&
       identical(cached.stylesJson, stylesJson) &&
       cached.globalDictCSS == globalDictCSS &&
@@ -867,6 +875,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     collapseDictionaries: appModel.collapseDictionaries,
     autoExpandRows: appModel.popupAutoExpandDictionaries,
     collapsedNames: collapsedNames,
+    expandedNames: expandedNames,
     hiddenNames: hiddenNames,
     stylesJson: stylesJson,
     globalDictCSS: globalDictCSS,

--- a/fushi/test/anki/ankimobile_ios_callback_static_test.dart
+++ b/fushi/test/anki/ankimobile_ios_callback_static_test.dart
@@ -70,6 +70,28 @@ void main() {
     expect(src, contains('"status"'));
   });
 
+  // 等 active 超时后**不能**再「尽力读一次」：非 active 下内容读不到、类型元数据
+  // 却看得见，三态必落 denied——把「app 还没回到前台」谎报成「iOS 拒绝了粘贴」。
+  // 超时那条路径必须回独立的 notActive（PR#1222 事后审查补修）。
+  test('等 active 超时报 notActive，而不是读出一个假的 denied', () {
+    final String src = File('ios/Runner/AppDelegate.swift').readAsStringSync();
+
+    expect(src, contains('"notActive"'));
+
+    const String anchor = 'let work = DispatchWorkItem {';
+    final int at = src.indexOf(anchor);
+    expect(at, greaterThan(-1), reason: '找不到超时 DispatchWorkItem，锚点失效');
+    final int end = src.indexOf('\n', at + anchor.length);
+    final String body = src.substring(at, end);
+    // 自检：截出来的必须真是那一行，否则下面的断言变空转。
+    expect(body.trim(), isNotEmpty);
+    expect(
+      body,
+      contains('finish(false)'),
+      reason: '超时路径必须以「没变成 active」的身份收尾，否则又会去读剪贴板',
+    );
+  });
+
   test('Dart startup consumes the AnkiMobile info callback', () {
     final main = File('lib/main.dart').readAsStringSync();
     final vm = File('lib/src/anki/anki_view_model.dart').readAsStringSync();

--- a/fushi/test/anki/ankimobile_pasteboard_states_test.dart
+++ b/fushi/test/anki/ankimobile_pasteboard_states_test.dart
@@ -110,6 +110,23 @@ void main() {
       );
     });
 
+    // app 一直没回到前台时，原生侧压根没读剪贴板。此前它超时后仍「尽力读一次」：
+    // 非 active 下内容读不到、类型元数据却看得见，三态必落 denied——把「没回前台」
+    // 谎报成「iOS 拒绝了粘贴」，把用户支去改一个没出问题的权限
+    // （PR#1222 事后审查补修）。
+    test('没回到前台 → not-active 码（不是 denied）', () async {
+      final result = await repoReading(
+        const AnkiMobilePasteboardRead.notActive(),
+      ).consumeInfoForAddingPasteboard();
+
+      expect(result, isA<AnkiFetchError>());
+      expect(
+        (result as AnkiFetchError).code,
+        AnkiErrorCode.ankiMobileNotActive,
+      );
+      expect(result.code, isNot(AnkiErrorCode.ankiMobilePasteboardDenied));
+    });
+
     test('回传了 JSON 但里面没牌组 → no-decks 码', () async {
       final result = await repoReading(
         const AnkiMobilePasteboardRead.ok('{"decks":[],"notetypes":[]}'),
@@ -192,6 +209,24 @@ void main() {
 
       expect(vm.state.errorMessage, isNull);
       expect(vm.state.isFetching, isFalse);
+    });
+
+    // 失败侧的对偶：此前只弹一条几秒即逝的 toast，设置页那行红字仍旧是中间态
+    // 「去 AnkiMobile 点同意」——用户于是反复回 AnkiMobile 同意，永远看不到真正
+    // 卡住的原因（PR#1222 事后审查补修）。
+    test('applyFetchedFailure 用真失败覆盖中间态，而不是让它继续挂着', () async {
+      final AnkiViewModel vm = AnkiViewModel(_AnkiMobileOpenedRepo());
+      await vm.fetchConfiguration();
+      expect(vm.state.errorMessage, t.anki_ankimobile_opened);
+
+      vm.applyFetchedFailure(
+        'iOS blocked reading the clipboard.',
+        AnkiErrorCode.ankiMobilePasteboardDenied,
+      );
+
+      expect(vm.state.isFetching, isFalse);
+      expect(vm.state.errorMessage, t.anki_error_ankimobile_pasteboard_denied);
+      expect(vm.state.errorMessage, isNot(t.anki_ankimobile_opened));
     });
   });
 

--- a/fushi/test/anki/ankimobile_platform_status_parse_test.dart
+++ b/fushi/test/anki/ankimobile_platform_status_parse_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/anki/ankimobile_repository.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+// PR#1222 事后审查补的缺口：原生侧回的 `{status, json}` 到 Dart 三态（四态）的
+// 解析此前**零覆盖**——所有测试都注入 `readInfoForAddingJson` 把它绕过去了，
+// Swift 侧守卫也只断言源码里出现过 `"denied"` / `"empty"` 这些字面量，没有任何
+// 测试断言 Dart 按同一批字面量解析。
+//
+// 失败场景：任一侧把字面量改成 `"DENIED"` 或改 key 名，编译过、全部测试绿，
+// 线上 denied 静默降级成 empty——用户又回到「AnkiMobile 没回传配置」这句
+// 与事实无关的诊断，正是 BUG-2150 要消灭的那类误导。
+//
+// 这里走真 MethodChannel（mock 的是原生那一端），所以字面量两侧必须真的对上。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('app.fushi.reader/ankimobile');
+
+  /// 让通道按原生侧的形状回一个 Map，然后走**未注入**的仓库（真解析路径）。
+  Future<AnkiFetchResult> consumeWithNativeReply(
+    Map<Object?, Object?>? reply,
+  ) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      expect(call.method, 'consumeInfoForAddingPasteboard');
+      return reply;
+    });
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+    final repo = AnkiMobileRepository(openUrl: (_) async => true);
+    return repo.consumeInfoForAddingPasteboard();
+  }
+
+  String? codeOf(AnkiFetchResult result) =>
+      result is AnkiFetchError ? result.code : null;
+
+  test('原生 "denied" 解析成 denied 码（不是降级成 empty）', () async {
+    final result = await consumeWithNativeReply(<Object?, Object?>{
+      'status': 'denied',
+    });
+    expect(codeOf(result), AnkiErrorCode.ankiMobilePasteboardDenied);
+  });
+
+  test('原生 "notActive" 解析成 not-active 码', () async {
+    final result = await consumeWithNativeReply(<Object?, Object?>{
+      'status': 'notActive',
+    });
+    expect(codeOf(result), AnkiErrorCode.ankiMobileNotActive);
+  });
+
+  test('原生 "empty" 解析成 pasteboard-empty 码', () async {
+    final result = await consumeWithNativeReply(<Object?, Object?>{
+      'status': 'empty',
+    });
+    expect(codeOf(result), AnkiErrorCode.ankiMobilePasteboardEmpty);
+  });
+
+  test('原生 "ok" + 有牌组的 JSON 一路走通到成功', () async {
+    final result = await consumeWithNativeReply(<Object?, Object?>{
+      'status': 'ok',
+      'json': '{"decks":[{"id":1,"name":"Default"}],'
+          '"notetypes":[{"id":2,"name":"Basic","fields":["Front","Back"]}]}',
+    });
+    expect(result, isA<AnkiFetchSuccess>());
+  });
+
+  test('原生 "ok" 但 json 为空 → empty，不当成功', () async {
+    final result = await consumeWithNativeReply(<Object?, Object?>{
+      'status': 'ok',
+      'json': '  ',
+    });
+    expect(codeOf(result), AnkiErrorCode.ankiMobilePasteboardEmpty);
+  });
+
+  test('通道回 null / 未知 status 一律退成 empty，不崩', () async {
+    expect(
+      codeOf(await consumeWithNativeReply(null)),
+      AnkiErrorCode.ankiMobilePasteboardEmpty,
+    );
+    expect(
+      codeOf(
+        await consumeWithNativeReply(<Object?, Object?>{'status': 'DENIED'}),
+      ),
+      AnkiErrorCode.ankiMobilePasteboardEmpty,
+    );
+  });
+}

--- a/fushi/test/anki/lapis_note_type_test.dart
+++ b/fushi/test/anki/lapis_note_type_test.dart
@@ -63,6 +63,18 @@ void main() {
       // appended after the vendored css so it wins by source order.
       expect(LapisNoteType.css, isNot(contains('Hibiki delta')),
           reason: 'vendored css must stay byte-identical to upstream');
+      // BUG-2151 / BUG-2155 曾把四处补丁直接写进 vendored `css`，而上面那条
+      // 只认 'Hibiki delta' 这一个串，没抓到。本仓的补丁一律带 `BUG-NNNN` 引用，
+      // 拿它当判据：vendored 常量里出现本仓的 bug 号 = 有人又在里面打补丁了。
+      // 代价是真实的：重新 vendor 会把补丁静默冲掉（没有守卫会红），且原版
+      // Lapis 用户会被 lapis_styling 的 pristine 集合判成「手改过」，每次点
+      // 「应用样式到 Anki」都要多确认一次。
+      expect(
+        RegExp(r'BUG-\d+').hasMatch(LapisNoteType.css),
+        isFalse,
+        reason: 'Hibiki 的 CSS 补丁只能写在 fushiCssOverride 里，'
+            '不能改 vendored 的 css 常量',
+      );
       expect(LapisNoteType.fushiCssOverride, contains('.def-info'));
       expect(LapisNoteType.fushiCssOverride, contains('Hibiki delta'));
       expect(LapisNoteType.fushiCssOverride, contains('margin-top'));

--- a/fushi/test/anki/lapis_pitch_tag_list_markup_test.dart
+++ b/fushi/test/anki/lapis_pitch_tag_list_markup_test.dart
@@ -105,7 +105,13 @@ void main() {
       return out;
     }
 
-    final List<List<String>> parsed = rules(maskCssComments(LapisNoteType.css));
+    // 断言目标必须是 `template.css`（= vendored `css` + `fushiCssOverride`），
+    // 不是裸的 `css`：Hibiki 的 delta 按 lapis_note_type.dart 文件头的规矩只能写在
+    // override 里（`css` 逐字节 vendored 自 donkuri/lapis 1.7.0，重新 vendor 会
+    // 把写进去的补丁静默冲掉，且会让原版 Lapis 用户被 lapis_styling 的 pristine
+    // 集合判成「手改过」）。而 `template.css` 才是真正推给 Anki 的那份。
+    final List<List<String>> parsed =
+        rules(maskCssComments(LapisNoteType.template.css));
 
     String declsOf(bool Function(List<String>) where, String what) {
       final Iterable<String> hits =

--- a/fushi/test/pages/popup_settings_injection_memo_test.dart
+++ b/fushi/test/pages/popup_settings_injection_memo_test.dart
@@ -411,6 +411,23 @@ void main() {
             ],
             marker: 'window.collapsedDictionaryNames = ["CollapsedDict"]',
           ),
+          // BUG-2158 补修：与折叠名单成对的第三态。它是三档转移里唯一**不动**
+          // collapsedLanguages 的那档，所以 memo 漏登记它时「继承 → 显式展开」
+          // 会静默失效（点『展开』毫无反应）。
+          (
+            name: 'expandedDictionaryNames（显式展开名单）',
+            mutate: (MemoAppModel m) => m.dictionariesValue = <Dictionary>[
+              Dictionary(
+                name: 'ExpandedDict',
+                formatKey: 'yomichan',
+                order: 0,
+                expandedLanguages: <String>[
+                  JapaneseLanguage.instance.languageCode,
+                ],
+              ),
+            ],
+            marker: 'window.expandedDictionaryNames = ["ExpandedDict"]',
+          ),
           (
             name: 'globalDictCSS',
             mutate: (MemoAppModel m) => m.globalDictCSSValue = '.g{color:blue}',

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -1347,6 +1347,9 @@ class AnkiErrorCode {
   /// `ankiMobilePasteboardEmpty`：剪贴板上没有 AnkiMobile 的数据——通常是用户没在
   ///   AnkiMobile 里同意那次请求。
   /// `ankiMobilePasteboardDenied`：数据在，但 iOS 不让读（「允许粘贴」被拒/弹不出）。
+  /// `ankiMobileNotActive`：app 一直没回到前台，剪贴板压根没被读过（等待超时）。
+  ///   与 denied 必须分开：非 active 时读出来的三态恒为 denied，合并会把「没回
+  ///   前台」谎报成「权限被拒」，把用户支去改一个没出问题的权限。
   /// `ankiMobileNoDecks`：AnkiMobile 回传了 JSON，但里面没有牌组或笔记类型。
   /// `ankiMobileUnavailable`：`anki://` 打不开——没装 AnkiMobile。
   static const String ankiMobileOpened = 'ANKI_MOBILE_OPENED';
@@ -1354,6 +1357,7 @@ class AnkiErrorCode {
       'ANKI_MOBILE_PASTEBOARD_EMPTY';
   static const String ankiMobilePasteboardDenied =
       'ANKI_MOBILE_PASTEBOARD_DENIED';
+  static const String ankiMobileNotActive = 'ANKI_MOBILE_NOT_ACTIVE';
   static const String ankiMobileNoDecks = 'ANKI_MOBILE_NO_DECKS';
   static const String ankiMobileUnavailable = 'ANKI_MOBILE_UNAVAILABLE';
 

--- a/packages/fushi_anki/lib/src/lapis_note_type.dart
+++ b/packages/fushi_anki/lib/src/lapis_note_type.dart
@@ -1177,17 +1177,6 @@ main {
   vertical-align: top;
   padding: 1px 3px;
   margin-right: -5px;
-
-  /* BUG-2155：`.tags` 给的是 `max-width: 60dvw` —— 一个**视口**相对的上限，塞进
-     `max-width: 820px` 的 .def-header 里毫无意义：宽屏上 60dvw 比整个卡头还宽，
-     标签框于是想多宽有多宽。改成相对容器，框永远待在词头这一列里。 */
-  max-width: 100%;
-
-  /* 同上：`.tags` 的 `white-space: nowrap` 是给「一个短标签」设计的。音标词典
-     （维基词典之类）一个词能给十几条，挤成一行只能靠 text-overflow 截掉大半。
-     这里允许多行，配合下面把列表改成 wrap 的 flex 容器，十几条音标全留住。 */
-  white-space: normal;
-
   &:has(li) {
     display: inline-block;
   }
@@ -1199,54 +1188,25 @@ main {
 }
 
 /* When multiple pitch */
-/* BUG-2151：`ol` 与 `ul` 一起归一。Lapis 自己的 handlePitches 只在字段里能解析出
-   数字/假名声调时才重建 `#pitch-tags`（英语 IPA 两者都没有 → 提前 return），此时框
-   里留的是制卡侧原样写入的列表 HTML。存量卡片的字段里存的是 `<ol>`（BUG-2151 之前
-   popup.js 的产出），漏掉 `ol` 就等于让这批已经躺在用户 Anki 里、改不了的卡继续吃
-   浏览器默认的 `padding-inline-start: 40px` + `margin-block: 1em`：黑框超高、左边一
-   大块空白、条目之间还没有分隔符。 */
 .pitch ul,
-.pitch ol {
+#pitch-tags ul {
   list-style: none;
   display: inline;
   margin: 0;
   padding: 0;
 }
 
-/* BUG-2155：标签框里的列表是 wrap 的 flex 容器，不是 inline 流。
-   为什么非得是 flex：制卡侧产出的是 `<li>…</li><li>…</li>`，**元素之间一个空白都
-   没有**，而行内流的换行点来自空白 —— 没有空白就没有换行机会，十几条音标只能挤成
-   一条撑爆卡头的长行。flex 容器的换行点在 item 边界，不依赖空白，于是既能换行、
-   又不会从某条音标中间断开。
-   日语那档（1~3 个短标签）一行放得下，wrap 不触发，渲染与原来的 inline 流一致。 */
-#pitch-tags ul,
-#pitch-tags ol {
-  list-style: none;
-  display: inline-flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-}
-
-.pitch li {
-  display: inline;
-}
-
-/* flex item 内部仍然不许断行：一条音标是一个整体，断成 `[/fɜː` + `st/]` 比换行更糟。 */
+.pitch li,
 #pitch-tags li {
   display: inline;
-  white-space: nowrap;
 }
 
-.pitch ul > li:not(:last-child)::after,
-.pitch ol > li:not(:last-child)::after {
+.pitch ul > li:not(:last-child)::after {
   content: "・";
   color: var(--fg-color);
 }
 
-#pitch-tags ul > li:not(:last-child)::after,
-#pitch-tags ol > li:not(:last-child)::after {
+#pitch-tags ul > li:not(:last-child)::after {
   content: "・";
   color: var(--bg-color);
   font-size: 0.8em;
@@ -1509,14 +1469,6 @@ footer {
   border-radius: 5px;
   flex: 1;
   /* takes up all available space */
-
-  /* BUG-2155：flex item 的 min-width 默认是 auto，也就是「不小于内容的最小尺寸」。
-     音标标签框（#pitch-tags）是个 inline-block，宽度就是它的内容宽，词典给出十几条
-     音标时轻松超过整个卡头 —— 于是这一列的最小宽度顶穿 .def-header，右边的
-     .dh-image 被压成 0，封面图整个消失。min-width: 0 解开这条约束：本列该让位就让位，
-     超出的部分交给 #pitch-tags 自己处理（换行 / 裁切）。
-     短音标（日语 [1]・[3]）本来就不顶宽，这行对它们是 no-op。 */
-  min-width: 0;
 }
 
 .dh-image {
@@ -1998,6 +1950,78 @@ html.mobile .sentence, html:not(.mobile) .sentence-alt,
 /* Hibiki delta — see LapisNoteType.fushiCssOverride doc. */
 .def-info {
   margin-top: 0.6em;
+}
+
+/* BUG-2155：`.tags` 给 `#pitch-tags` 的是 `max-width: 60dvw` —— 一个**视口**相对
+   的上限，塞进 `max-width: 820px` 的 .def-header 里毫无意义：宽屏上 60dvw 比整个
+   卡头还宽，标签框于是想多宽有多宽。改成相对容器，框永远待在词头这一列里。
+   `white-space` 同理：`.tags` 的 nowrap 是给「一个短标签」设计的，音标词典一个词
+   能给十几条，挤成一行只能靠 text-overflow 截掉大半。同特异性、后置胜出。 */
+#pitch-tags {
+  max-width: 100%;
+  white-space: normal;
+}
+
+/* BUG-2151：`ol` 与 `ul` 一起归一。Lapis 自己的 handlePitches 只在字段里能解析出
+   数字/假名声调时才重建 `#pitch-tags`（英语 IPA 两者都没有 → 提前 return），此时
+   框里留的是制卡侧原样写入的列表 HTML。存量卡片的字段里存的是 `<ol>`（BUG-2151
+   之前 popup.js 的产出），漏掉 `ol` 就等于让这批已经躺在用户 Anki 里、改不了的卡
+   继续吃浏览器默认的 `padding-inline-start: 40px` + `margin-block: 1em`：黑框超
+   高、左边一大块空白、条目之间还没有分隔符。上游只写了 `ul`，这里补 `ol` 的对偶
+   （全新选择器，不与上游冲突）。 */
+.pitch ol {
+  list-style: none;
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.pitch ol > li {
+  display: inline;
+}
+
+.pitch ol > li:not(:last-child)::after {
+  content: "・";
+  color: var(--fg-color);
+}
+
+/* BUG-2155：标签框里的列表是 wrap 的 flex 容器，不是 inline 流。
+   为什么非得是 flex：制卡侧产出的是 `<li>…</li><li>…</li>`，**元素之间一个空白都
+   没有**，而行内流的换行点来自空白 —— 没有空白就没有换行机会，十几条音标只能挤成
+   一条撑爆卡头的长行。flex 容器的换行点在 item 边界，不依赖空白，于是既能换行、
+   又不会从某条音标中间断开。
+   日语那档（1~3 个短标签）一行放得下，wrap 不触发，渲染与原来的 inline 流一致。
+   与上游 `#pitch-tags ul{display:inline}` 同特异性、后置胜出。 */
+#pitch-tags ul,
+#pitch-tags ol {
+  list-style: none;
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
+/* flex item 内部仍然不许断行：一条音标是一个整体，断成 `[/fɜː` + `st/]` 比换行更糟。 */
+#pitch-tags li {
+  display: inline;
+  white-space: nowrap;
+}
+
+#pitch-tags ol > li:not(:last-child)::after {
+  content: "・";
+  color: var(--bg-color);
+  font-size: 0.8em;
+}
+
+/* BUG-2155：flex item 的 min-width 默认是 auto，也就是「不小于内容的最小尺寸」。
+   音标标签框（#pitch-tags）是个 inline-block，宽度就是它的内容宽，词典给出十几条
+   音标时轻松超过整个卡头 —— 于是这一列的最小宽度顶穿 .def-header，右边的
+   .dh-image 被压成 0，封面图整个消失。min-width: 0 解开这条约束：本列该让位就让位，
+   超出的部分交给 #pitch-tags 自己处理（换行 / 裁切）。
+   短音标（日语 [1]・[3]）本来就不顶宽，这行对它们是 no-op。 */
+.dh-vocab {
+  min-width: 0;
 }
 ''';
 


### PR DESCRIPTION
这批 PR（#1222 #1223 #1226 #1227）已经合进 develop 了，本 PR 是**事后代码审查**查出来的补修。六条，都在主干上。

## #1222 iOS AnkiMobile 配置回传（BUG-2150）

1. **失败侧不写回 ViewModel**（`main.dart`）。中间态「已跳转 AnkiMobile，去那边点同意」是 `fetchConfiguration` 写进 `errorMessage` 的，此前只有成功侧清它；失败侧只弹一条几秒即逝的 toast，设置页那行红字仍旧说「去点同意」。用户于是反复回 AnkiMobile 同意，永远看不到真正卡住的原因（例如系统「允许粘贴」被拒）——正是 BUG-2150 要消灭的那类误导诊断，只在成功侧修了一半。新增 `applyFetchedFailure`。

2. **成功 toast 是硬编码英文**（`main.dart:1079`）。整条 PR 的主诉就是「中文 UI 里显示英文原文」，五个失败码都本地化了，唯独同一个 switch 里的成功那句留着裸英文。

3. **等 active 超时后谎报 denied**（`AppDelegate.swift`）。超时那条路径此前仍「尽力读一次」：非 active 下 `data(forPasteboardType:)` 必然返回 nil，而 `contains(pasteboardTypes:)` 只查元数据、照样返回 true，于是三态判定必落 `denied`——把「app 还没回到前台」（来电/系统弹窗压住、用户回来又切走）谎报成「iOS 拒绝了粘贴」，把用户支去改一个根本没出问题的权限。改成超时不读、回独立的 `notActive`（新错误码 + 新文案，指向「回到 Fushi 后重试」）。

## #1226 行内 `\fs`（BUG-2157）

4. **BUG 号写错**（`video_subtitle_overlay.dart` 两处引用 `BUG-2149`，而 `docs/bugs` 下没有这个号）。代码引用指向不存在的号会让按号回溯根因直接断链。

## #1223 音标列表（BUG-2151 / BUG-2155）

5. **四处 Hibiki 补丁写进了标着「Do not hand-edit」的 vendored 常量**（`lapis_note_type.dart`）。该文件头写死 `css` 逐字节 vendored 自 donkuri/lapis 1.7.0，`fushiCssOverride` 存在的全部理由就是「让 css 与上游逐字节一致，将来重新 vendor 不会冲掉 delta」。这是历史上第一次有 Hibiki 内容进去，两个具体后果：将来按 pinned tag 重新 vendor 时四处补丁**静默消失**（BUG-2151 的 ol 兼容半边和 BUG-2155 全部回归，没有任何守卫会红）；`lapis_styling.dart` 的 pristine 集合含 `LapisNoteType.css`，原版 Lapis 用户从此不再命中 → 判 foreignEdit → 每次点「应用样式到 Anki」多弹一次「疑似手改」。

   修法：`css` 恢复 pristine，四处改写成 override 里的独立规则（特异性逐条核过）。既有守卫只认 `'Hibiki delta'` 这一个串、四处补丁一个都没带它于是全溜过去——改成「vendored css 里不得出现 `BUG-\d+`」。`lapis_pitch_tag_list_markup_test` 的断言目标同步换成 `LapisNoteType.template.css`（真正推给 Anki 的那份），否则它正好把「补丁必须写在 vendored 里」这个错误契约钉死。

## #1227 词典折叠三态（BUG-2158）

6. **新注入值没进 memo 失效判据**（`popup_settings_injection.dart`）。`expandedNames` 产出了、写进 head 了，但命中比较链、memo 字段表、存回三处都漏了它，而该类文档写死「命中判据是产物**全部输入**的廉价投影」。今天不中招的原因不是代码对，是被一个无关副作用盖住：`persistDictionary` 顺带让 `stylesJson` 换了新实例（等于每次点击整个重载 native 词典引擎）。一旦有人给 `_rebuildDictPathsCache` 加一句「路径集合没变就跳过」（它的注释自己就在担心 O(N²) 成本），「继承 → 显式展开」这一档转移就静默失效——它是三档里唯一不动 `collapsedLanguages` 的那档，用户点「展开」毫无反应，BUG-2158 原样复发。

## 测试

补的都是审查指出的**零覆盖**点，不是凑数：

- 新增 `ankimobile_platform_status_parse_test.dart`：走真 MethodChannel（mock 原生那端）跑「`{status,json}` → 四态」的解析。此前这段零覆盖——所有测试都注入 `readInfoForAddingJson` 绕过它，Swift 侧守卫也只断言源码里出现过字面量；两侧字面量对不上时编译过、全绿、线上静默降级。
- `ankimobile_pasteboard_states_test`：+`notActive` 不等于 `denied`、+`applyFetchedFailure` 覆盖中间态。
- `ankimobile_ios_callback_static_test`：+超时路径必须以 `finish(false)` 收尾（带锚点自检）。
- `lapis_note_type_test`：+vendored 常量不得含 `BUG-` 引用。
- `popup_settings_injection_memo_test`：+`expandedDictionaryNames` 穷举用例（清单原本有折叠没有展开）。

## 验证

- `flutter analyze` 全量（含 test 目录）：**No issues found**
- `test/anki` 336 tests 全过
- `test/anki` + `test/pages` + i18n 完整性共 **3672 tests**；2 条红是本仓已知的并发伪红形态（`loading <file>` 无 Expected = suite 装载失败），单独重跑 `lookup_search_placeholder_dialog_test` + `lyrics_dialog_md3_static_test` → All tests passed
- **变异实测三条**：把 `notActive` 并回 `denied` → 新用例立刻红在 `ankimobile_platform_status_parse_test.dart:52`；往 vendored css 里塞 `BUG-9999` 注释 → 新守卫红；撤掉 `cached.expandedNames == expandedNames` → 只有新加的展开名单用例红、其余 28 条照绿

https://claude.ai/code/session_01J9c2xkytFudNrzzsoZDZzx
