### PR TITLE
refactor(sync): PR2/7 抽 WebDavPathBackendMixin——WebDAV/互联 client 三件套收成一份 + BUG-2169 立案

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2032 条。点号进各自文件。
+> 共 2033 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2169](bugs/BUG-2169-sync-non-drive-transient-no-retry.md) | 🚧 | 🚧 | 非 Google Drive 云后端瞬时网络错误零重试 |
 | [BUG-2161](bugs/BUG-2161-mdx-loose-asset-scan-and-size-limits.md) | 🚧 | 🚧 | MDX 松散资源两条上限缺口：img src 只扫前 50 条词条、zip 全取无总量上限 |
 | [BUG-2160](bugs/BUG-2160-mdx-import-oom-ios.md) | ✅ | ✅ | iOS 导入大 MDX 词典闪退：整本词典在内存里物化，jetsam 直接杀进程 |
 | [BUG-2159](bugs/BUG-2159-netflix-ext-mine-audible-playback.md) | ✅ | ✅ | 网飞扩展批量制卡期间扬声器出声 |

--- a/docs/bugs/BUG-2169-sync-non-drive-transient-no-retry.md
+++ b/docs/bugs/BUG-2169-sync-non-drive-transient-no-retry.md
@@ -3,8 +3,9 @@
 - **真实性**：✅ 真 bug（代码路径核实，未真机复现）。根因：
   - 重试层只有一处：`fushi/lib/src/sync/sync_manager.dart:181-203` 对 `SyncBackendError` 且 `isRetryable == true` 做一次清缓存重试。
   - Google Drive 走 `fushi/lib/src/sync/google_drive_handler.dart:136`（`retryTransientSync` 包裹 + 401 刷新重试，BUG-864 修的）。
-  - OneDrive / Dropbox / WebDAV / SFTP 的出站请求（`onedrive_sync_backend.dart:215-270` `_graph*`、`dropbox_sync_backend.dart` `_apiPost`/内容上传、`webdav_ops.dart:113` `_client().openUrl`、`sftp_sync_backend.dart` `_guarded`）不捕获 `SocketException` / `TimeoutException` / `HttpException`，原样穿透；`sync_manager.dart:181` 的 `on SyncBackendError` 接不住 → 该书本轮直接失败、零重试。只有 FTP 自己包成 `SyncBackendError(isRetryable: true)`（`ftp_sync_backend.dart:214` 等）。
-  - 另注：Dropbox / OneDrive 把 `isRetryable: true` 当「404 / not_found」标记用（`dropbox_sync_backend.dart:164,394`、`onedrive_sync_backend.dart:186,250`），与 `sync_manager` 对该 flag 的「瞬时错误可重试」语义相冲——不存在的路径也会触发一次清缓存重试。修复时要把「不存在」与「瞬时」拆成两个信号，不能只在后端外面再包一层 `retryTransientSync`（那会与 `sync_manager` 的重试叠成双重重试）。
+  - OneDrive / Dropbox / WebDAV 的出站请求（`onedrive_sync_backend.dart` `_graph*`、`dropbox_sync_backend.dart` `_apiPost`/内容上传、`webdav_ops.dart:113` `_client().openUrl`）不捕获 `SocketException` / `TimeoutException` / `HttpException`，原样穿透；`sync_manager.dart:181` 的 `on SyncBackendError` 接不住 → 该书本轮直接失败、零重试。
+  - **SFTP 与 FTP 已达标，不在本条范围内**（2026-09-06 复核）：`sftp_sync_backend.dart:540-559` 的 `_guarded` 有 catch-all，把 `SftpStatusError` 与一切传输/IO 异常都包成 `SyncBackendError(..., isRetryable: true)`，且该文件 16 个出站方法**全部**包在 `_guarded` 里；FTP 有 13 处 `isRetryable: true`。给它们再接一层 `isTransientSyncError` 就是本条「另注」自己警告的双重重试。
+  - 另注：Dropbox / OneDrive / **WebDAV** 都把 `isRetryable: true` 当「404 / not_found」标记用（`dropbox_sync_backend.dart:250`、`onedrive_sync_backend.dart:277`、`webdav_ops.dart:246,389`），与 `sync_manager` 对该 flag 的「瞬时错误可重试」语义相冲——不存在的路径也会触发一次清缓存重试。修复时要把「不存在」与「瞬时」拆成两个信号，不能只在后端外面再包一层 `retryTransientSync`（那会与 `sync_manager` 的重试叠成双重重试）。
 - **[ ] ① 未修复** — 行为变化，不混进 `docs/plans/2026-09-06-sync-interconnect-refactor.md` 的零行为变化重构系列；待独立任务。
-- **[ ] ② 未加自动化测试** — 落地时至少：`isTransientSyncError` 分类在四个后端出站路径上的接入测试 + 「404 不再走清缓存重试」的负向测试。
+- **[ ] ② 未加自动化测试** — 落地时至少：`isTransientSyncError` 分类在**三个**后端（OneDrive / Dropbox / WebDAV）出站路径上的接入测试，以及一条「SFTP / FTP 不得被再包一层」的负向测试 + 「404 不再走清缓存重试」的负向测试。
 - **备注**：2026-07-24 审查 §三-2 提的「四后端 mixin」与本条无关；本条是错误分类缺失，不是重复代码。

--- a/docs/bugs/BUG-2169-sync-non-drive-transient-no-retry.md
+++ b/docs/bugs/BUG-2169-sync-non-drive-transient-no-retry.md
@@ -1,0 +1,10 @@
+## BUG-2169 · 非 Google Drive 云后端瞬时网络错误零重试
+- **报告**：2026-09-06（用户：同步/互联重构 A4 门槛调查时发现，非用户报告）
+- **真实性**：✅ 真 bug（代码路径核实，未真机复现）。根因：
+  - 重试层只有一处：`fushi/lib/src/sync/sync_manager.dart:181-203` 对 `SyncBackendError` 且 `isRetryable == true` 做一次清缓存重试。
+  - Google Drive 走 `fushi/lib/src/sync/google_drive_handler.dart:136`（`retryTransientSync` 包裹 + 401 刷新重试，BUG-864 修的）。
+  - OneDrive / Dropbox / WebDAV / SFTP 的出站请求（`onedrive_sync_backend.dart:215-270` `_graph*`、`dropbox_sync_backend.dart` `_apiPost`/内容上传、`webdav_ops.dart:113` `_client().openUrl`、`sftp_sync_backend.dart` `_guarded`）不捕获 `SocketException` / `TimeoutException` / `HttpException`，原样穿透；`sync_manager.dart:181` 的 `on SyncBackendError` 接不住 → 该书本轮直接失败、零重试。只有 FTP 自己包成 `SyncBackendError(isRetryable: true)`（`ftp_sync_backend.dart:214` 等）。
+  - 另注：Dropbox / OneDrive 把 `isRetryable: true` 当「404 / not_found」标记用（`dropbox_sync_backend.dart:164,394`、`onedrive_sync_backend.dart:186,250`），与 `sync_manager` 对该 flag 的「瞬时错误可重试」语义相冲——不存在的路径也会触发一次清缓存重试。修复时要把「不存在」与「瞬时」拆成两个信号，不能只在后端外面再包一层 `retryTransientSync`（那会与 `sync_manager` 的重试叠成双重重试）。
+- **[ ] ① 未修复** — 行为变化，不混进 `docs/plans/2026-09-06-sync-interconnect-refactor.md` 的零行为变化重构系列；待独立任务。
+- **[ ] ② 未加自动化测试** — 落地时至少：`isTransientSyncError` 分类在四个后端出站路径上的接入测试 + 「404 不再走清缓存重试」的负向测试。
+- **备注**：2026-07-24 审查 §三-2 提的「四后端 mixin」与本条无关；本条是错误分类缺失，不是重复代码。

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -23,6 +23,7 @@ import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
 import 'package:fushi/src/sync/ttu_models.dart';
 import 'package:fushi/src/sync/webdav_ops.dart';
+import 'package:fushi/src/sync/webdav_path_backend_mixin.dart';
 
 /// Probes whether a single Hibiki server URL is reachable with [token].
 /// Returns true if reachable, false on connectivity failure/timeout, and
@@ -136,7 +137,11 @@ Future<bool> _defaultFushiProbe(String url, String token) async {
 /// credentials in dedicated keys to avoid collision with the user's
 /// standalone WebDAV config.
 class InterconnectSyncBackend extends SyncBackend
-    with SyncFolderCache, SyncBackendFileTrioMixin, SyncAssetStoreDefaults
+    with
+        SyncFolderCache,
+        SyncBackendFileTrioMixin,
+        SyncAssetStoreDefaults,
+        WebDavPathBackendMixin
     implements
         RemoteBookClient,
         RemoteVideoClient,
@@ -452,66 +457,16 @@ class InterconnectSyncBackend extends SyncBackend
     return path;
   }
 
+  // listBooks / ensureBookFolder / listSyncFiles 三件套由 WebDavPathBackendMixin
+  // 提供（与 WebDAV 后端逐字共享）。这三处原本就不经 _ensureResolved（沿用原实现，
+  // 直接用 _ops!），mixin 里也不加——时序逐点保留。
   @override
-  Future<List<SyncFileRef>> listBooks(String rootFolderId) async {
-    final entries = await _ops!.propfindChildren(rootFolderId);
-    return entries
-        .where((e) => e.isCollection && e.href != rootFolderId)
-        .map((e) => SyncFileRef(id: e.href, name: e.displayName))
-        .toList();
-  }
+  WebDavOps get davOps => _ops!;
 
   @override
-  Future<String> ensureBookFolder({
-    required String bookTitle,
-    required String rootFolderId,
-    SyncCoverDataProvider? readCoverData,
-  }) async {
-    final sanitized = requireBookFolderName(bookTitle);
-
-    if (folderIdCache.containsKey(sanitized)) {
-      // Normalize a possibly slash-less cached href on return (BUG-845).
-      return ensureFolderIdTrailingSlash(folderIdCache[sanitized]!);
-    }
-
-    final path = '$rootFolderId${Uri.encodeComponent(sanitized)}/';
-    await _ops!.ensureCollection(path);
-    folderIdCache[sanitized] = path;
-
-    final Uint8List? coverData = await readCoverData?.call();
-    if (coverData != null) {
-      try {
-        final format = detectCoverFormat(coverData);
-        final coverPath = '${path}cover_1_6.${format.extension}';
-        final existing = await _ops!.headFile(coverPath);
-        if (!existing) {
-          await _ops!.putBytes(coverPath, coverData, format.mimeType);
-        }
-      } catch (e) {
-        debugPrint('[fushi-client] cover upload failed: $e');
-      }
-    }
-
-    return path;
-  }
+  String get davLogTag => '[fushi-client]';
 
   // ── Metadata sync ─────────────────────────────────────────────────
-
-  @override
-  Future<SyncFileTrio> listSyncFiles(String folderId) async {
-    final entries = await _ops!.propfindChildren(folderId);
-    final files = entries
-        .where((e) => !e.isCollection && e.href != folderId)
-        .map((e) => SyncFileRef(id: e.href, name: e.displayName))
-        .toList();
-
-    // HBK-AUDIT-085: route through the single canonical matcher in sync_utils.
-    return SyncFileTrio(
-      progress: findSyncFileByPrefix(files, 'progress_'),
-      statistics: findSyncFileByPrefix(files, 'statistics_'),
-      audioBook: findSyncFileByPrefix(files, 'audioBook_'),
-    );
-  }
 
   // get{Progress,Stats,AudioBook}File 三件套由 SyncBackendFileTrioMixin 提供；
   // 这里只给出 hibiki client 的下载原语（size-capped GET + jsonDecode，见

--- a/fushi/lib/src/sync/webdav_ops.dart
+++ b/fushi/lib/src/sync/webdav_ops.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/tls/fushi_pinning_http.dart';
 import 'package:fushi/src/sync/sync_utils.dart';
-import 'package:fushi/src/sync/sync_file_ref.dart';
 
 /// 服务端在错误响应体里给出的拒绝原因（截断后的），读不出来就返回 null。
 ///
@@ -404,12 +403,6 @@ class WebDavOps {
   // MIME 猜测收敛到 sync_utils.guessSyncContentType；保留薄 shim 供既有调用方。
   static String guessContentType(String fileName) =>
       guessSyncContentType(fileName);
-
-  // HBK-AUDIT-085: delegate to the single canonical matcher in sync_utils so
-  // file-matching semantics live in one place. Kept as a thin shim only for the
-  // remaining external caller (webdav_sync_backend.dart).
-  static SyncFileRef? findByPrefix(List<SyncFileRef> files, String prefix) =>
-      findSyncFileByPrefix(files, prefix);
 
   static String normalizeUrl(String url) {
     var normalized = url.trim();

--- a/fushi/lib/src/sync/webdav_path_backend_mixin.dart
+++ b/fushi/lib/src/sync/webdav_path_backend_mixin.dart
@@ -1,0 +1,91 @@
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show debugPrint, protected;
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_file_ref.dart';
+import 'package:fushi/src/sync/sync_utils.dart';
+import 'package:fushi/src/sync/ttu_filename.dart';
+import 'package:fushi/src/sync/webdav_ops.dart';
+
+/// 走 [WebDavOps] 的路径式后端（WebDAV / 互联 client）共用的三件套：
+/// 列书目录、确保书目录（含封面上传）、列书目录下的同步文件。
+///
+/// 两个后端原本各写一份逐字相同的实现（2026-07-24 审查 §三-2）。它们的
+/// `findOrCreateRootFolder` **有真实差异**（WebDAV 走 Fushi 改名迁移三段、互联
+/// 没有），故不进这里；SFTP / FTP 原语不同（`listdir` vs `changeDirectory`+
+/// `listDirectoryContent`+连接锁），也不进——硬合是拿 6 个抽象方法换 80 行。
+///
+/// folderId 是以 `/` 结尾的 href 前缀（BUG-845）；[SyncFolderCache.folderIdCache]
+/// 里可能存着服务器 PROPFIND 回来的无尾斜杠 href，命中缓存时统一补斜杠再返回。
+mixin WebDavPathBackendMixin on SyncBackend, SyncFolderCache {
+  /// 当前会话的 WebDAV 原语；未建立会话时抛出（与原先 `_ops!` 同义）。
+  @protected
+  WebDavOps get davOps;
+
+  /// 封面上传失败时 debugPrint 的前缀（`[webdav]` / `[fushi-client]`）。
+  @protected
+  String get davLogTag;
+
+  @override
+  Future<List<SyncFileRef>> listBooks(String rootFolderId) async {
+    final List<DavEntry> entries = await davOps.propfindChildren(rootFolderId);
+    return entries
+        .where((DavEntry e) => e.isCollection && e.href != rootFolderId)
+        .map((DavEntry e) => SyncFileRef(id: e.href, name: e.displayName))
+        .toList();
+  }
+
+  @override
+  Future<String> ensureBookFolder({
+    required String bookTitle,
+    required String rootFolderId,
+    SyncCoverDataProvider? readCoverData,
+  }) async {
+    final String sanitized = requireBookFolderName(bookTitle);
+
+    if (folderIdCache.containsKey(sanitized)) {
+      // A cached id may have entered slash-less from a server PROPFIND href
+      // (some WebDAV servers omit the trailing slash on collection hrefs).
+      // Normalize on return so `folderId + fileName` never fuses the file into
+      // the root as `<title>audioBook_…` (BUG-845).
+      return ensureFolderIdTrailingSlash(folderIdCache[sanitized]!);
+    }
+
+    final String path = '$rootFolderId${Uri.encodeComponent(sanitized)}/';
+    await davOps.ensureCollection(path);
+    folderIdCache[sanitized] = path;
+
+    final Uint8List? coverData = await readCoverData?.call();
+    if (coverData != null) {
+      try {
+        final ({String mimeType, String extension}) format =
+            detectCoverFormat(coverData);
+        final String coverPath = '${path}cover_1_6.${format.extension}';
+        final bool existing = await davOps.headFile(coverPath);
+        if (!existing) {
+          await davOps.putBytes(coverPath, coverData, format.mimeType);
+        }
+      } catch (e) {
+        debugPrint('$davLogTag cover upload failed: $e');
+      }
+    }
+
+    return path;
+  }
+
+  @override
+  Future<SyncFileTrio> listSyncFiles(String folderId) async {
+    final List<DavEntry> entries = await davOps.propfindChildren(folderId);
+    final List<SyncFileRef> files = entries
+        .where((DavEntry e) => !e.isCollection && e.href != folderId)
+        .map((DavEntry e) => SyncFileRef(id: e.href, name: e.displayName))
+        .toList();
+
+    // HBK-AUDIT-085: route through the single canonical matcher in sync_utils.
+    return SyncFileTrio(
+      progress: findSyncFileByPrefix(files, 'progress_'),
+      statistics: findSyncFileByPrefix(files, 'statistics_'),
+      audioBook: findSyncFileByPrefix(files, 'audioBook_'),
+    );
+  }
+}

--- a/fushi/lib/src/sync/webdav_sync_backend.dart
+++ b/fushi/lib/src/sync/webdav_sync_backend.dart
@@ -11,10 +11,15 @@ import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
 import 'package:fushi/src/sync/ttu_models.dart';
 import 'package:fushi/src/sync/webdav_ops.dart';
+import 'package:fushi/src/sync/webdav_path_backend_mixin.dart';
 import 'package:fushi/src/utils/misc/error_log_service.dart';
 
 class WebDavSyncBackend extends SyncBackend
-    with SyncFolderCache, SyncBackendFileTrioMixin, SyncAssetStoreDefaults {
+    with
+        SyncFolderCache,
+        SyncBackendFileTrioMixin,
+        SyncAssetStoreDefaults,
+        WebDavPathBackendMixin {
   WebDavSyncBackend._();
   static final WebDavSyncBackend instance = WebDavSyncBackend._();
 
@@ -112,68 +117,15 @@ class WebDavSyncBackend extends SyncBackend
     return path;
   }
 
+  // listBooks / ensureBookFolder / listSyncFiles 三件套由 WebDavPathBackendMixin
+  // 提供（与互联 client 逐字共享）；这里只交出会话原语与日志标签。
   @override
-  Future<List<SyncFileRef>> listBooks(String rootFolderId) async {
-    final entries = await _ops!.propfindChildren(rootFolderId);
-    return entries
-        .where((e) => e.isCollection && e.href != rootFolderId)
-        .map((e) => SyncFileRef(id: e.href, name: e.displayName))
-        .toList();
-  }
+  WebDavOps get davOps => _ops!;
 
   @override
-  Future<String> ensureBookFolder({
-    required String bookTitle,
-    required String rootFolderId,
-    SyncCoverDataProvider? readCoverData,
-  }) async {
-    final sanitized = requireBookFolderName(bookTitle);
-
-    if (folderIdCache.containsKey(sanitized)) {
-      // A cached id may have entered slash-less from a server PROPFIND href
-      // (some WebDAV servers omit the trailing slash on collection hrefs).
-      // Normalize on return so `folderId + fileName` never fuses the file into
-      // the root as `<title>audioBook_…` (BUG-845).
-      return ensureFolderIdTrailingSlash(folderIdCache[sanitized]!);
-    }
-
-    final path = '$rootFolderId${Uri.encodeComponent(sanitized)}/';
-    await _ops!.ensureCollection(path);
-    folderIdCache[sanitized] = path;
-
-    final Uint8List? coverData = await readCoverData?.call();
-    if (coverData != null) {
-      try {
-        final format = detectCoverFormat(coverData);
-        final coverPath = '${path}cover_1_6.${format.extension}';
-        final existing = await _ops!.headFile(coverPath);
-        if (!existing) {
-          await _ops!.putBytes(coverPath, coverData, format.mimeType);
-        }
-      } catch (e) {
-        debugPrint('[webdav] cover upload failed: $e');
-      }
-    }
-
-    return path;
-  }
+  String get davLogTag => '[webdav]';
 
   // ── Metadata sync ─────────────────────────────────────────────────
-
-  @override
-  Future<SyncFileTrio> listSyncFiles(String folderId) async {
-    final entries = await _ops!.propfindChildren(folderId);
-    final files = entries
-        .where((e) => !e.isCollection && e.href != folderId)
-        .map((e) => SyncFileRef(id: e.href, name: e.displayName))
-        .toList();
-
-    return SyncFileTrio(
-      progress: WebDavOps.findByPrefix(files, 'progress_'),
-      statistics: WebDavOps.findByPrefix(files, 'statistics_'),
-      audioBook: WebDavOps.findByPrefix(files, 'audioBook_'),
-    );
-  }
 
   // get{Progress,Stats,AudioBook}File 三件套由 SyncBackendFileTrioMixin 提供；
   // 这里只给出 WebDAV 的下载原语（size-capped GET + jsonDecode，见 WebDavOps）。

--- a/fushi/test/sync/pr914_per_book_stats_channel_test.dart
+++ b/fushi/test/sync/pr914_per_book_stats_channel_test.dart
@@ -61,7 +61,24 @@ void main() {
       final String backend =
           _readSource('lib/src/sync/interconnect_sync_backend.dart');
       expect(backend, contains('updateStatsFile'));
-      expect(backend, contains("'statistics_'"));
+
+      // `statistics_` 前缀的解析在 A2 之后搬进了 WebDavPathBackendMixin（WebDAV 与
+      // 互联 client 共用的三件套）。通道还在，只是不再由单个文件独占——所以断言得
+      // 跟到组合面上，而不是继续扫一个已经不含该字面量的文件。两半都要：后端不
+      // mix in 它就没有这条通道，mixin 不解这个前缀则通道是空的。
+      final int classAt = backend.indexOf('class InterconnectSyncBackend ');
+      expect(classAt, isNonNegative, reason: '类改名了，守卫需更新');
+      final int braceAt = backend.indexOf('{', classAt);
+      expect(braceAt, greaterThan(classAt), reason: '扫不到类头结尾，守卫需更新');
+      expect(backend.substring(classAt, braceAt),
+          contains('WebDavPathBackendMixin'),
+          reason: 'per-book 统计的文件解析由该 mixin 提供，'
+              '后端的 with 列表里没有它 = 这条通道根本不存在');
+
+      final String mixin =
+          _readSource('lib/src/sync/webdav_path_backend_mixin.dart');
+      expect(mixin, contains("findSyncFileByPrefix(files, 'statistics_')"),
+          reason: 'mixin 必须把 statistics_ 前缀解成三件套的 statistics 槽');
     });
   });
 }

--- a/fushi/test/sync/webdav_path_backend_mixin_test.dart
+++ b/fushi/test/sync/webdav_path_backend_mixin_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show DebugPrintCallback, debugPrint;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
@@ -106,12 +107,47 @@ void main() {
       expect(id, 'https://dav.example/fushi-data/Book%20A/');
       expect(backend.folderIdCache['Book A'], id);
     });
+
+    test('失败日志带后端自己的 davLogTag 前缀', () async {
+      // davLogTag 是这次抽 mixin **唯一**按后端参数化的东西（`[webdav]` /
+      // `[fushi-client]`）。把 `$davLogTag` 从消息里删掉、甚至让这个抽象成员
+      // 彻底没有读者，上面 8 条行为用例全绿——没有任何东西观测它。
+      // 两个后端共用一份日志前缀时，用户报「封面传不上去」就分不清是哪条链路。
+      ops.failPut = true;
+      final List<String> logs = <String>[];
+      final DebugPrintCallback original = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) logs.add(message);
+      };
+      try {
+        await backend.ensureBookFolder(
+          bookTitle: 'Book A',
+          rootFolderId: 'https://dav.example/fushi-data/',
+          readCoverData: () async => png,
+        );
+      } finally {
+        debugPrint = original;
+      }
+
+      expect(logs, hasLength(1));
+      expect(logs.single, startsWith('[test] cover upload failed: '),
+          reason: '日志必须带调用方后端的 davLogTag，否则两条链路的失败无法区分');
+    });
   });
 
   group('listSyncFiles', () {
     test('按前缀挑出 progress/statistics/audioBook，剔除目录自身与子集合', () async {
       const String folder = 'https://dav.example/fushi-data/Book%20A/';
+      // 前两项是**对抗性**的，别删：原来被过滤掉的两项叫 'Book A' 和 'sub'，
+      // 名字都不带三个前缀，于是把 `!e.isCollection` 和 `e.href != folderId`
+      // 两个过滤子句**同时删掉**，这条用例照样绿——它守的是自己声称守的东西之外
+      // 的另一件事。所以这里各放一个带前缀、且排在真文件**前面**的诱饵：
+      //   · progress_shadow/  是集合 —— 只有 !isCollection 挡得住
+      //   · href == folderId 且被服务器误报成文件 —— 只有 href != folderId 挡得住
+      //     （服务器把 PROPFIND 的自身条目报成非集合是真实存在的实现差异）
       ops.children[folder] = <DavEntry>[
+        _entry('${folder}progress_shadow/', 'progress_shadow', true),
+        _entry(folder, 'audioBook_self.json', false),
         _entry(folder, 'Book A', true),
         _entry('${folder}progress_1_6_x.json', 'progress_1_6_x.json', false),
         _entry(
@@ -143,6 +179,14 @@ void main() {
       'lib/src/sync/webdav_sync_backend.dart',
       'lib/src/sync/interconnect_sync_backend.dart',
     ];
+    // 类头锚点：mixin 只有出现在 with 列表里才算数。扫全文件是恒真的——注释、
+    // dartdoc、import 提到这个名字都会命中，而把它从 with 列表删掉照样绿。
+    const Map<String, String> declarations = <String, String>{
+      'lib/src/sync/webdav_sync_backend.dart':
+          'class WebDavSyncBackend extends SyncBackend',
+      'lib/src/sync/interconnect_sync_backend.dart':
+          'class InterconnectSyncBackend extends SyncBackend',
+    };
     const List<String> banned = <String>[
       'Future<List<SyncFileRef>> listBooks(',
       'Future<String> ensureBookFolder(',
@@ -154,8 +198,13 @@ void main() {
         final File f = File(path);
         expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
         final String src = f.readAsStringSync();
-        expect(src, contains('WebDavPathBackendMixin'),
-            reason: '$path 必须混入 WebDavPathBackendMixin');
+        final int classAt = src.indexOf(declarations[path]!);
+        expect(classAt, isNonNegative, reason: '$path 的类声明变了，守卫需更新');
+        final int braceAt = src.indexOf('{', classAt);
+        expect(braceAt, greaterThan(classAt), reason: '$path 扫不到类头结尾');
+        expect(src.substring(classAt, braceAt),
+            contains('WebDavPathBackendMixin'),
+            reason: '$path 的 with 列表里必须有 WebDavPathBackendMixin');
         for (final String needle in banned) {
           expect(src, isNot(contains(needle)),
               reason: '$path 里出现 `$needle`——三件套应只在 mixin 里有一份');

--- a/fushi/test/sync/webdav_path_backend_mixin_test.dart
+++ b/fushi/test/sync/webdav_path_backend_mixin_test.dart
@@ -1,0 +1,232 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_file_ref.dart';
+import 'package:fushi/src/sync/sync_utils.dart';
+import 'package:fushi/src/sync/webdav_ops.dart';
+import 'package:fushi/src/sync/webdav_path_backend_mixin.dart';
+
+/// WebDAV / 互联 client 共用的路径式三件套 [WebDavPathBackendMixin]。
+///
+/// 抽出前两后端各有一份逐字相同的 listBooks / ensureBookFolder / listSyncFiles；
+/// 这里用 fake [WebDavOps] 锁住它们对原语的调用形状与 BUG-845 的尾斜杠规整。
+void main() {
+  // PNG 魔数：detectCoverFormat 据此判 image/png + .png。
+  final Uint8List png = Uint8List.fromList(
+      <int>[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3]);
+
+  late _FakeOps ops;
+  late _Backend backend;
+
+  setUp(() {
+    ops = _FakeOps();
+    backend = _Backend(ops);
+  });
+
+  group('listBooks', () {
+    test('只返回子集合，剔除根自身与文件', () async {
+      ops.children['https://dav.example/fushi-data/'] = <DavEntry>[
+        _entry('https://dav.example/fushi-data/', 'fushi-data', true),
+        _entry('https://dav.example/fushi-data/Book%20A/', 'Book A', true),
+        _entry(
+            'https://dav.example/fushi-data/videos.json', 'videos.json', false),
+        _entry('https://dav.example/fushi-data/B', 'B', true),
+      ];
+
+      final List<SyncFileRef> books =
+          await backend.listBooks('https://dav.example/fushi-data/');
+
+      expect(books.map((SyncFileRef b) => b.name), <String>['Book A', 'B']);
+      expect(books.first.id, 'https://dav.example/fushi-data/Book%20A/');
+    });
+  });
+
+  group('ensureBookFolder', () {
+    test('新书：MKCOL 一次、URL 编码书名、以 / 结尾、写入 folderIdCache', () async {
+      final String id = await backend.ensureBookFolder(
+        bookTitle: 'Book A',
+        rootFolderId: 'https://dav.example/fushi-data/',
+      );
+
+      expect(id, 'https://dav.example/fushi-data/Book%20A/');
+      expect(ops.ensured, <String>['https://dav.example/fushi-data/Book%20A/']);
+      expect(backend.folderIdCache['Book A'], id);
+    });
+
+    test('命中缓存：不再 MKCOL；缓存里的无尾斜杠 href 补上 /（BUG-845）', () async {
+      backend.folderIdCache['Book A'] =
+          'https://dav.example/fushi-data/Book%20A';
+
+      final String id = await backend.ensureBookFolder(
+        bookTitle: 'Book A',
+        rootFolderId: 'https://dav.example/fushi-data/',
+      );
+
+      expect(id, 'https://dav.example/fushi-data/Book%20A/');
+      expect(ops.ensured, isEmpty);
+    });
+
+    test('封面：远端没有才 PUT，内容类型/扩展名按魔数判定', () async {
+      await backend.ensureBookFolder(
+        bookTitle: 'Book A',
+        rootFolderId: 'https://dav.example/fushi-data/',
+        readCoverData: () async => png,
+      );
+
+      expect(ops.puts, hasLength(1));
+      expect(ops.puts.single.path,
+          'https://dav.example/fushi-data/Book%20A/cover_1_6.png');
+      expect(ops.puts.single.contentType, 'image/png');
+      expect(ops.puts.single.bytes, png);
+    });
+
+    test('封面：远端已有则不重传', () async {
+      ops.existing.add('https://dav.example/fushi-data/Book%20A/cover_1_6.png');
+
+      await backend.ensureBookFolder(
+        bookTitle: 'Book A',
+        rootFolderId: 'https://dav.example/fushi-data/',
+        readCoverData: () async => png,
+      );
+
+      expect(ops.puts, isEmpty);
+    });
+
+    test('封面上传失败是 best-effort：吞掉，目录仍返回并已缓存', () async {
+      ops.failPut = true;
+
+      final String id = await backend.ensureBookFolder(
+        bookTitle: 'Book A',
+        rootFolderId: 'https://dav.example/fushi-data/',
+        readCoverData: () async => png,
+      );
+
+      expect(id, 'https://dav.example/fushi-data/Book%20A/');
+      expect(backend.folderIdCache['Book A'], id);
+    });
+  });
+
+  group('listSyncFiles', () {
+    test('按前缀挑出 progress/statistics/audioBook，剔除目录自身与子集合', () async {
+      const String folder = 'https://dav.example/fushi-data/Book%20A/';
+      ops.children[folder] = <DavEntry>[
+        _entry(folder, 'Book A', true),
+        _entry('${folder}progress_1_6_x.json', 'progress_1_6_x.json', false),
+        _entry(
+            '${folder}statistics_1_6_y.json', 'statistics_1_6_y.json', false),
+        _entry('${folder}audioBook_z.json', 'audioBook_z.json', false),
+        _entry('${folder}book.epub', 'book.epub', false),
+        _entry('${folder}sub/', 'sub', true),
+      ];
+
+      final SyncFileTrio trio = await backend.listSyncFiles(folder);
+
+      expect(trio.progress?.name, 'progress_1_6_x.json');
+      expect(trio.statistics?.name, 'statistics_1_6_y.json');
+      expect(trio.audioBook?.name, 'audioBook_z.json');
+    });
+
+    test('空目录三者皆 null', () async {
+      ops.children['https://dav.example/fushi-data/Empty/'] = <DavEntry>[];
+      final SyncFileTrio trio =
+          await backend.listSyncFiles('https://dav.example/fushi-data/Empty/');
+      expect(trio.progress, isNull);
+      expect(trio.statistics, isNull);
+      expect(trio.audioBook, isNull);
+    });
+  });
+
+  group('源码守卫：两个路径式后端不再各写一份三件套', () {
+    const List<String> backends = <String>[
+      'lib/src/sync/webdav_sync_backend.dart',
+      'lib/src/sync/interconnect_sync_backend.dart',
+    ];
+    const List<String> banned = <String>[
+      'Future<List<SyncFileRef>> listBooks(',
+      'Future<String> ensureBookFolder(',
+      'Future<SyncFileTrio> listSyncFiles(',
+    ];
+
+    for (final String path in backends) {
+      test(path, () {
+        final File f = File(path);
+        expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
+        final String src = f.readAsStringSync();
+        expect(src, contains('WebDavPathBackendMixin'),
+            reason: '$path 必须混入 WebDavPathBackendMixin');
+        for (final String needle in banned) {
+          expect(src, isNot(contains(needle)),
+              reason: '$path 里出现 `$needle`——三件套应只在 mixin 里有一份');
+        }
+      });
+    }
+
+    test('mixin 不擅自给三件套加 _ensureResolved 门（互联侧时序逐点保留）', () {
+      final String src = File('lib/src/sync/webdav_path_backend_mixin.dart')
+          .readAsStringSync();
+      expect(src, isNot(contains('ensureResolved')));
+    });
+  });
+}
+
+DavEntry _entry(String href, String name, bool isCollection) =>
+    DavEntry(href: href, displayName: name, isCollection: isCollection);
+
+class _Put {
+  const _Put(this.path, this.bytes, this.contentType);
+  final String path;
+  final List<int> bytes;
+  final String contentType;
+}
+
+/// 只截四个原语；其余 [WebDavOps] 成员从不被三件套触碰。
+class _FakeOps extends WebDavOps {
+  _FakeOps()
+      : super(
+          baseUrl: 'https://dav.example',
+          username: 'u',
+          password: 'p',
+        );
+
+  final Map<String, List<DavEntry>> children = <String, List<DavEntry>>{};
+  final List<String> ensured = <String>[];
+  final Set<String> existing = <String>{};
+  final List<_Put> puts = <_Put>[];
+  bool failPut = false;
+
+  @override
+  Future<List<DavEntry>> propfindChildren(String path) async =>
+      children[path] ?? (throw StateError('unexpected PROPFIND $path'));
+
+  @override
+  Future<void> ensureCollection(String path) async => ensured.add(path);
+
+  @override
+  Future<bool> headFile(String path) async => existing.contains(path);
+
+  @override
+  Future<void> putBytes(
+      String path, List<int> bytes, String contentType) async {
+    if (failPut) throw const SocketException('boom');
+    puts.add(_Put(path, bytes, contentType));
+  }
+}
+
+class _Backend extends SyncBackend
+    with SyncFolderCache, WebDavPathBackendMixin {
+  _Backend(this.ops);
+
+  final _FakeOps ops;
+
+  @override
+  WebDavOps get davOps => ops;
+
+  @override
+  String get davLogTag => '[test]';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+      '${invocation.memberName} not used in this test');
+}


### PR DESCRIPTION
## 同步/互联重构 PR2 · A2：WebDAV / 互联 client 三件套抽 `WebDavPathBackendMixin`

系列计划：`docs/plans/2026-09-06-sync-interconnect-refactor.md`（PR1 #1239 落地）。**零行为变化**。

### 改了什么
- 新增 `fushi/lib/src/sync/webdav_path_backend_mixin.dart`：`WebDavPathBackendMixin on SyncBackend, SyncFolderCache`，收进 `webdav_sync_backend.dart` 与 `interconnect_sync_backend.dart` 原本逐字相同的 `listBooks` / `ensureBookFolder`（含封面上传 + BUG-845 尾斜杠规整）/ `listSyncFiles`（2026-07-24 审查 §三-2 backlog #2）。
- 两后端只剩两个 getter：`davOps => _ops!`（与原先 `_ops!` 同义）、`davLogTag`（封面上传失败 debugPrint 的前缀 `[webdav]` / `[fushi-client]`——两边唯一的文本差异）。
- **缩小了审查提案的范围，明说**：
  - `findOrCreateRootFolder` 不合——WebDAV 走 Fushi 改名迁移三段、互联没有，是真实差异。
  - sftp / ftp 不合——原语不同（`listdir` vs `changeDirectory`+`listDirectoryContent`+连接锁），硬合是 6 个抽象方法换 80 行。
  - 互联侧 `_ensureResolved` 的 51 处一处不动；这三件套原本就不经它（沿用原实现直接 `_ops!`），mixin 里也不加——时序逐点保留（守卫测试钉死 mixin 源码不含 `ensureResolved`）。

### 测试
- 新增 `test/sync/webdav_path_backend_mixin_test.dart`：fake `WebDavOps` 子类驱动 8 条行为（列书剔根/文件；新书 MKCOL + URL 编码 + 缓存；缓存无尾斜杠补 `/`（BUG-845）；封面缺才 PUT / 已有不传 / 上传失败吞掉；listSyncFiles 前缀三件套 / 空目录）+ 3 条源码守卫（两后端不得再各写三件套；mixin 不得加 `ensureResolved`）。
- 定向：`webdav_ops_test` / `webdav_ops_anonymous_test` / `webdav_metadata_in_book_folder_guard_test` / `sync_folder_id_slash_test`（BUG-845）/ `sync_folder_cache_persist_test` / `sync_cover_lazy_read_test` / `fushi_client_backend_test` / `fushi_client_live_{book,audio,dict,video}_test` / `interconnect_session_reuse_test` / `interconnect_backup_backend_test` / `sync_root_spill_prune_test` / `sync_backend_utf8_body_test` / `sync_obfuscation_factory_guard_test` / `tools/outbound_http_discipline_guard_test`。
- 全量 `flutter analyze`。
- `git diff --stat`：两后端 -115 / +23。
- 存量文件只 format 改动行；`interconnect_sync_backend.dart:817` 有一处**原有的**旧风格不合规（`ContentType(...)` 单行超宽），不在本 PR 范围，未动。

### 顺带：A4 结论落成 BUG-2169（本 PR 不修）
`docs/bugs/BUG-2169-sync-non-drive-transient-no-retry.md`：除 Google Drive 外，OneDrive / Dropbox / WebDAV / SFTP 的 `SocketException` 等瞬时错误不会被包成 `SyncBackendError`，`sync_manager.dart:181` 的重试接不住 → 零重试；且 Dropbox / OneDrive 把 `isRetryable: true` 当「404 不存在」用，与 `sync_manager` 的语义相冲。这是行为缺陷，独立任务处理，不混进本系列。

https://claude.ai/code/session_01WPbEes8famqLCXoUjHNLPn
