### PR TITLE
refactor(sync): PR1/7 抽 PkceOAuthBackendMixin——Dropbox/OneDrive 认证外壳收成一份 + 补 OAuth 单测

### DIFF
--- a/docs/plans/2026-09-06-sync-interconnect-refactor.md
+++ b/docs/plans/2026-09-06-sync-interconnect-refactor.md
@@ -1,0 +1,185 @@
+# 同步 / 互联重构计划（A 消重 + B 拆巨类）
+
+基线：`origin/develop`（开工前 fetch，worktree 起点显式写 `origin/develop`）。
+目标目录：`fushi/lib/src/sync/`（112 文件 / 50.0k 行）。
+铁律：**零行为变化**（wire / 偏好键 / manifest 字节 / 路由面 / 公开 API 语义全部冻结）；一簇一 PR，每 PR 独立可合。
+
+## 冻结面（任何一条动了都是 bug）
+
+- manifest canonical JSON 字节确定性：`collection_manifest.dart` / `video_manifest.dart` / `aggregate_snapshot.dart` / `sync_manifest_codec.dart`（orchestrator 靠字节相等跳过重写）。
+- 远端保留名：`__aggregate__` `__collections__` `__dictionaries__` `__tombstones__` `__videos__` `__all__`；`collections.json` `videos.json` `manifest.json` `tags.json` `book_css.json` `manga.json` `backup_meta.json`；`.fushidict` / `.fushiaudio`。
+- HTTP 面：`fushi_sync_server.dart:533-627` 全部 `/api/*` 路径 + WebDAV 动词（PROPFIND/PUT/MKCOL/DELETE/HEAD/OPTIONS）+ `yomitan_api_server.dart:304-336`；自定义头 `X-Hibiki-Book-Display-Title[-At]` / `X-Hibiki-Video-Title`。
+- 偏好键：`sync_repository.dart:184-1024` 全部 `sync_*` / `interconnect_*`。
+- DTO 线格式：`test/sync/remote_dto_wire_format_golden_test.dart` 是金样，动 DTO 必须金样不变。
+- `SyncBackend` 抽象（40+ 成员，34 个 importer）与 `SyncRepository`（35 个 importer）签名不动。
+
+## 守卫约束（拆/改名必须连带）
+
+83 个源码扫描守卫钉了 58 个 sync 文件的路径字面量。本计划触碰的：
+
+| 文件 | 钉它的守卫 |
+|---|---|
+| `backup_service.dart` | `test/media/db_source_pref_key_test.dart`、`test/sync/backup_device_local_leak_guard_test.dart`、`test/sync/backup_import_streaming_guard_test.dart`、`test/tools/fushi_rename_guard_test.dart` |
+| `sync_orchestrator.dart` | `test/sync/interconnect_service_config_test.dart`、`server_lifecycle_appmodel_guard_test.dart`、`sync_audiobook_download_wiring_guard_test.dart`、`sync_progress_test.dart`、`test/tools/fushi_rename_guard_test.dart` |
+| `fushi_sync_server.dart` | `test/sync/fushi_sync_server_asset_gate_test.dart`、`fushi_sync_server_hardening_test.dart`、`interconnect_profile_transfer_test.dart`、`interconnect_token_display_guard_test.dart`、`pairing/pin_no_plaintext_guard_test.dart` |
+| `app_model_library_host_service.dart` | `test/media/audiobook/audio_reference_import_guard_test.dart`、`test/media/media_cover_write_guard_test.dart`、`test/pages/video_delete_reclaim_entry_guard_test.dart`、`test/sync/fushi_library_collections_test.dart` |
+
+规则：代码挪到新文件后，守卫的扫描面必须**跟着挪**（改成扫新文件或扫多个文件），不能只让守卫"仍然能读到旧文件"就算过——那是守卫失效不是守卫通过。每个 PR 的验证项里逐条列出改了哪个守卫、改前故意破坏一次确认它仍会红。
+
+---
+
+## A. 消重（4 个 PR）
+
+### A1. Dropbox ↔ OneDrive PKCE 外壳（PR 1）
+
+**现状**：`dropbox_sync_backend.dart:119-224` ↔ `onedrive_sync_backend.dart:115-210` 五段近逐字：`handleAuthCode` / `_exchangeCode` / `restoreAuth` / `refreshAuth` / `_authHeaders`，外加 `_pendingVerifier`/`_pendingRepo`/`_accessToken`/`_refreshToken` 四个字段。两者已共享 `pkce_oauth.dart` 的 token 交换，但持久化 + 恢复 + 头拼装各写一份，且**两边零 OAuth 单测**（2026-07-24 审查 §三-1）。
+
+**改法**：新增 `pkce_oauth_backend_mixin.dart`：
+```dart
+mixin PkceOAuthBackendMixin on SyncBackend {
+  PkceOAuthFlow get oauth;                       // 各自的 client id / endpoint
+  String get redirectUri;                        // 各自的 custom scheme
+  Future<String?> loadStoredRefreshToken(SyncRepository repo);
+  Future<void> storeRefreshToken(SyncRepository repo, String? token);
+  Future<void> fetchUserEmail();                 // 各自 API 不同，保留抽象
+  // 共享实现：handleAuthCode / exchangeCode / restoreAuth / refreshAuth /
+  // bearerJsonHeaders；字段 accessToken / refreshToken / pendingVerifier / pendingRepo
+}
+```
+- 两个后端各删五段 + 四字段，`signOut` 不合（Dropbox 有 revoke 调用，OneDrive 没有——这是真实差异）。
+- 桌面 loopback 分支（`_startDesktopFlow` 类的东西）两边是否也逐字？实施时 diff 一次决定进不进 mixin；不进则明说。
+
+**测试**：新增 `test/sync/pkce_oauth_backend_mixin_test.dart`——用 fake `PkceOAuthFlow`（子类覆写 `exchangeCode`/`refreshTokens`）覆盖：① exchangeCode 后 refresh token 落 repo；② restoreAuth 刷新失败 → 两个 token 清空、返回 false（HBK-AUDIT-159 的行为）；③ refresh 响应缺 refresh_token 时保留旧值；④ 无 pending flow 调 handleAuthCode 抛 `SyncAuthError`。这是补上审查点名的零覆盖，不是顺手加。
+
+**爆炸半径**：`oauth_backend_config_test.dart` / `oauth_proxy_and_browser_timeout_test.dart` 定向重跑；无守卫钉这两个文件。
+
+### A2. WebDAV 路径后端三件套（PR 2）
+
+**现状**：`webdav_sync_backend.dart:116-175` ↔ `interconnect_sync_backend.dart:456-` 的 `listBooks` / `ensureBookFolder`（含封面上传）/ `listSyncFiles` 逐字相同，都打同一个 `WebDavOps`。interconnect 这三处**不**调 `_ensureResolved`（只 `findOrCreateRootFolder` :445 调），所以抽出来零时序变化。
+
+**改法**：新增 `webdav_path_backend_mixin.dart`：
+```dart
+mixin WebDavPathBackendMixin on SyncBackend {
+  WebDavOps get davOps;
+  // listBooks / ensureBookFolder / listSyncFiles 共享实现（用 rootFolderIdCache / folderIdCache）
+}
+```
+- `findOrCreateRootFolder` **不合**：webdav 有 Fushi 改名迁移三段，interconnect 没有，这是真实差异。
+- sftp / ftp **不合**：原语不同（`listdir` vs `changeDirectory`+`listDirectoryContent`+`_opLock`+`_resetConnection`），硬合是 6 个抽象方法换 80 行，不值。计划里明说"审查报告 §三-2 的四后端 mixin 提案缩到两后端"。
+- interconnect 其余 51 处 `_ensureResolved()` 一处不动。
+
+**测试**：`webdav_metadata_in_book_folder_guard_test.dart` 若扫 `webdav_sync_backend.dart` 里的 `ensureBookFolder` 文本，改扫 mixin 文件。定向：`test/sync/webdav_*`、`interconnect_sync_backend*`、BUG-845 相关（`ensureFolderIdTrailingSlash`）。
+
+### A3. 两台服务器的六条重复路由（PR 3）
+
+**现状**：`fushi_sync_server.dart` 与 `yomitan_api_server.dart` 都服务 `/api/lookup/dictionary` `/api/lookup/audio` `/api/lookup/audio/file` `/api/mine` `/api/mine/forward` `/api/duplicate` `/api/extension/status` `/api/anki/note-type/{read,styling,templates}`。payload 已共享（`fushi_remote_api_handlers.dart` 的 `build*Response`），重复的是：JSON 读体 + 405 门 + 各 handler 壳 + **单词音频短命 token 存储**（`yomitan_api_server.dart:172` 自述"与 FushiSyncServer 同款模型"）。
+
+**改法**：
+1. 新增 `remote_audio_token_store.dart`：`RemoteAudioTokenStore`（mint / take / prune / 容量上限），两台服务器各删自己那份。
+2. 新增 `remote_lookup_routes.dart`：`RemoteLookupRoutes`，构造注入 `FushiRemoteLookupService? / FushiRemoteMiningService? / RemoteAudioTokenStore / now`，暴露 `Future<shelf.Response?> tryHandle(shelf.Request, String method, String path)`——不是它的路径返回 null。两台服务器 `_handleRequest` 顶部先问它。
+3. **鉴权不合**：sync server 是 Basic + peer token，yomitan 是 x-api-key 多来源；都留在各自 middleware。
+4. 实施第一步是 **diff 两边六个 handler 的正文**——若发现语义分叉（如 yomitan 侧有 `_onExtensionSeen` / `_onLookupActivity` 副作用），分叉部分留在调用方钩子里，不悄悄统一。
+
+**测试**：`yomitan_api_server_test.dart`（4 个文件）+ `fushi_sync_server_*`（含 asset_gate / hardening）定向重跑；`fushi_sync_server_hardening_test` 若断言音频 token 上限/过期文本，改扫 store 文件。
+
+### A4. 五个后端的重试层——先查再定（不单独 PR）
+
+**现状**：只有 Google Drive 有 `retryTransientSync` 包裹（`google_drive_handler.dart:136`）；ftp 抛 `SyncBackendError(isRetryable: true)`。
+
+**门槛**：grep `isRetryable` 的消费方。若 `sync_orchestrator` / `sync_auto_trigger` 已在 op 层重试 → 后端层再包 = 双重重试（4×4），**不加**，只在 A2 的 PR 描述里记一句结论。若无人消费 → 那是独立 bug（"transient 错误一次即败"），走 `dart run tool/bug.dart new` 开 BUG 单另做，**不混进重构 PR**（它是行为变化）。
+
+---
+
+## B. 拆五个巨类（4 个 PR，每类一 PR）
+
+拆分手法统一用本仓库既有习惯——**`part` 文件**（`reader_fushi/` 8 个 part、`video_fushi/` 18 个 part 都是这么做的）：类不变、私有字段共享、公开 API 零变化、调用方零改动。真正按职责拆成独立类只在"职责之间没有共享私有状态"时做（B1 的备份是这种；B2/B3/B4 不是）。
+
+### B1. `backup_service.dart` 4625 行 → 导出 / 恢复分家（PR 4）
+
+**现状**：`BackupService` 一个纯 static 类 ~150 方法、≥9 种关心点，导出与导入/合并同住。对外 12 个方法名、~27 个调用点（`createBackup`×4、`restoreBackup`×4、`mergeRestoreBackup`×6、`recoverPendingRestore`×4、`previewMergeRestore`×2，其余各 1）。
+
+**切法**（按调用方向，不按"看起来像"）：
+| 去向 | 内容 |
+|---|---|
+| `backup_service.dart`（保留名，导出侧） | `BackupCategory` / `BackupMeta` / `BackupContentSummary` / `createBackup` / `validateBackup` / `summarizeBackupFile` / `defaultFilename` / `settingsPrefPredicate` / `archiveBooksPrefix`；私有：DB VACUUM/复制、isolate 写 ZIP、剥密钥（`_stripCredentials*`）、按类别删行（`_stripExcludedDataCategories` / `_stripOrphanUserDataTables`） |
+| `backup_restore_service.dart`（新，`BackupRestoreService`） | `restoreBackup` / `mergeRestoreBackup` / `previewMergeRestore` / `recoverMergeRestore` / `recoverPendingRestore` / `importBackupFiles` / `mergeImportBackupFiles` / `previewMergeImport` / `recoverMergeImport` / `recoverPendingImport`；私有：流式解包、设备本地表回填、崩溃恢复 |
+| `backup_path_rebase.dart`（新，顶层函数） | `_rebase*` 五族（书/视频/字体/本地音频/播放列表，:3896-4284）——纯函数、无状态，是最干净的一刀 |
+| `backup_fs_retry.dart`（新，顶层函数） | `deleteDirectoryWithRetry` / `renameDirectoryWithRetry` |
+
+- **两侧都用的私有 helper** → 放 `backup_common.dart` 顶层函数并公开（加 `@internal` 语义注释），不允许一份留 export 一份复制到 restore。
+- 调用点直接改到新类名，**不留 `BackupService.restoreBackup` 转发外壳**。
+- `_BackupExtractRequest` 跟流式解包走。
+
+**守卫**：4 个（见上表）逐个看它扫什么：`backup_device_local_leak_guard`（设备本地表回填 → 跟 restore 走）、`backup_import_streaming_guard`（流式解包 → 跟 restore 走）、`db_source_pref_key`（看它扫的符号在哪侧）、`fushi_rename_guard`（只是文件名列表，加新文件）。`backup_delete_retry_test` / `backup_rename_retry_test` 改 import。
+
+**测试**：`test/sync/backup_*`（≥5 个大文件，最大 1600 行）全部定向重跑 + `test/tools/`。
+
+### B2. `sync_orchestrator.dart` 3335 行 → 按域 part（PR 5）
+
+**现状**：一个类 ~50 方法，每域一对 `syncX`（云）/`_syncXLive`（互联）；10 个 `@visibleForTesting …ForTest` 纯转发（:788-3025）。
+
+**改法**：`sync_orchestrator/` 下 part：`books.part.dart`、`book_progress.part.dart`、`videos.part.dart`、`audiobooks.part.dart`、`local_audio.part.dart`、`dictionaries.part.dart`、`collections.part.dart`、`tombstones.part.dart`、`aggregate.part.dart`；主文件留构造、字段、sweep 驱动（`runSync` 类的入口）、`SyncConflict` / `SyncRunReport` / `SyncAuthFailure` 等值类型（或把值类型移 `sync_run_report.dart`，看 importer 数决定）。
+
+- **不**做"每域一个类 + `SyncContext`"：那是重写，~15 个共享字段要么塞 context 对象要么构造爆炸，在 3335 行、上百测试覆盖的核心上风险与收益不成比例。这条作为拆完 part 之后**可选**的第二步，本计划不做。
+- `…ForTest` 10 个：逐个看，纯转发（`syncXLiveForTest(a) => _syncXLive(a)`）的删掉、把 `_syncXLive` 改公开 `syncXLive` + `@visibleForTesting`；带默认参数填充的保留。测试调用点用 sed 批改（实施时先 grep 计数，写进 PR 描述）。
+
+**守卫**：5 个（见上表），`server_lifecycle_appmodel_guard` 可能扫"不 import AppModel"——part 文件继承主文件 import，守卫改成扫目录。
+
+### B3. `fushi_sync_server.dart` 3194 行 → 抽认证 / 配对 / WebDAV / 流 token（PR 6）
+
+**现状**：八合一（路由链 / 认证 / 配对状态机 / 临时 token / 库 REST / Range 流 / WebDAV / TLS）。构造注入 5 个服务 + SecurityContext。
+
+**改法**（这四块没有共享私有状态，可以真拆成类；库 REST 与 server 共享 `_libraryService` 等字段，用 part）：
+| 去向 | 内容 |
+|---|---|
+| `fushi_server_auth.dart`（新，`FushiServerAuthenticator`） | `_validateAuth` / `_validatePeerAuth` / `_basicPassword` / `_peerTokens` 缓存 / `invalidatePeerTokenCache` / `_constantTimeEquals`（:444-528） |
+| `fushi_server_pairing.dart`（新，`FushiPairingHandler`） | `_handlePair` / `_handlePairV2` / `_handlePairConfirm` / `_pairSessions` / `FushiPinRateLimiter` 持有 / `_prunePairSessions` / `onPairRequest` / `onPairPinGenerated` 回调（:693-900, :2672） |
+| `fushi_server_dav.dart`（新，`FushiDavHandler`） | 路径穿越围栏 + `_serializeDavWrite` 写链 + PROPFIND/GET/PUT/MKCOL/DELETE/HEAD/OPTIONS + XML 转义（:630-680, :2706-2862） |
+| `remote_audio_token_store.dart`（A3 已建）+ `fushi_server_stream_tokens.dart` | `_RemoteAudioToken` 并入 store；`_VideoStreamToken` 同型另建 `VideoStreamTokenStore`（:2353-2670）；Range 解析 `ByteRange` 随流走 |
+| `fushi_sync_server/library_*.part.dart` | `_handleLibraryDictionaries` / Books / LocalAudio / Audiobooks / Videos / Aggregate / Activity / Collections（:1411-2609） |
+| 主文件 | 构造、生命周期（bind/close/TLS）、middleware 装配、`_handleRequest` 分发链、`FushiPairRequest` / `FushiPairedPeerRegistration` / `SyncServerPortInUseException` 等公开类型 |
+
+- `_handleRequest` 的 30 臂 if 链：抽完后剩 ~15 臂，改成"精确匹配 map + 前缀列表"两张表，**匹配顺序按现状逐条保留**（精确先、前缀按声明序）。
+- `fushi_server_controller.dart` 调 `invalidatePeerTokenCache` 等 → 经 server 转发到 authenticator（这是 server 的公开 API，不动签名）。
+
+**守卫**：`pin_no_plaintext_guard_test`（配对 PIN 不明文 → 改扫 `fushi_server_pairing.dart`）、`interconnect_token_display_guard`（token 显示 → 看扫哪段）、`hardening_test`（token 上限/TTL → store 文件）、`asset_gate_test`、`interconnect_profile_transfer_test`。本文件是并发热点（源码里自述"本文件是共享热点"），**这条 PR 开工前 fetch、完工当天合**，不隔夜。
+
+### B4. `app_model_library_host_service.dart` 2079 行 → 改名 + 按域 part（PR 7）
+
+**现状**：一个类 implements 7 个接口；名字里的 `AppModel` 是谎言——它不 import `app_model.dart`，状态经 17 个回调注入。与 `fushi_library_host_service.dart` 是接口/实现关系，不是重复。
+
+**改法**：
+- 改名 `LocalLibraryHostService`，文件 `local_library_host_service.dart`（"host" 是术语表定案词，"local" 不在淘汰表）。
+- `local_library_host_service/` 下 part 按接口/域：`books.part.dart`、`videos.part.dart`（含 sidecar 字幕发现 + ffmpeg 封面）、`audiobooks.part.dart`、`local_audio.part.dart`、`dictionaries.part.dart`、`collections.part.dart`、`tombstones.part.dart`、`aggregate.part.dart`、`profile.part.dart`。7 个接口保留（它们是消费方契约）。
+- `fushi_library_host_service.dart`（1987 行 DTO + 接口）**不拆**：它是 23 个 importer 的公开面，1620 行 DTO 只是长不是混，且金样已钉。
+
+**守卫**：4 个（上表）改路径；`app_model.dart` 与全仓 importer 改类名（实施时 grep 计数）。
+
+### B5. `fushi_library_host_service.dart` — 明确不做
+
+理由见 B4。
+
+---
+
+## PR 顺序与合并纪律
+
+```
+PR1 A1 OAuth mixin        独立
+PR2 A2 WebDAV mixin       独立
+PR3 A3 路由 + token store  独立           ─┐
+PR6 B3 sync_server 拆      依赖 PR3（store） ─┘ 串行
+PR4 B1 backup 分家         独立
+PR5 B2 orchestrator part   独立
+PR7 B4 host service 改名   独立
+```
+- 每 PR：`dart format`（**新文件用 `--language-version=3.6`，存量文件只 format 改动行、绝不整文件**，本机 3.44 是 tall style）→ 全量 `flutter analyze`（含 test）→ 定向 `flutter test <目标> --no-pub` → 守卫整批（51 条目录枚举型）→ 合入前 `dart run tool/flutter_test_failures.dart --no-pub --output-dir <私有目录>` 只认 `FLUTTER TEST VERDICT` 行。
+- 挪代码 PR 的自检：`git diff --stat` 删行 ≈ 加行（±新 mixin/类的声明开销）；多出来的加行逐条解释。
+- 每 PR 开工前 `git fetch` + 从 `origin/develop` 切，完工当天合；不在 `fushi_sync_server.dart` 这种热点上隔夜。
+- 不 bump 版本号（纯重构、不发版）。
+
+## 风险
+
+1. **守卫失效比守卫红更危险**：挪走代码后旧守卫扫旧文件仍"通过"（扫描面空了）。每个 PR 对改过的守卫做一次"故意破坏 → 红 → 还原"。
+2. **A3 的 handler 可能已语义分叉**：先 diff 再合，分叉留钩子，不悄悄统一。
+3. **并发 agent 冲突**：`fushi_sync_server.dart` / `sync_orchestrator.dart` 是高频修改文件，part 拆分会与任何在途 PR 冲突。开工前 `gh pr list` 看有没有在途 PR 碰这两个文件；有就等它合完再拆。
+4. **`ForTest` 清理的 180 文件 grep 命中是全仓的**，实施时只改 orchestrator 那 10 个的调用方，其余不碰。

--- a/docs/plans/2026-09-06-sync-interconnect-refactor.md
+++ b/docs/plans/2026-09-06-sync-interconnect-refactor.md
@@ -183,3 +183,22 @@ PR7 B4 host service 改名   独立
 2. **A3 的 handler 可能已语义分叉**：先 diff 再合，分叉留钩子，不悄悄统一。
 3. **并发 agent 冲突**：`fushi_sync_server.dart` / `sync_orchestrator.dart` 是高频修改文件，part 拆分会与任何在途 PR 冲突。开工前 `gh pr list` 看有没有在途 PR 碰这两个文件；有就等它合完再拆。
 4. **`ForTest` 清理的 180 文件 grep 命中是全仓的**，实施时只改 orchestrator 那 10 个的调用方，其余不碰。
+
+## 落地记录（2026-09-06，11 条 draft PR）
+
+| PR | 分支 | 落地 | 与计划的偏差 |
+|---|---|---|---|
+| #1239 A1 | `refactor/sync-a1-oauth-mixin` | `PkceOAuthBackendMixin` + 4 条单测 | 无 |
+| #1240 A2 | `refactor/sync-a2-webdav-mixin` | `WebDavPathBackendMixin` | 非 Drive 后端瞬态零重试另立 BUG-2169，本批不修 |
+| #1241 A3 | `refactor/sync-a3-remote-routes` | `RemoteAudioTokenStore` + `RemoteLookupRoutes` | 无 |
+| #1242–#1245 C0–C3 | `refactor/sync-c*` | 设置子页框架 / 同步页 / 互联页 / 对比对话框 + golden 基线 | 中途加的 UI 重组，见 `2026-09-06-sync-ui-layout.md` |
+| #1247 B1 | `refactor/sync-b1-backup-split` | `BackupRestoreService` + `path_rebase` / `fs_retry` part | 无 |
+| #1249 B2 | `refactor/sync-b2-orchestrator-parts` | 8 个 extension part | ① `book_progress` 并进 `books.part`；② **`…ForTest` 纯转发清理作废**：库私有 extension 的成员对别的库不可见，公开入口和测试桥必须留在 class 本体，part 只放 `_syncXLive` 私有实现，10 个包装原样保留 |
+| #1250 B3 | `refactor/sync-b3-server-parts`（堆叠在 A3 上） | 7 个 extension part（auth / pairing / lookup / library / video / sync_state / webdav） | ① **没拆独立类**（`FushiServerAuthenticator` / `FushiPairingHandler` / `FushiDavHandler` / `VideoStreamTokenStore`）：为守住"零行为改动 + 当天可合"，全部用 part 逐字搬；独立类抽取留作可选第二步；② `_handleRequest` 的 if 链**未**改成两张表，逐字保留；③ private static 提到库顶层（extension 体内看不到宿主类 static） |
+| #1251 B4 | `refactor/sync-b4-host-service-parts` | 改名 `LocalLibraryHostService` + 6 个 **mixin** part | ① **单位是 mixin 不是 extension**：类 90% 方法是 7 个接口的 `@override`，extension 成员满足不了接口契约（第一版 88 条 `override_on_non_overriding_member`）。形状：`abstract class _LocalLibraryHostBase implements 7 接口 { 19 个抽象私有 getter }` + `mixin _X on _Base, _Shared` + 具体类 `extends _Base with …`；② collections / tombstones / aggregate / profile 并进 `sync_state.part`；③ 两个提交（第一个是误提交的裸 `git mv`，合并时 squash） |
+
+**拆分单位的选择规则（补进计划，供后续巨类参考）**：类没有 `implements` → extension part（reader_fushi / video_fushi / B2 / B3 惯例）；类 `implements` 接口且方法多为 `@override` → mixin part（B4）。两种都要把 private static 提到库顶层。
+
+**守卫**：三份新语料 helper（`sync_orchestrator_source_corpus.dart` / `fushi_sync_server_source_corpus.dart` / `local_library_host_service_source_corpus.dart`）复用 `helpers/part_corpus.dart` 磁盘枚举；`hardening_test` 里 `_serializeDavWrite` 切片终点换成同 part 的 `_handlePropfind(`（原终点 `_handlePair(` 已在别的 part、语料里排前面）；`remote_lookup_routes_test` 负向清单改按来源函数取语料。
+
+**验证状态**：每条 PR 各自 `flutter analyze` 全量零问题 + 定向套件绿（B2 2857 / B3 2882 / B4 2877）。**合入 develop 前**仍须：全量 `dart run tool/flutter_test_failures.dart --no-pub --output-dir <私有目录>` + 51 条目录枚举型守卫 + `dart run tool/bug.dart check`；B3 须先合 A3。

--- a/fushi/lib/src/sync/dropbox_sync_backend.dart
+++ b/fushi/lib/src/sync/dropbox_sync_backend.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-import 'package:fushi/src/sync/desktop_oauth.dart';
 import 'package:fushi/src/sync/pkce_oauth.dart';
+import 'package:fushi/src/sync/pkce_oauth_backend_mixin.dart';
 import 'package:fushi/src/sync/sync_http.dart';
 import 'package:fushi/src/sync/sync_asset_store.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
@@ -17,14 +17,17 @@ import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
 import 'package:fushi/src/sync/ttu_models.dart';
 import 'package:fushi/src/utils/misc/error_log_service.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// Dropbox sync backend via Dropbox API v2.
 ///
-/// Auth: OAuth 2.0 PKCE flow.
+/// Auth: OAuth 2.0 PKCE flow（外壳在 [PkceOAuthBackendMixin]）.
 /// Folder IDs are path strings like `/fushi-data/BookTitle`.
 class DropboxSyncBackend extends SyncBackend
-    with SyncFolderCache, SyncBackendFileTrioMixin, SyncAssetStoreDefaults
+    with
+        SyncFolderCache,
+        SyncBackendFileTrioMixin,
+        SyncAssetStoreDefaults,
+        PkceOAuthBackendMixin
     implements RemoteListingCapable {
   DropboxSyncBackend._();
   static final DropboxSyncBackend instance = DropboxSyncBackend._();
@@ -42,10 +45,6 @@ class DropboxSyncBackend extends SyncBackend
   static const _contentBase = 'https://content.dropboxapi.com/2';
   static const _rootFolderPath = '/$kSyncRootFolderName';
 
-  String? _accessToken;
-  String? _refreshToken;
-  String? _email;
-
   /// Shared OAuth 2.0 PKCE token exchange (verifier/challenge + code/refresh).
   static final PkceOAuthFlow _oauth = PkceOAuthFlow(
     clientId: _clientId,
@@ -55,20 +54,22 @@ class DropboxSyncBackend extends SyncBackend
   // ── Auth ──────────────────────────────────────────────────────────
 
   @override
-  Future<bool> get isAuthenticated async => _accessToken != null;
+  PkceOAuthFlow get oauth => _oauth;
 
   @override
-  Future<String?> get currentEmail async => _email;
+  String get providerName => 'Dropbox';
 
-  String? _pendingVerifier;
-  SyncRepository? _pendingRepo;
+  @override
+  String get mobileRedirectUri => _redirectUri;
 
   /// Fixed loopback port for desktop OAuth. Dropbox requires an exact
   /// redirect-URI match, so this must be registered verbatim in the Dropbox
   /// app console as `http://localhost:9004`.
-  static const int _desktopLoopbackPort = 9004;
+  @override
+  int get desktopLoopbackPort => 9004;
 
-  Uri _buildAuthUrl(String challenge, String redirectUri) =>
+  @override
+  Uri buildAuthUrl(String challenge, String redirectUri) =>
       Uri.parse(_authorizeEndpoint).replace(queryParameters: {
         'client_id': _clientId,
         'response_type': 'code',
@@ -79,141 +80,33 @@ class DropboxSyncBackend extends SyncBackend
       });
 
   @override
-  Future<void> authenticate({required SyncRepository repo}) async {
-    if (_clientId.startsWith('YOUR_')) {
-      throw SyncAuthError('Dropbox integration not configured');
-    }
-    _pendingVerifier = null;
-    _pendingRepo = null;
+  Future<String?> readStoredToken(SyncRepository repo) =>
+      repo.getDropboxToken();
 
-    final verifier = PkceOAuthFlow.generateCodeVerifier();
-    final challenge = PkceOAuthFlow.codeChallenge(verifier);
-
-    // Desktop: loopback HTTP redirect (RFC 8252), exchange inline.
-    if (isDesktopOAuthPlatform) {
-      final result = await runDesktopOAuthLoopback(
-        buildAuthUrl: (redirectUri) => _buildAuthUrl(challenge, redirectUri),
-        port: _desktopLoopbackPort,
-      );
-      await _exchangeCode(
-        code: result.code,
-        verifier: verifier,
-        redirectUri: result.redirectUri,
-        repo: repo,
-      );
-      return;
-    }
-
-    // Mobile: custom-URI-scheme redirect handled later by [handleAuthCode].
-    final authUrl = _buildAuthUrl(challenge, _redirectUri);
-    if (!await launchUrl(authUrl, mode: LaunchMode.externalApplication)) {
-      throw SyncAuthError('Failed to launch browser for Dropbox auth');
-    }
-
-    _pendingVerifier = verifier;
-    _pendingRepo = repo;
-  }
-
-  /// Called when the app receives the redirect URI with an auth code (mobile
-  /// custom-scheme flow).
-  Future<void> handleAuthCode(String code) async {
-    final verifier = _pendingVerifier;
-    final repo = _pendingRepo;
-    if (verifier == null || repo == null) {
-      throw SyncAuthError('No pending auth flow');
-    }
-    _pendingVerifier = null;
-    _pendingRepo = null;
-
-    await _exchangeCode(
-      code: code,
-      verifier: verifier,
-      redirectUri: _redirectUri,
-      repo: repo,
-    );
-  }
-
-  /// Exchange an authorization code for tokens. [redirectUri] must match the
-  /// value sent in the authorization request (custom scheme on mobile, the
-  /// loopback URL on desktop).
-  Future<void> _exchangeCode({
-    required String code,
-    required String verifier,
-    required String redirectUri,
-    required SyncRepository repo,
-  }) async {
-    final tokens = await _oauth.exchangeCode(
-      code: code,
-      redirectUri: redirectUri,
-      verifier: verifier,
-    );
-    _accessToken = tokens.accessToken;
-    _refreshToken = tokens.refreshToken;
-
-    await _fetchUserEmail();
-    await repo.setDropboxToken(jsonEncode({'refresh_token': _refreshToken}));
-  }
+  @override
+  Future<void> writeStoredToken(SyncRepository repo, String? token) =>
+      repo.setDropboxToken(token);
 
   @override
   Future<void> signOut({required SyncRepository repo}) async {
     // Revoke the token.
-    if (_accessToken != null) {
+    if (accessToken != null) {
       try {
         await (await obtainSyncHttpClient()).post(
           Uri.parse('$_apiBase/auth/token/revoke'),
-          headers: {'Authorization': 'Bearer $_accessToken'},
+          headers: {'Authorization': 'Bearer $accessToken'},
         );
       } catch (_) {/* best-effort: failure is non-critical here */}
     }
-    _accessToken = null;
-    _refreshToken = null;
-    _email = null;
-    clearCache();
-    await repo.setDropboxToken(null);
+    await super.signOut(repo: repo);
   }
 
   @override
-  Future<bool> restoreAuth(SyncRepository repo) async {
-    final stored = await repo.getDropboxToken();
-    if (stored == null) return false;
-
-    try {
-      final json = jsonDecode(stored) as Map<String, dynamic>;
-      _refreshToken = json['refresh_token'] as String?;
-      if (_refreshToken == null) return false;
-
-      await refreshAuth();
-      await _fetchUserEmail();
-      return true;
-    } catch (_) {
-      // Refresh failed — drop the stale tokens so isAuthenticated reports
-      // false instead of letting sync proceed with an expired token and loop
-      // on non-retryable 401s (HBK-AUDIT-159).
-      _accessToken = null;
-      _refreshToken = null;
-      return false;
-    }
-  }
-
-  @override
-  Future<void> refreshAuth() async {
-    if (_refreshToken == null) {
-      throw SyncAuthError('No refresh token available');
-    }
-
-    final tokens = await _oauth.refreshTokens(refreshToken: _refreshToken!);
-    _accessToken = tokens.accessToken;
-    // Dropbox may or may not return a new refresh token.
-    if (tokens.refreshToken != null) {
-      _refreshToken = tokens.refreshToken;
-    }
-  }
-
-  Future<void> _fetchUserEmail() async {
+  Future<void> fetchUserEmail() async {
     try {
       final resp = await _apiPost('/users/get_current_account', null);
       final json = jsonDecode(resp.body) as Map<String, dynamic>;
-      _email = json['email'] as String?;
+      email = json['email'] as String?;
     } catch (_) {
       // Non-fatal.
     }
@@ -221,16 +114,11 @@ class DropboxSyncBackend extends SyncBackend
 
   // ── HTTP helpers ──────────────────────────────────────────────────
 
-  Map<String, String> get _authHeaders => {
-        'Authorization': 'Bearer $_accessToken',
-        'Content-Type': 'application/json',
-      };
-
   Future<http.Response> _apiPost(
       String endpoint, Map<String, dynamic>? body) async {
     final resp = await (await obtainSyncHttpClient()).post(
       Uri.parse('$_apiBase$endpoint'),
-      headers: _authHeaders,
+      headers: bearerJsonHeaders,
       body: body != null ? jsonEncode(body) : null,
     );
     _checkResponse(resp, 'POST $endpoint');
@@ -452,7 +340,7 @@ class DropboxSyncBackend extends SyncBackend
       'POST',
       Uri.parse('$_contentBase/files/upload'),
     );
-    request.headers['Authorization'] = 'Bearer $_accessToken';
+    request.headers['Authorization'] = 'Bearer $accessToken';
     request.headers['Content-Type'] = 'application/octet-stream';
     request.headers['Dropbox-API-Arg'] = apiArg;
     request.contentLength = fileLength;
@@ -475,7 +363,7 @@ class DropboxSyncBackend extends SyncBackend
       'POST',
       Uri.parse('$_contentBase/files/download'),
     );
-    request.headers['Authorization'] = 'Bearer $_accessToken';
+    request.headers['Authorization'] = 'Bearer $accessToken';
     request.headers['Dropbox-API-Arg'] = apiArg;
 
     final streamedResp = await (await obtainSyncHttpClient()).send(request);
@@ -647,7 +535,7 @@ class DropboxSyncBackend extends SyncBackend
     final resp = await (await obtainSyncHttpClient()).post(
       Uri.parse('$_contentBase/files/download'),
       headers: {
-        'Authorization': 'Bearer $_accessToken',
+        'Authorization': 'Bearer $accessToken',
         'Dropbox-API-Arg': apiArg,
       },
     );
@@ -683,7 +571,7 @@ class DropboxSyncBackend extends SyncBackend
     final resp = await (await obtainSyncHttpClient()).post(
       Uri.parse('$_contentBase/files/upload'),
       headers: {
-        'Authorization': 'Bearer $_accessToken',
+        'Authorization': 'Bearer $accessToken',
         'Dropbox-API-Arg': apiArg,
         'Content-Type': 'application/octet-stream',
       },

--- a/fushi/lib/src/sync/onedrive_sync_backend.dart
+++ b/fushi/lib/src/sync/onedrive_sync_backend.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
-import 'package:fushi/src/sync/desktop_oauth.dart';
 import 'package:fushi/src/sync/pkce_oauth.dart';
+import 'package:fushi/src/sync/pkce_oauth_backend_mixin.dart';
 import 'package:fushi/src/sync/sync_http.dart';
 import 'package:fushi/src/sync/sync_asset_store.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
@@ -16,14 +16,17 @@ import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
 import 'package:fushi/src/sync/ttu_models.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// OneDrive sync backend via Microsoft Graph API.
 ///
-/// Auth: OAuth 2.0 PKCE flow.
+/// Auth: OAuth 2.0 PKCE flow（外壳在 [PkceOAuthBackendMixin]）.
 /// Redirect URI: `fushi://auth/onedrive`
 class OneDriveSyncBackend extends SyncBackend
-    with SyncFolderCache, SyncBackendFileTrioMixin, SyncAssetStoreDefaults {
+    with
+        SyncFolderCache,
+        SyncBackendFileTrioMixin,
+        SyncAssetStoreDefaults,
+        PkceOAuthBackendMixin {
   OneDriveSyncBackend._();
   static final OneDriveSyncBackend instance = OneDriveSyncBackend._();
 
@@ -42,10 +45,6 @@ class OneDriveSyncBackend extends SyncBackend
   static const _scopes = 'Files.ReadWrite.All User.Read offline_access';
   static const _rootFolderName = kSyncRootFolderName;
 
-  String? _accessToken;
-  String? _refreshToken;
-  String? _email;
-
   /// Shared OAuth 2.0 PKCE token exchange (verifier/challenge + code/refresh).
   /// OneDrive requires the `scope` param echoed on token refresh.
   static final PkceOAuthFlow _oauth = PkceOAuthFlow(
@@ -57,15 +56,16 @@ class OneDriveSyncBackend extends SyncBackend
   // ── Auth ──────────────────────────────────────────────────────────
 
   @override
-  Future<bool> get isAuthenticated async => _accessToken != null;
+  PkceOAuthFlow get oauth => _oauth;
 
   @override
-  Future<String?> get currentEmail async => _email;
+  String get providerName => 'OneDrive';
 
-  String? _pendingVerifier;
-  SyncRepository? _pendingRepo;
+  @override
+  String get mobileRedirectUri => _redirectUri;
 
-  Uri _buildAuthUrl(String challenge, String redirectUri) =>
+  @override
+  Uri buildAuthUrl(String challenge, String redirectUri) =>
       Uri.parse(_authorizeEndpoint).replace(queryParameters: {
         'client_id': _clientId,
         'response_type': 'code',
@@ -76,130 +76,19 @@ class OneDriveSyncBackend extends SyncBackend
       });
 
   @override
-  Future<void> authenticate({required SyncRepository repo}) async {
-    if (_clientId.startsWith('YOUR_')) {
-      throw SyncAuthError('OneDrive integration not configured');
-    }
-    _pendingVerifier = null;
-    _pendingRepo = null;
-
-    final verifier = PkceOAuthFlow.generateCodeVerifier();
-    final challenge = PkceOAuthFlow.codeChallenge(verifier);
-
-    // Desktop: loopback HTTP redirect (RFC 8252), exchange inline.
-    if (isDesktopOAuthPlatform) {
-      final result = await runDesktopOAuthLoopback(
-        buildAuthUrl: (redirectUri) => _buildAuthUrl(challenge, redirectUri),
-      );
-      await _exchangeCode(
-        code: result.code,
-        verifier: verifier,
-        redirectUri: result.redirectUri,
-        repo: repo,
-      );
-      return;
-    }
-
-    // Mobile: custom-URI-scheme redirect handled later by [handleAuthCode].
-    final authUrl = _buildAuthUrl(challenge, _redirectUri);
-    if (!await launchUrl(authUrl, mode: LaunchMode.externalApplication)) {
-      throw SyncAuthError('Failed to launch browser for OneDrive auth');
-    }
-
-    _pendingVerifier = verifier;
-    _pendingRepo = repo;
-  }
-
-  /// Called when the app receives the redirect URI with an auth code (mobile
-  /// custom-scheme flow).
-  Future<void> handleAuthCode(String code) async {
-    final verifier = _pendingVerifier;
-    final repo = _pendingRepo;
-    if (verifier == null || repo == null) {
-      throw SyncAuthError('No pending auth flow');
-    }
-    _pendingVerifier = null;
-    _pendingRepo = null;
-
-    await _exchangeCode(
-      code: code,
-      verifier: verifier,
-      redirectUri: _redirectUri,
-      repo: repo,
-    );
-  }
-
-  /// Exchange an authorization code for tokens. [redirectUri] must match the
-  /// value sent in the authorization request (custom scheme on mobile, the
-  /// loopback URL on desktop).
-  Future<void> _exchangeCode({
-    required String code,
-    required String verifier,
-    required String redirectUri,
-    required SyncRepository repo,
-  }) async {
-    final tokens = await _oauth.exchangeCode(
-      code: code,
-      redirectUri: redirectUri,
-      verifier: verifier,
-    );
-    _accessToken = tokens.accessToken;
-    _refreshToken = tokens.refreshToken;
-
-    await _fetchUserEmail();
-    await repo.setOneDriveToken(jsonEncode({'refresh_token': _refreshToken}));
-  }
+  Future<String?> readStoredToken(SyncRepository repo) =>
+      repo.getOneDriveToken();
 
   @override
-  Future<void> signOut({required SyncRepository repo}) async {
-    _accessToken = null;
-    _refreshToken = null;
-    _email = null;
-    clearCache();
-    await repo.setOneDriveToken(null);
-  }
+  Future<void> writeStoredToken(SyncRepository repo, String? token) =>
+      repo.setOneDriveToken(token);
 
   @override
-  Future<bool> restoreAuth(SyncRepository repo) async {
-    final stored = await repo.getOneDriveToken();
-    if (stored == null) return false;
-
-    try {
-      final json = jsonDecode(stored) as Map<String, dynamic>;
-      _refreshToken = json['refresh_token'] as String?;
-      if (_refreshToken == null) return false;
-
-      await refreshAuth();
-      await _fetchUserEmail();
-      return true;
-    } catch (_) {
-      // Refresh failed — drop the stale tokens so isAuthenticated reports
-      // false instead of letting sync proceed with an expired token and loop
-      // on non-retryable 401s (HBK-AUDIT-159).
-      _accessToken = null;
-      _refreshToken = null;
-      return false;
-    }
-  }
-
-  @override
-  Future<void> refreshAuth() async {
-    if (_refreshToken == null) {
-      throw SyncAuthError('No refresh token available');
-    }
-
-    final tokens = await _oauth.refreshTokens(refreshToken: _refreshToken!);
-    _accessToken = tokens.accessToken;
-    if (tokens.refreshToken != null) {
-      _refreshToken = tokens.refreshToken;
-    }
-  }
-
-  Future<void> _fetchUserEmail() async {
+  Future<void> fetchUserEmail() async {
     try {
       final resp = await _graphGet('/me');
       final json = jsonDecode(resp.body) as Map<String, dynamic>;
-      _email = json['mail'] as String? ?? json['userPrincipalName'] as String?;
+      email = json['mail'] as String? ?? json['userPrincipalName'] as String?;
     } catch (_) {
       // Non-fatal: email is optional for display.
     }
@@ -207,15 +96,10 @@ class OneDriveSyncBackend extends SyncBackend
 
   // ── HTTP helpers ──────────────────────────────────────────────────
 
-  Map<String, String> get _authHeaders => {
-        'Authorization': 'Bearer $_accessToken',
-        'Content-Type': 'application/json',
-      };
-
   Future<http.Response> _graphGet(String path) async {
     final resp = await (await obtainSyncHttpClient()).get(
       Uri.parse('$_apiBase$path'),
-      headers: _authHeaders,
+      headers: bearerJsonHeaders,
     );
     _checkResponse(resp, 'GET $path');
     return resp;
@@ -225,7 +109,7 @@ class OneDriveSyncBackend extends SyncBackend
       String path, Map<String, dynamic> body) async {
     final resp = await (await obtainSyncHttpClient()).post(
       Uri.parse('$_apiBase$path'),
-      headers: _authHeaders,
+      headers: bearerJsonHeaders,
       body: jsonEncode(body),
     );
     _checkResponse(resp, 'POST $path');
@@ -236,7 +120,7 @@ class OneDriveSyncBackend extends SyncBackend
       String path, Map<String, dynamic> body) async {
     final resp = await (await obtainSyncHttpClient()).patch(
       Uri.parse('$_apiBase$path'),
-      headers: _authHeaders,
+      headers: bearerJsonHeaders,
       body: jsonEncode(body),
     );
     _checkResponse(resp, 'PATCH $path');
@@ -248,7 +132,7 @@ class OneDriveSyncBackend extends SyncBackend
     final resp = await (await obtainSyncHttpClient()).put(
       Uri.parse('$_apiBase$path'),
       headers: {
-        'Authorization': 'Bearer $_accessToken',
+        'Authorization': 'Bearer $accessToken',
         'Content-Type': contentType,
       },
       body: bytes,
@@ -260,7 +144,7 @@ class OneDriveSyncBackend extends SyncBackend
   Future<http.Response> _graphDelete(String path) async {
     final resp = await (await obtainSyncHttpClient()).delete(
       Uri.parse('$_apiBase$path'),
-      headers: {'Authorization': 'Bearer $_accessToken'},
+      headers: {'Authorization': 'Bearer $accessToken'},
     );
     // 204 No Content is success for DELETE.
     if (resp.statusCode != 204 && resp.statusCode != 404) {
@@ -476,7 +360,7 @@ class OneDriveSyncBackend extends SyncBackend
       Uri.parse(
           '$_apiBase/me/drive/items/$folderId:/${Uri.encodeComponent(fileName)}:/content'),
     );
-    request.headers['Authorization'] = 'Bearer $_accessToken';
+    request.headers['Authorization'] = 'Bearer $accessToken';
     request.headers['Content-Type'] = _guessContentType(fileName);
     request.contentLength = fileLength;
 
@@ -601,7 +485,7 @@ class OneDriveSyncBackend extends SyncBackend
 
     while (url != null) {
       final resp = await (await obtainSyncHttpClient())
-          .get(Uri.parse(url), headers: _authHeaders);
+          .get(Uri.parse(url), headers: bearerJsonHeaders);
       _checkResponse(resp, 'GET $firstPath');
       final json = jsonDecode(resp.body) as Map<String, dynamic>;
       items.addAll((json['value'] as List).cast<Map<String, dynamic>>());

--- a/fushi/lib/src/sync/pkce_oauth_backend_mixin.dart
+++ b/fushi/lib/src/sync/pkce_oauth_backend_mixin.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show protected;
+import 'package:fushi/src/sync/desktop_oauth.dart';
+import 'package:fushi/src/sync/pkce_oauth.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// OAuth 2.0 PKCE 后端（Dropbox / OneDrive）共用的认证外壳。
+///
+/// [PkceOAuthFlow] 只负责 token 端点的两次交换；这层再往上——桌面 loopback /
+/// 移动 custom-scheme 两条授权流、pending verifier 的持有与消费、refresh token
+/// 落库与恢复、过期刷新、Bearer 头拼装——两个后端原本各写一份逐字相同的实现
+/// （2026-07-24 审查 §三-1）。这里收成一份，后端只剩真正因 provider 而异的部分：
+/// 授权 URL 的查询参数、token 在 [SyncRepository] 里的存取键、用户邮箱的 API、
+/// 以及 Dropbox 独有的登出 revoke。
+///
+/// 语义与抽出前逐字一致：
+/// * 恢复时刷新失败要把两个 token 都清掉，让 `isAuthenticated` 如实报 false，
+///   而不是带着过期 token 进同步再在不可重试的 401 上打转（HBK-AUDIT-159）。
+/// * 刷新响应缺 `refresh_token` 时保留旧值（provider 可能不回新的）。
+mixin PkceOAuthBackendMixin on SyncBackend {
+  // ── provider 差异钩子 ──────────────────────────────────────────────
+
+  /// 本 provider 的 token 交换（client id / token endpoint / 刷新额外参数）。
+  @protected
+  PkceOAuthFlow get oauth;
+
+  /// 错误文案里的 provider 名（`Dropbox` / `OneDrive`）。
+  @protected
+  String get providerName;
+
+  /// 移动端 custom-scheme 回跳地址；桌面端的 loopback 地址由
+  /// [runDesktopOAuthLoopback] 生成后经 [buildAuthUrl] 传回。
+  @protected
+  String get mobileRedirectUri;
+
+  /// 桌面 loopback 固定端口；0 = 临时端口。Dropbox 要求回跳地址精确匹配，
+  /// 必须固定；OneDrive 允许任意 localhost 端口。
+  @protected
+  int get desktopLoopbackPort => 0;
+
+  /// 授权页 URL；`code_challenge` 已按 S256 算好，其余查询参数各 provider 自定。
+  @protected
+  Uri buildAuthUrl(String challenge, String redirectUri);
+
+  /// 读 / 写落库的 token JSON（`{"refresh_token": ...}`）；`null` = 清除。
+  @protected
+  Future<String?> readStoredToken(SyncRepository repo);
+  @protected
+  Future<void> writeStoredToken(SyncRepository repo, String? token);
+
+  /// 取当前账号邮箱写进 [email]。**不得抛出**——邮箱只作展示，失败非致命。
+  @protected
+  Future<void> fetchUserEmail();
+
+  // ── 共享状态 ────────────────────────────────────────────────────────
+
+  @protected
+  String? accessToken;
+  @protected
+  String? refreshToken;
+  @protected
+  String? email;
+
+  String? _pendingVerifier;
+  SyncRepository? _pendingRepo;
+
+  @override
+  Future<bool> get isAuthenticated async => accessToken != null;
+
+  @override
+  Future<String?> get currentEmail async => email;
+
+  /// `Authorization: Bearer` + JSON 内容类型，普通 API 调用的默认头。
+  @protected
+  Map<String, String> get bearerJsonHeaders => <String, String>{
+        'Authorization': 'Bearer $accessToken',
+        'Content-Type': 'application/json',
+      };
+
+  // ── 授权流 ──────────────────────────────────────────────────────────
+
+  @override
+  Future<void> authenticate({required SyncRepository repo}) async {
+    if (oauth.clientId.startsWith('YOUR_')) {
+      throw SyncAuthError('$providerName integration not configured');
+    }
+    _pendingVerifier = null;
+    _pendingRepo = null;
+
+    final String verifier = PkceOAuthFlow.generateCodeVerifier();
+    final String challenge = PkceOAuthFlow.codeChallenge(verifier);
+
+    // Desktop: loopback HTTP redirect (RFC 8252), exchange inline.
+    if (isDesktopOAuthPlatform) {
+      final DesktopOAuthResult result = await runDesktopOAuthLoopback(
+        buildAuthUrl: (String redirectUri) =>
+            buildAuthUrl(challenge, redirectUri),
+        port: desktopLoopbackPort,
+      );
+      await exchangeCode(
+        code: result.code,
+        verifier: verifier,
+        redirectUri: result.redirectUri,
+        repo: repo,
+      );
+      return;
+    }
+
+    // Mobile: custom-URI-scheme redirect handled later by [handleAuthCode].
+    final Uri authUrl = buildAuthUrl(challenge, mobileRedirectUri);
+    if (!await launchUrl(authUrl, mode: LaunchMode.externalApplication)) {
+      throw SyncAuthError('Failed to launch browser for $providerName auth');
+    }
+
+    _pendingVerifier = verifier;
+    _pendingRepo = repo;
+  }
+
+  /// Called when the app receives the redirect URI with an auth code (mobile
+  /// custom-scheme flow).
+  Future<void> handleAuthCode(String code) async {
+    final String? verifier = _pendingVerifier;
+    final SyncRepository? repo = _pendingRepo;
+    if (verifier == null || repo == null) {
+      throw SyncAuthError('No pending auth flow');
+    }
+    _pendingVerifier = null;
+    _pendingRepo = null;
+
+    await exchangeCode(
+      code: code,
+      verifier: verifier,
+      redirectUri: mobileRedirectUri,
+      repo: repo,
+    );
+  }
+
+  /// Exchange an authorization code for tokens. [redirectUri] must match the
+  /// value sent in the authorization request (custom scheme on mobile, the
+  /// loopback URL on desktop).
+  @protected
+  Future<void> exchangeCode({
+    required String code,
+    required String verifier,
+    required String redirectUri,
+    required SyncRepository repo,
+  }) async {
+    final PkceTokens tokens = await oauth.exchangeCode(
+      code: code,
+      redirectUri: redirectUri,
+      verifier: verifier,
+    );
+    accessToken = tokens.accessToken;
+    refreshToken = tokens.refreshToken;
+
+    await fetchUserEmail();
+    await writeStoredToken(repo, jsonEncode({'refresh_token': refreshToken}));
+  }
+
+  /// 清 token 与邮箱、清文件夹缓存、删落库 token。有 revoke 步骤的 provider
+  /// 先 revoke 再 `super.signOut`。
+  @override
+  Future<void> signOut({required SyncRepository repo}) async {
+    accessToken = null;
+    refreshToken = null;
+    email = null;
+    clearCache();
+    await writeStoredToken(repo, null);
+  }
+
+  @override
+  Future<bool> restoreAuth(SyncRepository repo) async {
+    final String? stored = await readStoredToken(repo);
+    if (stored == null) return false;
+
+    try {
+      final Map<String, dynamic> json =
+          jsonDecode(stored) as Map<String, dynamic>;
+      refreshToken = json['refresh_token'] as String?;
+      if (refreshToken == null) return false;
+
+      await refreshAuth();
+      await fetchUserEmail();
+      return true;
+    } catch (_) {
+      // Refresh failed — drop the stale tokens so isAuthenticated reports
+      // false instead of letting sync proceed with an expired token and loop
+      // on non-retryable 401s (HBK-AUDIT-159).
+      accessToken = null;
+      refreshToken = null;
+      return false;
+    }
+  }
+
+  @override
+  Future<void> refreshAuth() async {
+    final String? current = refreshToken;
+    if (current == null) {
+      throw SyncAuthError('No refresh token available');
+    }
+
+    final PkceTokens tokens = await oauth.refreshTokens(refreshToken: current);
+    accessToken = tokens.accessToken;
+    // The provider may or may not return a new refresh token.
+    if (tokens.refreshToken != null) {
+      refreshToken = tokens.refreshToken;
+    }
+  }
+}

--- a/fushi/test/sync/pkce_oauth_backend_mixin_test.dart
+++ b/fushi/test/sync/pkce_oauth_backend_mixin_test.dart
@@ -1,0 +1,258 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/pkce_oauth.dart';
+import 'package:fushi/src/sync/pkce_oauth_backend_mixin.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+
+/// Dropbox / OneDrive 共用的 PKCE 认证外壳 [PkceOAuthBackendMixin]。
+///
+/// 抽 mixin 之前两个后端各有一份逐字相同的实现，且**两边都没有单测**
+/// （2026-07-24 审查 §三-1）。这里用 fake [PkceOAuthFlow] 把 token 端点隔开，
+/// 直接锁四条行为：换码落库、恢复保留旧 refresh token、恢复失败清空状态
+/// （HBK-AUDIT-159）、无 pending 流拒绝回跳。
+void main() {
+  group('PkceOAuthBackendMixin', () {
+    late _FakeFlow flow;
+    late _TestBackend backend;
+    final SyncRepository repo = _UnusedRepo();
+
+    setUp(() {
+      flow = _FakeFlow();
+      backend = _TestBackend(flow);
+    });
+
+    test('exchangeCode：写入两个 token、取邮箱、把 refresh token 落库', () async {
+      flow.onExchange =
+          (String code, String redirectUri, String verifier) async {
+        expect(code, 'code-1');
+        expect(redirectUri, 'fushi://auth/test');
+        expect(verifier, 'v-1');
+        return const PkceTokens(accessToken: 'a1', refreshToken: 'r1');
+      };
+
+      await backend.exchangeForTest(
+        code: 'code-1',
+        verifier: 'v-1',
+        redirectUri: 'fushi://auth/test',
+        repo: repo,
+      );
+
+      expect(backend.access, 'a1');
+      expect(backend.refresh, 'r1');
+      expect(await backend.isAuthenticated, isTrue);
+      expect(await backend.currentEmail, 'u@example.com');
+      expect(backend.emailFetches, 1);
+      expect(jsonDecode(backend.stored!), {'refresh_token': 'r1'});
+    });
+
+    test('restoreAuth：用落库 refresh token 换新 access；响应缺 refresh_token 时保留旧值',
+        () async {
+      backend.stored = jsonEncode({'refresh_token': 'r-stored'});
+      flow.onRefresh = (String refreshToken) async {
+        expect(refreshToken, 'r-stored');
+        return const PkceTokens(accessToken: 'a-new');
+      };
+
+      expect(await backend.restoreAuth(repo), isTrue);
+      expect(backend.access, 'a-new');
+      expect(backend.refresh, 'r-stored');
+      expect(backend.emailFetches, 1);
+      expect(flow.refreshCalls, 1);
+    });
+
+    test(
+        'restoreAuth：刷新失败必须清空两个 token，isAuthenticated 如实报 false（HBK-AUDIT-159）',
+        () async {
+      backend.stored = jsonEncode({'refresh_token': 'r-stale'});
+      backend.seedAccess('a-stale');
+      flow.onRefresh = (_) async => throw SyncAuthError('invalid_grant');
+
+      expect(await backend.restoreAuth(repo), isFalse);
+      expect(backend.access, isNull);
+      expect(backend.refresh, isNull);
+      expect(await backend.isAuthenticated, isFalse);
+      expect(backend.emailFetches, 0);
+    });
+
+    test('restoreAuth：没落库 / 落库缺 refresh_token 都直接 false，不打 token 端点', () async {
+      flow.onRefresh = (_) async => fail('must not refresh');
+
+      backend.stored = null;
+      expect(await backend.restoreAuth(repo), isFalse);
+
+      backend.stored = jsonEncode({'other': 1});
+      expect(await backend.restoreAuth(repo), isFalse);
+      expect(flow.refreshCalls, 0);
+    });
+
+    test(
+        'refreshAuth：provider 回了新 refresh token 就替换；没有 refresh token 时抛 SyncAuthError',
+        () async {
+      await expectLater(backend.refreshAuth(), throwsA(isA<SyncAuthError>()));
+
+      backend.stored = jsonEncode({'refresh_token': 'r1'});
+      flow.onRefresh =
+          (_) async => const PkceTokens(accessToken: 'a2', refreshToken: 'r2');
+      expect(await backend.restoreAuth(repo), isTrue);
+      expect(backend.refresh, 'r2');
+    });
+
+    test('handleAuthCode：没有 pending 流时拒绝，且不碰 token 端点', () async {
+      flow.onExchange = (_, __, ___) async => fail('must not exchange');
+      await expectLater(
+        backend.handleAuthCode('unsolicited'),
+        throwsA(isA<SyncAuthError>()),
+      );
+    });
+
+    test('signOut：清 token 与邮箱、清文件夹缓存、删落库 token', () async {
+      backend.stored = jsonEncode({'refresh_token': 'r1'});
+      flow.onRefresh = (_) async => const PkceTokens(accessToken: 'a1');
+      expect(await backend.restoreAuth(repo), isTrue);
+
+      await backend.signOut(repo: repo);
+
+      expect(backend.access, isNull);
+      expect(backend.refresh, isNull);
+      expect(await backend.currentEmail, isNull);
+      expect(backend.clearCacheCalls, 1);
+      expect(backend.stored, isNull);
+    });
+  });
+
+  group('源码守卫：两个 OAuth 后端不再各写一份认证外壳', () {
+    const List<String> backends = <String>[
+      'lib/src/sync/dropbox_sync_backend.dart',
+      'lib/src/sync/onedrive_sync_backend.dart',
+    ];
+    // 抽走前两边逐字重复的五段；任何一段回流都说明有人又复制了一份。
+    const List<String> banned = <String>[
+      'Future<void> handleAuthCode(',
+      'Future<bool> restoreAuth(',
+      'Future<void> refreshAuth(',
+      'Future<void> authenticate(',
+      'get _authHeaders',
+    ];
+
+    for (final String path in backends) {
+      test(path, () {
+        final File f = File(path);
+        expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
+        final String src = f.readAsStringSync();
+        expect(src, contains('PkceOAuthBackendMixin'),
+            reason: '$path 必须混入 PkceOAuthBackendMixin');
+        for (final String needle in banned) {
+          expect(src, isNot(contains(needle)),
+              reason: '$path 里出现 `$needle`——认证外壳应只在 mixin 里有一份');
+        }
+      });
+    }
+  });
+}
+
+/// 把 token 端点两次交换换成可编程的桩；未设置的回调一律 fail，避免静默通过。
+class _FakeFlow extends PkceOAuthFlow {
+  _FakeFlow()
+      : super(
+          clientId: 'real-client-id',
+          tokenEndpoint: 'https://example.invalid/token',
+        );
+
+  Future<PkceTokens> Function(String code, String redirectUri, String verifier)?
+      onExchange;
+  Future<PkceTokens> Function(String refreshToken)? onRefresh;
+  int refreshCalls = 0;
+
+  @override
+  Future<PkceTokens> exchangeCode({
+    required String code,
+    required String redirectUri,
+    required String verifier,
+  }) {
+    final Future<PkceTokens> Function(String, String, String)? cb = onExchange;
+    if (cb == null) fail('exchangeCode not expected');
+    return cb(code, redirectUri, verifier);
+  }
+
+  @override
+  Future<PkceTokens> refreshTokens({required String refreshToken}) {
+    refreshCalls++;
+    final Future<PkceTokens> Function(String)? cb = onRefresh;
+    if (cb == null) fail('refreshTokens not expected');
+    return cb(refreshToken);
+  }
+}
+
+/// 最小宿主：只实现 mixin 的 provider 钩子，其余 [SyncBackend] 成员经
+/// [noSuchMethod] 兜底（本测试不碰文件夹/文件操作）。
+class _TestBackend extends SyncBackend with PkceOAuthBackendMixin {
+  _TestBackend(this.flow);
+
+  final _FakeFlow flow;
+  String? stored;
+  int emailFetches = 0;
+  int clearCacheCalls = 0;
+
+  @override
+  PkceOAuthFlow get oauth => flow;
+
+  @override
+  String get providerName => 'Test';
+
+  @override
+  String get mobileRedirectUri => 'fushi://auth/test';
+
+  @override
+  Uri buildAuthUrl(String challenge, String redirectUri) => Uri.parse(
+      'https://example.invalid/authorize?c=$challenge&r=$redirectUri');
+
+  @override
+  Future<String?> readStoredToken(SyncRepository repo) async => stored;
+
+  @override
+  Future<void> writeStoredToken(SyncRepository repo, String? token) async {
+    stored = token;
+  }
+
+  @override
+  Future<void> fetchUserEmail() async {
+    emailFetches++;
+    email = 'u@example.com';
+  }
+
+  @override
+  void clearCache() {
+    clearCacheCalls++;
+  }
+
+  // 受保护状态的测试口——只在子类内部触碰 @protected 成员。
+  String? get access => accessToken;
+  String? get refresh => refreshToken;
+  void seedAccess(String token) => accessToken = token;
+  Future<void> exchangeForTest({
+    required String code,
+    required String verifier,
+    required String redirectUri,
+    required SyncRepository repo,
+  }) =>
+      exchangeCode(
+        code: code,
+        verifier: verifier,
+        redirectUri: redirectUri,
+        repo: repo,
+      );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+      '${invocation.memberName} not used in this test');
+}
+
+/// mixin 的存取钩子已被 [_TestBackend] 截住，repo 只是个占位。
+class _UnusedRepo implements SyncRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('repo not used in this test');
+}

--- a/fushi/test/sync/pkce_oauth_backend_mixin_test.dart
+++ b/fushi/test/sync/pkce_oauth_backend_mixin_test.dart
@@ -137,19 +137,77 @@ void main() {
       'get _authHeaders',
     ];
 
+    // 类头锚点：`PkceOAuthBackendMixin` 只能在 with 列表里算数。两个文件的 dartdoc
+    // 里就写着 `[PkceOAuthBackendMixin]`，扫全文件是恒真的——把 with 列表里的 mixin
+    // 删掉，那种断言照样绿（真正会红的是编译器，不是这条守卫）。
+    const Map<String, String> declarations = <String, String>{
+      'lib/src/sync/dropbox_sync_backend.dart':
+          'class DropboxSyncBackend extends SyncBackend',
+      'lib/src/sync/onedrive_sync_backend.dart':
+          'class OneDriveSyncBackend extends SyncBackend',
+    };
+    // 抽 mixin 之后，每个后端**唯一**剩下的自有认证代码就是 readStoredToken /
+    // writeStoredToken 两个存储钩子。它们接错对家照样编译、照样跑绿所有行为测试，
+    // 后果却是两个后端共用一份凭据：登录 Dropbox 顶掉 OneDrive 的 token。
+    // 这是 mixin 抽取最典型的复制粘贴翻车点，只能靠字面量守。
+    const Map<String, String> ownProvider = <String, String>{
+      'lib/src/sync/dropbox_sync_backend.dart': 'Dropbox',
+      'lib/src/sync/onedrive_sync_backend.dart': 'OneDrive',
+    };
+
     for (final String path in backends) {
       test(path, () {
         final File f = File(path);
         expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
         final String src = f.readAsStringSync();
-        expect(src, contains('PkceOAuthBackendMixin'),
-            reason: '$path 必须混入 PkceOAuthBackendMixin');
+
+        final int classAt = src.indexOf(declarations[path]!);
+        expect(classAt, isNonNegative, reason: '$path 的类声明变了，守卫需更新');
+        final int braceAt = src.indexOf('{', classAt);
+        expect(braceAt, greaterThan(classAt), reason: '$path 扫不到类头结尾');
+        expect(src.substring(classAt, braceAt),
+            contains('PkceOAuthBackendMixin'),
+            reason: '$path 的 with 列表里必须有 PkceOAuthBackendMixin');
+
         for (final String needle in banned) {
           expect(src, isNot(contains(needle)),
               reason: '$path 里出现 `$needle`——认证外壳应只在 mixin 里有一份');
         }
+
+        final String own = ownProvider[path]!;
+        final String other = own == 'Dropbox' ? 'OneDrive' : 'Dropbox';
+        expect(src, contains('repo.get${own}Token()'),
+            reason: '$path 的 readStoredToken 必须读自己那把存储键');
+        expect(src, contains('repo.set${own}Token('),
+            reason: '$path 的 writeStoredToken 必须写自己那把存储键');
+        expect(src, isNot(contains('${other}Token')),
+            reason: '$path 碰了对家的凭据键：两个后端会共用一份 token，'
+                '登录一边顶掉另一边');
       });
     }
+
+    test('Dropbox 的 revoke 必须排在 super.signOut 之前', () {
+      // 抽 mixin 之前，撤销服务端 token 和清空本地凭据在同一个方法体里，顺序一眼
+      // 可见。现在清空搬进了 mixin，顺序变成跨文件的隐式约定：把
+      // `await super.signOut(repo: repo)` 挪到 revoke 前面，全套测试照样绿，
+      // 而线上会拿 `Bearer null` 去 revoke——请求静默失败，服务端 token 永不撤销。
+      const String path = 'lib/src/sync/dropbox_sync_backend.dart';
+      final String src = File(path).readAsStringSync();
+      const String anchor = 'Future<void> signOut({required SyncRepository repo';
+      final int at = src.indexOf(anchor);
+      expect(at, isNonNegative, reason: 'signOut 签名变了，守卫需更新');
+      final int end = src.indexOf('\n  }', at);
+      expect(end, greaterThan(at), reason: '扫不到 signOut 结尾，守卫需更新');
+      final String body = src.substring(at, end);
+
+      final int revokeAt = body.indexOf('/auth/token/revoke');
+      final int superAt = body.indexOf('super.signOut(');
+      expect(revokeAt, isNonNegative, reason: 'Dropbox 登出必须撤销服务端 token');
+      expect(superAt, isNonNegative, reason: '清空本地凭据必须复用 mixin 的 signOut');
+      expect(revokeAt, lessThan(superAt),
+          reason: 'super.signOut 会把 accessToken 置空；顺序反了就是拿 '
+              '`Bearer null` 去 revoke——静默失败，服务端 token 永不撤销');
+    });
   });
 }
 


### PR DESCRIPTION
## 同步/互联重构 PR1 · A1：Dropbox / OneDrive PKCE OAuth 外壳抽 mixin

系列计划：`docs/plans/2026-09-06-sync-interconnect-refactor.md`（本 PR 顺带落地该文档）。**零行为变化**。

### 改了什么
- 新增 `fushi/lib/src/sync/pkce_oauth_backend_mixin.dart`：`PkceOAuthBackendMixin on SyncBackend`，收进两后端原本逐字相同的 `authenticate` / `handleAuthCode` / `exchangeCode` / `restoreAuth` / `refreshAuth` / `signOut`(默认) / `bearerJsonHeaders` 与 `accessToken` / `refreshToken` / `email` / pending 四字段（2026-07-24 审查 §三-1 backlog #1）。
- 两后端只剩 provider 差异钩子：`oauth`（client id / endpoint / 刷新额外参数）、`providerName`、`mobileRedirectUri`、`desktopLoopbackPort`（Dropbox 9004，OneDrive 默认 0 = 与原先不传等价）、`buildAuthUrl`、`readStoredToken` / `writeStoredToken`、`fetchUserEmail`。
- Dropbox 的登出 revoke 是真实差异，保留为 override → `super.signOut`，调用顺序与原实现一致（revoke → 清字段 → clearCache → 删落库）。
- `sftp`/`ftp`/`webdav`/`interconnect` 不碰（它们不是 PKCE）。

### 语义逐字保留的点
- 恢复时刷新失败清空两个 token（HBK-AUDIT-159）。
- 刷新响应缺 `refresh_token` 时保留旧值。
- `isConfigured` 静态 getter 与 `authenticate` 的 `YOUR_` 占位判断不变（mixin 用 `oauth.clientId` 判同一谓词）。

### 测试
- 新增 `test/sync/pkce_oauth_backend_mixin_test.dart`：7 条行为（换码落库 / 恢复保留旧 refresh / 恢复失败清空 / 无落库或缺键直接 false / 刷新替换与无 token 抛错 / 无 pending 拒绝回跳 / 登出清理）+ 2 条源码守卫（两后端源码不得再出现五段外壳）。**这是补上审查点名的零 OAuth 覆盖**。
- 定向：`oauth_backend_config_test` / `oauth_proxy_and_browser_timeout_test` / `desktop_oauth_launch_test` / `desktop_oauth_wait_dialog_test` / `cloud_remote_book_client_guard_test` / `sync_transient_error_test` / `sync_obfuscation_factory_guard_test` / `tools/fushi_rename_guard_test` 全绿（56 + 5 + 9 条）。
- 全量 `flutter analyze`：No issues found。
- `git diff --stat`：两后端 -284 / +56。

### A4（后端重试层）的结论——不做，另开 bug
`sync_manager.dart:182` 已对 `SyncBackendError(isRetryable)` 做一次清缓存重试，后端层再包 `retryTransientSync` = 双重重试，故不加。但除 Google Drive 外，其余后端的 `SocketException` 等瞬时错误不会被包成 `SyncBackendError`，原样穿透 → 零重试（BUG-864 只修了 Drive）。这是行为缺陷，不混进重构，PR2 时开 BUG 单。

https://claude.ai/code/session_01WPbEes8famqLCXoUjHNLPn
