### PR TITLE
refactor(sync): PR3/7 抽 RemoteLookupRoutes + RemoteAudioTokenStore——两台服务器共享查词/制卡 handler 壳

### DIFF
--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -405,7 +405,7 @@ class FushiSyncServer {
         // Remote lookup audio file URLs are handed to platform audio players,
         // which issue a bare GET without Authorization. The lookup endpoint
         // stays authenticated; the file endpoint is guarded by an opaque,
-        // short-lived in-memory id in _handleAudioFile.
+        // short-lived in-memory id in RemoteLookupRoutes.handleAudioFile.
         if (_isLookupAudioFilePath(request.url.path)) {
           return innerHandler(request);
         }
@@ -2238,7 +2238,7 @@ class FushiSyncServer {
   }
 
   /// BUG-1568：守住视频流 token 上限。TTL prune 之后仍达到 [_maxVideoStreamTokens]
-  /// 时，按 createdAt 淘汰最旧者直到回到上限内（对照 [_enforceAudioTokenCap]）。
+  /// 时，按 createdAt 淘汰最旧者直到回到上限内（对照 [RemoteAudioTokenStore]）。
   /// 签发前调用，使插入新 token 后总数 <= [_maxVideoStreamTokens]。
   void _enforceVideoTokenCap() {
     while (_videoStreamTokens.length >= _maxVideoStreamTokens) {

--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -22,6 +22,7 @@ import 'package:fushi/src/sync/interconnect_device_name.dart';
 import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
 import 'package:fushi/src/sync/pairing/fushi_pairing_protocol.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
+import 'package:fushi/src/sync/remote_lookup_routes.dart';
 import 'package:fushi_core/fushi_core.dart' show mimeTypeForFilePath;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -198,14 +199,16 @@ class FushiSyncServer {
   final Uint8List? Function(String dictionary, String path)?
       _dictionaryMediaProvider;
   final DateTime Function() _now;
-  final Map<String, _RemoteAudioToken> _remoteAudioTokens =
-      <String, _RemoteAudioToken>{};
 
-  /// BUG-908(a)：音频查词 token 的数量上限。POST 侧签发前先按 TTL prune、再淘汰最旧
-  /// 者收束到上限内（对照 [_maxPairSessions]）。只 POST /api/lookup/audio 却从不 GET
-  /// 取文件的调用者会让 [_remoteAudioTokens] 无界堆积（内存膨胀 DoS）——GET 侧的
-  /// [_pruneAudioTokens] 永远等不到，故上限必须在 POST 侧强制。
-  static const int _maxAudioTokens = 128;
+  /// 单词音频 token（TTL 5 分钟 + BUG-908(a) 上限 128）与查词/制卡端点的 handler
+  /// 正文都收在 [RemoteLookupRoutes]，与 YomitanApiServer 共用一份。
+  late final RemoteAudioTokenStore _audioTokens =
+      RemoteAudioTokenStore(now: _now);
+  late final RemoteLookupRoutes _lookupRoutes = RemoteLookupRoutes(
+    audioTokens: _audioTokens,
+    lookup: _remoteLookupService,
+    mining: _miningService,
+  );
 
   final Map<String, _VideoStreamToken> _videoStreamTokens =
       <String, _VideoStreamToken>{};
@@ -544,15 +547,15 @@ class FushiSyncServer {
     }
     if (reqPath == '/api/mine') {
       if (method != 'POST') return shelf.Response(405);
-      return _handleMine(request);
+      return _lookupRoutes.handleMine(request);
     }
     if (reqPath == '/api/mine/forward') {
       if (method != 'POST') return shelf.Response(405);
-      return _handleMineForward(request);
+      return _lookupRoutes.handleMineForward(request);
     }
     if (reqPath.startsWith('/api/anki/note-type/')) {
       if (method != 'POST') return shelf.Response(405);
-      return _handleAnkiNoteType(request, reqPath);
+      return _lookupRoutes.handleAnkiNoteType(request, reqPath);
     }
     if (reqPath.startsWith('/api/anki/media/dedup/')) {
       if (method != 'POST') return shelf.Response(405);
@@ -564,11 +567,11 @@ class FushiSyncServer {
     }
     if (reqPath == '/api/duplicate') {
       if (method != 'POST') return shelf.Response(405);
-      return _handleDuplicate(request);
+      return _lookupRoutes.handleDuplicate(request);
     }
     if (reqPath == '/api/extension/status') {
       if (method != 'POST') return shelf.Response(405);
-      return _jsonResponse(<String, dynamic>{
+      return jsonResponse(<String, dynamic>{
         'app': 'fushi',
         'ready': true,
         'port': port,
@@ -715,7 +718,7 @@ class FushiSyncServer {
     );
     if (v1PinRequired) return _pairDenied('upgrade_required');
     String? name;
-    final Map<String, dynamic>? body = await _readJsonObject(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final String? reported = body?['name']?.toString().trim();
     // Reject a "localhost"/loopback advertisement so it is never stored as this
     // peer's device name — the paired-devices list would otherwise show
@@ -730,7 +733,7 @@ class FushiSyncServer {
       remoteAddress: pairRemote,
     ));
     if (!approved) return _pairDenied('declined');
-    return _jsonResponse(<String, dynamic>{'token': _token});
+    return jsonResponse(<String, dynamic>{'token': _token});
   }
 
   /// A 403 carrying a machine-readable [reason] ('declined' | 'unavailable' |
@@ -753,7 +756,7 @@ class FushiSyncServer {
     if (request.method.toUpperCase() != 'POST') return shelf.Response(405);
     // No approval UI wired → never start a pairing handshake unattended.
     if (onPairRequest == null) return _pairDenied('unavailable');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final String? clientNonce = body?['clientNonce']?.toString();
     if (clientNonce == null || clientNonce.trim().isEmpty) {
       return shelf.Response(400, body: 'Missing clientNonce');
@@ -845,7 +848,7 @@ class FushiSyncServer {
     _pairSessions[sessionId] = stored;
 
     // 响应只含 sessionId / pinRequired / hostNonce —— 绝不含 PIN 明文。
-    return _jsonResponse(<String, dynamic>{
+    return jsonResponse(<String, dynamic>{
       'sessionId': sessionId,
       'pinRequired': pinRequired,
       'hostNonce': hostNonce,
@@ -859,7 +862,7 @@ class FushiSyncServer {
     if (request.method.toUpperCase() != 'POST') return shelf.Response(405);
     final Future<bool> Function(FushiPairRequest)? approve = onPairRequest;
     if (approve == null) return _pairDenied('unavailable');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final String? sessionId = body?['sessionId']?.toString();
     if (sessionId == null || sessionId.trim().isEmpty) {
       return shelf.Response(400, body: 'Missing sessionId');
@@ -959,7 +962,7 @@ class FushiSyncServer {
     // client。任一缺失（纯协议单测无 DB / 旧 client 不上报 deviceId）则回退共享
     // [_token]——既有行为零变化、老设备继续可配对（Never break userspace）。
     final String issuedToken = await _issuePeerTokenOrFallback(session);
-    return _jsonResponse(<String, dynamic>{
+    return jsonResponse(<String, dynamic>{
       'token': issuedToken,
       if (_securityContext != null && _hostFingerprint != null)
         'hostFingerprint': _hostFingerprint,
@@ -1035,11 +1038,11 @@ class FushiSyncServer {
     }
     if (reqPath == '/api/lookup/audio') {
       if (method != 'POST') return shelf.Response(405);
-      return _handleAudioLookup(request);
+      return _lookupRoutes.handleAudioLookup(request);
     }
     if (reqPath == '/api/lookup/audio/file') {
       if (method != 'GET' && method != 'HEAD') return shelf.Response(405);
-      return _handleAudioFile(request, method == 'HEAD');
+      return _lookupRoutes.handleAudioFile(request, headOnly: method == 'HEAD');
     }
     return shelf.Response.notFound('Not found');
   }
@@ -1047,76 +1050,15 @@ class FushiSyncServer {
   Future<shelf.Response> _handleDictionaryLookup(shelf.Request request) async {
     final FushiRemoteLookupService? service = _remoteLookupService;
     if (service == null) return shelf.Response.notFound('Remote lookup off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
     // 契约与 YomitanApiServer 共享（BUG-530，单一真相源）。
-    return _jsonResponse(await buildRemoteDictionaryLookupResponse(
+    return jsonResponse(await buildRemoteDictionaryLookupResponse(
       body,
       lookup: service,
       history: _historyService,
     ));
   }
-
-  Future<shelf.Response> _handleAudioLookup(shelf.Request request) async {
-    final FushiRemoteLookupService? service = _remoteLookupService;
-    if (service == null) return shelf.Response.notFound('Remote lookup off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-
-    final String expression = body['expression']?.toString() ?? '';
-    final String reading = body['reading']?.toString() ?? '';
-    if (expression.trim().isEmpty) return _audioMissResponse();
-
-    final RemoteAudioLookup? lookup = await service.lookupAudio(
-      expression: expression,
-      reading: reading,
-    );
-    if (lookup == null) return _audioMissResponse();
-
-    // BUG-908(a)：签发前先按 TTL 清过期，再把数量收束到 [_maxAudioTokens] 内（淘汰
-    // 最旧者）。否则只 POST 不 GET 的调用者会让 [_remoteAudioTokens] 无界膨胀——GET
-    // 侧的 [_pruneAudioTokens] 永远不会被触发。
-    _pruneAudioTokens();
-    _enforceAudioTokenCap();
-    final String id = _generateAudioToken();
-    _remoteAudioTokens[id] = _RemoteAudioToken(
-      bytes: lookup.bytes,
-      contentType: lookup.contentType,
-      createdAt: _now(),
-    );
-    final Uri url = request.requestedUri.replace(
-      path: '/api/lookup/audio/file',
-      queryParameters: <String, String>{'id': id},
-    );
-    return _jsonResponse(<String, dynamic>{
-      'type': 'audioResult',
-      'url': url.toString(),
-      'contentType': lookup.contentType,
-    });
-  }
-
-  shelf.Response _handleAudioFile(shelf.Request request, bool headOnly) {
-    _pruneAudioTokens();
-    final String? id = request.url.queryParameters['id'];
-    final _RemoteAudioToken? token = id == null ? null : _remoteAudioTokens[id];
-    if (token == null) return shelf.Response.notFound('Not found');
-    // TODO-766: 命中即续期。重置该 token 的时间戳，使其 5 分钟窗口从「最近一次被
-    // 访问」起算，正在使用中的音频不会中途被 [_pruneAudioTokens] 清掉。
-    token.createdAt = _now();
-    return shelf.Response.ok(
-      headOnly ? null : token.bytes,
-      headers: <String, String>{
-        'Content-Type': token.contentType,
-        'Content-Length': '${token.bytes.length}',
-      },
-    );
-  }
-
-  shelf.Response _audioMissResponse() => _jsonResponse(<String, dynamic>{
-        'type': 'audioResult',
-        'url': null,
-        'contentType': null,
-      });
 
   static bool _isDictionaryMediaPath(String urlPath) =>
       urlPath == 'api/media/dictionary';
@@ -1175,65 +1117,9 @@ class FushiSyncServer {
     );
   }
 
-  Future<shelf.Response> _handleMine(shelf.Request request) async {
-    final FushiRemoteMiningService? svc = _miningService;
-    if (svc == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    // 契约与 YomitanApiServer 共享（BUG-530，单一真相源）。fields 缺失/类型错 → 400。
-    try {
-      return _jsonResponse(await buildRemoteMineResponse(body, mining: svc));
-    } on FormatException {
-      return shelf.Response(400, body: 'Missing fields');
-    }
-  }
-
-  /// 互联「制卡到服务端」：客户端转发未渲染的制卡请求 + 全部媒体字节，本机用自己的 Anki
-  /// 配置落卡。契约与 YomitanApiServer 共享（buildForwardedMineResponse，单一真相源）。
-  /// rawPayloadJson 缺失/类型错 → 400；未注入挖词 service → 404。
-  Future<shelf.Response> _handleMineForward(shelf.Request request) async {
-    final FushiRemoteMiningService? svc = _miningService;
-    if (svc == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    try {
-      return _jsonResponse(await buildForwardedMineResponse(body, mining: svc));
-    } on FormatException {
-      return shelf.Response(400, body: 'Missing rawPayloadJson');
-    }
-  }
-
-  /// 互联 Lapis 客制化：客户端（手机 AnkiDroid 等无模板 API 的平台）经互联读写本机
-  /// Anki 的 note type（读定义 / 写 styling / 写卡模板）。契约与 YomitanApiServer 共享
-  /// （buildAnkiNoteType*Response，单一真相源）。未注入挖词 service → 404（旧版客户端
-  /// 不会打这些端点，旧版主机对新客户端返回 404 → 客户端按「后端不支持」降级）；
-  /// modelName/css/templates 缺失或类型错 → 400。
-  Future<shelf.Response> _handleAnkiNoteType(
-    shelf.Request request,
-    String path,
-  ) async {
-    final FushiRemoteMiningService? svc = _miningService;
-    if (svc == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    try {
-      switch (path) {
-        case '/api/anki/note-type/read':
-          return _jsonResponse(
-              await buildAnkiNoteTypeReadResponse(body, mining: svc));
-        case '/api/anki/note-type/styling':
-          return _jsonResponse(
-              await buildAnkiNoteTypeStylingResponse(body, mining: svc));
-        case '/api/anki/note-type/templates':
-          return _jsonResponse(
-              await buildAnkiNoteTypeTemplatesResponse(body, mining: svc));
-        default:
-          return shelf.Response.notFound('Unknown endpoint');
-      }
-    } on FormatException catch (e) {
-      return shelf.Response(400, body: e.message);
-    }
-  }
+  // /api/mine、/api/mine/forward、/api/anki/note-type/*、/api/duplicate、
+  // /api/lookup/audio[/file] 的 handler 正文在 [RemoteLookupRoutes]（与
+  // YomitanApiServer 共用）；本文件只留互联独有的端点。
 
   /// 互联媒体存储优化：客户端（手机）经互联对**主机端** collection.media 做字节级
   /// 去重——卡片落在主机的 Anki 上，重复媒体也堆在主机，客户端本机根本没有那个
@@ -1245,15 +1131,15 @@ class FushiSyncServer {
   ) async {
     final FushiRemoteMiningService? svc = _miningService;
     if (svc == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJsonObject(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
     try {
       switch (path) {
         case '/api/anki/media/dedup/probe':
-          return _jsonResponse(
+          return jsonResponse(
               await buildAnkiMediaDedupProbeResponse(mining: svc));
         case '/api/anki/media/dedup/run':
-          return _jsonResponse(
+          return jsonResponse(
               await buildAnkiMediaDedupRunResponse(body, mining: svc));
         default:
           return shelf.Response.notFound('Unknown endpoint');
@@ -1263,24 +1149,11 @@ class FushiSyncServer {
     }
   }
 
-  /// TODO-1176：浏览器扩展查词弹窗制卡按钮真查重（`+`→`✓`）。契约与 YomitanApiServer
-  /// 共享（单一真相源）。未注入挖词 service 时返回 `{duplicate:false}`（弹窗降级为「+」，
-  /// 绝不阻断查词）。
-  Future<shelf.Response> _handleDuplicate(shelf.Request request) async {
-    final FushiRemoteMiningService? svc = _miningService;
-    final Map<String, dynamic>? body = await _readJsonObject(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    if (svc == null) {
-      return _jsonResponse(<String, dynamic>{'duplicate': false});
-    }
-    return _jsonResponse(await buildRemoteDuplicateResponse(body, mining: svc));
-  }
-
   /// TODO-963 M2: 无鉴权轻量探测。手动输入 IP 的 client 在「填 IP → 探测 → 配对」流程
   /// 里用它确认地址可达、读 host 展示名 + 是否支持 v2 配对 + （TLS 开时）host 证书指纹
   /// 供 TOFU 钉扎。只读、不含任何数据/凭据。绝不回传 token。
   shelf.Response _handlePing() {
-    return _jsonResponse(<String, dynamic>{
+    return jsonResponse(<String, dynamic>{
       // 互联 wire 服务字段：与 client 侧 probeFushiPing 的 app == 'fushi'
       // 同版本对切（R11 已接受跨版本配对探测互不识别）。
       'app': 'fushi',
@@ -1299,7 +1172,7 @@ class FushiSyncServer {
     // 漫画 P3 能力协商：仅接线了 OCR 任务管理器的 host 带 `mangaOcr` 字段；老
     // host 响应里没有该字段 → client 隐藏「已配对主机」OCR 选项（零破坏）。
     final Map<String, Object?>? mangaOcr = await _mangaOcrJobs?.capability();
-    return _jsonResponse(<String, dynamic>{
+    return jsonResponse(<String, dynamic>{
       if (mangaOcr != null) 'mangaOcr': mangaOcr,
       'liveLibrary': <String, dynamic>{
         'dictionaries': lib,
@@ -1724,7 +1597,7 @@ class FushiSyncServer {
         case 'GET':
           final ({int delayMs, int updatedAtMs}) d =
               await delayHost.getAudiobookDelay(delayIdentity);
-          return _jsonResponse(<String, dynamic>{
+          return jsonResponse(<String, dynamic>{
             'delayMs': d.delayMs,
             'delayUpdatedAtMs': d.updatedAtMs,
           });
@@ -1923,7 +1796,7 @@ class FushiSyncServer {
         streamUrlId,
         episodeIndex,
       );
-      return _jsonResponse(<String, dynamic>{
+      return jsonResponse(<String, dynamic>{
         'url': streamUri.toString(),
         'subtitleUrl': subtitleUri?.toString(),
         if (sub != null) 'subtitleFileName': p.basename(sub.path),
@@ -2035,7 +1908,7 @@ class FushiSyncServer {
         case 'GET':
           final ({int positionMs, int updatedAtMs}) p = await svc
               .getVideoPosition(positionId, episodeIndex: episodeIndex);
-          return _jsonResponse(<String, dynamic>{
+          return jsonResponse(<String, dynamic>{
             'positionMs': p.positionMs,
             'positionUpdatedAtMs': p.updatedAtMs,
           });
@@ -2080,7 +1953,7 @@ class FushiSyncServer {
         case 'GET':
           final VideoPlaybackSyncState s =
               await playbackHost.getVideoPlayback(playbackId);
-          return _jsonResponse(s.toJson());
+          return jsonResponse(s.toJson());
         case 'PUT':
           final String body = await request.readAsString();
           Map<String, dynamic> json;
@@ -2416,7 +2289,7 @@ class FushiSyncServer {
           },
         );
       case 'PUT':
-        final Map<String, dynamic>? json = await _readJsonObject(request);
+        final Map<String, dynamic>? json = await readJsonObjectBody(request);
         if (json == null) return shelf.Response(400, body: 'Invalid JSON');
         // fromJson 容错：未知高版本 / 缺字段 / 坏行降级为空或跳过，绝不抛。
         final AggregateSnapshot snapshot = AggregateSnapshot.fromJson(json);
@@ -2459,7 +2332,7 @@ class FushiSyncServer {
           },
         );
       case 'POST':
-        final Map<String, dynamic>? json = await _readJsonObject(request);
+        final Map<String, dynamic>? json = await readJsonObjectBody(request);
         if (json == null) return shelf.Response(400, body: 'Invalid JSON');
         CollectionManifest incoming;
         try {
@@ -2564,7 +2437,7 @@ class FushiSyncServer {
     }
     try {
       final String name = await host.importInterconnectProfile(body);
-      return _jsonResponse(<String, dynamic>{'name': name});
+      return jsonResponse(<String, dynamic>{'name': name});
     } on FormatException catch (e) {
       // 载荷不是合法的 Profile 导出（魔数/版本/结构不对）：400，且 host 侧 DB 零改动
       // （解析在写库之前，见 ProfileRepository.parseProfileExport）。
@@ -2607,67 +2480,12 @@ class FushiSyncServer {
     );
   }
 
-  Future<Map<String, dynamic>?> _readJsonObject(shelf.Request request) async {
-    try {
-      final String body = await request.readAsString();
-      final dynamic decoded = jsonDecode(body);
-      if (decoded is Map<String, dynamic>) return decoded;
-      if (decoded is Map) return Map<String, dynamic>.from(decoded);
-    } catch (_) {
-      return null;
-    }
-    return null;
-  }
-
-  shelf.Response _jsonResponse(Map<String, dynamic> body) {
-    return shelf.Response.ok(
-      jsonEncode(body),
-      // TODO-752a：必须带 charset=utf-8。否则远程查词 client 用 package:http 的
-      // `.body` 读取时按 latin1 默认解码，CJK 词典义项/书名直接乱码。
-      headers: <String, String>{
-        'Content-Type': 'application/json; charset=utf-8'
-      },
-    );
-  }
-
-  String _generateAudioToken() {
-    final Random random = Random.secure();
-    final List<int> bytes = List<int>.generate(18, (_) => random.nextInt(256));
-    return base64UrlEncode(bytes);
-  }
-
-  void _pruneAudioTokens() {
-    final DateTime cutoff = _now().subtract(const Duration(minutes: 5));
-    _remoteAudioTokens.removeWhere(
-      (String _, _RemoteAudioToken token) => token.createdAt.isBefore(cutoff),
-    );
-  }
-
-  /// BUG-908(a)：守住音频 token 上限。TTL prune 之后仍达到 [_maxAudioTokens] 时，按
-  /// createdAt 淘汰最旧者直到回到上限内（对照 [_enforcePairSessionCap]）。签发前调用，
-  /// 使插入新 token 后总数 <= [_maxAudioTokens]。只 POST 不 GET 的膨胀攻击的兜底。
-  void _enforceAudioTokenCap() {
-    while (_remoteAudioTokens.length >= _maxAudioTokens) {
-      String? oldestKey;
-      DateTime? oldestAt;
-      for (final MapEntry<String, _RemoteAudioToken> e
-          in _remoteAudioTokens.entries) {
-        if (oldestAt == null || e.value.createdAt.isBefore(oldestAt)) {
-          oldestAt = e.value.createdAt;
-          oldestKey = e.key;
-        }
-      }
-      if (oldestKey == null) break;
-      _remoteAudioTokens.remove(oldestKey);
-    }
-  }
-
   /// BUG-908(a) 测试钩子：当前驻留的音频 token 数（验证 cap 逐出行为）。
   @visibleForTesting
-  int get remoteAudioTokenCount => _remoteAudioTokens.length;
+  int get remoteAudioTokenCount => _audioTokens.count;
 
   /// TODO-961 M1：清掉 [_pairSessionTtl] 之前创建的配对会话。对照
-  /// [_pruneAudioTokens] / [_pruneVideoTokens]：按 createdAt + 注入的 [_now] 判定，
+  /// [RemoteAudioTokenStore.prune] / [_pruneVideoTokens]：按 createdAt + 注入的 [_now] 判定，
   /// 可单测。在 pair/v2 创建与 confirm 两处调用，使过期会话既不堆积也不可被 confirm。
   void _prunePairSessions() {
     final DateTime cutoff = _now().subtract(_pairSessionTtl);
@@ -3157,21 +2975,6 @@ class _DavEntry {
   final bool isCollection;
   final String displayName;
   final int contentLength;
-}
-
-class _RemoteAudioToken {
-  _RemoteAudioToken({
-    required this.bytes,
-    required this.contentType,
-    required this.createdAt,
-  });
-
-  final Uint8List bytes;
-  final String contentType;
-
-  /// TODO-766: 不是 final——每次被 [_handleAudioFile] 命中都刷新，重置 5 分钟
-  /// 过期窗口，使「正在被访问」的音频 token 不会在使用途中过期（惠及播放与制卡）。
-  DateTime createdAt;
 }
 
 /// 视频流短时 token（P4-2）。

--- a/fushi/lib/src/sync/remote_lookup_routes.dart
+++ b/fushi/lib/src/sync/remote_lookup_routes.dart
@@ -1,0 +1,273 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
+import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
+import 'package:shelf/shelf.dart' as shelf;
+
+/// 单词音频短命 token：`/api/lookup/audio` 存字节、返回免鉴权的
+/// `/api/lookup/audio/file?id=` URL；命中即续期，TTL 内无访问后 prune。
+///
+/// `createdAt` 不是 final——每次被 [RemoteAudioTokenStore.take] 命中都刷新，重置
+/// 过期窗口，使「正在被访问」的音频 token 不会在使用途中过期（TODO-766）。
+class RemoteAudioToken {
+  RemoteAudioToken({
+    required this.bytes,
+    required this.contentType,
+    required this.createdAt,
+  });
+
+  final Uint8List bytes;
+  final String contentType;
+  DateTime createdAt;
+}
+
+/// 音频 token 的签发 / 取用 / 过期 / 上限，[FushiSyncServer] 与 [YomitanApiServer]
+/// 共用一份（原本两边各一份「同款模型」，且只有前者修了 BUG-908(a) 的上限）。
+///
+/// * TTL prune：[ttl] 内无访问的 token 被清掉；签发与取用前都先 prune。
+/// * 上限（BUG-908(a)）：prune 后仍达到 [maxTokens] 时按 createdAt 淘汰最旧者，
+///   使插入新 token 后总数 <= [maxTokens]。只 POST 不 GET 的调用者再也撑不爆内存。
+/// * [now] 可注入，测试用固定时钟验证 TTL 与逐出。
+class RemoteAudioTokenStore {
+  RemoteAudioTokenStore({
+    DateTime Function()? now,
+    this.maxTokens = 128,
+    this.ttl = const Duration(minutes: 5),
+  }) : _now = now ?? DateTime.now;
+
+  final DateTime Function() _now;
+  final int maxTokens;
+  final Duration ttl;
+  final Map<String, RemoteAudioToken> _tokens = <String, RemoteAudioToken>{};
+
+  /// 当前驻留的 token 数（验证 cap 逐出行为的测试钩子）。
+  int get count => _tokens.length;
+
+  /// 签发一个不可猜的 id 并存入字节；先 prune 再收束上限。
+  String mint(Uint8List bytes, String contentType) {
+    prune();
+    _enforceCap();
+    final String id = _generateId();
+    _tokens[id] = RemoteAudioToken(
+      bytes: bytes,
+      contentType: contentType,
+      createdAt: _now(),
+    );
+    return id;
+  }
+
+  /// 取 [id] 对应的 token；命中即续期。未命中 / [id] 为空返回 null。
+  RemoteAudioToken? take(String? id) {
+    prune();
+    final RemoteAudioToken? token = id == null ? null : _tokens[id];
+    if (token != null) token.createdAt = _now();
+    return token;
+  }
+
+  /// 清掉 [ttl] 之前最后一次被访问的 token。
+  void prune() {
+    final DateTime cutoff = _now().subtract(ttl);
+    _tokens.removeWhere(
+      (String _, RemoteAudioToken token) => token.createdAt.isBefore(cutoff),
+    );
+  }
+
+  void _enforceCap() {
+    while (_tokens.length >= maxTokens) {
+      String? oldestKey;
+      DateTime? oldestAt;
+      for (final MapEntry<String, RemoteAudioToken> e in _tokens.entries) {
+        if (oldestAt == null || e.value.createdAt.isBefore(oldestAt)) {
+          oldestAt = e.value.createdAt;
+          oldestKey = e.key;
+        }
+      }
+      if (oldestKey == null) break;
+      _tokens.remove(oldestKey);
+    }
+  }
+
+  static String _generateId() {
+    final Random random = Random.secure();
+    final List<int> bytes = List<int>.generate(18, (_) => random.nextInt(256));
+    return base64UrlEncode(bytes);
+  }
+}
+
+/// 读请求体为 JSON object；非法 JSON / 空体 / 非 object 一律 null，由调用方回 400。
+Future<Map<String, dynamic>?> readJsonObjectBody(shelf.Request request) async {
+  try {
+    final String raw = await request.readAsString();
+    if (raw.isEmpty) return null;
+    final dynamic decoded = jsonDecode(raw);
+    if (decoded is Map<String, dynamic>) return decoded;
+    if (decoded is Map) return Map<String, dynamic>.from(decoded);
+  } catch (_) {
+    // 客户端请求体非法 JSON：当作无 body 处理。
+  }
+  return null;
+}
+
+/// 200 + `application/json; charset=utf-8`。
+///
+/// TODO-752a：必须带 charset=utf-8。否则远程查词 client 用 package:http 的 `.body`
+/// 读取时按 latin1 默认解码，CJK 词典义项/书名直接乱码。[extraHeaders] 铺在前面，
+/// Content-Type 不可被覆盖。
+shelf.Response jsonRawResponse(
+  String body, {
+  Map<String, String> extraHeaders = const <String, String>{},
+}) =>
+    shelf.Response.ok(
+      body,
+      headers: <String, String>{
+        ...extraHeaders,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+    );
+
+shelf.Response jsonResponse(Object body) => jsonRawResponse(jsonEncode(body));
+
+/// 两台 HTTP 服务器（互联 host [FushiSyncServer]、浏览器扩展 [YomitanApiServer]）
+/// 共同服务的查词/制卡端点的 handler 正文。payload 契约本就共享在
+/// `fushi_remote_api_handlers.dart`（BUG-530 单一真相源）；这里再把「读体 → 404/400
+/// 门 → 调 builder → JSON 信封」这层壳也收成一份。
+///
+/// **不在这里的东西**（两边有真实差异，各留各的）：路由分发与 405 门、鉴权、
+/// `/api/lookup/dictionary`（扩展侧多下发主题/音频源/自动朗读/扩展版本/弹窗 CSS）、
+/// `/api/extension/status`（扩展侧上报扩展版本）、互联独有的 `/api/anki/media/dedup/*`
+/// 与 `/api/media/dictionary`。
+class RemoteLookupRoutes {
+  RemoteLookupRoutes({
+    required this.audioTokens,
+    this.lookup,
+    this.mining,
+  });
+
+  final RemoteAudioTokenStore audioTokens;
+  final FushiRemoteLookupService? lookup;
+  final FushiRemoteMiningService? mining;
+
+  /// 单词音频①：查到字节就签发 token，返回免鉴权的取字节 URL；未命中返回
+  /// `{url:null}`（弹窗降级为 ✕）。
+  Future<shelf.Response> handleAudioLookup(shelf.Request request) async {
+    final FushiRemoteLookupService? service = lookup;
+    if (service == null) return shelf.Response.notFound('Remote lookup off');
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+
+    final String expression = body['expression']?.toString() ?? '';
+    final String reading = body['reading']?.toString() ?? '';
+    if (expression.trim().isEmpty) return _audioMissResponse();
+
+    final RemoteAudioLookup? found = await service.lookupAudio(
+      expression: expression,
+      reading: reading,
+    );
+    if (found == null) return _audioMissResponse();
+
+    final String id = audioTokens.mint(found.bytes, found.contentType);
+    final Uri url = request.requestedUri.replace(
+      path: '/api/lookup/audio/file',
+      queryParameters: <String, String>{'id': id},
+    );
+    return jsonResponse(<String, dynamic>{
+      'type': 'audioResult',
+      'url': url.toString(),
+      'contentType': found.contentType,
+    });
+  }
+
+  /// 单词音频②：GET/HEAD `?id=` 取字节（免鉴权，靠不可猜 id）；命中即续期。
+  shelf.Response handleAudioFile(shelf.Request request,
+      {required bool headOnly}) {
+    final RemoteAudioToken? token =
+        audioTokens.take(request.url.queryParameters['id']);
+    if (token == null) return shelf.Response.notFound('Not found');
+    return shelf.Response.ok(
+      headOnly ? null : token.bytes,
+      headers: <String, String>{
+        'Content-Type': token.contentType,
+        'Content-Length': '${token.bytes.length}',
+      },
+    );
+  }
+
+  shelf.Response _audioMissResponse() => jsonResponse(<String, dynamic>{
+        'type': 'audioResult',
+        'url': null,
+        'contentType': null,
+      });
+
+  /// 制卡（BUG-530）。未注入挖词 service → 404；fields 缺失/类型错 → 400。
+  Future<shelf.Response> handleMine(shelf.Request request) async {
+    final FushiRemoteMiningService? svc = mining;
+    if (svc == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      return jsonResponse(await buildRemoteMineResponse(body, mining: svc));
+    } on FormatException {
+      return shelf.Response(400, body: 'Missing fields');
+    }
+  }
+
+  /// 「制卡到服务端」：客户端转发未渲染的制卡请求 + 全部媒体字节，本机用自己的
+  /// Anki 配置落卡。rawPayloadJson 缺失/类型错 → 400；未注入挖词 service → 404。
+  Future<shelf.Response> handleMineForward(shelf.Request request) async {
+    final FushiRemoteMiningService? svc = mining;
+    if (svc == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      return jsonResponse(await buildForwardedMineResponse(body, mining: svc));
+    } on FormatException {
+      return shelf.Response(400, body: 'Missing rawPayloadJson');
+    }
+  }
+
+  /// Lapis 客制化：客户端（手机 AnkiDroid 等无模板 API 的平台）读写本机 Anki 的
+  /// note type（读定义 / 写 styling / 写卡模板）。未注入挖词 service → 404（旧版主机
+  /// 对新客户端返回 404 → 客户端按「后端不支持」降级）；modelName/css/templates
+  /// 缺失或类型错 → 400；[path] 不是三者之一 → 404。
+  Future<shelf.Response> handleAnkiNoteType(
+    shelf.Request request,
+    String path,
+  ) async {
+    final FushiRemoteMiningService? svc = mining;
+    if (svc == null) return shelf.Response.notFound('Mining off');
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    try {
+      switch (path) {
+        case '/api/anki/note-type/read':
+          return jsonResponse(
+              await buildAnkiNoteTypeReadResponse(body, mining: svc));
+        case '/api/anki/note-type/styling':
+          return jsonResponse(
+              await buildAnkiNoteTypeStylingResponse(body, mining: svc));
+        case '/api/anki/note-type/templates':
+          return jsonResponse(
+              await buildAnkiNoteTypeTemplatesResponse(body, mining: svc));
+        default:
+          return shelf.Response.notFound('Unknown endpoint');
+      }
+    } on FormatException catch (e) {
+      return shelf.Response(400, body: e.message);
+    }
+  }
+
+  /// TODO-1176：查词弹窗制卡按钮真查重（`+`→`✓`）。未注入挖词 service 时返回
+  /// `{duplicate:false}`（弹窗降级为「+」，绝不阻断查词）；读体在判 service 之前，
+  /// 故非法 JSON 的 400 优先于降级。
+  Future<shelf.Response> handleDuplicate(shelf.Request request) async {
+    final FushiRemoteMiningService? svc = mining;
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
+    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
+    if (svc == null) {
+      return jsonResponse(<String, dynamic>{'duplicate': false});
+    }
+    return jsonResponse(await buildRemoteDuplicateResponse(body, mining: svc));
+  }
+}

--- a/fushi/lib/src/sync/yomitan_api_server.dart
+++ b/fushi/lib/src/sync/yomitan_api_server.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:shelf/shelf.dart' as shelf;
@@ -15,6 +13,7 @@ import 'package:fushi/src/media/video/youtube_source_resolver.dart'
     show resolveYoutubeCaptionsForExtension;
 import 'package:fushi/src/sync/fushi_remote_api_handlers.dart';
 import 'package:fushi/src/sync/remote_jimaku_subtitle_handlers.dart';
+import 'package:fushi/src/sync/remote_lookup_routes.dart';
 import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
 import 'package:fushi/src/sync/fushi_sync_server.dart'
     show SyncServerPortInUseException, isAddressInUseError;
@@ -169,10 +168,14 @@ class YomitanApiServer {
     }
   }
 
-  // 单词音频短命 token（与 FushiSyncServer 同款模型）：/api/lookup/audio 存字节、返
-  // 免鉴权的 /api/lookup/audio/file?id= URL；命中即续期，5 分钟无访问后 prune。
-  final Map<String, _YomitanAudioToken> _remoteAudioTokens =
-      <String, _YomitanAudioToken>{};
+  // 单词音频短命 token 与查词/制卡端点的 handler 正文收在 [RemoteLookupRoutes]，
+  // 与 FushiSyncServer 共用一份（TTL 5 分钟 + BUG-908(a) 上限 128）。
+  final RemoteAudioTokenStore _audioTokens = RemoteAudioTokenStore();
+  late final RemoteLookupRoutes _lookupRoutes = RemoteLookupRoutes(
+    audioTokens: _audioTokens,
+    lookup: _lookup,
+    mining: _mining,
+  );
 
   bool get isRunning => _server != null;
   int get port => _server?.port ?? _requestedPort;
@@ -286,7 +289,7 @@ class YomitanApiServer {
       if (method != 'GET' && method != 'HEAD') {
         return shelf.Response(405, body: 'Method Not Allowed');
       }
-      return _handleAudioFile(request, headOnly: method == 'HEAD');
+      return _lookupRoutes.handleAudioFile(request, headOnly: method == 'HEAD');
     }
     if (method != 'POST') {
       return shelf.Response(405, body: 'Method Not Allowed');
@@ -302,9 +305,9 @@ class YomitanApiServer {
     }
     switch (path) {
       case '/serverVersion':
-        return _json(<String, dynamic>{'version': 1});
+        return jsonResponse(<String, dynamic>{'version': 1});
       case '/yomitanVersion':
-        return _json(<String, dynamic>{'version': '0.0.0.0'});
+        return jsonResponse(<String, dynamic>{'version': '0.0.0.0'});
       case '/termEntries':
         return _handleTermEntries(request);
       case '/tokenize':
@@ -312,17 +315,17 @@ class YomitanApiServer {
       case '/api/lookup/dictionary':
         return _handleDictionaryLookup(request);
       case '/api/lookup/audio':
-        return _handleAudioLookup(request);
+        return _lookupRoutes.handleAudioLookup(request);
       case '/api/mine':
-        return _handleMine(request);
+        return _lookupRoutes.handleMine(request);
       case '/api/mine/forward':
-        return _handleMineForward(request);
+        return _lookupRoutes.handleMineForward(request);
       case '/api/anki/note-type/read':
       case '/api/anki/note-type/styling':
       case '/api/anki/note-type/templates':
-        return _handleAnkiNoteType(request, path);
+        return _lookupRoutes.handleAnkiNoteType(request, path);
       case '/api/duplicate':
-        return _handleDuplicate(request);
+        return _lookupRoutes.handleDuplicate(request);
       case '/api/extension/popup-size':
         return _handleExtensionPopupSize(request);
       case '/api/extension/status':
@@ -344,9 +347,9 @@ class YomitanApiServer {
   /// 逻辑在 [buildJimakuSearchResponse]（含真人剧 anime=false 补搜）；候选按 handle
   /// 暂存供 fetch。
   Future<shelf.Response> _handleJimakuSearch(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    return _json(await buildJimakuSearchResponse(
+    return jsonResponse(await buildJimakuSearchResponse(
       body,
       clientProvider: _jimakuClientFor,
       rememberCandidate: _rememberJimakuCandidate,
@@ -356,9 +359,9 @@ class YomitanApiServer {
   /// 「Jimaku 查字幕」扩展桥②下载+解析：body `{handle}`。响应与 `/api/subtitle/parse`
   /// 同形（`{format, cues:[...]}` + filename/language），扩展直接走既有 InstallTrack 落地。
   Future<shelf.Response> _handleJimakuFetch(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    return _json(await buildJimakuFetchResponse(
+    return jsonResponse(await buildJimakuFetchResponse(
       body,
       clientProvider: _jimakuClientFor,
       resolveCandidate: (String handle) => _jimakuCandidates[handle],
@@ -374,7 +377,7 @@ class YomitanApiServer {
   /// 有非空 build 时经 [_onExtensionReport] 记到 app 侧。旧扩展发 '{}' / 空 body /
   /// 非法 JSON 一律容错——不回调、不报错，响应与现状完全一致（向后兼容）。
   Future<shelf.Response> _handleExtensionStatus(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final Object? reportedBuild = body?['build'];
     if (reportedBuild is String && reportedBuild.isNotEmpty) {
       final Object? reportedVersion = body?['version'];
@@ -386,7 +389,7 @@ class YomitanApiServer {
       );
     }
     final String? extensionBuild = _extensionBuildProvider?.call();
-    return _json(<String, dynamic>{
+    return jsonResponse(<String, dynamic>{
       'app': 'fushi',
       'ready': true,
       'port': port,
@@ -398,7 +401,7 @@ class YomitanApiServer {
   Future<shelf.Response> _handleDictionaryLookup(shelf.Request request) async {
     final Stopwatch serverWatch = Stopwatch()..start();
     final Stopwatch requestJsonWatch = Stopwatch()..start();
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     requestJsonWatch.stop();
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
 
@@ -436,7 +439,7 @@ class YomitanApiServer {
             traceIdMatch.end == rawTraceId.length
         ? rawTraceId
         : null;
-    return _jsonRaw(
+    return jsonRawResponse(
       encoded,
       extraHeaders: <String, String>{
         'Server-Timing': _dictionaryLookupServerTiming(
@@ -454,74 +457,9 @@ class YomitanApiServer {
     );
   }
 
-  /// BUG-530：浏览器扩展制卡端点（与 FushiSyncServer 共享契约）。未注入挖词 service
-  /// 时 404（mining off）；fields 缺失/类型错 → 400。
-  Future<shelf.Response> _handleMine(shelf.Request request) async {
-    final FushiRemoteMiningService? mining = _mining;
-    if (mining == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJson(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    try {
-      return _json(await buildRemoteMineResponse(body, mining: mining));
-    } on FormatException {
-      return shelf.Response(400, body: 'Missing fields');
-    }
-  }
-
-  /// 互联「制卡到服务端」端点（与 FushiSyncServer 共享契约 buildForwardedMineResponse）。
-  /// 未注入挖词 service → 404；rawPayloadJson 缺失/类型错 → 400。
-  Future<shelf.Response> _handleMineForward(shelf.Request request) async {
-    final FushiRemoteMiningService? mining = _mining;
-    if (mining == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJson(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    try {
-      return _json(await buildForwardedMineResponse(body, mining: mining));
-    } on FormatException {
-      return shelf.Response(400, body: 'Missing rawPayloadJson');
-    }
-  }
-
-  /// 互联 Lapis 客制化端点（与 FushiSyncServer 共享契约 buildAnkiNoteType*Response）。
-  /// 手机端经互联读写主机 Anki 的 note type。未注入挖词 service → 404；
-  /// modelName/css/templates 缺失或类型错 → 400。
-  Future<shelf.Response> _handleAnkiNoteType(
-    shelf.Request request,
-    String path,
-  ) async {
-    final FushiRemoteMiningService? mining = _mining;
-    if (mining == null) return shelf.Response.notFound('Mining off');
-    final Map<String, dynamic>? body = await _readJson(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    try {
-      switch (path) {
-        case '/api/anki/note-type/read':
-          return _json(
-              await buildAnkiNoteTypeReadResponse(body, mining: mining));
-        case '/api/anki/note-type/styling':
-          return _json(
-              await buildAnkiNoteTypeStylingResponse(body, mining: mining));
-        default:
-          return _json(
-              await buildAnkiNoteTypeTemplatesResponse(body, mining: mining));
-      }
-    } on FormatException catch (e) {
-      return shelf.Response(400, body: e.message);
-    }
-  }
-
-  /// TODO-1176：浏览器扩展查词弹窗制卡按钮真查重端点（`+`→`✓`，与 FushiSyncServer 共享
-  /// 契约）。扩展默认指向本 server（19633），故这里是真正被命中的路径。未注入挖词 service
-  /// 时返回 `{duplicate:false}`（弹窗降级为「+」）。
-  Future<shelf.Response> _handleDuplicate(shelf.Request request) async {
-    final FushiRemoteMiningService? mining = _mining;
-    final Map<String, dynamic>? body = await _readJson(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    if (mining == null) {
-      return _json(<String, dynamic>{'duplicate': false});
-    }
-    return _json(await buildRemoteDuplicateResponse(body, mining: mining));
-  }
+  // /api/mine、/api/mine/forward、/api/anki/note-type/*、/api/duplicate、
+  // /api/lookup/audio[/file] 的 handler 正文在 [RemoteLookupRoutes]（与
+  // FushiSyncServer 共用）；扩展默认指向本 server（19633），故那是真正被命中的路径。
 
   /// A（BUG-783 后续）：浏览器扩展抓 YouTube 网页视频**真整集字幕**端点——复用 app 内已
   /// 修好的 `resolveYoutubeCaptionsForExtension`（androidVr getPlayerResponse + 现在认得
@@ -529,14 +467,14 @@ class YomitanApiServer {
   /// body：`{videoId 或 url, preferLang?}`。best-effort：无字幕/失败返回 `{tracks:[]}`（扩展
   /// 面板回落 live 采样，视频照看）。
   Future<shelf.Response> _handleYoutubeCaptions(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
     final Object? id = body['videoId'] ?? body['url'];
     if (id is! String || id.isEmpty) {
       return shelf.Response(400, body: 'Missing videoId');
     }
     final Object? lang = body['preferLang'];
-    return _json(await resolveYoutubeCaptionsForExtension(
+    return jsonResponse(await resolveYoutubeCaptionsForExtension(
       id,
       preferLang: lang is String && lang.isNotEmpty ? lang : 'ja',
     ));
@@ -546,14 +484,14 @@ class YomitanApiServer {
   /// srt/ass/vtt 文本 POST 上来，server 复用 app 内已测的 SRT/ASS/VTT parser 解析成 cue，扩展把
   /// cue 叠到当前网页视频。body：`{filename, content}`。不支持的扩展名回 `{error:'unsupported'}`。
   Future<shelf.Response> _handleSubtitleParse(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
     final Object? filename = body['filename'];
     final Object? content = body['content'];
     if (filename is! String || content is! String || filename.isEmpty) {
       return shelf.Response(400, body: 'Missing filename/content');
     }
-    return _json(
+    return jsonResponse(
         buildParsedSubtitleResponse(filename: filename, content: content));
   }
 
@@ -567,7 +505,7 @@ class YomitanApiServer {
       shelf.Request request) async {
     final void Function(double, double)? sink = _onExtensionPopupSize;
     if (sink == null) return shelf.Response.notFound('Popup size sink off');
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     if (body == null) return shelf.Response(400, body: 'Invalid JSON');
     final dynamic w = body['maxWidth'];
     final dynamic h = body['maxHeight'];
@@ -575,90 +513,20 @@ class YomitanApiServer {
       return shelf.Response(400, body: 'Missing maxWidth/maxHeight');
     }
     sink(w.toDouble(), h.toDouble());
-    return _json(<String, dynamic>{'ok': true});
-  }
-
-  /// 单词音频①解析：POST /api/lookup/audio {expression,reading}。用与 app 同一
-  /// [FushiRemoteLookupService.lookupAudio]（本地音频库）解析出字节，存进短命 token，
-  /// 返回免鉴权的 /api/lookup/audio/file?id= URL 供扩展 HTML5 Audio 直接播放。未命中
-  /// 返回 {url:null}（弹窗降级为 ✕，与 app 一致）。与 FushiSyncServer 同款实现。
-  Future<shelf.Response> _handleAudioLookup(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
-    if (body == null) return shelf.Response(400, body: 'Invalid JSON');
-    final String expression = body['expression']?.toString() ?? '';
-    final String reading = body['reading']?.toString() ?? '';
-    if (expression.trim().isEmpty) return _audioMissResponse();
-    final RemoteAudioLookup? lookup = await _lookup.lookupAudio(
-      expression: expression,
-      reading: reading,
-    );
-    if (lookup == null) return _audioMissResponse();
-    final String id = _generateAudioToken();
-    _remoteAudioTokens[id] = _YomitanAudioToken(
-      bytes: lookup.bytes,
-      contentType: lookup.contentType,
-      createdAt: DateTime.now(),
-    );
-    final Uri url = request.requestedUri.replace(
-      path: '/api/lookup/audio/file',
-      queryParameters: <String, String>{'id': id},
-    );
-    return _json(<String, dynamic>{
-      'type': 'audioResult',
-      'url': url.toString(),
-      'contentType': lookup.contentType,
-    });
-  }
-
-  /// 单词音频②取字节：GET /api/lookup/audio/file?id=（免鉴权，靠不可猜 id）。命中即续期
-  /// 5 分钟窗口，使正在播放的音频不会中途被 prune。
-  shelf.Response _handleAudioFile(shelf.Request request,
-      {required bool headOnly}) {
-    _pruneAudioTokens();
-    final String? id = request.url.queryParameters['id'];
-    final _YomitanAudioToken? token =
-        id == null ? null : _remoteAudioTokens[id];
-    if (token == null) return shelf.Response.notFound('Not found');
-    token.createdAt = DateTime.now();
-    return shelf.Response.ok(
-      headOnly ? null : token.bytes,
-      headers: <String, String>{
-        'Content-Type': token.contentType,
-        'Content-Length': '${token.bytes.length}',
-      },
-    );
-  }
-
-  shelf.Response _audioMissResponse() => _json(<String, dynamic>{
-        'type': 'audioResult',
-        'url': null,
-        'contentType': null,
-      });
-
-  String _generateAudioToken() {
-    final Random random = Random.secure();
-    final List<int> bytes = List<int>.generate(18, (_) => random.nextInt(256));
-    return base64UrlEncode(bytes);
-  }
-
-  void _pruneAudioTokens() {
-    final DateTime cutoff = DateTime.now().subtract(const Duration(minutes: 5));
-    _remoteAudioTokens.removeWhere(
-      (String _, _YomitanAudioToken token) => token.createdAt.isBefore(cutoff),
-    );
+    return jsonResponse(<String, dynamic>{'ok': true});
   }
 
   Future<shelf.Response> _handleTermEntries(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final dynamic term = body?['term'];
     if (term is List) {
       final List<Map<String, dynamic>> out = <Map<String, dynamic>>[];
       for (int i = 0; i < term.length; i++) {
         out.add(await _termEntriesFor(term[i]?.toString() ?? '', i));
       }
-      return _jsonRaw(jsonEncode(out));
+      return jsonRawResponse(jsonEncode(out));
     }
-    return _json(await _termEntriesFor(term?.toString() ?? '', 0));
+    return jsonResponse(await _termEntriesFor(term?.toString() ?? '', 0));
   }
 
   Future<Map<String, dynamic>> _termEntriesFor(String term, int index) async {
@@ -674,7 +542,7 @@ class YomitanApiServer {
   }
 
   Future<shelf.Response> _handleTokenize(shelf.Request request) async {
-    final Map<String, dynamic>? body = await _readJson(request);
+    final Map<String, dynamic>? body = await readJsonObjectBody(request);
     final dynamic text = body?['text'];
     if (text is List) {
       final List<Map<String, dynamic>> out = <Map<String, dynamic>>[];
@@ -686,26 +554,14 @@ class YomitanApiServer {
           readingOf: _readingResolver,
         ));
       }
-      return _jsonRaw(jsonEncode(out));
+      return jsonRawResponse(jsonEncode(out));
     }
-    return _json(buildYomitanTokenizeResponse(
+    return jsonResponse(buildYomitanTokenizeResponse(
       text: text?.toString() ?? '',
       index: 0,
       tokenize: _tokenizer,
       readingOf: _readingResolver,
     ));
-  }
-
-  Future<Map<String, dynamic>?> _readJson(shelf.Request request) async {
-    try {
-      final String raw = await request.readAsString();
-      if (raw.isEmpty) return null;
-      final dynamic decoded = jsonDecode(raw);
-      if (decoded is Map) return Map<String, dynamic>.from(decoded);
-    } catch (_) {
-      // 客户端请求体非法 JSON：当作无 body 处理，由调用方回 400。
-    }
-    return null;
   }
 
   String _dictionaryLookupServerTiming({
@@ -734,33 +590,4 @@ class YomitanApiServer {
       metric('server-total', serverTotalMicros),
     ].join(', ');
   }
-
-  shelf.Response _json(Object body) => _jsonRaw(jsonEncode(body));
-
-  shelf.Response _jsonRaw(
-    String body, {
-    Map<String, String> extraHeaders = const <String, String>{},
-  }) =>
-      shelf.Response.ok(
-        body,
-        headers: <String, String>{
-          ...extraHeaders,
-          'Content-Type': 'application/json; charset=utf-8',
-        },
-      );
-}
-
-/// 单词音频短命 token（[YomitanApiServer] 私有，镜像 FushiSyncServer 的同款模型）。
-/// createdAt 非 final——每次被 [YomitanApiServer._handleAudioFile] 命中即刷新，重置 5
-/// 分钟过期窗口，使正在被访问的音频不会中途过期。
-class _YomitanAudioToken {
-  _YomitanAudioToken({
-    required this.bytes,
-    required this.contentType,
-    required this.createdAt,
-  });
-
-  final Uint8List bytes;
-  final String contentType;
-  DateTime createdAt;
 }

--- a/fushi/test/sync/remote_lookup_routes_test.dart
+++ b/fushi/test/sync/remote_lookup_routes_test.dart
@@ -225,6 +225,24 @@ void main() {
       expect(
           await jsonResponse(<String, int>{'a': 1}).readAsString(), '{"a":1}');
     });
+
+    test('小写 content-type 同样不可覆盖（HTTP 头名大小写不敏感）', () async {
+      // 上一条只喂大写 'Content-Type'——那种情况下 Dart map 里是同一个键，靠后写
+      // 覆盖。传小写时 map 里是**两个**键，两条都进 shelf 的 CaseInsensitiveMap，
+      // 靠「显式那条排在展开之后」才赢。当前实现是对的（map 字面量迭代序 = 插入
+      // 序），但这条正确性完全押在写法顺序上：谁把 extraHeaders 挪到 Content-Type
+      // 后面展开、或者改成按精确键名 remove 再展开，小写这一路就会漏，而只喂大写
+      // 的上一条测不出来。这条就是补那个盲区的。
+      final shelf.Response r =
+          jsonRawResponse('{"a":1}', extraHeaders: <String, String>{
+        'content-type': 'text/plain',
+        'Server-Timing': 'lookup;dur=3',
+      });
+      expect(r.headers['content-type'], 'application/json; charset=utf-8',
+          reason: 'CJK 词典义项会被 client 按 latin1 解码成乱码（TODO-752a）');
+      expect(r.headers['server-timing'], 'lookup;dur=3',
+          reason: '剔除只能针对 content-type，别的透传头不能被误伤');
+    });
   });
 
   group('源码守卫：两台服务器不再各写一份 handler 壳 / 音频 token 模型', () {
@@ -250,23 +268,49 @@ void main() {
         '_handleAudioFile(',
         '_generateAudioToken(',
         '_pruneAudioTokens(',
-        'DateTime.now()',
+        'createdAt: DateTime.now()',
       ],
     };
+
+    // 正向断言必须是**调用点**。原来写的是 `contains('RemoteLookupRoutes')`，而两个
+    // 文件的注释里就写着这个类名——把六条分发全删光、只留注释，那条照样绿。
+    const List<String> callSites = <String>[
+      '_lookupRoutes.handleMine(',
+      '_lookupRoutes.handleMineForward(',
+      '_lookupRoutes.handleAnkiNoteType(',
+      '_lookupRoutes.handleDuplicate(',
+      '_lookupRoutes.handleAudioLookup(',
+      '_lookupRoutes.handleAudioFile(',
+    ];
 
     banned.forEach((String path, List<String> needles) {
       test(path, () {
         final File f = File(path);
         expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
         final String src = f.readAsStringSync();
-        expect(src, contains('RemoteLookupRoutes'),
-            reason: '$path 必须经 RemoteLookupRoutes 服务共享端点');
+        for (final String site in callSites) {
+          expect(src, contains(site),
+              reason: '$path 少了 `$site`——这条端点没走共享壳，'
+                  '要么被删了要么又被抄回本地一份');
+        }
         for (final String needle in needles) {
           expect(src, isNot(contains(needle)),
               reason:
                   '$path 里出现 `$needle`——共享壳应只在 remote_lookup_routes.dart 有一份');
         }
       });
+    });
+
+    test('音频 token 的 id 必须来自 Random.secure()', () {
+      // 这是整个 RemoteAudioTokenStore 唯一的安全属性：id 是能拿到任意查词音频的
+      // bearer。换成 Random()（时间种子、可预测）之后，长度断言、`isNot(b)`
+      // 断言、TTL 断言、上限断言**全部照绿**——没有任何别的测试会红。
+      final String src =
+          File('lib/src/sync/remote_lookup_routes.dart').readAsStringSync();
+      expect(src, contains('Random.secure()'),
+          reason: '音频 token id 是 bearer，必须用密码学随机源');
+      expect(src, isNot(contains('Random()')),
+          reason: '出现了可预测的 Random()：token 能被枚举出来');
     });
   });
 }

--- a/fushi/test/sync/remote_lookup_routes_test.dart
+++ b/fushi/test/sync/remote_lookup_routes_test.dart
@@ -1,0 +1,306 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/fushi_remote_lookup_service.dart';
+import 'package:fushi/src/sync/remote_lookup_routes.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'package:shelf/shelf.dart' as shelf;
+
+/// [FushiSyncServer] 与 [YomitanApiServer] 共用的查词/制卡 handler 壳与音频 token
+/// 存储。抽出前两边各一份，且只有互联侧修了 BUG-908(a) 的上限——合成一份后扩展侧
+/// 也有了上限（本文件把这条行为钉死）。两台服务器各自的 HTTP 级用例
+/// （`fushi_sync_server_*_test` / `yomitan_api_server_*_test`）继续覆盖分发与鉴权。
+void main() {
+  group('RemoteAudioTokenStore', () {
+    late DateTime clock;
+    late RemoteAudioTokenStore store;
+    final Uint8List mp3 = Uint8List.fromList(utf8.encode('MP3'));
+
+    setUp(() {
+      clock = DateTime(2026, 9, 6, 12);
+      store = RemoteAudioTokenStore(now: () => clock);
+    });
+
+    test('mint 后可 take；id 不可猜（24 字节 base64url）且每次不同', () {
+      final String a = store.mint(mp3, 'audio/mpeg');
+      final String b = store.mint(mp3, 'audio/mpeg');
+      expect(a, isNot(b));
+      expect(a.length, 24);
+      expect(store.take(a)?.contentType, 'audio/mpeg');
+      expect(store.take(null), isNull);
+      expect(store.take('nope'), isNull);
+    });
+
+    test('TTL：5 分钟无访问被 prune；命中即续期（TODO-766）', () {
+      final String id = store.mint(mp3, 'audio/mpeg');
+
+      clock = clock.add(const Duration(minutes: 4));
+      expect(store.take(id), isNotNull, reason: '4 分钟内命中 → 续期');
+
+      clock = clock.add(const Duration(minutes: 4));
+      expect(store.take(id), isNotNull, reason: '距上次命中 4 分钟 → 仍在窗口内（续期生效）');
+
+      clock = clock.add(const Duration(minutes: 5, seconds: 1));
+      expect(store.take(id), isNull, reason: '5 分钟无访问 → 过期');
+      expect(store.count, 0);
+    });
+
+    test('上限（BUG-908(a)）：时钟不动狂签发时按最旧逐出，总数 <= maxTokens', () {
+      final RemoteAudioTokenStore capped =
+          RemoteAudioTokenStore(now: () => clock, maxTokens: 4);
+      final List<String> ids = <String>[];
+      for (int i = 0; i < 10; i++) {
+        clock = clock.add(const Duration(seconds: 1));
+        ids.add(capped.mint(mp3, 'audio/mpeg'));
+      }
+      expect(capped.count, lessThanOrEqualTo(4));
+      expect(capped.take(ids.first), isNull, reason: '最旧的被逐出');
+      expect(capped.take(ids.last), isNotNull, reason: '最新的还在');
+    });
+
+    test('默认上限 128、TTL 5 分钟——与互联侧 BUG-908(a) 修复值一致', () {
+      final RemoteAudioTokenStore defaults = RemoteAudioTokenStore();
+      expect(defaults.maxTokens, 128);
+      expect(defaults.ttl, const Duration(minutes: 5));
+    });
+  });
+
+  group('RemoteLookupRoutes', () {
+    final Uint8List mp3 = Uint8List.fromList(utf8.encode('MP3'));
+
+    shelf.Request post(String path, Object? body) => shelf.Request(
+          'POST',
+          Uri.parse('http://127.0.0.1:1$path'),
+          body: body is String ? body : jsonEncode(body),
+        );
+
+    test('audio：查到即签发 token，URL 指向免鉴权取字节端点；取字节带长度头', () async {
+      final RemoteLookupRoutes routes = RemoteLookupRoutes(
+        audioTokens: RemoteAudioTokenStore(),
+        lookup: _StubLookup(mp3),
+      );
+
+      final shelf.Response res = await routes.handleAudioLookup(
+          post('/api/lookup/audio', {'expression': '猫', 'reading': 'ねこ'}));
+      expect(res.statusCode, 200);
+      expect(res.headers['content-type'], 'application/json; charset=utf-8');
+      final Map<String, dynamic> json =
+          jsonDecode(await res.readAsString()) as Map<String, dynamic>;
+      expect(json['type'], 'audioResult');
+      expect(json['contentType'], 'audio/mpeg');
+      final Uri url = Uri.parse(json['url'] as String);
+      expect(url.path, '/api/lookup/audio/file');
+      expect(url.queryParameters['id'], isNotEmpty);
+
+      final shelf.Response file = routes.handleAudioFile(
+        shelf.Request('GET', url),
+        headOnly: false,
+      );
+      expect(file.statusCode, 200);
+      expect(file.headers['content-type'], 'audio/mpeg');
+      expect(file.headers['content-length'], '3');
+      expect(await file.readAsString(), 'MP3');
+
+      final shelf.Response head = routes.handleAudioFile(
+        shelf.Request('HEAD', url),
+        headOnly: true,
+      );
+      expect(head.statusCode, 200);
+      expect(head.headers['content-length'], '3');
+    });
+
+    test('audio：空 expression / 未命中 → {url:null}；无 service → 404；非法 JSON → 400',
+        () async {
+      final RemoteLookupRoutes hit = RemoteLookupRoutes(
+        audioTokens: RemoteAudioTokenStore(),
+        lookup: _StubLookup(mp3),
+      );
+      final shelf.Response empty = await hit
+          .handleAudioLookup(post('/api/lookup/audio', {'expression': '  '}));
+      expect(jsonDecode(await empty.readAsString())['url'], isNull);
+
+      final RemoteLookupRoutes miss = RemoteLookupRoutes(
+        audioTokens: RemoteAudioTokenStore(),
+        lookup: _StubLookup(null),
+      );
+      final shelf.Response none = await miss
+          .handleAudioLookup(post('/api/lookup/audio', {'expression': '猫'}));
+      expect(jsonDecode(await none.readAsString())['url'], isNull);
+
+      final RemoteLookupRoutes off =
+          RemoteLookupRoutes(audioTokens: RemoteAudioTokenStore());
+      expect(
+          (await off.handleAudioLookup(
+                  post('/api/lookup/audio', {'expression': '猫'})))
+              .statusCode,
+          404);
+      expect(
+          (await hit.handleAudioLookup(post('/api/lookup/audio', '{not json')))
+              .statusCode,
+          400);
+      expect(
+          routes404(hit.handleAudioFile(
+              shelf.Request('GET', Uri.parse('http://h/api/lookup/audio/file')),
+              headOnly: false)),
+          isTrue);
+    });
+
+    test(
+        'mine / forward / note-type：无挖词 service → 404 Mining off；非法 JSON → 400',
+        () async {
+      final RemoteLookupRoutes off =
+          RemoteLookupRoutes(audioTokens: RemoteAudioTokenStore());
+      for (final Future<shelf.Response> f in <Future<shelf.Response>>[
+        off.handleMine(post('/api/mine', {})),
+        off.handleMineForward(post('/api/mine/forward', {})),
+        off.handleAnkiNoteType(
+            post('/api/anki/note-type/read', {}), '/api/anki/note-type/read'),
+      ]) {
+        final shelf.Response r = await f;
+        expect(r.statusCode, 404);
+        expect(await r.readAsString(), 'Mining off');
+      }
+
+      final RemoteLookupRoutes on = RemoteLookupRoutes(
+        audioTokens: RemoteAudioTokenStore(),
+        mining: _NeverCalledMining(),
+      );
+      for (final Future<shelf.Response> f in <Future<shelf.Response>>[
+        on.handleMine(post('/api/mine', '{bad')),
+        on.handleMineForward(post('/api/mine/forward', '')),
+        on.handleAnkiNoteType(post('/api/anki/note-type/read', '[1]'),
+            '/api/anki/note-type/read'),
+        on.handleDuplicate(post('/api/duplicate', 'null')),
+      ]) {
+        final shelf.Response r = await f;
+        expect(r.statusCode, 400);
+        expect(await r.readAsString(), 'Invalid JSON');
+      }
+    });
+
+    test('note-type：三条子路径之外 → 404 Unknown endpoint（不碰 service）', () async {
+      final RemoteLookupRoutes on = RemoteLookupRoutes(
+        audioTokens: RemoteAudioTokenStore(),
+        mining: _NeverCalledMining(),
+      );
+      final shelf.Response r = await on.handleAnkiNoteType(
+          post('/api/anki/note-type/bogus', {}), '/api/anki/note-type/bogus');
+      expect(r.statusCode, 404);
+      expect(await r.readAsString(), 'Unknown endpoint');
+    });
+
+    test('duplicate：无挖词 service 降级为 {duplicate:false}，但非法 JSON 的 400 优先',
+        () async {
+      final RemoteLookupRoutes off =
+          RemoteLookupRoutes(audioTokens: RemoteAudioTokenStore());
+      final shelf.Response r =
+          await off.handleDuplicate(post('/api/duplicate', {'term': '猫'}));
+      expect(r.statusCode, 200);
+      expect(jsonDecode(await r.readAsString()), {'duplicate': false});
+      expect(
+          (await off.handleDuplicate(post('/api/duplicate', '{'))).statusCode,
+          400);
+    });
+
+    test('readJsonObjectBody：空体 / 非 object / 非法 JSON 一律 null；object 原样返回',
+        () async {
+      expect(await readJsonObjectBody(post('/x', '')), isNull);
+      expect(await readJsonObjectBody(post('/x', '[1,2]')), isNull);
+      expect(await readJsonObjectBody(post('/x', '{')), isNull);
+      expect(await readJsonObjectBody(post('/x', {'a': 1})), {'a': 1});
+    });
+
+    test(
+        'jsonResponse / jsonRawResponse：utf-8 charset 不可被 extraHeaders 覆盖（TODO-752a）',
+        () async {
+      final shelf.Response r =
+          jsonRawResponse('{"a":1}', extraHeaders: <String, String>{
+        'Content-Type': 'text/plain',
+        'X-Extra': 'y',
+      });
+      expect(r.headers['content-type'], 'application/json; charset=utf-8');
+      expect(r.headers['x-extra'], 'y');
+      expect(
+          await jsonResponse(<String, int>{'a': 1}).readAsString(), '{"a":1}');
+    });
+  });
+
+  group('源码守卫：两台服务器不再各写一份 handler 壳 / 音频 token 模型', () {
+    const Map<String, List<String>> banned = <String, List<String>>{
+      'lib/src/sync/fushi_sync_server.dart': <String>[
+        'class _RemoteAudioToken',
+        'Future<shelf.Response> _handleMine(',
+        'Future<shelf.Response> _handleMineForward(',
+        'Future<shelf.Response> _handleAnkiNoteType(',
+        'Future<shelf.Response> _handleDuplicate(',
+        'Future<shelf.Response> _handleAudioLookup(',
+        '_handleAudioFile(',
+        '_generateAudioToken(',
+        '_pruneAudioTokens(',
+      ],
+      'lib/src/sync/yomitan_api_server.dart': <String>[
+        'class _YomitanAudioToken',
+        'Future<shelf.Response> _handleMine(',
+        'Future<shelf.Response> _handleMineForward(',
+        'Future<shelf.Response> _handleAnkiNoteType(',
+        'Future<shelf.Response> _handleDuplicate(',
+        'Future<shelf.Response> _handleAudioLookup(',
+        '_handleAudioFile(',
+        '_generateAudioToken(',
+        '_pruneAudioTokens(',
+        'DateTime.now()',
+      ],
+    };
+
+    banned.forEach((String path, List<String> needles) {
+      test(path, () {
+        final File f = File(path);
+        expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
+        final String src = f.readAsStringSync();
+        expect(src, contains('RemoteLookupRoutes'),
+            reason: '$path 必须经 RemoteLookupRoutes 服务共享端点');
+        for (final String needle in needles) {
+          expect(src, isNot(contains(needle)),
+              reason:
+                  '$path 里出现 `$needle`——共享壳应只在 remote_lookup_routes.dart 有一份');
+        }
+      });
+    });
+  });
+}
+
+bool routes404(shelf.Response r) => r.statusCode == 404;
+
+class _StubLookup implements FushiRemoteLookupService {
+  _StubLookup(this._bytes);
+
+  final Uint8List? _bytes;
+
+  @override
+  Future<RemoteAudioLookup?> lookupAudio({
+    required String expression,
+    required String reading,
+  }) async {
+    final Uint8List? b = _bytes;
+    return b == null
+        ? null
+        : RemoteAudioLookup(bytes: b, contentType: 'audio/mpeg');
+  }
+
+  @override
+  Future<DictionarySearchResult?> searchDictionary({
+    required String term,
+    required bool wildcards,
+    required int maximumTerms,
+  }) async =>
+      null;
+}
+
+/// 本文件只走 404/400/降级路径，任何触达 service 的调用都是错误。
+class _NeverCalledMining implements FushiRemoteMiningService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      fail('mining service must not be called: ${invocation.memberName}');
+}


### PR DESCRIPTION
## 同步/互联重构 PR3 · A3：两台服务器共享的查词/制卡 handler 壳 + 音频 token store

系列计划：`docs/plans/2026-09-06-sync-interconnect-refactor.md`（PR1 #1239、PR2 #1240）。

### 改了什么
- 新增 `fushi/lib/src/sync/remote_lookup_routes.dart`：
  - `RemoteAudioTokenStore`：单词音频短命 token 的签发 / 取用（命中即续期）/ TTL prune / 上限逐出，时钟可注入。原本 `FushiSyncServer` 与 `YomitanApiServer` 各一份「同款模型」。
  - `RemoteLookupRoutes`：`/api/lookup/audio[/file]`、`/api/mine`、`/api/mine/forward`、`/api/anki/note-type/*`、`/api/duplicate` 的 handler 正文（读体 → 404/400 门 → 调 `fushi_remote_api_handlers` 的 builder → JSON 信封）。
  - `readJsonObjectBody` / `jsonResponse` / `jsonRawResponse`：两边各一份的 JSON 读体与信封 helper（TODO-752a 的 `charset=utf-8` 不可覆盖）。
- `fushi_sync_server.dart`：删 `_RemoteAudioToken`、5 个 handler、token 生成/prune/cap、JSON helper；分发链改调 `_lookupRoutes.*`；`remoteAudioTokenCount` 测试钩子保留（转发 store）。
- `yomitan_api_server.dart`：删 `_YomitanAudioToken`、6 个 handler、token 生成/prune、`_readJson`/`_json`/`_jsonRaw`；`dart:math` / `dart:typed_data` import 随之删除。

### 有意不合的（两边有真实差异，各留各的）
- 路由分发与 405 门（互联侧裸 405、扩展侧带 body）、鉴权（Basic + peer token vs api-key 多来源）、`_onExtensionSeen` / `_onLookupActivity` 副作用。
- `/api/lookup/dictionary`：扩展侧多下发主题色 / 音频源 / 自动朗读 / 扩展版本 / 弹窗 CSS 并带 `Server-Timing`，互联侧只有 lookup+history。
- `/api/extension/status`：扩展侧读 body 上报扩展版本；互联侧只回 `{app, ready, port}`。
- 互联独有：`/api/anki/media/dedup/*`、`/api/media/dictionary`。

### 唯一一处行为变化（有意，已加测试）
`YomitanApiServer` 的音频 token 原本**只 prune 不设上限**、且用 `DateTime.now()`；互联侧早在 BUG-908(a) 修了 128 上限。合成一个 store 后扩展侧也有了同样的上限与最旧逐出——只 POST 不 GET 的调用者再也撑不爆内存。`remote_lookup_routes_test.dart` 钉死默认值 128 / 5 分钟与逐出行为。

### 测试
- 新增 `test/sync/remote_lookup_routes_test.dart`：store 4 条（签发/取用、TTL 与续期、上限逐出、默认值）+ routes 7 条（audio 签发→取字节→HEAD、audio 空/未命中/无 service/非法 JSON、mine/forward/note-type 的 404 与 400、note-type 未知子路径 404、duplicate 降级与 400 优先、读体、信封）+ 2 条源码守卫（两台服务器不得再各写一份）。
- 定向：`fushi_sync_server_{test,audio_token_refresh,hardening,mine,record,asset_gate}` / `yomitan_api_server_{test,extension_endpoints,status_report,manager}` / `interconnect_token_display_guard` / `interconnect_profile_transfer` / `pairing/pin_no_plaintext_guard` / `anki_note_type_response` / `anki_media_dedup_response` / `remote_lookup_auto_read` / `remote_lookup_dictionary_css` / `remote_mine_response_diagnostics` / `lookup/browser_extension_{lastseen_wiring,mine_duplicate,startup_version_check,update_stale}_guard` / `profile/media_type_binding_new_kinds_guard` / `build/browser_extension_{connection_heartbeat,dict_media_mirror}_guard` / `sync_obfuscation_factory_guard`。
- 全量 `flutter analyze`。

https://claude.ai/code/session_01WPbEes8famqLCXoUjHNLPn
