### PR TITLE
feat(settings): C0 子 schema 页 + 一等状态行——同步/互联 UI 排版重组的框架前置

### DIFF
--- a/docs/plans/2026-09-06-sync-ui-layout.md
+++ b/docs/plans/2026-09-06-sync-ui-layout.md
@@ -1,0 +1,91 @@
+# C · 同步/互联 UI 排版重组计划
+
+用户诉求：四类界面（设置页 / 同步对比对话框 / 手动同步面板与进度 / 互联配对与远程库）全部重做优化；痛点 **「一屏铺太长、分组乱」**，重点是设置的排版。
+原则：在现有 schema 化设置体系上改（不从零写、不换渲染器）；MD3 list-detail 不动（`docs/specs/2026-06-02-desktop-settings-md3-design.md` 已定案）；宽屏 detail 不设最大宽度（BUG-1643 用户决策）。
+
+## 现状（子代理盘点，file:line 见盘点原文）
+
+**同步与备份页**（`sync_settings_schema.dart:83`）4 节 / 22 项：
+```
+§同步方式   mode 选择器 | 账号状态(OAuth) | WebDAV 3 字段表单 | FTP 5 项表单 | SFTP 5 字段表单 | 互联指路行      ← 5 个按 backend 条件显隐
+§同步内容   auto_sync | statistics | 资产旧格式提示 | 词典 上传/下载 | 本地音频 上传/下载 | content | audiobook_files | video_files | show_remote_entries   ← 开关与动作行混排 11 项
+§操作       server_mode_note | 立即同步 | 对比
+§备份(折叠)  导出 | 导入 | 迁移(Android)
+```
+**互联页**（`:446`）7 节 / 19 项：
+```
+§(无题)     总开关
+§客户端     _FushiServerConfigWidget（~660 行：对端列表+排序+修复+删除+添加+token 折叠+测试）| _LanDiscoveryWidget
+§上传       content | dictionary | audiobook_files | video_files
+§共享       statistics | favorites
+§委托主机   mine_to_server | backup_backend | service_config_sync | profile 上传 | profile 下载
+§主机服务   _ServerModeWidget（开关+端口+TLS+token+复制/重生成+已配对列表）| profile_transfer_host
+§相关       远程查词 | 音频源 | 显示远程条目   ← 三个别处设置的镜像
+```
+问题的本质：**页面把"选择方式 / 填凭据 / 选内容 / 触发操作 / 管理设备 / 当主机"六种不同频率的事平铺在一层**；最高的三个 custom widget（对端列表、LAN 发现、主机服务）与一行开关同层排列，正是 BUG-037 说的高度悬殊来源。
+
+**框架可用原语**：`SettingsSection.collapsedByDefault`、`SettingsNavigationItem`（推任意页）、`SettingsCustomItem`；**没有**状态行/横幅/子 schema 页原语。子页现在只能推非 schema 的自定义页，其内容进不了设置搜索（只能靠 `bodySearchEntries` 手工登记——这是个特殊情况补丁）。
+
+## 方案
+
+### C0 · 框架：子页也是 schema（消除 bodySearchEntries 这个特殊情况）
+- `SettingsNavigationItem` 新增 `child: SettingsDestination Function()`；渲染器点进去推 `SettingsDetailPage(child())`（onboarding 已经这么推顶层页，`onboarding_wizard_page.dart:832`）。
+- `settings_search.dart` 索引时递归走 `child`，命中后先进父页再进子页并定位（复用 `SettingsSearchReveal.pendingItemId`）。
+- 新增 `SettingsStatusItem`（图标 + 标题 + 状态文本 + 可选动作按钮）替换现在 4 处用 `SettingsCustomItem` 手拼 `AdaptiveSettingsRow` 的状态/指路行（`sync.interconnect_config_note` / `sync.server_mode_note` / `sync.asset_legacy_notice` / `sync.account_status` 的展示部分）。
+- 守卫：`settings_schema_coverage_test`（焦点遍历）要能遍历进子页；`settings_schema_cache_test`（零参构造）对子页构造器同样成立。
+
+### C1 · 同步与备份页 → 两层
+```
+§同步方式      [mode 选择器]  [账号状态 / 服务器设置 ›]            ← 凭据表单挪进子页「服务器设置」，主页不再随 backend 伸缩
+§同步什么      statistics | content | audiobook_files | video_files | show_remote_entries      ← 五个同形态开关
+§何时同步      auto_sync | 立即同步 | 对比 | (server_mode_note 状态行)
+§资产传输      词典 [上传][下载] | 本地音频 [上传][下载] | 旧格式提示      ← 用户定：上传/下载不各占一行，合成一行两个按钮；压缩后留主页不进子页
+§备份与恢复 ›  子页：导出 | 导入 | 迁移
+```
+主页 5 节 ~12 项 + 2 个子页。`sync.mode` 等 id 不改（`settings_redesign_static_test` 钉 `sync.mode`/`sync.statistics`/`sync.dictionary_upload`/`sync.local_audio_download` 是 `SettingsCustomItem`——挪到子页仍满足）。
+
+### C2 · 互联页 → 两层
+```
+§(无题)        总开关 + footer
+§设备          [已配对 N 台 · 状态摘要]  配对与设备 ›     ← 子页：对端列表 + LAN 发现（两个最高的 widget）
+§作为主机      [主机服务 开关 + 端口/状态摘要]  主机服务 ›  ← 子页：端口 / TLS / token / 已配对 / profile_transfer_host
+§同步内容      content | dictionary | audiobook_files | video_files | statistics | favorites   ← 上传+共享合一组，footer 合并
+§委托主机      mine_to_server | backup_backend | service_config_sync | profile 上传/下载
+§相关设置      三个镜像改成 footer 文字链接（或删除，待定）
+```
+主页 6 节 ~13 项 + 2 个子页。`_FushiServerConfigWidget` / `_LanDiscoveryWidget` / `_ServerModeWidget` **代码不重写**，只是从主页挪到子页；主页摘要行是新的薄 widget（读同一份状态）。
+
+### C3 · 同步对比对话框
+- 三段（冲突 / 全部书籍 / 词典）改 sticky 段头 + 计数 chip；顶部加「只看冲突」过滤；批量选择菜单从溢出菜单提到段头右侧（现在藏在 `FushiOverflowMenu` 里）。
+- 每行的三态 segmented 保留；宽度上限 720 不动。
+
+### C4 · 手动同步反馈
+- 现状已是最小（1 行横幅 + 2px 进度；SnackBar），排版上没有"太长"问题。只做一件事：横幅文案接 `SettingsStatusItem` 同一套状态语义，保证设置页的状态行与库页横幅用词一致。若用户没有别的痛点，C4 可不做。
+
+### C5 · 远程库
+- 浏览远程库的 UI 内联在 `reader_history/remote.part.dart`（1199 行）和 `media_sources_view.dart`（1721 行），不在设置页；本轮**不动**（另立项）。配对流程已被 C2 的子页覆盖。
+
+## 前置：先拿基线截图
+- 用 `test/goldens/` 的 golden 机制渲染 `buildSyncBackupDestination()` / `buildInterconnectDestination()` 在 1280×800（宽屏两栏）与 400×800（窄屏）两档，作为改前基线；改后同样出图对比。比真机快、可进 CI。
+
+## 守卫更新清单（有意重钉）
+- `test/sync/sync_settings_visibility_test.dart`：两页节数 / 每节 id 顺序 / 可见性谓词——按新结构重写断言（这是布局的规格书，不是障碍）。
+- `test/settings/settings_schema_coverage_test.dart` / `settings_detail_scroll_stable_test` / `sync_settings_no_touch_scroll_test` / `sync_action_rows_focus_test`：渲染路径变了要复跑；子页要进覆盖遍历。
+- `md3_design_system_static_test`：新 `SettingsStatusItem` 的渲染要过它的 MD3 白名单。
+- `interconnect_*_guard_test`（token 折叠、客户端面板、配对入口）：源码扫描面从 `interconnect.part.dart` 变成子页文件，逐个改扫描路径。
+- onboarding 两处深链（`onboarding_wizard_page.dart:832/851`）与 `media_sources_view.dart:306` 的第二个互联开关：不受影响，但要复测。
+
+## PR 切分
+```
+PR-C0 框架：child 子页 + 搜索递归 + SettingsStatusItem   （不改任何 sync 页面，零视觉变化）
+PR-C1 同步与备份页重组                                    依赖 C0
+PR-C2 互联页重组                                          依赖 C0
+PR-C3 对比对话框                                          独立
+PR-C4 手动同步反馈（可选）
+```
+
+## 已拍板（2026-09-06）
+1. 互联页「相关设置」三个镜像 → footer 文字链接（可点跳转），不再重复渲染开关。
+2. 资产传输：上传/下载**不各占一行**——词典、本地音频各合成一行，行尾一个「传输 ▾」菜单按钮（上传 / 下载两项）。不用"一行两个按钮"：焦点模型是「一行 = 一个 FushiFocusTarget」（BUG-016，`actions.part.dart:17-20` 明文），两个按钮要给手柄/键盘开左右键特例；菜单让鼠标、键盘、手柄走同一条路径。压缩后留主页成节，不进子页。
+3. C4 不做。
+4. 基线/验收用 golden 渲染（1280×800 宽屏两栏 / 400×800 窄屏）。

--- a/fushi/integration_test/navigation_stability_test.dart
+++ b/fushi/integration_test/navigation_stability_test.dart
@@ -356,7 +356,9 @@ bool _settingsDestinationShown(SettingsDestinationId id) {
   final bool pushedDetail = find
       .byWidgetPredicate(
         (Widget widget) =>
-            widget is SettingsDetailPage && widget.destination.id == id,
+            // 子 schema 页（SettingsDetailPage.subPage）destination 为 null：
+            // 它不是某个顶层分类的详情，按身份判就不算。
+            widget is SettingsDetailPage && widget.destination?.id == id,
       )
       .evaluate()
       .isNotEmpty;

--- a/fushi/lib/src/settings/settings_destination.dart
+++ b/fushi/lib/src/settings/settings_destination.dart
@@ -295,17 +295,55 @@ class SettingsNavigationItem extends SettingsItem {
     super.titleBuilder,
     this.builder,
     this.onTap,
+    this.child,
     this.showIcon = false,
     super.subtitle,
     super.icon,
     super.visible,
     super.reader,
     super.video,
-  }) : assert(builder != null || onTap != null);
+  }) : assert(builder != null || onTap != null || child != null);
 
   final WidgetBuilder? builder;
   final SettingsItemAction? onTap;
+
+  /// 子 schema 页：点本行推一个与顶层分类同一套详情壳的 [SettingsDestination]
+  /// （`SettingsDetailPage.subPage`）。与 [builder] / [SettingsDestination.body]
+  /// 逃生口的区别：子页的行是真正的 schema item——进设置搜索索引（命中后先进父页
+  /// 再推子页定位）、进焦点覆盖遍历，不需要 `bodySearchEntries` 手工登记。
+  ///
+  /// 子页共用父分类的 [SettingsDestination.id]（枚举不为子页扩容）；它靠本闭包而非
+  /// id 取新鲜树，所以闭包必须是零参、构造期只读 i18n 常量（与顶层分类同一条
+  /// `settings_schema_cache_test` 纪律）。
+  final SettingsDestination Function()? child;
   final bool showIcon;
+}
+
+/// 只读状态行：图标 + 标题 + 状态文本 + 可选一个行尾动作按钮。
+///
+/// 存在的理由：设置页里「当前账号 / 服务在跑在哪个端口 / 此项已挪到别处」这类
+/// 指路与状态行此前只能用 [SettingsCustomItem] 手拼 `AdaptiveSettingsRow`——四处
+/// 各写一份、且默认进不了搜索。收成一等 item 后渲染、搜索、焦点遍历都走框架。
+/// 状态文本随运行期变化时用 [subtitleBuilder]；无动作时整行不可点。
+class SettingsStatusItem extends SettingsItem {
+  const SettingsStatusItem({
+    required super.id,
+    required super.title,
+    super.titleBuilder,
+    super.subtitle,
+    super.subtitleBuilder,
+    super.icon,
+    super.visible,
+    super.reader,
+    super.video,
+    this.actionLabel,
+    this.onAction,
+  }) : assert((actionLabel == null) == (onAction == null),
+            'actionLabel 与 onAction 必须同时给或同时不给');
+
+  /// 行尾动作按钮文案；null = 无按钮。
+  final String? actionLabel;
+  final SettingsItemAction? onAction;
 }
 
 class SettingsActionItem extends SettingsItem {

--- a/fushi/lib/src/settings/settings_detail_page.dart
+++ b/fushi/lib/src/settings/settings_detail_page.dart
@@ -36,11 +36,20 @@ Widget buildSettingsDetailShell({
 
 class SettingsDetailPage extends BasePage {
   const SettingsDetailPage({
-    required this.destination,
+    required SettingsDestination this.destination,
     super.key,
-  });
+  }) : subPageBuilder = null;
 
-  final SettingsDestination destination;
+  /// 子 schema 页（[SettingsNavigationItem.child]）：与顶层分类同一套详情壳，但
+  /// 新鲜树来自 [subPageBuilder] 而不是按 id 到顶层 schema 里找——子页共用父分类的
+  /// id，按 id 找会把父页渲染出来。
+  const SettingsDetailPage.subPage(
+    SettingsDestination Function() this.subPageBuilder, {
+    super.key,
+  }) : destination = null;
+
+  final SettingsDestination? destination;
+  final SettingsDestination Function()? subPageBuilder;
 
   @override
   BasePageState<SettingsDetailPage> createState() => _SettingsDetailPageState();
@@ -97,10 +106,13 @@ class _SettingsDetailPageState extends BasePageState<SettingsDetailPage>
   }
 
   SettingsDestination _freshDestination(SettingsContext settingsContext) {
+    final SettingsDestination Function()? subPage = widget.subPageBuilder;
+    if (subPage != null) return subPage();
+    final SettingsDestination top = widget.destination!;
     for (final SettingsDestination destination
         in buildSettingsSchema(settingsContext)) {
-      if (destination.id == widget.destination.id) return destination;
+      if (destination.id == top.id) return destination;
     }
-    return widget.destination;
+    return top;
   }
 }

--- a/fushi/lib/src/settings/settings_home_page.dart
+++ b/fushi/lib/src/settings/settings_home_page.dart
@@ -228,10 +228,20 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
       _searchQuery = '';
       if (wide) _selectedDestinationId = entry.destination.id;
     });
+    final NavigatorState navigator = Navigator.of(context);
     if (!wide) {
-      Navigator.of(context).push(
+      navigator.push(
         MaterialPageRoute<void>(
           builder: (_) => SettingsDetailPage(destination: entry.destination),
+        ),
+      );
+    }
+    // 子 schema 页里的命中：父页之上再逐级推子页，挂点由最里层页面的目标行消费。
+    for (final SettingsNavigationItem hop in entry.subPagePath) {
+      final SettingsDestination Function() child = hop.child!;
+      navigator.push(
+        MaterialPageRoute<void>(
+          builder: (_) => SettingsDetailPage.subPage(child),
         ),
       );
     }

--- a/fushi/lib/src/settings/settings_schema_widgets.dart
+++ b/fushi/lib/src/settings/settings_schema_widgets.dart
@@ -162,19 +162,32 @@ class SettingsSchemaItem extends StatelessWidget {
 
   Widget _status(SettingsStatusItem status) {
     final SettingsItemAction? onAction = status.onAction;
+    // 行级 onTap 让本行注册成 FushiFocusTarget，方向导航 / 手柄 A 才到得了
+    // （BUG-016）。`AdaptiveSettingsRow` 里 `if (onTap == null) return content;`
+    // ——没有 onTap 的行根本不包 _SettingsRowFocusTarget、不进 FushiFocusController
+    // 的注册表，而方向导航只走已注册目标。带行尾按钮却不给行级 onTap，键盘/手柄
+    // 用户从上一行按 Down 会**整行被跳过**，本面板下方再无目标时焦点还会跨 pane
+    // 落到左侧导航栏——BUG-016 实报的原症状。
+    //
+    // 纯状态行（onAction == null）**故意**不给 onTap：它没有可执行的动作，不该
+    // 成为焦点停靠点。
+    Future<void> runAction() async {
+      await onAction!(settingsContext);
+      settingsContext.refresh();
+    }
+
     return AdaptiveSettingsRow(
       // resolveTitle / resolveSubtitle：状态文本在渲染时求值（schema 树是缓存的常量树）。
       title: status.resolveTitle(settingsContext),
       subtitle: status.resolveSubtitle(settingsContext),
       icon: status.icon,
       showIcon: showIcons,
+      controlBelow: onAction != null,
+      onTap: onAction == null ? null : runAction,
       trailing: onAction == null
           ? null
           : FilledButton.tonal(
-              onPressed: () async {
-                await onAction(settingsContext);
-                settingsContext.refresh();
-              },
+              onPressed: runAction,
               child: Text(status.actionLabel!),
             ),
     );

--- a/fushi/lib/src/settings/settings_schema_widgets.dart
+++ b/fushi/lib/src/settings/settings_schema_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_detail_page.dart';
 import 'package:fushi/src/settings/settings_schema_fields.dart';
 import 'package:fushi/src/settings/settings_search.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
@@ -116,6 +117,7 @@ class SettingsSchemaItem extends StatelessWidget {
       SettingsStepperItem stepper => _stepper(stepper),
       SettingsTextItem text => _text(text),
       SettingsNumberItem number => _number(number),
+      SettingsStatusItem status => _status(status),
       SettingsCustomItem custom => custom.builder(settingsContext),
     };
     // 设置搜索跳转落点：本项是待定位目标时消费一次性挂点，包上滚动定位 +
@@ -142,10 +144,39 @@ class SettingsSchemaItem extends StatelessWidget {
           await navigation.onTap!(settingsContext);
           return;
         }
+        final SettingsDestination Function()? child = navigation.child;
+        if (child != null) {
+          // 子 schema 页：与顶层分类同一套详情壳；取新鲜树靠闭包而非 id。
+          Navigator.of(context).push(routeBuilder(
+            context,
+            (_) => SettingsDetailPage.subPage(child),
+          ));
+          return;
+        }
         final WidgetBuilder? builder = navigation.builder;
         if (builder == null) return;
         Navigator.of(context).push(routeBuilder(context, builder));
       },
+    );
+  }
+
+  Widget _status(SettingsStatusItem status) {
+    final SettingsItemAction? onAction = status.onAction;
+    return AdaptiveSettingsRow(
+      // resolveTitle / resolveSubtitle：状态文本在渲染时求值（schema 树是缓存的常量树）。
+      title: status.resolveTitle(settingsContext),
+      subtitle: status.resolveSubtitle(settingsContext),
+      icon: status.icon,
+      showIcon: showIcons,
+      trailing: onAction == null
+          ? null
+          : FilledButton.tonal(
+              onPressed: () async {
+                await onAction(settingsContext);
+                settingsContext.refresh();
+              },
+              child: Text(status.actionLabel!),
+            ),
     );
   }
 

--- a/fushi/lib/src/settings/settings_search.dart
+++ b/fushi/lib/src/settings/settings_search.dart
@@ -26,15 +26,22 @@ class SettingsSearchEntry {
     required this.item,
     this.sectionTitle,
     this.isBodyEntry = false,
+    this.subPagePath = const <SettingsNavigationItem>[],
     String? resolvedTitle,
   }) : _resolvedTitle = resolvedTitle;
 
   /// 展平时就地求好的标题（带 [SettingsItem.titleBuilder] 的行才有意义）。
   final String? _resolvedTitle;
 
+  /// 所属**顶层**分类（子页里的行也指向其顶层分类——宽屏切换主从选中、窄屏
+  /// push 详情页都以它为起点）。
   final SettingsDestination destination;
   final String? sectionTitle;
   final SettingsItem item;
+
+  /// 从顶层分类走到 [item] 所在页要依次推入的子页（[SettingsNavigationItem.child]
+  /// 链）；空 = 行就在顶层分类里。
+  final List<SettingsNavigationItem> subPagePath;
 
   /// true = 由 [SettingsDestination.bodySearchEntries] 合成（body 逃生口正文
   /// 里的行）。命中后只跳转分类，不登记滚动定位挂点——body 行不是 schema item，
@@ -73,19 +80,14 @@ List<SettingsSearchEntry> flattenVisibleSettings(
   final List<SettingsSearchEntry> entries = <SettingsSearchEntry>[];
   for (final SettingsDestination destination in destinations) {
     if (!destination.isVisible(context)) continue;
-    for (final SettingsSection section
-        in destination.visibleSections(context)) {
-      for (final SettingsItem item in section.items) {
-        final String title = settingsItemSearchTitle(item, context);
-        if (title.isEmpty) continue;
-        entries.add(SettingsSearchEntry(
-          destination: destination,
-          sectionTitle: section.title,
-          item: item,
-          resolvedTitle: title,
-        ));
-      }
-    }
+    _flattenPageInto(
+      entries,
+      root: destination,
+      page: destination,
+      context: context,
+      subPagePath: const <SettingsNavigationItem>[],
+      pageTitle: null,
+    );
     // body 逃生口正文（如「制卡」的 AnkiSettingsBody）不走 sections，索引器
     // 看不见其中的行；把 destination 声明的 bodySearchEntries 合成为普通搜索
     // 条目（复用 custom 项的 searchTitle 通道），命中后跳转到该分类正文。
@@ -105,6 +107,53 @@ List<SettingsSearchEntry> flattenVisibleSettings(
     }
   }
   return entries;
+}
+
+/// 展平一页（顶层分类或子页）的可见行；遇到带 [SettingsNavigationItem.child] 的
+/// 导航行就递归进子页——子页的行也是 schema item，与顶层行同等进索引，面包屑
+/// 变成「分类 › 子页 › 分区」。
+void _flattenPageInto(
+  List<SettingsSearchEntry> entries, {
+  required SettingsDestination root,
+  required SettingsDestination page,
+  required SettingsContext context,
+  required List<SettingsNavigationItem> subPagePath,
+  required String? pageTitle,
+}) {
+  for (final SettingsSection section in page.visibleSections(context)) {
+    final String? sectionTitle = _joinBreadcrumb(pageTitle, section.title);
+    for (final SettingsItem item in section.items) {
+      final String title = settingsItemSearchTitle(item, context);
+      if (title.isNotEmpty) {
+        entries.add(SettingsSearchEntry(
+          destination: root,
+          sectionTitle: sectionTitle,
+          item: item,
+          resolvedTitle: title,
+          subPagePath: subPagePath,
+        ));
+      }
+      if (item is! SettingsNavigationItem) continue;
+      final SettingsDestination Function()? childBuilder = item.child;
+      if (childBuilder == null) continue;
+      final SettingsDestination child = childBuilder();
+      if (!child.isVisible(context)) continue;
+      _flattenPageInto(
+        entries,
+        root: root,
+        page: child,
+        context: context,
+        subPagePath: <SettingsNavigationItem>[...subPagePath, item],
+        pageTitle: _joinBreadcrumb(pageTitle, child.title),
+      );
+    }
+  }
+}
+
+String? _joinBreadcrumb(String? head, String? tail) {
+  if (head == null || head.isEmpty) return tail;
+  if (tail == null || tail.isEmpty) return head;
+  return '$head › $tail';
 }
 
 /// 纯过滤：大小写不敏感子串匹配，命中位置决定排序权重

--- a/fushi/lib/src/settings/settings_search.dart
+++ b/fushi/lib/src/settings/settings_search.dart
@@ -109,6 +109,9 @@ List<SettingsSearchEntry> flattenVisibleSettings(
   return entries;
 }
 
+/// 子页最大嵌套层数（见 [_flattenPageInto] 里为什么必须有上限）。
+const int _kSubPageMaxDepth = 3;
+
 /// 展平一页（顶层分类或子页）的可见行；遇到带 [SettingsNavigationItem.child] 的
 /// 导航行就递归进子页——子页的行也是 schema item，与顶层行同等进索引，面包屑
 /// 变成「分类 › 子页 › 分区」。
@@ -136,6 +139,18 @@ void _flattenPageInto(
       if (item is! SettingsNavigationItem) continue;
       final SettingsDestination Function()? childBuilder = item.child;
       if (childBuilder == null) continue;
+      // 深度上限：`child` 是闭包，每次调用返回**新实例**，所以基于 identical 的
+      // 环检测无效。A 的子页是 B、B 的子页又是 A 这种写法会让索引器在用户往搜索框
+      // 敲第一个字符时直接栈溢出（`_buildSearchResults` 每次击键都重新展平）。
+      // 三层已经远超现有形态（分类 › 子页 › 子页）。
+      if (subPagePath.length >= _kSubPageMaxDepth) {
+        assert(
+          false,
+          '设置子页嵌套超过 $_kSubPageMaxDepth 层：'
+          '要么 schema 真的这么深，要么 child 闭包成了环',
+        );
+        continue;
+      }
       final SettingsDestination child = childBuilder();
       if (!child.isVisible(context)) continue;
       _flattenPageInto(

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -941,7 +941,8 @@ void main() {
               readerSource: ReaderFushiSource.instance,
               refresh: () {},
             );
-            final List<SettingsDestination> all = buildSettingsSchema(sctx);
+            final List<SettingsDestination> all =
+                _withSubPages(buildSettingsSchema(sctx));
             destinations = all;
             return ValueListenableBuilder<SettingsDestination?>(
               valueListenable: destNotifier,
@@ -1322,4 +1323,38 @@ class _CoverageAppModel extends AppModel {
 
   @override
   PackageInfo get packageInfo => _packageInfo;
+}
+
+/// 顶层 destination + 它们经 [SettingsNavigationItem.child] 挂出来的**子 schema 页**。
+///
+/// C0 引入子页之后，本 harness 如果只枚举 `buildSettingsSchema()` 的顶层结果，
+/// 那么 C1/C2 把同步/互联的行搬进子页的那一刻，这些行就**静默退出**了覆盖面——
+/// 测试照样绿，只是少测了 N 行。而本文件头部写的契约恰恰是「no silent caps：
+/// 每个 changed 但未 effect-verified 的设置都必须有去处」，静默缩小枚举面正是
+/// 它要防的事。
+///
+/// 子页复用 [SettingsDetailPage] 同一套详情壳，所以在这里把它们展平成同级
+/// destination 喂给同一个渲染 + Tab 遍历循环即可（子页共用父分类的 id，
+/// `probeFor(dest.id)` 因此继续命中父分类的探针）。
+///
+/// 深度上限 3：`child` 是闭包，每次调用返回新实例，基于 identical 的环检测无效，
+/// A→B→A 这种写法会直接栈溢出。
+List<SettingsDestination> _withSubPages(List<SettingsDestination> tops) {
+  final List<SettingsDestination> out = <SettingsDestination>[];
+  void visit(SettingsDestination destination, int depth) {
+    out.add(destination);
+    if (depth >= 3) return;
+    for (final SettingsSection section in destination.sections) {
+      for (final SettingsItem item in section.items) {
+        if (item is SettingsNavigationItem && item.child != null) {
+          visit(item.child!(), depth + 1);
+        }
+      }
+    }
+  }
+
+  for (final SettingsDestination destination in tops) {
+    visit(destination, 0);
+  }
+  return out;
 }

--- a/fushi/test/settings/settings_subpage_schema_test.dart
+++ b/fushi/test/settings/settings_subpage_schema_test.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/media/sources/reader_fushi_source.dart';
+import 'package:fushi/src/settings/settings_context.dart';
+import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_detail_page.dart';
+import 'package:fushi/src/settings/settings_schema_widgets.dart';
+import 'package:fushi/src/settings/settings_search.dart';
+import 'package:fushi/src/utils/components/settings_shared.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// C0（同步/互联 UI 排版重组的框架前置）：
+/// * [SettingsNavigationItem.child] 子 schema 页——行是真正的 schema item，进搜索、
+///   进覆盖遍历，不再靠 `bodySearchEntries` 手工登记（消掉那个特殊情况）。
+/// * [SettingsStatusItem] 一等状态行——替换四处手拼的 `SettingsCustomItem`。
+void main() {
+  late SettingsContext sctx;
+  int refreshes = 0;
+
+  Future<void> pumpContext(WidgetTester tester, {Widget? child}) async {
+    refreshes = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: Consumer(
+              builder: (BuildContext context, WidgetRef ref, _) {
+                sctx = SettingsContext(
+                  context: context,
+                  appModel: _TestAppModel(),
+                  ref: ref,
+                  readerSource: ReaderFushiSource.instance,
+                  refresh: () => refreshes++,
+                );
+                return child ?? const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  SettingsDestination childPage({bool visible = true}) => SettingsDestination(
+        id: SettingsDestinationId.syncBackup,
+        title: '子页',
+        icon: Icons.folder_outlined,
+        visible: (_) => visible,
+        sections: <SettingsSection>[
+          SettingsSection(
+            title: '分区',
+            items: <SettingsItem>[
+              SettingsSwitchItem(
+                id: 'c.x',
+                title: '子页开关',
+                value: (_) => true,
+                onChanged: (_, __) {},
+              ),
+            ],
+          ),
+          SettingsSection(
+            items: <SettingsItem>[
+              const SettingsStatusItem(
+                id: 'c.status',
+                title: '状态行',
+                subtitle: '正在运行',
+              ),
+            ],
+          ),
+        ],
+      );
+
+  SettingsNavigationItem navTo(SettingsDestination Function() child) =>
+      SettingsNavigationItem(id: 'p.sub', title: '进入子页', child: child);
+
+  SettingsDestination parentPage(SettingsNavigationItem nav) =>
+      SettingsDestination(
+        id: SettingsDestinationId.syncBackup,
+        title: 'Parent',
+        icon: Icons.sync,
+        sections: <SettingsSection>[
+          SettingsSection(
+            title: 'A',
+            items: <SettingsItem>[
+              SettingsSwitchItem(
+                id: 'p.a',
+                title: '父页开关',
+                value: (_) => true,
+                onChanged: (_, __) {},
+              ),
+              nav,
+            ],
+          ),
+        ],
+      );
+
+  group('搜索索引递归进子页', () {
+    testWidgets('子页的行进索引：destination 指顶层、subPagePath 记链、面包屑带子页名',
+        (WidgetTester tester) async {
+      await pumpContext(tester);
+      final SettingsNavigationItem nav = navTo(childPage);
+      final SettingsDestination parent = parentPage(nav);
+
+      final List<SettingsSearchEntry> entries =
+          flattenVisibleSettings(<SettingsDestination>[parent], sctx);
+
+      expect(entries.map((SettingsSearchEntry e) => e.item.id),
+          <String>['p.a', 'p.sub', 'c.x', 'c.status']);
+      final SettingsSearchEntry cx =
+          entries.firstWhere((SettingsSearchEntry e) => e.item.id == 'c.x');
+      expect(identical(cx.destination, parent), isTrue);
+      expect(cx.subPagePath, <SettingsNavigationItem>[nav]);
+      expect(cx.sectionTitle, '子页 › 分区');
+      expect(settingsSearchBreadcrumb(cx), 'Parent › 子页 › 分区');
+      final SettingsSearchEntry status = entries
+          .firstWhere((SettingsSearchEntry e) => e.item.id == 'c.status');
+      expect(status.sectionTitle, '子页', reason: '无题分区只显示子页名');
+      expect(status.title, '状态行', reason: '状态行默认可搜');
+      // 顶层行的既有语义不变：无路径、分区名原样。
+      final SettingsSearchEntry pa =
+          entries.firstWhere((SettingsSearchEntry e) => e.item.id == 'p.a');
+      expect(pa.subPagePath, isEmpty);
+      expect(pa.sectionTitle, 'A');
+    });
+
+    testWidgets('子页 visible=false：导航行仍可搜，子页里的行不进索引',
+        (WidgetTester tester) async {
+      await pumpContext(tester);
+      final SettingsDestination parent =
+          parentPage(navTo(() => childPage(visible: false)));
+
+      final List<String> ids =
+          flattenVisibleSettings(<SettingsDestination>[parent], sctx)
+              .map((SettingsSearchEntry e) => e.item.id)
+              .toList();
+
+      expect(ids, <String>['p.a', 'p.sub']);
+    });
+
+    testWidgets('子页里再套子页：路径按进入顺序累积', (WidgetTester tester) async {
+      await pumpContext(tester);
+      final SettingsNavigationItem inner = navTo(childPage);
+      final SettingsNavigationItem outer = SettingsNavigationItem(
+        id: 'p.mid',
+        title: '中间页',
+        child: () => SettingsDestination(
+          id: SettingsDestinationId.syncBackup,
+          title: '中间',
+          icon: Icons.layers_outlined,
+          sections: <SettingsSection>[
+            SettingsSection(items: <SettingsItem>[inner]),
+          ],
+        ),
+      );
+      final SettingsDestination parent = parentPage(outer);
+
+      final SettingsSearchEntry cx =
+          flattenVisibleSettings(<SettingsDestination>[parent], sctx)
+              .firstWhere((SettingsSearchEntry e) => e.item.id == 'c.x');
+
+      expect(cx.subPagePath, <SettingsNavigationItem>[outer, inner]);
+      expect(cx.sectionTitle, '中间 › 子页 › 分区');
+    });
+  });
+
+  group('渲染', () {
+    testWidgets('带 child 的导航行：点击推 SettingsDetailPage.subPage（不是 builder 页）',
+        (WidgetTester tester) async {
+      WidgetBuilder? pushed;
+      await pumpContext(
+        tester,
+        child: Builder(
+          builder: (BuildContext context) => SettingsSchemaItem(
+            item: navTo(childPage),
+            settingsContext: sctx,
+            showIcons: false,
+            routeBuilder: (BuildContext ctx, WidgetBuilder builder) {
+              pushed = builder;
+              return MaterialPageRoute<void>(
+                  builder: (_) => const SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('进入子页'));
+      await tester.pump();
+
+      expect(pushed, isNotNull, reason: '导航行必须经 routeBuilder 推页');
+      final Widget page = pushed!(tester.element(find.byType(Scaffold)));
+      expect(page, isA<SettingsDetailPage>());
+      final SettingsDetailPage detail = page as SettingsDetailPage;
+      expect(detail.destination, isNull);
+      expect(detail.subPageBuilder, isNotNull);
+      expect(detail.subPageBuilder!().title, '子页');
+    });
+
+    testWidgets('状态行：标题 + 运行期副标题；无动作时不渲染按钮', (WidgetTester tester) async {
+      int port = 41000;
+      await pumpContext(
+        tester,
+        // sctx 在 Consumer 构建时才赋值：行必须在其之后的 Builder 里构造。
+        child: Builder(
+          builder: (BuildContext context) => SettingsSchemaItem(
+            item: SettingsStatusItem(
+              id: 's',
+              title: '主机服务',
+              subtitleBuilder: (_) => '端口 $port',
+            ),
+            settingsContext: sctx,
+            showIcons: false,
+            routeBuilder: (_, WidgetBuilder b) =>
+                MaterialPageRoute<void>(builder: b),
+          ),
+        ),
+      );
+
+      expect(find.byType(AdaptiveSettingsRow), findsOneWidget);
+      expect(find.text('主机服务'), findsOneWidget);
+      expect(find.text('端口 41000'), findsOneWidget);
+      expect(find.byType(FilledButton), findsNothing);
+    });
+
+    testWidgets('状态行：有动作时渲染行尾按钮，点击调 onAction 并 refresh',
+        (WidgetTester tester) async {
+      int calls = 0;
+      await pumpContext(
+        tester,
+        child: Builder(
+          builder: (BuildContext context) => SettingsSchemaItem(
+            item: SettingsStatusItem(
+              id: 's',
+              title: '账号',
+              subtitle: 'user@example.com',
+              actionLabel: '退出',
+              onAction: (_) async => calls++,
+            ),
+            settingsContext: sctx,
+            showIcons: false,
+            routeBuilder: (_, WidgetBuilder b) =>
+                MaterialPageRoute<void>(builder: b),
+          ),
+        ),
+      );
+
+      expect(find.widgetWithText(FilledButton, '退出'), findsOneWidget);
+      await tester.tap(find.text('退出'));
+      await tester.pump();
+      expect(calls, 1);
+      expect(refreshes, 1);
+    });
+  });
+
+  group('源码守卫：子页与状态行走框架，不走逃生口', () {
+    String read(String path) {
+      final File f = File(path);
+      expect(f.existsSync(), isTrue, reason: '$path 不存在（请从 fushi/ 包根跑测试）');
+      return f.readAsStringSync();
+    }
+
+    test('渲染分发：状态行有专属分支；child 导航行推 SettingsDetailPage.subPage', () {
+      final String widgets =
+          read('lib/src/settings/settings_schema_widgets.dart');
+      expect(widgets, contains('SettingsStatusItem status => _status(status)'));
+      expect(widgets, contains('SettingsDetailPage.subPage(child)'));
+    });
+
+    test('搜索：索引递归进子页；命中后逐级推子页', () {
+      expect(read('lib/src/settings/settings_search.dart'),
+          contains('_flattenPageInto('));
+      expect(read('lib/src/settings/settings_home_page.dart'),
+          contains('entry.subPagePath'));
+    });
+
+    test('详情页：子页靠闭包取新鲜树，不按 id 到顶层找', () {
+      final String page = read('lib/src/settings/settings_detail_page.dart');
+      expect(page, contains('SettingsDetailPage.subPage('));
+      expect(page, contains('if (subPage != null) return subPage();'));
+    });
+  });
+}
+
+class _TestAppModel extends AppModel {
+  _TestAppModel() : super(testPlatformServices());
+}

--- a/fushi/test/settings/settings_subpage_schema_test.dart
+++ b/fushi/test/settings/settings_subpage_schema_test.dart
@@ -254,6 +254,72 @@ void main() {
       expect(calls, 1);
       expect(refreshes, 1);
     });
+
+    testWidgets('状态行：有动作时必须有行级 onTap（否则方向导航到不了这一行，BUG-016）',
+        (WidgetTester tester) async {
+      // 上面那条用 tester.tap 点行尾按钮，对本条完全不敏感：有没有行级 onTap，
+      // 鼠标点按钮都过。而 `AdaptiveSettingsRow` 里
+      // `if (onTap == null) return content;` —— 没有 onTap 的行根本不包
+      // _SettingsRowFocusTarget、不进 FushiFocusController 的注册表，而方向导航
+      // 只走已注册目标。带行尾按钮却不给行级 onTap，键盘/手柄用户从上一行按 Down
+      // 会整行被跳过，本面板下方再无目标时焦点还会跨 pane 落到左侧导航栏。
+      int calls = 0;
+      await pumpContext(
+        tester,
+        child: Builder(
+          builder: (BuildContext context) => SettingsSchemaItem(
+            item: SettingsStatusItem(
+              id: 's',
+              title: '主机服务',
+              subtitle: '未启动',
+              actionLabel: '重新生成 token',
+              onAction: (_) async => calls++,
+            ),
+            settingsContext: sctx,
+            showIcons: false,
+            routeBuilder: (_, WidgetBuilder b) =>
+                MaterialPageRoute<void>(builder: b),
+          ),
+        ),
+      );
+
+      final AdaptiveSettingsRow row =
+          tester.widget<AdaptiveSettingsRow>(find.byType(AdaptiveSettingsRow));
+      expect(row.onTap, isNotNull,
+          reason: '有行尾动作的状态行必须同时有行级 onTap —— 那是它进入'
+              'FushiFocusController 注册表的唯一条件（BUG-016）');
+
+      // 行级 onTap 必须跑同一个动作：手柄 A / Enter 落在行上，用户预期与按按钮一致。
+      await tester.tap(find.text('主机服务'));
+      await tester.pump();
+      expect(calls, 1);
+      expect(refreshes, 1);
+    });
+
+    testWidgets('状态行：纯状态行（无动作）不得有行级 onTap', (WidgetTester tester) async {
+      // 反向的一半：没有可执行动作的行不该成为焦点停靠点，否则方向导航会在一串
+      // 只读状态行上空转。
+      await pumpContext(
+        tester,
+        child: Builder(
+          builder: (BuildContext context) => SettingsSchemaItem(
+            item: const SettingsStatusItem(
+              id: 's',
+              title: '当前设备',
+              subtitle: 'Windows',
+            ),
+            settingsContext: sctx,
+            showIcons: false,
+            routeBuilder: (_, WidgetBuilder b) =>
+                MaterialPageRoute<void>(builder: b),
+          ),
+        ),
+      );
+
+      final AdaptiveSettingsRow row =
+          tester.widget<AdaptiveSettingsRow>(find.byType(AdaptiveSettingsRow));
+      expect(row.onTap, isNull, reason: '纯状态行没有动作，不该是焦点停靠点');
+    });
   });
 
   group('源码守卫：子页与状态行走框架，不走逃生口', () {

--- a/fushi/test/tools/itest_settings_destination_identity_guard_test.dart
+++ b/fushi/test/tools/itest_settings_destination_identity_guard_test.dart
@@ -45,10 +45,24 @@ void main() {
     final String code = maskComments(itest.readAsStringSync());
 
     // ① 身份判据必须在场。
+    //
+    // C0 起 SettingsDetailPage 多了一个 `.subPage` 构造器：子页共用父分类的
+    // destination id，所以**子页的 destination 恒为 null**，「这是哪个顶层目的地」
+    // 只有顶层页答得上来。`?.` 正是这个语义——子页上 `null == id` 恒假，顶层页照旧
+    // 命中；反向也不会恒假（顶层构造器 required non-null）。
     expect(
       code,
-      contains('widget is SettingsDetailPage && widget.destination.id == id'),
-      reason: '窄屏必须按推栈详情页自带的 destination.id 判身份',
+      contains('widget is SettingsDetailPage && widget.destination?.id == id'),
+      reason: '窄屏必须按推栈详情页自带的 destination.id 判身份；'
+          '子页 destination 为 null，所以只能用 `?.`',
+    );
+    // 用 `!` 把空断掉会有两种坏结局：子页一进来就运行期崩，或者有人为了不崩
+    // 改成「子页也填父 destination」——那样谓词对子页恒真，requireTransition 的
+    // 前置条件（「现在还没到那个目的地」）整条失效，导航证据退化成恒真。
+    expect(
+      code,
+      isNot(contains('widget.destination!.id')),
+      reason: '不得用 ! 断掉子页的 null destination',
     );
     expect(
       code,


### PR DESCRIPTION
## 同步/互联 UI 排版重组 · C0：设置框架前置（子 schema 页 + 一等状态行）

系列计划：`docs/plans/2026-09-06-sync-ui-layout.md`（本 PR 落地该文档）。**本 PR 不改任何 sync 页面，零视觉变化**——只给 C1/C2 铺路。

### 为什么
同步/互联两页「一屏铺太长、分组乱」的根子是六种不同频率的事平铺在一层；要拆成两层，框架得先有「子页」。现状的子页出口 `SettingsNavigationItem.builder` 推的是非 schema 的自定义页：里面的行进不了设置搜索、进不了焦点覆盖遍历，只能靠 `bodySearchEntries` 手工登记——那是个特殊情况补丁。子页也是 schema，特殊情况就没了。

### 改了什么
- `SettingsNavigationItem.child: SettingsDestination Function()?`——子 schema 页。渲染点击推 `SettingsDetailPage.subPage(child)`（与顶层分类同一套详情壳）。子页共用父分类的 `SettingsDestinationId`（枚举不为子页扩容），新鲜树靠闭包取，不按 id 到顶层找（按 id 找会渲染出父页）。
- `SettingsDetailPage.subPage(builder)` 命名构造；`destination` 改可空。既有 `SettingsDetailPage(destination:)` 调用面不变。
- `settings_search.dart`：`flattenVisibleSettings` 递归进子页；`SettingsSearchEntry.subPagePath` 记从顶层到行所在页的导航链；面包屑「分类 › 子页 › 分区」；`_openSearchResult` 命中后先进父页再逐级推子页，挂点由最里层页面的目标行消费。
- 新增 `SettingsStatusItem`（图标 + 标题 + 状态文本（可 `subtitleBuilder`）+ 可选行尾动作按钮 `FilledButton.tonal`，与 `actions.part.dart` 既有写法一致）。替换四处手拼 `SettingsCustomItem(AdaptiveSettingsRow)` 的状态/指路行留给 C1/C2。
- `SettingsItem` 是 sealed 类；全仓唯一的穷举 switch 在 `settings_schema_widgets.dart:119`，已补分支。

### 测试
- 新增 `test/settings/settings_subpage_schema_test.dart`：搜索递归 3 条（子页行进索引/路径/面包屑；子页不可见时行不进索引；两级嵌套路径累积）+ 渲染 3 条（child 导航行推 `SettingsDetailPage.subPage`；状态行标题/运行期副标题/无按钮；有动作时按钮调 onAction 并 refresh）+ 源码守卫 3 条。
- 整个 `test/settings` 目录（含 `settings_schema_coverage` / `settings_schema_cache` / `md3_design_system_static` / `settings_renderer` / `settings_search`）。
- 全量 `flutter analyze`。
- 存量文件只 format 改动行；`settings_destination.dart:381` 有一处**原有**的旧风格不合规（多一空行），未动。

https://claude.ai/code/session_01WPbEes8famqLCXoUjHNLPn
