### PR TITLE
refactor(sync): PR4/7 backup_service 导出/恢复分家——BackupRestoreService + path_rebase / fs_retry part

### DIFF
--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2470,7 +2470,7 @@ class AppModel with ChangeNotifier {
       // 3) migrate the mutually-exclusive `backendType==fushiServer` interconnect
       //    selection to the independent interconnect toggle (interconnect and a
       //    cloud backup backend can now coexist).
-      await BackupService.recoverPendingImport(_databaseDirectory.path);
+      await BackupRestoreService.recoverPendingRestore(_databaseDirectory.path);
 
       // 沙箱重定位自愈：数据根被**平台**挪走后，把库里的绝对路径重基过去。
       //

--- a/fushi/lib/src/pages/implementations/migration_import_page.dart
+++ b/fushi/lib/src/pages/implementations/migration_import_page.dart
@@ -19,7 +19,7 @@ import 'package:path/path.dart' as p;
 /// 「从 Hibiki 导入」页（改名迁移计划 P2-2/P2-3，Fushi 侧）。
 ///
 /// 扫描老包写下的中转目录 → 逐批校验（清单 sha256+size）→ 走
-/// [BackupService.mergeRestoreBackup] 逐批合并（关库一次、批间不重启）→
+/// [BackupRestoreService.mergeRestoreBackup] 逐批合并（关库一次、批间不重启）→
 /// 行数聚合校验 → 删除已导入批文件 → 重启。**任一批校验不符：保留文件、
 /// 提示回老包重传、绝不进入卸载流程**。
 ///
@@ -191,7 +191,7 @@ class _MigrationImportPageState extends State<MigrationImportPage>
           setState(() => _status =
               t.migration_import_running(batch: _batchLabel(batch.batch)));
         }
-        await BackupService.mergeRestoreBackup(
+        await BackupRestoreService.mergeRestoreBackup(
           dbDirectory: appModel.databaseDirectory.path,
           zipPath: batch.archivePath,
           dictionaryResourceDirectory:

--- a/fushi/lib/src/sync/backup_merge_engine.dart
+++ b/fushi/lib/src/sync/backup_merge_engine.dart
@@ -1319,7 +1319,7 @@ class BackupMergeEngine {
   ///
   /// 平局（`>` 不成立）保留本机。旧备份的行经 merge 前的 schema 迁移拿到
   /// `updated_at = 0`（备份库先被开一次升到当前 schema，见
-  /// `BackupService.mergeRestoreBackup` 的第 2 步），于是与本机存量行平局 →
+  /// `BackupRestoreService.mergeRestoreBackup` 的第 2 步），于是与本机存量行平局 →
   /// 行为逐字等于本轮之前的 insert-if-absent，零回归；而任一侧真正改过一次名
   /// （戳 > 0）之后立刻胜出，母设备的第二次改名终于能并进来。
   Future<void> _mergeOverrideTitlePrefs() async {
@@ -1345,7 +1345,7 @@ class BackupMergeEngine {
 
   /// The audio-source registry prefs are CONTENT config, not device settings:
   /// the local-audio `.db` files they reference DO travel in the backup (packed
-  /// under `localAudio/` and copied by [BackupService.mergeRestoreBackup]),
+  /// under `localAudio/` and copied by [BackupRestoreService.mergeRestoreBackup]),
   /// so their config must travel too — otherwise the restored files are orphaned
   /// and "音频来源" is silently lost on a merge (the pref-non-merge default
   /// dropped them). Adopt the backup's value when the device has none/an empty

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -18,6 +18,10 @@ import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:path/path.dart' as p;
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 
+part 'backup_service/fs_retry.part.dart';
+part 'backup_service/path_rebase.part.dart';
+part 'backup_service/restore.part.dart';
+
 /// 本地备份导出物文件名口径。存储页与导出前清扫共用，避免一边展示、一边认不出。
 ///
 /// 形状 = [BackupService.defaultFilename] 产出的 `fushi-backup-<日期>.fushi.zip`
@@ -431,6 +435,346 @@ class BackupContentSummary {
   bool has(BackupCategory c) => present.contains(c);
 }
 
+// ── 导出侧与恢复侧共用的常量 / 纯 SQL helper ───────────────────────────
+// 归属拆分见 docs/plans/2026-09-06-sync-interconnect-refactor.md B1：两侧都用的
+// 东西提到库级顶层，导出类（本文件）与恢复类（restore.part.dart）引用零改动。
+
+/// 备份归档里主库条目名 = 活库文件名（fushi_core 单一真相源）。写侧（导出/
+/// bak/临时提取路径）一律用它；读老归档（Hibiki 时代备份 / 迁移压缩包，条目名
+/// `hibiki.db`）经 [_findDbEntry] 做 legacy 回退（Never break userspace）。
+const String _dbName = fushiDatabaseFileName;
+const String _metaName = 'backup_meta.json';
+const String _dictionaryResourcesPrefix = 'dictionaryResources';
+
+/// 书树条目在归档里的前缀。写侧一律用它；读侧经 [archiveBooksPrefix] 对旧
+/// Hibiki 归档（前缀 `hoshi_books`）做 legacy 回退（Never break userspace，
+/// 同 [_dbName] 的 `_findDbEntry` 先例）。
+const String _booksPrefix = 'fushi_books';
+
+/// 旧 Hibiki 时代备份/迁移归档的书树前缀（W2-7 读侧回退输入；旧字面量只
+/// 允许活在读旧归档的回退里）。
+const String _legacyBooksPrefix = 'hoshi_books';
+const String _audiobooksPrefix = 'audiobooks';
+const String _fontsPrefix = 'custom_fonts';
+const String _videosPrefix = 'videos';
+const String _localAudioPrefix = 'localAudio';
+
+/// Preference key (in the `preferences` table) whose JSON value is the
+/// local-audio library list `[{path, displayName, enabled, sources}]`. The
+/// `path` of each entry points at a `local_audio_*.db` file in the support
+/// directory and is rebased onto this device's root on import (TODO-941).
+const String _localAudioDbsPrefKey = 'local_audio_dbs';
+const String _audioSourceConfigsPrefKey = 'audio_source_configs';
+
+/// Matches a packed local-audio database file (and its `-wal`/`-shm`
+/// siblings). Only these are packed from the support directory so the export
+/// never sweeps in `fushi.db` or other unrelated support files.
+final RegExp _localAudioFileName = RegExp(r'^local_audio_\d+\.db(-wal|-shm)?$');
+
+/// Matches ONLY a packed local-audio database file (not its `-wal`/`-shm`
+/// siblings), for counting distinct local-audio databases in a summary.
+final RegExp _localAudioDbOnly = RegExp(r'^local_audio_\d+\.db$');
+
+/// Persisted preference key (ReaderSettings prefix included) whose JSON
+/// value is the canonical catalog `{version, fonts:[{id, name, path}]}`.
+const String _fontCatalogPrefKey = 'src:reader_fushi:font_catalog';
+
+/// Persisted legacy shadow preference keys (ReaderSettings prefix included)
+/// whose JSON value is a font list `[{name, path, enabled}]`. These remain
+/// import-compatible while `font_catalog` is the canonical model.
+const List<String> _legacyFontPrefKeys = <String>[
+  'src:reader_fushi:custom_fonts',
+  'src:reader_fushi:app_ui_fonts',
+  'src:reader_fushi:dict_fonts',
+  'src:reader_fushi:video_sub_fonts',
+  'src:reader_fushi:game_lookup_fonts',
+];
+
+/// Preference key holding the favorite-sentence JSON list (mirrors
+/// `FavoriteSentenceRepository._key` / `BackupMergeEngine`). It is CONTENT
+/// (favorite sentences travel / merge as content), so the `settings` category
+/// strip must never delete it.
+const String _favoriteSentencesPrefKey = 'favorite_sentences';
+
+/// Device-local tables that must NEVER travel in a shared backup and are
+/// always restored from this device's pre-restore bak on an overwrite import
+/// (BUG-816). Same philosophy as [SyncRepository.deviceLocalPrefKeys]:
+///   - `fushi_paired_peers` — LAN pairing rows including the plaintext auth
+///     `token` (a live credential the HBK-AUDIT-012 pref-key sweep missed
+///     because it lives in its own table, not `preferences`).
+///   - `sync_baselines`      — per-asset incremental-sync causality; carrying
+///     it to another device corrupts later fork detection (mirrors why
+///     `_keyCollectionsBaselineMs` is device-local).
+///   - `manga_*`             — Mihon repositories, executable-extension
+///     identities, signer trust decisions, source state and arbitrary
+///     extension preferences. APKs and runtime cookies deliberately do not
+///     travel, so exporting these rows would both create broken ghost
+///     extensions and risk leaking source credentials stored as preferences.
+///   - `video_download_*`    — durable jobs/subscriptions are tied to this
+///     installation's backend fingerprint, local paths and source-library
+///     ids. Sending them to another device could enqueue work against the
+///     wrong backend. Their five-table FK graph is ordered explicitly below.
+///
+/// [_deviceLocalTables] is CHILD-first and is the only order allowed for a
+/// wipe. [_deviceLocalTablesParentFirst] is the inverse dependency order used
+/// for restore. Keeping two named lists is intentional: reusing one loop for
+/// both directions silently worked before the v78 graph existed, but now
+/// fails with `foreign_keys=ON`.
+const List<String> _deviceLocalTables = <String>[
+  'video_download_subscription_items',
+  'video_download_job_subtitles',
+  'video_download_job_files',
+  'video_download_subscriptions',
+  'video_download_jobs',
+  'manga_source_preferences',
+  'manga_online_sources',
+  'manga_extensions',
+  'manga_extension_stores',
+  'manga_trusted_signers',
+  'sync_baselines',
+  'fushi_paired_peers',
+  'web_mine_queue',
+  'video_file_specs',
+];
+
+const List<String> _deviceLocalTablesParentFirst = <String>[
+  'video_file_specs',
+  'web_mine_queue',
+  'sync_baselines',
+  'fushi_paired_peers',
+  'manga_extension_stores',
+  'manga_extensions',
+  'manga_online_sources',
+  'manga_source_preferences',
+  'manga_trusted_signers',
+  'video_download_jobs',
+  'video_download_subscriptions',
+  'video_download_job_files',
+  'video_download_job_subtitles',
+  'video_download_subscription_items',
+];
+
+/// Content tables stripped from the exported DB copy when the `statistics`
+/// category is unticked (TODO-1193). None is FK-targeted by another content
+/// table, so a wholesale DELETE is safe (`galgame_sessions` is itself an FK
+/// CHILD of `galgames`; nothing references it, so deleting it trips nothing).
+///
+/// `activity_events` / `galgame_sessions` are session-granularity FACT
+/// streams, not aggregates, but they are what the statistics pages render
+/// from — the untick promise ("my stats don't travel") must cover them too.
+/// The `galgames` library rows stay: games are content, their sessions are
+/// statistics (mirrors `clearAllGalgameStatistics`, which deletes only the
+/// session facts).
+const List<String> _statisticsTables = <String>[
+  'reading_statistics',
+  'reading_hourly_logs',
+  'video_watch_statistics',
+  'video_hourly_logs',
+  'mining_statistics',
+  'lookup_mining_counters',
+  'mined_sentences',
+  'favorite_words',
+  'activity_events',
+  'galgame_sessions',
+];
+
+/// The four profile-layer tables in CHILD-first order, so a DELETE sweep of
+/// the `profiles` category (TODO-1193) never trips an enforced FK to
+/// `profiles`. The reverse of [_settingsLayerTables] (which is parent-first
+/// for INSERT).
+const List<String> _profilesLayerTablesChildFirst = <String>[
+  'profile_settings',
+  'media_type_profiles',
+  'book_profiles',
+  'profiles',
+];
+
+/// SQL predicate selecting the `preferences` rows the `settings` backup
+/// category governs (TODO-1193): the PURE app/reader settings only. It
+/// EXCLUDES (preserves) the rows owned by other categories or that are
+/// content, so an "exclude settings" export never collaterally drops them:
+///   - `audiobook_pos_*`         -> progress (the `progress` category)
+///   - `favorite_sentences`      -> favorites content, gated on `books`
+///     (BUG-816, stripped/restored separately by the content-registry path)
+///   - `local_audio_dbs`         -> local-audio registry (`localAudio`, BUG-816)
+///   - `audio_source_configs`    -> audio-source config (`localAudio`, BUG-816)
+///   - font catalog + legacy font prefs -> font registry (`fonts`, BUG-816)
+///   - `*override_title://*`     -> 用户给书改的名字，是**内容**不是设置
+///     (BUG-1488)。`ProfileKeys.isExcludedPref` 早就这么归类（改名不进 Profile
+///     快照），这里却把它当 app 设置 strip 掉 —— 不勾 `settings` 导出，用户
+///     所有书的改名一并消失（视频改名落在 `video_books.title` 列上，不受影响，
+///     所以这条不对称只砸书）。
+/// BUG-816: `sync_*` behaviour toggles ARE settings (see `sync_repository.dart`
+/// — they are treated as user settings that travel), so they are NO LONGER
+/// excepted here: unticking `settings` now strips them from the export and the
+/// import restores them from bak. The device-local sync CONFIG / credentials
+/// (`deviceLocalPrefKeys`) are handled out-of-band by `_stripCredentials`
+/// (export) + `_applyPreservedConfig` (import, authoritative last word), so
+/// letting this predicate also touch them on a settings-excluded restore is a
+/// harmless no-op that `_applyPreservedConfig` overrides.
+/// Used SYMMETRICALLY by the export strip and the import preserve-from-bak so
+/// a `settings`-excluded backup and its restore never diverge.
+final String settingsPrefPredicate = _buildSettingsPrefPredicate();
+
+String _buildSettingsPrefPredicate() {
+  final List<String> preservedExactKeys = <String>[
+    _favoriteSentencesPrefKey,
+    _localAudioDbsPrefKey,
+    _audioSourceConfigsPrefKey,
+    _fontCatalogPrefKey,
+    ..._legacyFontPrefKeys,
+  ];
+  final String notIn = preservedExactKeys
+      .map((String k) => "'${k.replaceAll("'", "''")}'")
+      .join(', ');
+  return "key NOT LIKE 'audiobook_pos_%' "
+      'AND key NOT IN ($notIn) '
+      'AND $_notOverrideTitleSql';
+}
+
+/// 「这行 pref 不是书名 override」的 SQL 判据。用 `instr` 而非 `LIKE '%…%'`：
+/// 前缀里的 `_` 在 LIKE 里是通配符，`instr` 是逐字节子串匹配，零歧义。
+const String _notOverrideTitleSql =
+    "instr(key, '$kOverrideTitleKeyMarker') = 0";
+
+/// Strips the four DB-only data categories (TODO-1193) from the standalone
+/// exported DB copy in [dbDirectory] when the user unticked them. Opened via
+/// [FushiDatabase] (the copy is already at the current schema, so no
+/// migration runs). Operates ONLY on the export copy — the live user DB is
+/// never touched.
+///
+/// - [stripProgress]   : `reader_positions`, `bookmarks`, and the
+///   `audiobook_pos_*` preference rows.
+/// - [stripStatistics] : [_statisticsTables].
+/// - [stripSettings]   : the pure-settings `preferences` rows
+///   ([settingsPrefPredicate]) — progress / favorites / content-registry /
+///   sync prefs are deliberately preserved.
+/// - [stripProfiles]   : the four profile-layer tables (child-first so an
+///   enforced FK to `profiles` never blocks the sweep).
+///
+/// A single VACUUM + checkpoint afterwards keeps the deleted rows out of the
+/// freelist pages so they cannot be recovered from the shared backup.
+Future<void> _stripExcludedDataCategories(
+  String dbDirectory, {
+  required bool stripProgress,
+  required bool stripStatistics,
+  required bool stripSettings,
+  required bool stripProfiles,
+}) async {
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    if (stripProgress) {
+      await db.customStatement('DELETE FROM reader_positions');
+      await db.customStatement('DELETE FROM bookmarks');
+      await db.customStatement(
+          "DELETE FROM preferences WHERE key LIKE 'audiobook_pos_%'");
+    }
+    if (stripStatistics) {
+      for (final String table in _statisticsTables) {
+        await db.customStatement('DELETE FROM $table');
+      }
+    }
+    if (stripSettings) {
+      await db.customStatement(
+          'DELETE FROM preferences WHERE $settingsPrefPredicate');
+    }
+    if (stripProfiles) {
+      for (final String table in _profilesLayerTablesChildFirst) {
+        await db.customStatement('DELETE FROM $table');
+      }
+    }
+    await db.customStatement('VACUUM');
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Deletes from the exported DB copy in [dbDirectory] every epub book whose
+/// `book_key` is NOT in [keep], plus all of that book's dependent rows via the
+/// canonical [FushiDatabase.deleteEpubBook] cascade (reader position,
+/// bookmarks, tag mappings, audiobook + cues, srt rows, shelf entry). [keep]
+/// empty strips every book (the "book content" category was unticked);
+/// a non-empty set keeps only the user-selected books (per-book export).
+///
+/// Root fix for the "ghost book" bug (TODO-1195 part C/A): the whole DB is
+/// exported as one VACUUM-INTO blob, so without this every book's `epub_books`
+/// row travelled even when its `hoshi_books/` files were left out — a
+/// restore/merge then inserted book rows with no content = un-openable books.
+/// Filtering the rows here makes the "book content" switch / per-book
+/// selection consistent: a book that isn't packed never appears after import.
+Future<void> _retainBooks(
+  String dbDirectory,
+  Set<String> keep,
+) async {
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    for (final EpubBookRow b in await db.getAllEpubBooks()) {
+      if (keep.contains(b.bookKey)) continue;
+      // Default (tombstone: false): stripping a book from an export copy is
+      // NOT a user deletion, so it must never write a resurrection tombstone
+      // into the backup DB (TODO-1195 part B interaction).
+      await db.deleteEpubBook(b.bookKey);
+    }
+    await db.customStatement('VACUUM');
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Per-video analogue of [_retainBooks]: DELETEs every `video_books` row whose
+/// `book_uid` is NOT in [keep] (plus its dependent rows — subtitle cues, tag
+/// mappings, shelf entry — via the canonical [FushiDatabase.deleteVideoBook]
+/// cascade). [keep] empty strips every video (the video category was
+/// unticked); a non-empty set keeps only the user-selected videos (per-video
+/// export). Same root fix as books: without stripping the row a restore/merge
+/// would insert a video record whose file never travelled = an un-openable
+/// "ghost video".
+Future<void> _retainVideos(
+  String dbDirectory,
+  Set<String> keep,
+) async {
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    for (final VideoBookRow v in await db.allVideoBooks()) {
+      if (keep.contains(v.bookUid)) continue;
+      await db.deleteVideoBook(v.bookUid);
+    }
+    await db.customStatement('VACUUM');
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Audiobook analogue of [_retainVideos] (BUG-781): DELETEs every `audiobooks`
+/// row whose `bookKey` is NOT in [keep], via the canonical
+/// [FushiDatabase.deleteAudiobookByBookKey] cascade (its `audio_cues` rows +
+/// the `srt` shelf entry). [keep] empty strips every audiobook (the audiobooks
+/// category was unticked). Same root fix as books/videos: an audiobook whose
+/// audio never travelled must not survive as a "ghost audiobook" (a shelf entry
+/// + alignment rows pointing at audio files that are not on this device). Does
+/// NOT touch standalone `srt_books` rows — those are their own shelf items, not
+/// counted in the audiobooks category (which is `getAllAudiobooks()` = the
+/// epub-attached `Audiobooks` table).
+Future<void> _retainAudiobooks(
+  String dbDirectory,
+  Set<String> keep,
+) async {
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    for (final AudiobookRow a in await db.getAllAudiobooks()) {
+      if (keep.contains(a.bookKey)) continue;
+      await db.deleteAudiobookByBookKey(a.bookKey);
+    }
+    await db.customStatement('VACUUM');
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
 class BackupService {
   BackupService({
     required FushiDatabase db,
@@ -469,247 +813,6 @@ class BackupService {
 
   final String _appVersion;
 
-  /// 备份归档里主库条目名 = 活库文件名（fushi_core 单一真相源）。写侧（导出/
-  /// bak/临时提取路径）一律用它；读老归档（Hibiki 时代备份 / 迁移压缩包，条目名
-  /// `hibiki.db`）经 [_findDbEntry] 做 legacy 回退（Never break userspace）。
-  static const String _dbName = fushiDatabaseFileName;
-  static const String _metaName = 'backup_meta.json';
-  static const String _dictionaryResourcesPrefix = 'dictionaryResources';
-
-  /// 书树条目在归档里的前缀。写侧一律用它；读侧经 [archiveBooksPrefix] 对旧
-  /// Hibiki 归档（前缀 `hoshi_books`）做 legacy 回退（Never break userspace，
-  /// 同 [_dbName] 的 `_findDbEntry` 先例）。
-  static const String _booksPrefix = 'fushi_books';
-
-  /// 旧 Hibiki 时代备份/迁移归档的书树前缀（W2-7 读侧回退输入；旧字面量只
-  /// 允许活在读旧归档的回退里）。
-  static const String _legacyBooksPrefix = 'hoshi_books';
-  static const String _audiobooksPrefix = 'audiobooks';
-  static const String _fontsPrefix = 'custom_fonts';
-  static const String _videosPrefix = 'videos';
-  static const String _localAudioPrefix = 'localAudio';
-
-  /// Preference key (in the `preferences` table) whose JSON value is the
-  /// local-audio library list `[{path, displayName, enabled, sources}]`. The
-  /// `path` of each entry points at a `local_audio_*.db` file in the support
-  /// directory and is rebased onto this device's root on import (TODO-941).
-  static const String _localAudioDbsPrefKey = 'local_audio_dbs';
-  static const String _audioSourceConfigsPrefKey = 'audio_source_configs';
-
-  /// Matches a packed local-audio database file (and its `-wal`/`-shm`
-  /// siblings). Only these are packed from the support directory so the export
-  /// never sweeps in `fushi.db` or other unrelated support files.
-  static final RegExp _localAudioFileName =
-      RegExp(r'^local_audio_\d+\.db(-wal|-shm)?$');
-
-  /// Matches ONLY a packed local-audio database file (not its `-wal`/`-shm`
-  /// siblings), for counting distinct local-audio databases in a summary.
-  static final RegExp _localAudioDbOnly = RegExp(r'^local_audio_\d+\.db$');
-
-  /// Persisted preference key (ReaderSettings prefix included) whose JSON
-  /// value is the canonical catalog `{version, fonts:[{id, name, path}]}`.
-  static const String _fontCatalogPrefKey = 'src:reader_fushi:font_catalog';
-
-  /// Persisted legacy shadow preference keys (ReaderSettings prefix included)
-  /// whose JSON value is a font list `[{name, path, enabled}]`. These remain
-  /// import-compatible while `font_catalog` is the canonical model.
-  static const List<String> _legacyFontPrefKeys = <String>[
-    'src:reader_fushi:custom_fonts',
-    'src:reader_fushi:app_ui_fonts',
-    'src:reader_fushi:dict_fonts',
-    'src:reader_fushi:video_sub_fonts',
-    'src:reader_fushi:game_lookup_fonts',
-  ];
-
-  /// Preference key holding the favorite-sentence JSON list (mirrors
-  /// `FavoriteSentenceRepository._key` / `BackupMergeEngine`). It is CONTENT
-  /// (favorite sentences travel / merge as content), so the `settings` category
-  /// strip must never delete it.
-  static const String _favoriteSentencesPrefKey = 'favorite_sentences';
-
-  /// Device-local tables that must NEVER travel in a shared backup and are
-  /// always restored from this device's pre-restore bak on an overwrite import
-  /// (BUG-816). Same philosophy as [SyncRepository.deviceLocalPrefKeys]:
-  ///   - `fushi_paired_peers` — LAN pairing rows including the plaintext auth
-  ///     `token` (a live credential the HBK-AUDIT-012 pref-key sweep missed
-  ///     because it lives in its own table, not `preferences`).
-  ///   - `sync_baselines`      — per-asset incremental-sync causality; carrying
-  ///     it to another device corrupts later fork detection (mirrors why
-  ///     `_keyCollectionsBaselineMs` is device-local).
-  ///   - `manga_*`             — Mihon repositories, executable-extension
-  ///     identities, signer trust decisions, source state and arbitrary
-  ///     extension preferences. APKs and runtime cookies deliberately do not
-  ///     travel, so exporting these rows would both create broken ghost
-  ///     extensions and risk leaking source credentials stored as preferences.
-  ///   - `video_download_*`    — durable jobs/subscriptions are tied to this
-  ///     installation's backend fingerprint, local paths and source-library
-  ///     ids. Sending them to another device could enqueue work against the
-  ///     wrong backend. Their five-table FK graph is ordered explicitly below.
-  ///
-  /// [_deviceLocalTables] is CHILD-first and is the only order allowed for a
-  /// wipe. [_deviceLocalTablesParentFirst] is the inverse dependency order used
-  /// for restore. Keeping two named lists is intentional: reusing one loop for
-  /// both directions silently worked before the v78 graph existed, but now
-  /// fails with `foreign_keys=ON`.
-  static const List<String> _deviceLocalTables = <String>[
-    'video_download_subscription_items',
-    'video_download_job_subtitles',
-    'video_download_job_files',
-    'video_download_subscriptions',
-    'video_download_jobs',
-    'manga_source_preferences',
-    'manga_online_sources',
-    'manga_extensions',
-    'manga_extension_stores',
-    'manga_trusted_signers',
-    'sync_baselines',
-    'fushi_paired_peers',
-    'web_mine_queue',
-    'video_file_specs',
-  ];
-
-  static const List<String> _deviceLocalTablesParentFirst = <String>[
-    'video_file_specs',
-    'web_mine_queue',
-    'sync_baselines',
-    'fushi_paired_peers',
-    'manga_extension_stores',
-    'manga_extensions',
-    'manga_online_sources',
-    'manga_source_preferences',
-    'manga_trusted_signers',
-    'video_download_jobs',
-    'video_download_subscriptions',
-    'video_download_job_files',
-    'video_download_job_subtitles',
-    'video_download_subscription_items',
-  ];
-
-  /// Content tables stripped from the exported DB copy when the `statistics`
-  /// category is unticked (TODO-1193). None is FK-targeted by another content
-  /// table, so a wholesale DELETE is safe (`galgame_sessions` is itself an FK
-  /// CHILD of `galgames`; nothing references it, so deleting it trips nothing).
-  ///
-  /// `activity_events` / `galgame_sessions` are session-granularity FACT
-  /// streams, not aggregates, but they are what the statistics pages render
-  /// from — the untick promise ("my stats don't travel") must cover them too.
-  /// The `galgames` library rows stay: games are content, their sessions are
-  /// statistics (mirrors `clearAllGalgameStatistics`, which deletes only the
-  /// session facts).
-  static const List<String> _statisticsTables = <String>[
-    'reading_statistics',
-    'reading_hourly_logs',
-    'video_watch_statistics',
-    'video_hourly_logs',
-    'mining_statistics',
-    'lookup_mining_counters',
-    'mined_sentences',
-    'favorite_words',
-    'activity_events',
-    'galgame_sessions',
-  ];
-
-  /// The four profile-layer tables in CHILD-first order, so a DELETE sweep of
-  /// the `profiles` category (TODO-1193) never trips an enforced FK to
-  /// `profiles`. The reverse of [_settingsLayerTables] (which is parent-first
-  /// for INSERT).
-  static const List<String> _profilesLayerTablesChildFirst = <String>[
-    'profile_settings',
-    'media_type_profiles',
-    'book_profiles',
-    'profiles',
-  ];
-
-  /// SQL predicate selecting the `preferences` rows the `settings` backup
-  /// category governs (TODO-1193): the PURE app/reader settings only. It
-  /// EXCLUDES (preserves) the rows owned by other categories or that are
-  /// content, so an "exclude settings" export never collaterally drops them:
-  ///   - `audiobook_pos_*`         -> progress (the `progress` category)
-  ///   - `favorite_sentences`      -> favorites content, gated on `books`
-  ///     (BUG-816, stripped/restored separately by the content-registry path)
-  ///   - `local_audio_dbs`         -> local-audio registry (`localAudio`, BUG-816)
-  ///   - `audio_source_configs`    -> audio-source config (`localAudio`, BUG-816)
-  ///   - font catalog + legacy font prefs -> font registry (`fonts`, BUG-816)
-  ///   - `*override_title://*`     -> 用户给书改的名字，是**内容**不是设置
-  ///     (BUG-1488)。`ProfileKeys.isExcludedPref` 早就这么归类（改名不进 Profile
-  ///     快照），这里却把它当 app 设置 strip 掉 —— 不勾 `settings` 导出，用户
-  ///     所有书的改名一并消失（视频改名落在 `video_books.title` 列上，不受影响，
-  ///     所以这条不对称只砸书）。
-  /// BUG-816: `sync_*` behaviour toggles ARE settings (see `sync_repository.dart`
-  /// — they are treated as user settings that travel), so they are NO LONGER
-  /// excepted here: unticking `settings` now strips them from the export and the
-  /// import restores them from bak. The device-local sync CONFIG / credentials
-  /// (`deviceLocalPrefKeys`) are handled out-of-band by `_stripCredentials`
-  /// (export) + `_applyPreservedConfig` (import, authoritative last word), so
-  /// letting this predicate also touch them on a settings-excluded restore is a
-  /// harmless no-op that `_applyPreservedConfig` overrides.
-  /// Used SYMMETRICALLY by the export strip and the import preserve-from-bak so
-  /// a `settings`-excluded backup and its restore never diverge.
-  static final String settingsPrefPredicate = _buildSettingsPrefPredicate();
-
-  static String _buildSettingsPrefPredicate() {
-    final List<String> preservedExactKeys = <String>[
-      _favoriteSentencesPrefKey,
-      _localAudioDbsPrefKey,
-      _audioSourceConfigsPrefKey,
-      _fontCatalogPrefKey,
-      ..._legacyFontPrefKeys,
-    ];
-    final String notIn = preservedExactKeys
-        .map((String k) => "'${k.replaceAll("'", "''")}'")
-        .join(', ');
-    return "key NOT LIKE 'audiobook_pos_%' "
-        'AND key NOT IN ($notIn) '
-        'AND $_notOverrideTitleSql';
-  }
-
-  /// 「这行 pref 不是书名 override」的 SQL 判据。用 `instr` 而非 `LIKE '%…%'`：
-  /// 前缀里的 `_` 在 LIKE 里是通配符，`instr` 是逐字节子串匹配，零歧义。
-  static const String _notOverrideTitleSql =
-      "instr(key, '$kOverrideTitleKeyMarker') = 0";
-
-  /// Predicate for the keep-THIS-device-settings restore ([_reapplySettingsLayer],
-  /// the `importSettings=false` overwrite path). Restores from bak every pref row
-  /// EXCEPT the ones that are CONTENT and must follow the imported backup:
-  ///   - `audiobook_pos_*`      -> reading progress (the `progress` category)
-  ///   - `favorite_sentences`   -> favorites content (travels)
-  ///   - `local_audio_dbs` / `audio_source_configs` -> audio-source registry that
-  ///     points at the imported local-audio `.db` files (BUG-780: the old
-  ///     `NOT LIKE 'audiobook_pos_%'` restored these from THIS device, wiping the
-  ///     backup's registration so the `.db` files landed but no source was
-  ///     registered → imported local audio silently stopped working).
-  ///   - font catalog + legacy font prefs -> font registry (the `fonts` category)
-  ///   - `*override_title://*`  -> 用户给书改的名字是内容，跟着导入的备份走
-  ///     （BUG-1488；与 [settingsPrefPredicate] 的内容/设置切分保持对称）
-  /// UNLIKE [settingsPrefPredicate] this KEEPS `sync_*` restored from bak: the
-  /// keep-settings path writes no `{'mode':'prefs'}` sidecar and never calls
-  /// [_applyPreservedConfig], so this wholesale restore is the ONLY place the
-  /// device's own (never-exported) sync config is preserved — excluding `sync_*`
-  /// here would drop it. Same content-vs-settings split as the export strip and
-  /// [_reapplyExcludedSettingsLayers], so the two restore paths stay symmetric.
-  static final String _keepDeviceSettingsPrefPredicate =
-      _buildKeepDeviceSettingsPrefPredicate();
-
-  static String _buildKeepDeviceSettingsPrefPredicate() {
-    final List<String> contentRegistryKeys = <String>[
-      _favoriteSentencesPrefKey,
-      _localAudioDbsPrefKey,
-      _audioSourceConfigsPrefKey,
-      _fontCatalogPrefKey,
-      ..._legacyFontPrefKeys,
-    ];
-    final String notIn = contentRegistryKeys
-        .map((String k) => "'${k.replaceAll("'", "''")}'")
-        .join(', ');
-    return "key NOT LIKE 'audiobook_pos_%' AND key NOT IN ($notIn) "
-        'AND $_notOverrideTitleSql';
-  }
-
-  /// Sidecar file holding this device's sync config across an import. Written
-  /// BEFORE the destructive DB overwrite so a crash mid-import is recoverable
-  /// (a startup sweep re-applies it). Deleted once the import completes.
-  static const String _preserveSidecar = '$_dbName.sync-preserve.json';
-
   String get _dbPath => p.join(_dbDirectory, _dbName);
 
   /// A streaming (URL) video book — its `video_path` is an http(s) URL and it is
@@ -724,195 +827,6 @@ class BackupService {
     final row =
         await _db.customSelect('SELECT COUNT(*) AS c FROM $table').getSingle();
     return row.data['c'] as int;
-  }
-
-  /// Item counts per file-tree category present in a backup's [archiveFileNames]
-  /// (posix or windows separators). Pure over the name list + [meta] so it is
-  /// trivially unit-testable and never opens the archive body / DB (TODO-1358).
-  ///
-  /// Counting unit per category: dictionaries / books / audiobooks = distinct
-  /// first path segment under the prefix (one directory each); fonts = font
-  /// files; videos = packed video files ([BackupMeta.videoFiles], else leaf
-  /// files); localAudio = `local_audio_<n>.db` files (the `-wal`/`-shm` siblings
-  /// are not separate databases).
-  static BackupContentSummary summarizeBackupEntries(
-    Iterable<String> archiveFileNames,
-    BackupMeta? meta, {
-    int? dbVideoBookCount,
-    int? dbAudiobookCount,
-  }) {
-    final Set<String> dictDirs = <String>{};
-    final Set<String> bookDirs = <String>{};
-    final Set<String> audioDirs = <String>{};
-    int fontFiles = 0;
-    int videoFiles = 0;
-    int localAudioDbs = 0;
-    for (final String raw in archiveFileNames) {
-      final String name = raw.replaceAll(r'\', '/');
-      final String? dictSeg =
-          _firstSegmentUnder(name, _dictionaryResourcesPrefix);
-      if (dictSeg != null) {
-        dictDirs.add(dictSeg);
-        continue;
-      }
-      final String? bookSeg = _firstSegmentUnder(name, _booksPrefix) ??
-          _firstSegmentUnder(name, _legacyBooksPrefix);
-      if (bookSeg != null) {
-        bookDirs.add(bookSeg);
-        continue;
-      }
-      final String? audioSeg = _firstSegmentUnder(name, _audiobooksPrefix);
-      if (audioSeg != null) {
-        audioDirs.add(audioSeg);
-        continue;
-      }
-      if (name.startsWith('$_fontsPrefix/')) {
-        if (name.length > _fontsPrefix.length + 1) fontFiles++;
-        continue;
-      }
-      if (name.startsWith('$_videosPrefix/')) {
-        if (name.length > _videosPrefix.length + 1) videoFiles++;
-        continue;
-      }
-      if (name.startsWith('$_localAudioPrefix/')) {
-        final String base = name.substring(_localAudioPrefix.length + 1);
-        if (_localAudioDbOnly.hasMatch(base)) localAudioDbs++;
-      }
-    }
-    // Video presence is decided by DB rows, NOT packed files: videos live in the
-    // overwrite DB blob and restore wholesale, so a files-only count would hide a
-    // streaming-video (no file) or old-backup video and import it uninvited
-    // (BUG-779). Priority: meta.videoBookCount (authoritative row count, new
-    // backups) → dbVideoBookCount (a DB-blob peek for old backups lacking the
-    // field) → packed-file fallback (legacy).
-    final int videoCount = meta?.videoBookCount ??
-        dbVideoBookCount ??
-        (meta != null && meta.videoFiles.isNotEmpty
-            ? meta.videoFiles.length
-            : videoFiles);
-    // Audiobooks decided by DB rows too (BUG-781), same priority chain: the
-    // audiobooks table rides the overwrite blob, so a files-only count would hide
-    // a row-only / old backup and import ghost audiobooks un-skippably.
-    final int audiobookCount =
-        meta?.audiobookCount ?? dbAudiobookCount ?? audioDirs.length;
-    final Map<BackupCategory, int> counts = <BackupCategory, int>{
-      if (dictDirs.isNotEmpty) BackupCategory.dictionary: dictDirs.length,
-      if (bookDirs.isNotEmpty) BackupCategory.books: bookDirs.length,
-      if (audiobookCount > 0) BackupCategory.audiobooks: audiobookCount,
-      if (fontFiles > 0) BackupCategory.fonts: fontFiles,
-      if (videoCount > 0) BackupCategory.videos: videoCount,
-      if (localAudioDbs > 0) BackupCategory.localAudio: localAudioDbs,
-    };
-    return BackupContentSummary(counts: counts, present: counts.keys.toSet());
-  }
-
-  /// First path segment directly under `<prefix>/` in [posixName], or null when
-  /// [posixName] is not under [prefix].
-  static String? _firstSegmentUnder(String posixName, String prefix) {
-    final String withSlash = '$prefix/';
-    if (!posixName.startsWith(withSlash)) return null;
-    final String rest = posixName.substring(withSlash.length);
-    if (rest.isEmpty) return null;
-    final int slash = rest.indexOf('/');
-    return slash < 0 ? rest : rest.substring(0, slash);
-  }
-
-  /// Reads a backup ZIP's central directory (never its file bodies) and returns
-  /// the "what's inside" manifest for the import dialog (TODO-1358). Streams like
-  /// [validateBackup]; returns an empty summary on any read error.
-  Future<BackupContentSummary> summarizeBackupFile(String zipPath) async {
-    InputFileStream? input;
-    try {
-      input = InputFileStream(zipPath);
-      final Archive archive = ZipDecoder().decodeBuffer(input);
-      final BackupMeta? meta = _readBackupMeta(archive);
-      final List<String> names = archive.files
-          .where((ArchiveFile f) => f.isFile)
-          .map((ArchiveFile f) => f.name)
-          .toList();
-      // Old backups (no video/audiobook row count in meta) that packed NO video
-      // or audiobook FILES would otherwise hide those categories even though the
-      // DB blob carries their rows → they import uninvited & un-skippable
-      // (BUG-779 video / BUG-781 audiobooks). Peek the DB blob for the row counts
-      // so the dialog can still offer the toggles. New backups carry the counts
-      // in meta, so the (one-time) peek is skipped for them.
-      int? dbVideoBookCount;
-      int? dbAudiobookCount;
-      final ArchiveFile? dbEntry = _findDbEntry(archive);
-      final bool needPeek =
-          (meta?.videoBookCount == null || meta?.audiobookCount == null) &&
-              dbEntry != null;
-      if (needPeek) {
-        final ({int videos, int audiobooks})? peek =
-            await _peekContentRowCounts(zipPath, dbEntry.name);
-        dbVideoBookCount = peek?.videos;
-        dbAudiobookCount = peek?.audiobooks;
-      }
-      return summarizeBackupEntries(names, meta,
-          dbVideoBookCount: dbVideoBookCount,
-          dbAudiobookCount: dbAudiobookCount);
-    } catch (e, st) {
-      debugPrint(
-          'BackupService.summarizeBackupFile failed for $zipPath: $e\n$st');
-      return const BackupContentSummary();
-    } finally {
-      await input?.close();
-    }
-  }
-
-  /// Streams the backup's main-DB blob (entry [dbEntryName]; the small metadata
-  /// DB — media lives in separate zip entries) to a temp file and returns its
-  /// `video_books` and `audiobooks` row counts, or null on any failure. Used by
-  /// [summarizeBackupFile] to offer the video / audiobooks import toggles for
-  /// OLD backups that predate [BackupMeta.videoBookCount] /
-  /// [BackupMeta.audiobookCount] (BUG-779 / BUG-781). Reuses the isolate-backed
-  /// [_extractEntriesStreaming] so a large metadata DB never materializes on
-  /// the UI isolate.
-  static Future<({int videos, int audiobooks})?> _peekContentRowCounts(
-    String zipPath,
-    String dbEntryName,
-  ) async {
-    final Directory tmp =
-        await Directory.systemTemp.createTemp('fushi_content_peek_');
-    final String dbTmp = p.join(tmp.path, _dbName);
-    try {
-      await _extractEntriesStreaming(
-        zipPath: zipPath,
-        entries: <MapEntry<String, String>>[
-          MapEntry<String, String>(dbEntryName, dbTmp),
-        ],
-      );
-      final sqlite.Database db =
-          sqlite.sqlite3.open(dbTmp, mode: sqlite.OpenMode.readOnly);
-      try {
-        return (
-          videos: _countTableIfPresent(db, 'video_books'),
-          audiobooks: _countTableIfPresent(db, 'audiobooks'),
-        );
-      } finally {
-        db.dispose();
-      }
-    } catch (e, st) {
-      debugPrint('BackupService._peekContentRowCounts failed: $e\n$st');
-      return null;
-    } finally {
-      try {
-        await tmp.delete(recursive: true);
-      } catch (_) {
-        // Best-effort temp cleanup; a leftover temp dir is harmless.
-      }
-    }
-  }
-
-  /// `SELECT COUNT(*)` of [table] on an open read-only sqlite [db], or 0 when the
-  /// table is absent (older-schema backup blob).
-  static int _countTableIfPresent(sqlite.Database db, String table) {
-    final sqlite.ResultSet has = db.select(
-      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
-      <Object?>[table],
-    );
-    if (has.isEmpty) return 0;
-    return db.select('SELECT COUNT(*) AS c FROM $table').first['c'] as int;
   }
 
   /// Builds the export "what's inside" summary from the live DB + this device's
@@ -1363,86 +1277,6 @@ class BackupService {
     );
   }
 
-  /// Whether a Windows OS error code is a transient filesystem-busy condition
-  /// that clears once an external handle is released. The recursive delete of
-  /// the export's temp dir runs right after [_stripCredentials] /
-  /// [_stripDictionaryState] closed their sqlite connections; on Windows the OS
-  /// (and Defender / search-indexer scanning the just-written `hibiki.db` copy)
-  /// can keep a handle open for a brief window after `close()` returns, so the
-  /// delete fails with ERROR_ACCESS_DENIED(5), ERROR_SHARING_VIOLATION(32) or
-  /// ERROR_DIR_NOT_EMPTY(145, a child file still locked). Same family as the
-  /// dictionary-import rename lock (BUG-050).
-  static bool _isWindowsTransientFsBusy(int? code) =>
-      code == 5 || code == 32 || code == 145;
-
-  /// Pure, dependency-injected core of [_deleteDirectoryIfPresent]: deletes a
-  /// directory tree, tolerating both a vanished tree ([PathNotFoundException]:
-  /// already cleaned up) and -- on Windows only -- a transient filesystem-busy
-  /// error (see [_isWindowsTransientFsBusy]) via a bounded, backing-off retry
-  /// that gives the lingering external handle time to release.
-  ///
-  /// A non-Windows error, or a Windows error that is NOT transient FS-busy, is
-  /// rethrown immediately (never swallowed -- a real cleanup failure must
-  /// surface). If every attempt hits transient FS-busy the last exception is
-  /// rethrown rather than silently leaving the temp tree on disk. POSIX deletes
-  /// succeed on the first attempt and never enter the retry branch.
-  @visibleForTesting
-  static Future<void> deleteDirectoryWithRetry({
-    required Future<bool> Function() exists,
-    required Future<void> Function() delete,
-    required Future<void> Function(int delayMs) sleep,
-    required bool isWindows,
-    int maxAttempts = 10,
-  }) async {
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        if (await exists()) {
-          await delete();
-        }
-        return;
-      } on PathNotFoundException {
-        // Cleanup is already satisfied if the temp tree vanished between the
-        // existence check and deletion.
-        return;
-      } on FileSystemException catch (e) {
-        final int? code = e.osError?.errorCode;
-        final bool transient = isWindows && _isWindowsTransientFsBusy(code);
-        if (!transient || attempt == maxAttempts) rethrow;
-        await sleep(50 * attempt); // backoff: 50ms,100ms,... let handle drop
-      }
-    }
-  }
-
-  /// Retries a directory [rename] that hits a transient Windows filesystem-busy
-  /// error (access denied / sharing violation — see [_isWindowsTransientFsBusy])
-  /// with a bounded backoff. The content-tree swap renames a freshly-EXTRACTED
-  /// `.import-tmp` into place; on Windows an antivirus / indexer scanning the
-  /// just-written tree briefly holds handles, so the immediate rename can fail
-  /// with `errno 5` (the "备份导入失败: Rename failed … 拒绝访问" the user hit).
-  /// A non-Windows error, or a non-transient Windows error, is rethrown at once.
-  /// The longer cap than the delete retry (backoff to ~1s/attempt) gives a big
-  /// multi-GB tree's scan time to finish.
-  @visibleForTesting
-  static Future<void> renameDirectoryWithRetry({
-    required Future<void> Function() rename,
-    required Future<void> Function(int delayMs) sleep,
-    required bool isWindows,
-    int maxAttempts = 20,
-  }) async {
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        await rename();
-        return;
-      } on FileSystemException catch (e) {
-        final int? code = e.osError?.errorCode;
-        final bool transient = isWindows && _isWindowsTransientFsBusy(code);
-        if (!transient || attempt == maxAttempts) rethrow;
-        // backoff: 100ms,200ms,... capped at 1s → ~15s total over 20 attempts.
-        await sleep((100 * attempt).clamp(100, 1000));
-      }
-    }
-  }
-
   /// Strips device-local config and credentials from the standalone DB copy in
   /// [dbDirectory] before it leaves the device. Opened via [FushiDatabase]
   /// (the copy is already at the current schema, so no migration runs).
@@ -1535,268 +1369,6 @@ class BackupService {
   @visibleForTesting
   static const String profilePrefCategory = 'pref';
 
-  /// Restores [_deviceLocalTables] from [bakPath] (this device's pre-import
-  /// snapshot) into the freshly-overwritten DB in [dbDirectory] (BUG-816). The
-  /// backup carries these tables EMPTY by design (`_stripCredentials`), so
-  /// without this the overwrite would wipe this device's LAN pairings and sync
-  /// baselines. Runs inline during import while both DBs are at the current
-  /// schema (bak is a copy of the live DB), so `SELECT *` columns align. No-op
-  /// (logged) if bak is gone.
-  static Future<bool> _reapplyDeviceLocalTablesFromBak(
-    String dbDirectory,
-    String bakPath,
-  ) async {
-    if (!File(bakPath).existsSync()) {
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
-          'pre-restore.bak missing — local pairing/baselines could not be '
-          'preserved on import.');
-      return false;
-    }
-    late final bool hasSqliteHeader;
-    try {
-      hasSqliteHeader = await _hasSqliteHeader(bakPath);
-    } catch (e, st) {
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
-          'pre-restore.bak could not be inspected: $e\n$st');
-      return false;
-    }
-    if (!hasSqliteHeader) {
-      // A few low-level restore callers intentionally swap opaque fixture
-      // bytes rather than a Hibiki database. Such a snapshot cannot contain
-      // device-local rows, so there is nothing to retry or retain.
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
-          'pre-restore.bak is not a SQLite database; no local tables to '
-          'preserve.');
-      return true;
-    }
-    FushiDatabase? db;
-    try {
-      db = FushiDatabase(dbDirectory);
-      final String safeBak =
-          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
-      await db.customStatement("ATTACH DATABASE '$safeBak' AS devbak");
-      await db.transaction(() async {
-        for (final String t in _deviceLocalTables) {
-          await db!.customStatement('DELETE FROM $t');
-        }
-        for (final String t in _deviceLocalTablesParentFirst) {
-          await _insertDeviceLocalTableFromBak(db!, t);
-        }
-      });
-      await db.customStatement('DETACH DATABASE devbak');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-      return true;
-    } catch (e, st) {
-      // Best-effort preservation: a corrupt/unreadable imported DB must not
-      // abort the whole restore (the primary overwrite already landed).
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak failed: '
-          '$e\n$st');
-      return false;
-    } finally {
-      try {
-        await db?.close();
-      } catch (_) {/* db may have failed to open */}
-    }
-  }
-
-  static Future<bool> _hasSqliteHeader(String path) async {
-    const List<int> expected = <int>[
-      0x53,
-      0x51,
-      0x4c,
-      0x69,
-      0x74,
-      0x65,
-      0x20,
-      0x66,
-      0x6f,
-      0x72,
-      0x6d,
-      0x61,
-      0x74,
-      0x20,
-      0x33,
-      0x00,
-    ];
-    final RandomAccessFile file = await File(path).open();
-    try {
-      if (await file.length() < expected.length) return false;
-      final List<int> actual = await file.read(expected.length);
-      for (int index = 0; index < expected.length; index++) {
-        if (actual[index] != expected[index]) return false;
-      }
-      return true;
-    } finally {
-      await file.close();
-    }
-  }
-
-  static Future<void> _insertDeviceLocalTableFromBak(
-    FushiDatabase db,
-    String table,
-  ) async {
-    switch (table) {
-      case 'video_download_jobs':
-        await _insertVideoDownloadJobsFromBak(db);
-      case 'video_download_subscriptions':
-        await _insertVideoDownloadSubscriptionsFromBak(db);
-      default:
-        await db.customStatement(
-          'INSERT INTO $table SELECT * FROM devbak.$table',
-        );
-    }
-  }
-
-  /// Rebind a local job only when the imported DB still has the same semantic
-  /// source/collection. Numeric ids are device-local autoincrements and may
-  /// collide with an unrelated row from the backup device, so id existence by
-  /// itself is not sufficient. A missing target is nulled and the job becomes
-  /// actionable instead of aborting the whole FK-checked restore.
-  static Future<void> _insertVideoDownloadJobsFromBak(
-    FushiDatabase db,
-  ) async {
-    final List<String> columns = await _tableColumns(db, 'video_download_jobs');
-    const String sourceLookup =
-        'SELECT current_source.id FROM media_sources AS current_source '
-        'JOIN devbak.media_sources AS old_source '
-        'ON current_source.media_kind = old_source.media_kind '
-        'AND current_source.transport = old_source.transport '
-        'AND current_source.root_path = old_source.root_path '
-        'WHERE old_source.id = j.target_source_id '
-        'ORDER BY current_source.id LIMIT 1';
-    const String collectionLookup = 'SELECT current_collection.id '
-        'FROM media_collections AS current_collection '
-        'JOIN devbak.media_collections AS old_collection '
-        'ON current_collection.name = old_collection.name '
-        'AND current_collection.collection_type = '
-        'old_collection.collection_type '
-        'WHERE old_collection.id = j.collection_id '
-        'ORDER BY current_collection.id LIMIT 1';
-    const String sourceMissing =
-        'j.target_source_id IS NOT NULL AND NOT EXISTS ($sourceLookup)';
-    const String collectionMissing =
-        'j.collection_id IS NOT NULL AND NOT EXISTS ($collectionLookup)';
-    const String referenceMissing =
-        '(($sourceMissing) OR ($collectionMissing))';
-    const String attentionMessage =
-        'needsAttention: restored target source or collection is unavailable '
-        'on this device';
-    final List<String> selectExpressions = columns.map((String column) {
-      switch (column) {
-        case 'target_source_id':
-          return 'CASE WHEN j.target_source_id IS NULL THEN NULL '
-              'ELSE ($sourceLookup) END';
-        case 'collection_id':
-          return 'CASE WHEN j.collection_id IS NULL THEN NULL '
-              'ELSE ($collectionLookup) END';
-        case 'lifecycle':
-          return "CASE WHEN $referenceMissing THEN 'needsAttention' "
-              'ELSE j.lifecycle END';
-        case 'claimed_by':
-        case 'claim_expires_at':
-          return 'NULL';
-        case 'next_attempt_at':
-          return 'CASE WHEN $referenceMissing THEN NULL '
-              'ELSE j.next_attempt_at END';
-        case 'last_error':
-          return 'CASE WHEN $referenceMissing THEN CASE '
-              'WHEN j.last_error IS NULL OR j.last_error = \'\' '
-              "THEN '$attentionMessage' "
-              "ELSE j.last_error || '; $attentionMessage' END "
-              'ELSE j.last_error END';
-        default:
-          return 'j.${_quoteIdentifier(column)}';
-      }
-    }).toList(growable: false);
-    await db.customStatement(
-      'INSERT INTO video_download_jobs '
-      '(${columns.map(_quoteIdentifier).join(', ')}) '
-      'SELECT ${selectExpressions.join(', ')} '
-      'FROM devbak.video_download_jobs AS j',
-    );
-  }
-
-  /// Subscriptions have no lifecycle field. Missing local targets are surfaced
-  /// by disabling the schedule, clearing its lease, and persisting the same
-  /// `needsAttention:` marker consumed by the task UI.
-  static Future<void> _insertVideoDownloadSubscriptionsFromBak(
-    FushiDatabase db,
-  ) async {
-    final List<String> columns =
-        await _tableColumns(db, 'video_download_subscriptions');
-    const String sourceLookup =
-        'SELECT current_source.id FROM media_sources AS current_source '
-        'JOIN devbak.media_sources AS old_source '
-        'ON current_source.media_kind = old_source.media_kind '
-        'AND current_source.transport = old_source.transport '
-        'AND current_source.root_path = old_source.root_path '
-        'WHERE old_source.id = s.target_source_id '
-        'ORDER BY current_source.id LIMIT 1';
-    const String collectionLookup = 'SELECT current_collection.id '
-        'FROM media_collections AS current_collection '
-        'JOIN devbak.media_collections AS old_collection '
-        'ON current_collection.name = old_collection.name '
-        'AND current_collection.collection_type = '
-        'old_collection.collection_type '
-        'WHERE old_collection.id = s.collection_id '
-        'ORDER BY current_collection.id LIMIT 1';
-    const String sourceMissing =
-        's.target_source_id IS NOT NULL AND NOT EXISTS ($sourceLookup)';
-    const String collectionMissing =
-        's.collection_id IS NOT NULL AND NOT EXISTS ($collectionLookup)';
-    const String referenceMissing =
-        '(($sourceMissing) OR ($collectionMissing))';
-    const String attentionMessage =
-        'needsAttention: restored target source or collection is unavailable '
-        'on this device';
-    final List<String> selectExpressions = columns.map((String column) {
-      switch (column) {
-        case 'target_source_id':
-          return 'CASE WHEN s.target_source_id IS NULL THEN NULL '
-              'ELSE ($sourceLookup) END';
-        case 'collection_id':
-          return 'CASE WHEN s.collection_id IS NULL THEN NULL '
-              'ELSE ($collectionLookup) END';
-        case 'enabled':
-          return 'CASE WHEN $referenceMissing THEN 0 ELSE s.enabled END';
-        case 'next_check_at':
-          return 'CASE WHEN $referenceMissing THEN NULL '
-              'ELSE s.next_check_at END';
-        case 'claimed_by':
-        case 'claim_expires_at':
-          return 'NULL';
-        case 'last_error':
-          return 'CASE WHEN $referenceMissing THEN CASE '
-              'WHEN s.last_error IS NULL OR s.last_error = \'\' '
-              "THEN '$attentionMessage' "
-              "ELSE s.last_error || '; $attentionMessage' END "
-              'ELSE s.last_error END';
-        default:
-          return 's.${_quoteIdentifier(column)}';
-      }
-    }).toList(growable: false);
-    await db.customStatement(
-      'INSERT INTO video_download_subscriptions '
-      '(${columns.map(_quoteIdentifier).join(', ')}) '
-      'SELECT ${selectExpressions.join(', ')} '
-      'FROM devbak.video_download_subscriptions AS s',
-    );
-  }
-
-  static Future<List<String>> _tableColumns(
-    FushiDatabase db,
-    String table,
-  ) async {
-    final List<QueryRow> rows =
-        await db.customSelect('PRAGMA table_info($table)').get();
-    return rows
-        .map((QueryRow row) => row.read<String>('name'))
-        .toList(growable: false);
-  }
-
-  static String _quoteIdentifier(String value) =>
-      '"${value.replaceAll('"', '""')}"';
-
   /// Removes dictionary rows from the exported DB copy when dictionary sync is
   /// disabled. Keeping DB metadata without matching `dictionaryResources/`
   /// files would restore ghost dictionaries that cannot be queried.
@@ -1805,59 +1377,6 @@ class BackupService {
     try {
       await db.clearDictionaryHistory();
       await db.clearAllDictionaryMeta();
-      await db.customStatement('VACUUM');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Strips the four DB-only data categories (TODO-1193) from the standalone
-  /// exported DB copy in [dbDirectory] when the user unticked them. Opened via
-  /// [FushiDatabase] (the copy is already at the current schema, so no
-  /// migration runs). Operates ONLY on the export copy — the live user DB is
-  /// never touched.
-  ///
-  /// - [stripProgress]   : `reader_positions`, `bookmarks`, and the
-  ///   `audiobook_pos_*` preference rows.
-  /// - [stripStatistics] : [_statisticsTables].
-  /// - [stripSettings]   : the pure-settings `preferences` rows
-  ///   ([settingsPrefPredicate]) — progress / favorites / content-registry /
-  ///   sync prefs are deliberately preserved.
-  /// - [stripProfiles]   : the four profile-layer tables (child-first so an
-  ///   enforced FK to `profiles` never blocks the sweep).
-  ///
-  /// A single VACUUM + checkpoint afterwards keeps the deleted rows out of the
-  /// freelist pages so they cannot be recovered from the shared backup.
-  static Future<void> _stripExcludedDataCategories(
-    String dbDirectory, {
-    required bool stripProgress,
-    required bool stripStatistics,
-    required bool stripSettings,
-    required bool stripProfiles,
-  }) async {
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      if (stripProgress) {
-        await db.customStatement('DELETE FROM reader_positions');
-        await db.customStatement('DELETE FROM bookmarks');
-        await db.customStatement(
-            "DELETE FROM preferences WHERE key LIKE 'audiobook_pos_%'");
-      }
-      if (stripStatistics) {
-        for (final String table in _statisticsTables) {
-          await db.customStatement('DELETE FROM $table');
-        }
-      }
-      if (stripSettings) {
-        await db.customStatement(
-            'DELETE FROM preferences WHERE $settingsPrefPredicate');
-      }
-      if (stripProfiles) {
-        for (final String table in _profilesLayerTablesChildFirst) {
-          await db.customStatement('DELETE FROM $table');
-        }
-      }
       await db.customStatement('VACUUM');
       await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
     } finally {
@@ -2113,1102 +1632,6 @@ class BackupService {
     );
   }
 
-  /// BUG-816: restores the content-registry preference rows from [bakPath] when
-  /// the backup EXCLUDED their owning category, so an overwrite import of a
-  /// books / fonts / localAudio-excluded backup never wipes this device's
-  /// favorites / font registry / local-audio registry to empty. Mirror of
-  /// [_stripExcludedContentRegistry]. `audio_source_configs` is restored whole
-  /// from bak (the device keeps its own audio setup when localAudio was
-  /// excluded), which subsumes the export-side B-filter. No-op (logged) if bak
-  /// is gone.
-  static Future<void> _reapplyExcludedContentRegistry(
-    String dbDirectory,
-    String bakPath, {
-    required bool reapplyFavorites,
-    required bool reapplyFonts,
-    required bool reapplyLocalAudio,
-  }) async {
-    final List<String> keys = <String>[
-      if (reapplyFavorites) _favoriteSentencesPrefKey,
-      if (reapplyFonts) ...<String>[
-        _fontCatalogPrefKey,
-        ..._legacyFontPrefKeys
-      ],
-      if (reapplyLocalAudio) ...<String>[
-        _localAudioDbsPrefKey,
-        _audioSourceConfigsPrefKey,
-      ],
-    ];
-    if (keys.isEmpty) return;
-    if (!File(bakPath).existsSync()) {
-      debugPrint('BackupService._reapplyExcludedContentRegistry: '
-          'pre-restore.bak missing — local favorites/fonts/audio registry could '
-          'not be preserved for a category-excluded backup.');
-      return;
-    }
-    FushiDatabase? db;
-    try {
-      db = FushiDatabase(dbDirectory);
-      final String safeBak =
-          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
-      final String inList =
-          keys.map((String k) => "'${k.replaceAll("'", "''")}'").join(', ');
-      await db.customStatement("ATTACH DATABASE '$safeBak' AS crbak");
-      await db.transaction(() async {
-        await db!
-            .customStatement('DELETE FROM preferences WHERE key IN ($inList)');
-        await db.customStatement('INSERT INTO preferences '
-            'SELECT * FROM crbak.preferences WHERE key IN ($inList)');
-      });
-      await db.customStatement('DETACH DATABASE crbak');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } catch (e, st) {
-      debugPrint('BackupService._reapplyExcludedContentRegistry failed: '
-          '$e\n$st');
-    } finally {
-      try {
-        await db?.close();
-      } catch (_) {/* db may have failed to open */}
-    }
-  }
-
-  /// 归档里主库条目的解析（读侧唯一入口）：新备份条目名是 [_dbName]（fushi.db），
-  /// 老 Hibiki 时代的备份 / Android 迁移压缩包条目名是
-  /// [legacyHibikiDatabaseFileName]（hibiki.db）。旧条目名属于「读旧数据的迁移
-  /// 代码」豁免；写侧（导出/提取目标路径）永远只落新名。
-  static ArchiveFile? _findDbEntry(Archive archive) =>
-      archive.findFile(_dbName) ??
-      archive.findFile(legacyHibikiDatabaseFileName);
-
-  /// Validate a backup ZIP. Returns metadata if valid.
-  ///
-  /// Streams the central directory via [InputFileStream] instead of reading the
-  /// whole archive into memory — a full-data backup can be many GB (book + audio
-  /// trees), so there is no size cap and the whole file must never be buffered.
-  /// Only the small `backup_meta.json` entry is decompressed; the db presence
-  /// check is metadata-only.
-  Future<BackupMeta?> validateBackup(String zipPath) async {
-    InputFileStream? input;
-    try {
-      input = InputFileStream(zipPath);
-      final archive = ZipDecoder().decodeBuffer(input);
-      final BackupMeta? meta = _readBackupMeta(archive);
-      if (meta == null) return null;
-      if (_findDbEntry(archive) == null) return null;
-      return meta;
-    } catch (e, st) {
-      // A null result tells the UI "invalid backup". Surface the real reason
-      // (corrupt zip / read error / OOM) so it is not silently indistinguishable
-      // from a genuinely malformed archive (review W4).
-      debugPrint('BackupService.validateBackup failed for $zipPath: $e\n$st');
-      return null;
-    } finally {
-      await input?.close();
-    }
-  }
-
-  /// Settings-layer tables restored from THIS device when [restoreBackup]
-  /// runs with importSettings=false. Order matters: `profiles` first (FK target
-  /// of the rest). `preferences` is handled separately (audiobook positions are
-  /// content and follow the backup). No content table FKs into these, and
-  /// `book_profiles.bookUid` is plain text, so a wholesale swap is FK-safe.
-  static const List<String> _settingsLayerTables = <String>[
-    'profiles',
-    'profile_settings',
-    'media_type_profiles',
-    'book_profiles',
-  ];
-
-  /// Restore a backup (overwrite mode), replacing the current database files.
-  /// 用户视角的「恢复备份」顶层入口；merge 模式见 [mergeRestoreBackup]，内部
-  /// 子步骤一律 reapply* 动词（restore 保留给本顶层语义）。
-  ///
-  /// This is a static method because the database must already be closed
-  /// before calling — the caller is responsible for closing the DB first.
-  ///
-  /// [importSettings] (default true = full restore):
-  /// - true: everything comes from the backup, EXCEPT device-local sync config
-  ///   ([SyncRepository.deviceLocalPrefKeys]) which is always preserved (the
-  ///   backup has none — they're stripped on export — so a naive swap would log
-  ///   you out). Re-applied immediately; crash-recoverable via the sidecar.
-  /// - false: keep THIS device's settings layer (preferences + profiles +
-  ///   bindings = fonts/appearance/reading/profiles); only CONTENT comes from
-  ///   the backup. Done inline: opening the imported DB migrates it to the
-  ///   current schema, then the settings layer is copied back from
-  ///   pre-restore.bak (both at current schema → column-aligned, FK-safe). The
-  ///   sidecar + bak written before the overwrite are a crash-recovery net so
-  ///   [recoverPendingRestore] can finish the restore if this crashes mid-way.
-  static Future<void> restoreBackup({
-    required String dbDirectory,
-    required String zipPath,
-    bool importSettings = true,
-    Set<BackupCategory>? categories,
-    String? dictionaryResourceDirectory,
-    String? booksRootDirectory,
-    String? audiobooksRootDirectory,
-    String? fontsRootDirectory,
-    String? videosRootDirectory,
-    void Function(double progress)? onProgress,
-  }) async {
-    final dbPath = p.join(dbDirectory, _dbName);
-    // Stream the central directory instead of buffering the whole (GB-scale)
-    // archive in memory. Each entry's bytes are read lazily on `.content`; the
-    // stream stays open until every read completes (closed in `finally`).
-    final InputFileStream input = InputFileStream(zipPath);
-    try {
-      final archive = ZipDecoder().decodeBuffer(input);
-      final ArchiveFile? dbFile = _findDbEntry(archive);
-      if (dbFile == null) throw StateError('No $_dbName in backup archive');
-
-      // TODO-1183: determinate progress across every streamed byte.
-      final void Function(int deltaBytes) reportBytes =
-          _archiveByteProgress(archive, onProgress);
-
-      // Parse the source-device content roots so book/audio paths can be
-      // rebased onto this device after the trees are restored.
-      final BackupMeta? meta = _readBackupMeta(archive);
-      // TODO-1193: a backup that unticked `settings` / `profiles` carries an
-      // EMPTY settings / profiles layer BY CHOICE. On an overwrite import the DB
-      // is replaced wholesale, so without a guard those empty layers would WIPE
-      // this device's settings/profiles. Detect the choice from the meta and
-      // preserve the LOCAL layer from bak below (mirrors BUG-454's dictionary
-      // preserve-on-absent). importSettings=false already keeps the whole
-      // settings layer from bak, so it is inherently safe.
-      final bool backupSettingsExcluded =
-          meta?.excludedCategories.contains(BackupCategory.settings.name) ??
-              false;
-      final bool backupProfilesExcluded =
-          meta?.excludedCategories.contains(BackupCategory.profiles.name) ??
-              false;
-      // BUG-816: content-registry prefs (favorites / fonts / local-audio) travel
-      // EMPTY when their owning category was unticked, so an overwrite import
-      // must preserve THIS device's rows from bak instead of wiping them.
-      final bool backupBooksExcluded =
-          meta?.excludedCategories.contains(BackupCategory.books.name) ?? false;
-      final bool backupFontsExcluded =
-          meta?.excludedCategories.contains(BackupCategory.fonts.name) ?? false;
-      final bool backupLocalAudioExcluded =
-          meta?.excludedCategories.contains(BackupCategory.localAudio.name) ??
-              false;
-
-      final String? dictionaryReapplyDirectory = dictionaryResourceDirectory;
-      List<MapEntry<ArchiveFile, String>>? dictionaryReapplyPlan;
-      if (dictionaryReapplyDirectory != null) {
-        dictionaryReapplyPlan = _buildDictionaryReapplyPlan(
-          archive: archive,
-          dictionaryResourceDirectory: dictionaryReapplyDirectory,
-        );
-      }
-      // BUG-454: a backup exported WITHOUT the dictionary category carries no
-      // `dictionaryResources/` files AND has its dictionary DB rows stripped on
-      // export (`_stripDictionaryState`). Detecting "the backup has no
-      // dictionary files" lets the overwrite import PRESERVE this device's
-      // existing dictionaries (metadata rows + resource files) instead of
-      // wiping them — the backup simply didn't include that category, the same
-      // selective-preserve contract the device-local sync prefs already follow.
-      final bool backupHasDictionaries = archive.files.any((ArchiveFile f) =>
-          f.isFile &&
-          f.name
-              .replaceAll(r'\', '/')
-              .startsWith('$_dictionaryResourcesPrefix/'));
-
-      // TODO-1358: honour a per-category IMPORT selection (overwrite path only;
-      // merge always combines everything). A null [categories] restores every
-      // category the backup carries (legacy). Unticking a category on import:
-      //  - dictionary -> treat as if the backup carries no dictionaries so the
-      //    BUG-454 path preserves THIS device dictionaries (re-seated from bak).
-      //  - audiobooks / fonts / videos / localAudio -> skip restoring those files
-      //    (and skip rebasing their paths); the DB library index still restores.
-      // Books / progress / statistics always restore (the core library index in
-      // the overwrite DB blob); settings / profiles stay governed by
-      // [importSettings].
-      bool wants(BackupCategory c) =>
-          categories == null || categories.contains(c);
-      final bool effectiveHasDictionaries =
-          backupHasDictionaries && wants(BackupCategory.dictionary);
-      final String? effAudiobooksRoot =
-          wants(BackupCategory.audiobooks) ? audiobooksRootDirectory : null;
-      final String? effFontsRoot =
-          wants(BackupCategory.fonts) ? fontsRootDirectory : null;
-      final String? effVideosRoot =
-          wants(BackupCategory.videos) ? videosRootDirectory : null;
-      final String? effLocalAudioRoot =
-          wants(BackupCategory.localAudio) ? dbDirectory : null;
-
-      final sidecar = File(p.join(dbDirectory, _preserveSidecar));
-      final String bakPath = '$dbPath.pre-restore.bak';
-      final currentDb = File(dbPath);
-      final bool haveCurrent = currentDb.existsSync();
-      bool deviceLocalTablesReapplied = !haveCurrent;
-
-      // 1) Snapshot the current DB (crash safety) + record what to preserve.
-      //    Skipped on a fresh install (no current DB) → backup applied verbatim,
-      //    so the toggle is moot there.
-      Map<String, String> preservedSync = const <String, String>{};
-      if (haveCurrent) {
-        late final Map<String, dynamic> sidecarPayload;
-        if (importSettings) {
-          preservedSync = await _readDeviceLocalPrefs(dbDirectory);
-          sidecarPayload = <String, dynamic>{
-            'mode': 'prefs',
-            'prefs': preservedSync,
-            'preserveDeviceLocalTables': true,
-            if (backupSettingsExcluded) 'preserveSettings': true,
-            if (backupProfilesExcluded) 'preserveProfiles': true,
-          };
-        } else {
-          sidecarPayload = <String, dynamic>{
-            'mode': 'settings',
-            'preserveDeviceLocalTables': true,
-          };
-        }
-        // The v78 download graph is device-local even when there are no sync
-        // preferences to preserve, so every destructive overwrite needs both
-        // artifacts. Copy the database first: a sidecar must never advertise a
-        // recoverable restore before its corresponding snapshot exists.
-        await currentDb.copy(bakPath);
-        await sidecar.writeAsString(
-          jsonEncode(sidecarPayload),
-          flush: true,
-        );
-      }
-
-      // Must delete -wal/-shm AFTER reading prefs (step 1 opened+closed a WAL
-      // connection) and BEFORE overwriting the main .db: leftover WAL frames
-      // from the old DB would otherwise be replayed against the imported file
-      // and corrupt it.
-      final walFile = File('$dbPath-wal');
-      if (walFile.existsSync()) await walFile.delete();
-      final shmFile = File('$dbPath-shm');
-      if (shmFile.existsSync()) await shmFile.delete();
-
-      // 2) Overwrite with the backup DB bytes — streamed on a background
-      //    isolate so a multi-GB DB never materializes in the heap (OOM,
-      //    TODO-1183) and never blocks the UI isolate.
-      await _extractEntriesStreaming(
-        zipPath: zipPath,
-        entries: <MapEntry<String, String>>[
-          MapEntry<String, String>(dbFile.name, dbPath),
-        ],
-        onBytes: reportBytes,
-      );
-
-      if (effectiveHasDictionaries &&
-          dictionaryReapplyPlan != null &&
-          dictionaryReapplyDirectory != null) {
-        // Backup carries dictionaries → replace this device's resources with
-        // the backup's (the DB overwrite already brought the matching rows).
-        await _reapplyDictionaryResources(
-          zipPath: zipPath,
-          reapplyPlan: dictionaryReapplyPlan,
-          dictionaryResourceDirectory: dictionaryReapplyDirectory,
-          onBytes: reportBytes,
-        );
-      } else if (!effectiveHasDictionaries &&
-          haveCurrent &&
-          dictionaryReapplyDirectory != null) {
-        // BUG-454: backup has NO dictionaries → keep this device's. The DB was
-        // just overwritten with the backup's (dictionary tables empty), so
-        // re-seat the local dictionary rows from pre-restore.bak. The resource
-        // FILES on disk were never touched (we skipped the unconditional wipe
-        // in _reapplyDictionaryResources), so rows + files stay consistent.
-        // Gated on a managed dictionary dir: the live app always supplies it;
-        // a null dir means the caller isn't managing dictionaries at all, so
-        // there is nothing to preserve (and bak may not even be a real DB in
-        // such minimal call sites).
-        await _reapplyDictionaryTablesFromBak(dbDirectory, bakPath);
-      }
-
-      // 2b) Restore the book + audiobook content trees (full-data backup).
-      //     PREPARE both (write to sibling `.import-tmp` dirs) BEFORE COMMITTING
-      //     either (fast rename-swap), so a failure during the GB-scale write
-      //     phase swaps nothing and leaves both existing trees intact — a user's
-      //     whole library must never be half-destroyed. Only runs when the
-      //     caller supplies the roots AND the backup carries that tree.
-      final List<String> toCommit = <String>[];
-      try {
-        if (booksRootDirectory != null &&
-            wants(BackupCategory.books) &&
-            await _prepareTreeReapply(zipPath, archive,
-                archiveBooksPrefix(archive), booksRootDirectory,
-                onBytes: reportBytes)) {
-          toCommit.add(booksRootDirectory);
-        }
-        if (effAudiobooksRoot != null &&
-            await _prepareTreeReapply(
-                zipPath, archive, _audiobooksPrefix, effAudiobooksRoot,
-                onBytes: reportBytes)) {
-          toCommit.add(effAudiobooksRoot);
-        }
-        if (effFontsRoot != null &&
-            await _prepareTreeReapply(
-                zipPath, archive, _fontsPrefix, effFontsRoot,
-                onBytes: reportBytes)) {
-          toCommit.add(effFontsRoot);
-        }
-        if (effVideosRoot != null &&
-            await _prepareTreeReapply(
-                zipPath, archive, _videosPrefix, effVideosRoot,
-                onBytes: reportBytes)) {
-          toCommit.add(effVideosRoot);
-        }
-      } catch (_) {
-        // A write failed: drop every staged temp dir; no tree was swapped.
-        if (booksRootDirectory != null) {
-          await _abortPreparedTree(booksRootDirectory);
-        }
-        if (effAudiobooksRoot != null) {
-          await _abortPreparedTree(effAudiobooksRoot);
-        }
-        if (effFontsRoot != null) {
-          await _abortPreparedTree(effFontsRoot);
-        }
-        if (effVideosRoot != null) {
-          await _abortPreparedTree(effVideosRoot);
-        }
-        rethrow;
-      }
-      // All writes succeeded → commit each prepared tree (fast renames).
-      for (final String root in toCommit) {
-        await _commitPreparedTree(root);
-      }
-
-      // 2c) Restore local-audio databases into the support directory. These are
-      //     individual files sharing the directory with hibiki.db, so they are
-      //     extracted file-by-file (never the destructive tree swap). When the
-      //     backup carries no localAudio/ prefix the existing local-audio DBs
-      //     are left untouched (same preserve-on-absent contract as the trees).
-      if (wants(BackupCategory.localAudio)) {
-        await _reapplyLocalAudioFiles(zipPath, archive, dbDirectory,
-            onBytes: reportBytes);
-      }
-
-      // 3) Restore what must stay on this device — inline, not deferred to
-      //    startup, so the common path never depends on bak surviving a restart.
-      if (importSettings) {
-        // TODO-1193: the backup EXCLUDED settings and/or profiles → its DB blob
-        // has those layers empty by choice. Preserve THIS device's layer from
-        // bak FIRST so the overwrite never wipes settings/profiles to empty.
-        // Runs before the sync re-apply so _applyPreservedConfig stays the
-        // authoritative last word on sync config (and clears the folder cache).
-        if ((backupSettingsExcluded || backupProfilesExcluded) && haveCurrent) {
-          await _reapplyExcludedSettingsLayers(
-            dbDirectory,
-            bakPath,
-            reapplySettings: backupSettingsExcluded,
-            reapplyProfiles: backupProfilesExcluded,
-          );
-        }
-        // Re-apply device-local sync config (preferences is schema-stable).
-        if (preservedSync.isNotEmpty) {
-          await _applyPreservedConfig(dbDirectory, preservedSync);
-        }
-      } else if (haveCurrent) {
-        // Keep this device's whole settings layer.
-        await _reapplySettingsLayer(dbDirectory);
-      }
-
-      // 3a) BUG-816: the export wipes device-local tables (LAN pairing token +
-      //     sync baselines) unconditionally, so they arrive EMPTY. Restore this
-      //     device's rows from bak on any overwrite import (both importSettings
-      //     branches) — else the overwrite would wipe the device's pairings and
-      //     baselines. No-op on a fresh install (no bak).
-      if (haveCurrent) {
-        deviceLocalTablesReapplied =
-            await _reapplyDeviceLocalTablesFromBak(dbDirectory, bakPath);
-        // BUG-816: preserve THIS device's content-registry prefs from bak when
-        // the backup excluded their owning category (books/fonts/localAudio) —
-        // runs in both importSettings branches, mirroring the export strip.
-        await _reapplyExcludedContentRegistry(
-          dbDirectory,
-          bakPath,
-          reapplyFavorites: backupBooksExcluded,
-          reapplyFonts: backupFontsExcluded,
-          reapplyLocalAudio: backupLocalAudioExcluded,
-        );
-      }
-
-      // 3b) Rebase the imported DB's stored absolute paths (which point at the
-      //     SOURCE device's roots) onto this device's roots. Books/audiobooks
-      //     are content, so they come from the backup in BOTH import modes →
-      //     always rebase. No-op for a legacy backup (meta has no roots).
-      if (meta != null) {
-        await _rebaseAllPaths(
-          dbDirectory: dbDirectory,
-          meta: meta,
-          newBooksRoot: booksRootDirectory,
-          newAudiobooksRoot: effAudiobooksRoot,
-          newFontsRoot: effFontsRoot,
-          newLocalAudioRoot: effLocalAudioRoot,
-          newVideosRoot: effVideosRoot,
-        );
-      }
-
-      // 3c) Honour the per-category IMPORT selection for the DB-content
-      //     categories the overwrite blob carries wholesale (TODO-1358). The
-      //     file categories are already gated above (skipped file restore), but
-      //     books / statistics / progress live in the swapped-in DB, so strip
-      //     the unticked ones here. Overwrite semantics: unticking = that
-      //     category's data does not end up on this device (the DB was replaced
-      //     wholesale, so there is no local layer to preserve — mirrors how the
-      //     statistics/progress strip already works on the export side).
-      if (!wants(BackupCategory.books)) {
-        // Strip every book row (+ its cascade) so no book from the backup
-        // travels; the hoshi_books tree restore was skipped above too.
-        await _retainBooks(dbDirectory, const <String>{});
-      }
-      if (!wants(BackupCategory.videos)) {
-        // Videos live in the overwrite DB blob (video_books + cascade), so
-        // unticking the video category must strip those rows too — skipping the
-        // FILE restore (effVideosRoot=null) alone left every video_books row in
-        // the swapped-in DB, so the videos imported uninvited & un-skippable even
-        // when the dialog did offer the toggle (BUG-779). Mirrors the books strip
-        // and the export-side [_retainVideos].
-        await _retainVideos(dbDirectory, const <String>{});
-      }
-      if (!wants(BackupCategory.audiobooks)) {
-        // Same class as videos (BUG-781): audiobook rows (audiobooks + audio_cues
-        // + srt shelf entry) ride the overwrite DB blob, so unticking the
-        // audiobooks category must strip them — the skipped FILE restore
-        // (effAudiobooksRoot=null) alone left ghost audiobooks (shelf + alignment
-        // rows pointing at audio that never travelled).
-        await _retainAudiobooks(dbDirectory, const <String>{});
-      }
-      if (!wants(BackupCategory.statistics) ||
-          !wants(BackupCategory.progress)) {
-        await _stripExcludedDataCategories(
-          dbDirectory,
-          stripProgress: !wants(BackupCategory.progress),
-          stripStatistics: !wants(BackupCategory.statistics),
-          // settings / profiles stay governed by the importSettings toggle and
-          // the excluded-layer preserve above — never touched by this strip.
-          stripSettings: false,
-          stripProfiles: false,
-        );
-      }
-
-      // 4) Success: drop the sidecar and the pre-restore copy (no disk leak).
-      // A failed device-local replay is recoverable at the next startup, but
-      // only while BOTH artifacts survive. The replay transaction starts with
-      // a child-first wipe and is therefore safe to run again.
-      if (deviceLocalTablesReapplied) {
-        await _safeDelete(sidecar.path);
-        await _safeDelete(bakPath);
-      } else {
-        debugPrint('BackupService.restoreBackup: device-local tables were not '
-            'reapplied; retaining restore sidecar and pre-restore.bak for '
-            'startup recovery.');
-      }
-    } finally {
-      await input.close();
-    }
-  }
-
-  /// Sidecar file marking a pending MERGE import (TODO-888). The merge runs in
-  /// one Drift transaction, so a crash leaves the DB already-consistent (the
-  /// transaction either committed or rolled back); this sidecar only drives
-  /// startup cleanup of the temp `merge-src` + `pre-merge.bak` files.
-  static const String _mergeSidecar = '$_dbName.merge-preserve.json';
-  static const String _mergeSrcName = '$_dbName.merge-src';
-
-  /// MERGE a backup into the current database instead of overwriting it
-  /// (TODO-888). The device keeps everything it has; the backup only ADDS what
-  /// is missing and MAX-unions statistics, so re-importing the same backup is
-  /// idempotent. Unlike [restoreBackup] this NEVER touches the destructive
-  /// overwrite path (`writeAsBytes`) or the two-phase tree swap; content trees
-  /// are restored copy-if-absent (existing files are never replaced or deleted).
-  ///
-  /// The caller must close the app's DB first (same contract as
-  /// [restoreBackup]); this opens its own connections. Crash safety: the
-  /// whole row merge is ONE [FushiDatabase.transaction] (rolled back on any
-  /// failure) plus a `pre-merge.bak` snapshot for manual recovery, and a
-  /// `mode:'merge'` sidecar so [recoverPendingRestore] cleans up temp files.
-  static Future<void> mergeRestoreBackup({
-    required String dbDirectory,
-    required String zipPath,
-    Set<BackupCategory>? categories,
-    String? dictionaryResourceDirectory,
-    String? booksRootDirectory,
-    String? audiobooksRootDirectory,
-    String? fontsRootDirectory,
-    String? videosRootDirectory,
-    void Function(double progress)? onProgress,
-    bool adoptSourcePreferences = false,
-  }) async {
-    // Per-category merge selection (import dialog, merge mode). null = merge
-    // every category (legacy full merge). Gates BOTH the DB row merge (via the
-    // engine) AND the content-tree copies below, so an unticked category adds
-    // nothing — neither rows nor files.
-    bool wants(BackupCategory c) =>
-        categories == null || categories.contains(c);
-    final Set<String>? enabledCategoryNames =
-        categories?.map((BackupCategory c) => c.name).toSet();
-    final String dbPath = p.join(dbDirectory, _dbName);
-    final String mergeSrcPath = p.join(dbDirectory, _mergeSrcName);
-    final String bakPath = '$dbPath.pre-merge.bak';
-    final File sidecar = File(p.join(dbDirectory, _mergeSidecar));
-
-    final InputFileStream input = InputFileStream(zipPath);
-    try {
-      final Archive archive = ZipDecoder().decodeBuffer(input);
-      final ArchiveFile? dbFile = _findDbEntry(archive);
-      if (dbFile == null) throw StateError('No $_dbName in backup archive');
-
-      // TODO-1183: determinate progress across every streamed byte.
-      final void Function(int deltaBytes) reportBytes =
-          _archiveByteProgress(archive, onProgress);
-
-      final BackupMeta? meta = _readBackupMeta(archive);
-
-      // 1) Extract the backup DB to a sibling temp file (NEVER overwrite the
-      //    live DB). Drop any stale merge-src/-wal/-shm from a prior crash.
-      await _safeDelete(mergeSrcPath);
-      await _safeDelete('$mergeSrcPath-wal');
-      await _safeDelete('$mergeSrcPath-shm');
-      await _extractEntriesStreaming(
-        zipPath: zipPath,
-        entries: <MapEntry<String, String>>[
-          MapEntry<String, String>(dbFile.name, mergeSrcPath),
-        ],
-        onBytes: reportBytes,
-      );
-
-      // 2) Migrate the backup DB up to the current schema so its columns align
-      //    with the live DB for the ATTACH-based row merge. (Its schemaVersion
-      //    is <= current — validated by the caller.) Opening + closing
-      //    FushiDatabase on its file runs onUpgrade if needed.
-      final FushiDatabase srcMigrate = FushiDatabase.atFile(mergeSrcPath);
-      try {
-        await srcMigrate.customStatement('PRAGMA user_version');
-      } finally {
-        await srcMigrate.close();
-      }
-      await _safeDelete('$mergeSrcPath-wal');
-      await _safeDelete('$mergeSrcPath-shm');
-
-      // 3) Snapshot the live DB for manual recovery + drop the crash-cleanup
-      //    sidecar BEFORE mutating the live DB.
-      final File currentDb = File(dbPath);
-      if (currentDb.existsSync()) {
-        await currentDb.copy(bakPath);
-      }
-      await sidecar.writeAsString(jsonEncode(<String, dynamic>{
-        'mode': 'merge',
-        'mergeSrc': mergeSrcPath,
-      }));
-
-      // 4) Open the live DB, ATTACH the backup, run the whole row merge in one
-      //    transaction (rolled back on any failure -> DB unchanged).
-      final FushiDatabase db = FushiDatabase(dbDirectory);
-      try {
-        final String safeSrc =
-            mergeSrcPath.replaceAll(r'\', '/').replaceAll("'", "''");
-        await db.customStatement("ATTACH DATABASE '$safeSrc' AS mergesrc");
-        try {
-          // TODO-1261: only import video rows whose file travelled (or streaming
-          // URLs) so a backup never lands a dead "empty video" shell. The carried
-          // set is the exact video files packed by export (meta.videoFiles keys).
-          await BackupMergeEngine(
-            db,
-            carriedVideoSourcePaths:
-                meta?.videoFiles.keys.toSet() ?? const <String>{},
-            enabledCategoryNames: enabledCategoryNames,
-            adoptSourcePreferences: adoptSourcePreferences,
-          ).merge();
-        } finally {
-          await db.customStatement('DETACH DATABASE mergesrc');
-        }
-        await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-      } finally {
-        await db.close();
-      }
-
-      // 5) Restore content trees COPY-IF-ABSENT (never delete/replace existing
-      //    files — the device's own library must stay intact). Each tree is
-      //    gated by its category so an unticked category copies no files (its
-      //    rows were likewise skipped by the engine above).
-      if (dictionaryResourceDirectory != null &&
-          wants(BackupCategory.dictionary)) {
-        await _copyTreeIfAbsent(zipPath, archive, _dictionaryResourcesPrefix,
-            dictionaryResourceDirectory,
-            onBytes: reportBytes);
-      }
-      if (booksRootDirectory != null && wants(BackupCategory.books)) {
-        await _copyTreeIfAbsent(
-            zipPath, archive, archiveBooksPrefix(archive), booksRootDirectory,
-            onBytes: reportBytes);
-      }
-      if (audiobooksRootDirectory != null && wants(BackupCategory.audiobooks)) {
-        await _copyTreeIfAbsent(
-            zipPath, archive, _audiobooksPrefix, audiobooksRootDirectory,
-            onBytes: reportBytes);
-      }
-      if (fontsRootDirectory != null && wants(BackupCategory.fonts)) {
-        await _copyTreeIfAbsent(
-            zipPath, archive, _fontsPrefix, fontsRootDirectory,
-            onBytes: reportBytes);
-      }
-      if (videosRootDirectory != null && wants(BackupCategory.videos)) {
-        await _copyTreeIfAbsent(
-            zipPath, archive, _videosPrefix, videosRootDirectory,
-            onBytes: reportBytes);
-      }
-      // Local-audio DBs are copy-if-absent into the support directory (never
-      // overwrite the device's own local_audio_*.db files).
-      if (wants(BackupCategory.localAudio)) {
-        await _reapplyLocalAudioFiles(zipPath, archive, dbDirectory,
-            overwrite: false, onBytes: reportBytes);
-      }
-
-      // 6) Rebase the newly-merged backup rows' stored paths onto this device's
-      //    roots. Device-local rows aren't under the backup's source root, so
-      //    rebasePath leaves them untouched (a no-op for them).
-      if (meta != null) {
-        await _rebaseAllPaths(
-          dbDirectory: dbDirectory,
-          meta: meta,
-          newBooksRoot: booksRootDirectory,
-          newAudiobooksRoot: audiobooksRootDirectory,
-          newFontsRoot: fontsRootDirectory,
-          newLocalAudioRoot: dbDirectory,
-          newVideosRoot: videosRootDirectory,
-        );
-      }
-
-      // 7) Success: drop the merge-src temp, the bak, and the sidecar.
-      await _safeDelete(mergeSrcPath);
-      await _safeDelete('$mergeSrcPath-wal');
-      await _safeDelete('$mergeSrcPath-shm');
-      await _safeDelete(bakPath);
-      await _safeDelete(sidecar.path);
-    } finally {
-      await input.close();
-    }
-  }
-
-  /// Temp filename for the preview-only extracted backup DB (TODO-1195 part B).
-  static const String _mergePreviewSrcName = '$_dbName.merge-preview-src';
-
-  /// Read-only estimate of what a MERGE import of [zipPath] would change on this
-  /// device, for the import confirm dialog (TODO-1195 part B). Extracts ONLY the
-  /// backup's main-DB entry to a temp file, migrates it to the current schema,
-  /// ATTACHes it to the still-open [liveDb] and runs [BackupMergeEngine.preview]
-  /// (no mutation, no transaction), then detaches and cleans up. Best-effort:
-  /// any failure returns null so the caller shows a generic dialog and the
-  /// import is never blocked by a preview problem. The content trees are NOT
-  /// extracted (only row counts matter), so this stays cheap even for a
-  /// multi-GB backup.
-  static Future<BackupMergePreview?> previewMergeRestore({
-    required FushiDatabase liveDb,
-    required String dbDirectory,
-    required String zipPath,
-  }) async {
-    final String tmpSrc = p.join(dbDirectory, _mergePreviewSrcName);
-    try {
-      final InputFileStream input = InputFileStream(zipPath);
-      final Archive archive;
-      try {
-        archive = ZipDecoder().decodeBuffer(input);
-      } finally {
-        await input.close();
-      }
-      final ArchiveFile? dbFile = _findDbEntry(archive);
-      if (dbFile == null) return null;
-
-      // TODO-1261: the merge only materialises REACHABLE video rows (streaming
-      // or a local file the backup carried), so the preview must count with the
-      // same predicate. The carried set is the packed video files (meta.videoFiles).
-      final BackupMeta? meta = _readBackupMeta(archive);
-      final Set<String> carriedVideoSourcePaths =
-          meta?.videoFiles.keys.toSet() ?? const <String>{};
-
-      await _safeDelete(tmpSrc);
-      await _safeDelete('$tmpSrc-wal');
-      await _safeDelete('$tmpSrc-shm');
-      await _extractEntriesStreaming(
-        zipPath: zipPath,
-        entries: <MapEntry<String, String>>[
-          MapEntry<String, String>(dbFile.name, tmpSrc),
-        ],
-      );
-
-      // Migrate the extracted DB up to the current schema so its columns align
-      // for the ATTACH-based COUNT queries (same contract as the real merge).
-      final FushiDatabase srcMigrate = FushiDatabase.atFile(tmpSrc);
-      try {
-        await srcMigrate.customStatement('PRAGMA user_version');
-      } finally {
-        await srcMigrate.close();
-      }
-      await _safeDelete('$tmpSrc-wal');
-      await _safeDelete('$tmpSrc-shm');
-
-      final String safeSrc = tmpSrc.replaceAll(r'\', '/').replaceAll("'", "''");
-      await liveDb.customStatement("ATTACH DATABASE '$safeSrc' AS previewsrc");
-      try {
-        return await BackupMergeEngine(
-          liveDb,
-          srcAlias: 'previewsrc',
-          carriedVideoSourcePaths: carriedVideoSourcePaths,
-        ).preview();
-      } finally {
-        await liveDb.customStatement('DETACH DATABASE previewsrc');
-      }
-    } catch (e, st) {
-      // Never block the import on a preview failure — fall back to a generic
-      // confirm dialog.
-      debugPrint('BackupService.previewMergeRestore failed: $e\n$st');
-      return null;
-    } finally {
-      await _safeDelete(tmpSrc);
-      await _safeDelete('$tmpSrc-wal');
-      await _safeDelete('$tmpSrc-shm');
-    }
-  }
-
-  /// Copies every file under `<prefix>/` in [archive] into [targetRootPath],
-  /// SKIPPING any whose destination already exists (the merge-import invariant:
-  /// never delete or overwrite the device's own content). Reuses the same path
-  /// traversal safety checks as the overwrite path's [_buildTreeReapplyPlan].
-  static Future<void> _copyTreeIfAbsent(
-    String zipPath,
-    Archive archive,
-    String prefix,
-    String targetRootPath, {
-    void Function(int deltaBytes)? onBytes,
-  }) async {
-    final List<MapEntry<ArchiveFile, String>> plan = _buildTreeReapplyPlan(
-      archive: archive,
-      prefix: prefix,
-      targetRootPath: targetRootPath,
-    );
-    final List<MapEntry<String, String>> toWrite = <MapEntry<String, String>>[];
-    for (final MapEntry<ArchiveFile, String> entry in plan) {
-      if (await File(entry.value).exists()) continue; // copy-if-absent
-      toWrite.add(MapEntry<String, String>(entry.key.name, entry.value));
-    }
-    await _extractEntriesStreaming(
-      zipPath: zipPath,
-      entries: toWrite,
-      onBytes: onBytes,
-    );
-  }
-
-  /// Cleans up a crashed/finished MERGE import's temp files (TODO-888). Returns
-  /// true when a merge sidecar was present (and was handled), false otherwise.
-  /// The DB itself is untouched: the merge transaction is all-or-nothing, so the
-  /// live DB is already consistent regardless of when a crash happened.
-  static Future<bool> recoverMergeRestore(String dbDirectory) async {
-    final File sidecar = File(p.join(dbDirectory, _mergeSidecar));
-    if (!sidecar.existsSync()) return false;
-    try {
-      final Map<String, dynamic> decoded =
-          jsonDecode(await sidecar.readAsString()) as Map<String, dynamic>;
-      final Object? mergeSrc = decoded['mergeSrc'];
-      if (mergeSrc is String) {
-        await _safeDelete(mergeSrc);
-        await _safeDelete('$mergeSrc-wal');
-        await _safeDelete('$mergeSrc-shm');
-      }
-    } catch (e, st) {
-      debugPrint('BackupService.recoverMergeRestore failed: $e\n$st');
-    }
-    await _safeDelete(p.join(dbDirectory, _mergeSrcName));
-    await _safeDelete(p.join(dbDirectory, '$_mergeSrcName-wal'));
-    await _safeDelete(p.join(dbDirectory, '$_mergeSrcName-shm'));
-    await _safeDelete(p.join(dbDirectory, '$_dbName.pre-merge.bak'));
-    await _safeDelete(sidecar.path);
-    return true;
-  }
-
-  /// Finish a pending import at startup, before any sync code reads prefs.
-  /// Handles both: (a) re-applying device-local sync prefs if a full-restore
-  /// import crashed mid-way; (b) restoring this device's settings layer for a
-  /// keep-settings import. No-op when no sidecar is present.
-  static Future<void> recoverPendingRestore(String dbDirectory) async {
-    // MERGE import (TODO-888) leaves its own sidecar. The row merge ran in ONE
-    // Drift transaction, so the live DB is already consistent whether or not we
-    // crashed (the transaction either committed or rolled back) — there is
-    // NOTHING to apply to the DB, only leftover temp files to sweep. Handle it
-    // first + return so a 'merge' marker can never fall through to the legacy
-    // bare-map prefs path and get mis-applied. (recoverMergeRestore is reused by
-    // tests; keep the sweep there.)
-    if (await recoverMergeRestore(dbDirectory)) return;
-
-    final sidecar = File(p.join(dbDirectory, _preserveSidecar));
-    if (!sidecar.existsSync()) return;
-    final String bakPath = p.join(dbDirectory, '$_dbName.pre-restore.bak');
-    bool sidecarStateApplied = false;
-    bool shouldReapplyDeviceLocalTables = false;
-    try {
-      final raw = await sidecar.readAsString();
-      final decoded = jsonDecode(raw) as Map<String, dynamic>;
-      shouldReapplyDeviceLocalTables =
-          decoded['preserveDeviceLocalTables'] == true;
-      if (decoded['mode'] == 'settings') {
-        await _reapplySettingsLayer(dbDirectory);
-      } else {
-        // 'prefs' mode, or a legacy bare-map sidecar (no 'mode' field).
-        // TODO-1193: preserve the LOCAL settings/profiles layer from bak first
-        // (a settings/profiles-excluded backup crashed mid-import), then re-apply
-        // device-local sync config — same order as the inline path.
-        final bool preserveSettings = decoded['preserveSettings'] == true;
-        final bool preserveProfiles = decoded['preserveProfiles'] == true;
-        if (preserveSettings || preserveProfiles) {
-          await _reapplyExcludedSettingsLayers(
-            dbDirectory,
-            p.join(dbDirectory, '$_dbName.pre-restore.bak'),
-            reapplySettings: preserveSettings,
-            reapplyProfiles: preserveProfiles,
-          );
-        }
-        final Map<String, dynamic> prefsRaw =
-            (decoded['prefs'] as Map<String, dynamic>?) ?? decoded;
-        final prefs = prefsRaw.map((k, v) => MapEntry(k, v as String));
-        if (prefs.isNotEmpty) await _applyPreservedConfig(dbDirectory, prefs);
-      }
-      sidecarStateApplied = true;
-    } on FormatException catch (e, st) {
-      // A malformed marker cannot describe settings/prefs, but the independent
-      // pre-restore DB snapshot can still rescue device-local tables. Preserve
-      // the historical behavior of dropping an irreparably corrupt marker once
-      // that table replay succeeds.
-      debugPrint('BackupService.recoverPendingRestore: corrupt sidecar: '
-          '$e\n$st');
-      sidecarStateApplied = true;
-    } on TypeError catch (e, st) {
-      debugPrint('BackupService.recoverPendingRestore: invalid sidecar shape: '
-          '$e\n$st');
-      sidecarStateApplied = true;
-    } catch (e, st) {
-      // Database/filesystem failures are retryable. Keep both artifacts so the
-      // next startup can replay the same idempotent operations.
-      debugPrint('BackupService.recoverPendingRestore failed: $e\n$st');
-      return;
-    }
-
-    if (!sidecarStateApplied) return;
-    if (shouldReapplyDeviceLocalTables) {
-      final bool deviceLocalTablesReapplied =
-          await _reapplyDeviceLocalTablesFromBak(dbDirectory, bakPath);
-      if (!deviceLocalTablesReapplied) {
-        debugPrint('BackupService.recoverPendingRestore: retaining sidecar and '
-            'pre-restore.bak because device-local table replay did not finish.');
-        return;
-      }
-    }
-    await _safeDelete(sidecar.path);
-    await _safeDelete(bakPath);
-  }
-
-  /// Restores the settings layer (preferences + profiles + bindings) from
-  /// pre-restore.bak into the freshly-imported DB, keeping the backup's content.
-  /// Runs at startup, so both DBs are at the current schema → `SELECT *` columns
-  /// align. audiobook positions are content and stay from the backup.
-  static Future<void> _reapplySettingsLayer(String dbDirectory) async {
-    final String bakPath = p.join(dbDirectory, '$_dbName.pre-restore.bak');
-    if (!File(bakPath).existsSync()) {
-      // bak is the only copy of this device's settings layer (the main DB was
-      // already overwritten with the backup). If it's gone we cannot restore —
-      // surface it loudly rather than silently dropping the user's settings.
-      // (Normal flow restores inline while bak definitely exists; reaching here
-      // means a crash + external deletion of bak before the next launch.)
-      debugPrint('BackupService._reapplySettingsLayer: pre-restore.bak missing '
-          '— local settings/profiles could not be preserved on import.');
-      return;
-    }
-    final db = FushiDatabase(dbDirectory);
-    try {
-      final String safeBak =
-          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
-      await db.customStatement("ATTACH DATABASE '$safeBak' AS bak");
-      await db.transaction(() async {
-        // preferences: keep this device's SETTINGS from bak, but let CONTENT
-        // prefs (audiobook positions, favorites, local-audio / audio-source
-        // registry, font registry) follow the imported backup — see
-        // [_keepDeviceSettingsPrefPredicate]. `sync_*` stays restored from bak
-        // (device-local, never exported), which this predicate keeps.
-        await db.customStatement(
-            'DELETE FROM preferences WHERE $_keepDeviceSettingsPrefPredicate');
-        await db.customStatement(
-            'INSERT INTO preferences SELECT * FROM bak.preferences '
-            'WHERE $_keepDeviceSettingsPrefPredicate');
-        // profiles before its FK dependents.
-        for (final String t in _settingsLayerTables) {
-          await db.customStatement('DELETE FROM $t');
-          await db.customStatement('INSERT INTO $t SELECT * FROM bak.$t');
-        }
-      });
-      await db.customStatement('DETACH DATABASE bak');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Restores ONLY the excluded settings and/or profiles layers from [bakPath]
-  /// (this device's pre-import snapshot) into the freshly-overwritten DB, so a
-  /// backup that UNTICKED the `settings` / `profiles` category never wipes this
-  /// device's settings/profiles to empty (TODO-1193). The exact mirror of the
-  /// export strip:
-  ///  - [reapplySettings]: the pure-settings preference rows
-  ///    ([settingsPrefPredicate]) — progress / favorites / content-registry /
-  ///    sync prefs stay from the backup (they are content or handled elsewhere).
-  ///  - [reapplyProfiles]: the four profile-layer tables (child-first DELETE
-  ///    then parent-first INSERT for FK-safety).
-  /// Runs while both DBs are at the current schema (bak is a copy of the live
-  /// DB), so `SELECT *` columns align. No-op (logged) if bak is gone.
-  static Future<void> _reapplyExcludedSettingsLayers(
-    String dbDirectory,
-    String bakPath, {
-    required bool reapplySettings,
-    required bool reapplyProfiles,
-  }) async {
-    if (!reapplySettings && !reapplyProfiles) return;
-    if (!File(bakPath).existsSync()) {
-      // bak is the only copy of this device's settings/profiles after the
-      // overwrite. Missing it means a crash + external deletion before this ran;
-      // surface loudly rather than silently wiping the layer to empty.
-      debugPrint('BackupService._reapplyExcludedSettingsLayers: '
-          'pre-restore.bak missing — local settings/profiles could not be '
-          'preserved for a settings/profiles-excluded backup.');
-      return;
-    }
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      final String safeBak =
-          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
-      await db.customStatement("ATTACH DATABASE '$safeBak' AS setbak");
-      await db.transaction(() async {
-        if (reapplySettings) {
-          await db.customStatement(
-              'DELETE FROM preferences WHERE $settingsPrefPredicate');
-          await db.customStatement(
-              'INSERT INTO preferences SELECT * FROM setbak.preferences '
-              'WHERE $settingsPrefPredicate');
-        }
-        if (reapplyProfiles) {
-          // Child-first DELETE so an enforced FK to `profiles` never blocks the
-          // wipe; parent-first INSERT ([_settingsLayerTables]) so children land
-          // after their profile row.
-          for (final String t in _profilesLayerTablesChildFirst) {
-            await db.customStatement('DELETE FROM $t');
-          }
-          for (final String t in _settingsLayerTables) {
-            await db.customStatement('INSERT INTO $t SELECT * FROM setbak.$t');
-          }
-        }
-      });
-      await db.customStatement('DETACH DATABASE setbak');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Tables holding this device's imported dictionaries. Re-seated from
-  /// pre-restore.bak when a backup that carries NO dictionaries is imported in
-  /// overwrite mode (BUG-454), so an unselected-dictionary backup never wipes
-  /// the device's dictionary library. `dictionary_metadata` is the queryable
-  /// dictionary set; `dictionary_history` is its recent-lookup list. Neither is
-  /// FK-targeted by content tables, so a wholesale per-table swap is FK-safe.
-  static const List<String> _dictionaryLayerTables = <String>[
-    'dictionary_metadata',
-    'dictionary_history',
-  ];
-
-  /// Restores [_dictionaryLayerTables] from [bakPath] (this device's pre-import
-  /// snapshot) into the freshly-overwritten DB in [dbDirectory]. Runs inline
-  /// during import while both DBs are at the current schema (bak is a copy of
-  /// the live DB), so `SELECT *` columns align. No-op (logged) if bak is gone.
-  static Future<void> _reapplyDictionaryTablesFromBak(
-    String dbDirectory,
-    String bakPath,
-  ) async {
-    if (!File(bakPath).existsSync()) {
-      // bak is the only copy of this device's dictionary rows after the
-      // overwrite. Missing it means a crash + external deletion before this
-      // ran; surface loudly rather than silently dropping the dictionaries.
-      debugPrint('BackupService._reapplyDictionaryTablesFromBak: '
-          'pre-restore.bak missing — local dictionaries could not be '
-          'preserved on import.');
-      return;
-    }
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      final String safeBak =
-          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
-      await db.customStatement("ATTACH DATABASE '$safeBak' AS dictbak");
-      await db.transaction(() async {
-        for (final String t in _dictionaryLayerTables) {
-          await db.customStatement('DELETE FROM $t');
-          await db.customStatement('INSERT INTO $t SELECT * FROM dictbak.$t');
-        }
-      });
-      await db.customStatement('DETACH DATABASE dictbak');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Reads this device's device-local / credential prefs from the DB in
-  /// [dbDirectory] so an import can write them back afterwards.
-  ///
-  /// Filters by [PrefRedactionPolicy] rather than enumerating
-  /// [SyncRepository.deviceLocalPrefKeys]: the policy also matches by prefix and
-  /// shape (`media_source_secret_<id>` is one key PER SOURCE ROW and could never
-  /// be listed), and — decisively — it is the SAME predicate the export strip
-  /// uses. Enumerating a fixed list here while the strip matched by shape is
-  /// exactly how the two sides would drift: every key the strip removed but the
-  /// list did not name would be deleted from the imported DB and never restored,
-  /// silently wiping this device's own SFTP passwords / API keys on import.
-  static Future<Map<String, String>> _readDeviceLocalPrefs(
-      String dbDirectory) async {
-    FushiDatabase? db;
-    try {
-      db = FushiDatabase(dbDirectory);
-      final all = await db.getAllPrefs();
-      final out = <String, String>{};
-      for (final MapEntry<String, String> entry in all.entries) {
-        if (PrefRedactionPolicy.isDeviceLocalOrCredential(entry.key)) {
-          out[entry.key] = entry.value;
-        }
-      }
-      return out;
-    } catch (e, st) {
-      // Current DB unreadable/corrupt: nothing to preserve. Import the backup
-      // as-is rather than aborting — a broken local DB shouldn't block restore.
-      debugPrint('BackupService._readDeviceLocalPrefs failed: $e\n$st');
-      return const <String, String>{};
-    } finally {
-      try {
-        await db?.close();
-      } catch (_) {/* db may have failed to open */}
-    }
-  }
-
-  /// Writes the preserved device-local [prefs] into the imported DB, clears the
-  /// stale (backup-origin) folder cache so the next sync rebuilds it against the
-  /// preserved backend account, then durably flushes.
-  static Future<void> _applyPreservedConfig(
-      String dbDirectory, Map<String, String> prefs) async {
-    final db = FushiDatabase(dbDirectory);
-    try {
-      for (final entry in prefs.entries) {
-        await db.setPref(entry.key, entry.value);
-      }
-      // The imported DB carries the BACKUP's folder cache (title → source
-      // account folder ids), which is wrong for the preserved local backend.
-      // BUG-1576：清**所有**通道那几格（含解耦前的旧全局键）。导入库里带的是备份
-      // 来源机的目录布局，对本机保留下来的后端账号一条都不成立。
-      await SyncRepository(db).clearAllFolderCaches();
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
   /// Walks [root] and adds every file to [into] keyed by its zip path
   /// (`<archivePrefix>/<relative>`, always posix separators). Does not read file
   /// contents — only paths — so it is cheap regardless of tree size.
@@ -3224,91 +1647,6 @@ class BackupService {
       final String archivePath =
           p.posix.join(archivePrefix, relativePath.replaceAll(r'\', '/'));
       into[archivePath] = entity.path;
-    }
-  }
-
-  /// Deletes from the exported DB copy in [dbDirectory] every epub book whose
-  /// `book_key` is NOT in [keep], plus all of that book's dependent rows via the
-  /// canonical [FushiDatabase.deleteEpubBook] cascade (reader position,
-  /// bookmarks, tag mappings, audiobook + cues, srt rows, shelf entry). [keep]
-  /// empty strips every book (the "book content" category was unticked);
-  /// a non-empty set keeps only the user-selected books (per-book export).
-  ///
-  /// Root fix for the "ghost book" bug (TODO-1195 part C/A): the whole DB is
-  /// exported as one VACUUM-INTO blob, so without this every book's `epub_books`
-  /// row travelled even when its `hoshi_books/` files were left out — a
-  /// restore/merge then inserted book rows with no content = un-openable books.
-  /// Filtering the rows here makes the "book content" switch / per-book
-  /// selection consistent: a book that isn't packed never appears after import.
-  static Future<void> _retainBooks(
-    String dbDirectory,
-    Set<String> keep,
-  ) async {
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      for (final EpubBookRow b in await db.getAllEpubBooks()) {
-        if (keep.contains(b.bookKey)) continue;
-        // Default (tombstone: false): stripping a book from an export copy is
-        // NOT a user deletion, so it must never write a resurrection tombstone
-        // into the backup DB (TODO-1195 part B interaction).
-        await db.deleteEpubBook(b.bookKey);
-      }
-      await db.customStatement('VACUUM');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Per-video analogue of [_retainBooks]: DELETEs every `video_books` row whose
-  /// `book_uid` is NOT in [keep] (plus its dependent rows — subtitle cues, tag
-  /// mappings, shelf entry — via the canonical [FushiDatabase.deleteVideoBook]
-  /// cascade). [keep] empty strips every video (the video category was
-  /// unticked); a non-empty set keeps only the user-selected videos (per-video
-  /// export). Same root fix as books: without stripping the row a restore/merge
-  /// would insert a video record whose file never travelled = an un-openable
-  /// "ghost video".
-  static Future<void> _retainVideos(
-    String dbDirectory,
-    Set<String> keep,
-  ) async {
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      for (final VideoBookRow v in await db.allVideoBooks()) {
-        if (keep.contains(v.bookUid)) continue;
-        await db.deleteVideoBook(v.bookUid);
-      }
-      await db.customStatement('VACUUM');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Audiobook analogue of [_retainVideos] (BUG-781): DELETEs every `audiobooks`
-  /// row whose `bookKey` is NOT in [keep], via the canonical
-  /// [FushiDatabase.deleteAudiobookByBookKey] cascade (its `audio_cues` rows +
-  /// the `srt` shelf entry). [keep] empty strips every audiobook (the audiobooks
-  /// category was unticked). Same root fix as books/videos: an audiobook whose
-  /// audio never travelled must not survive as a "ghost audiobook" (a shelf entry
-  /// + alignment rows pointing at audio files that are not on this device). Does
-  /// NOT touch standalone `srt_books` rows — those are their own shelf items, not
-  /// counted in the audiobooks category (which is `getAllAudiobooks()` = the
-  /// epub-attached `Audiobooks` table).
-  static Future<void> _retainAudiobooks(
-    String dbDirectory,
-    Set<String> keep,
-  ) async {
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      for (final AudiobookRow a in await db.getAllAudiobooks()) {
-        if (keep.contains(a.bookKey)) continue;
-        await db.deleteAudiobookByBookKey(a.bookKey);
-      }
-      await db.customStatement('VACUUM');
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
     }
   }
 
@@ -3577,8 +1915,8 @@ class BackupService {
       encoder.create(outputPath);
       try {
         final List<int> metaBytes = utf8.encode(metaJson);
-        encoder.addArchiveFile(
-            ArchiveFile(metaName, metaBytes.length, metaBytes));
+        encoder
+            .addArchiveFile(ArchiveFile(metaName, metaBytes.length, metaBytes));
         for (final MapEntry<String, String> entry
             in archivePathToSource.entries) {
           final File file = File(entry.value);
@@ -3624,860 +1962,6 @@ class BackupService {
     return false;
   }
 
-  static List<ArchiveFile> _dictionaryResourceFiles(Archive archive) {
-    return archive.files.where((ArchiveFile file) {
-      if (!file.isFile) return false;
-      return file.name
-          .replaceAll(r'\', '/')
-          .startsWith('$_dictionaryResourcesPrefix/');
-    }).toList();
-  }
-
-  static List<MapEntry<ArchiveFile, String>> _buildDictionaryReapplyPlan({
-    required Archive archive,
-    required String dictionaryResourceDirectory,
-  }) {
-    final Directory targetRoot = Directory(dictionaryResourceDirectory);
-    final String canonicalRoot = p.canonicalize(targetRoot.path);
-    final List<MapEntry<ArchiveFile, String>> reapplyPlan =
-        <MapEntry<ArchiveFile, String>>[];
-    for (final ArchiveFile file in _dictionaryResourceFiles(archive)) {
-      final String rawName = file.name.replaceAll(r'\', '/');
-      final String relativePath =
-          rawName.substring(_dictionaryResourcesPrefix.length + 1);
-      final String normalizedRelative = p.posix.normalize(relativePath);
-      if (relativePath.isEmpty ||
-          p.posix.isAbsolute(relativePath) ||
-          normalizedRelative == '..' ||
-          normalizedRelative.startsWith('../')) {
-        throw FormatException('Invalid dictionary resource path: ${file.name}');
-      }
-
-      final String targetPath = p.normalize(
-        p.join(targetRoot.path, normalizedRelative),
-      );
-      final String canonicalTarget = p.canonicalize(targetPath);
-      if (canonicalTarget != canonicalRoot &&
-          !p.isWithin(canonicalRoot, canonicalTarget)) {
-        throw FormatException('Invalid dictionary resource path: ${file.name}');
-      }
-      reapplyPlan.add(MapEntry<ArchiveFile, String>(file, targetPath));
-    }
-    return reapplyPlan;
-  }
-
-  static Future<void> _reapplyDictionaryResources({
-    required String zipPath,
-    required List<MapEntry<ArchiveFile, String>> reapplyPlan,
-    required String dictionaryResourceDirectory,
-    void Function(int deltaBytes)? onBytes,
-  }) async {
-    final Directory targetRoot = Directory(dictionaryResourceDirectory);
-    // 引擎常驻映射着每本词典的 hash.table / blobs.bin（native map_rd）；Windows 上
-    // 只要 view 还活着，删资源根一律 ERROR_USER_MAPPED_FILE，整个恢复流程就断在
-    // 这一行（BUG-1756）。恢复流程收尾必定重启 app（backupImportRestart），故这里
-    // 把引擎清空不需要再装回来。
-    FushiDicts.releaseAllMappings();
-    if (await targetRoot.exists()) {
-      await targetRoot.delete(recursive: true);
-    }
-    await targetRoot.create(recursive: true);
-    await _extractEntriesStreaming(
-      zipPath: zipPath,
-      entries: reapplyPlan
-          .map((MapEntry<ArchiveFile, String> e) =>
-              MapEntry<String, String>(e.key.name, e.value))
-          .toList(),
-      onBytes: onBytes,
-    );
-  }
-
-  /// Extracts the packed local-audio databases (`localAudio/<file>`) into the
-  /// support directory [dbDirectory]. Unlike the content TREES these are
-  /// individual files SHARING the directory with `hibiki.db`, so they are
-  /// written file-by-file rather than via the destructive tree swap. Only file
-  /// names matching [_localAudioFileName] are accepted (defense in depth: an
-  /// archive entry naming `hibiki.db` under `localAudio/` is rejected).
-  ///
-  /// When the backup carries no `localAudio/` entries this is a no-op, so an
-  /// audio-less backup leaves this device's local-audio DBs intact (the same
-  /// preserve-on-absent contract the content trees follow — BUG-454 family).
-  ///
-  /// [overwrite] true (overwrite import) replaces an existing same-named file;
-  /// false (merge import) keeps the device's own file (copy-if-absent).
-  static Future<void> _reapplyLocalAudioFiles(
-    String zipPath,
-    Archive archive,
-    String dbDirectory, {
-    bool overwrite = true,
-    void Function(int deltaBytes)? onBytes,
-  }) async {
-    final Directory targetRoot = Directory(dbDirectory);
-    final List<MapEntry<String, String>> plan = <MapEntry<String, String>>[];
-    for (final ArchiveFile file in archive.files) {
-      if (!file.isFile) continue;
-      final String rawName = file.name.replaceAll(r'\', '/');
-      if (!rawName.startsWith('$_localAudioPrefix/')) continue;
-      final String name = rawName.substring(_localAudioPrefix.length + 1);
-      // Reject nested paths / traversal / non-local-audio names: these files
-      // must land flat in the support dir and never escape it or clobber
-      // hibiki.db.
-      if (name.isEmpty ||
-          name.contains('/') ||
-          !_localAudioFileName.hasMatch(name)) {
-        throw FormatException('Invalid local audio backup path: ${file.name}');
-      }
-      final File dest = File(p.join(targetRoot.path, name));
-      if (!overwrite && await dest.exists()) continue; // copy-if-absent (merge)
-      plan.add(MapEntry<String, String>(file.name, dest.path));
-    }
-    await _extractEntriesStreaming(
-      zipPath: zipPath,
-      entries: plan,
-      onBytes: onBytes,
-    );
-  }
-
-  /// Files in [archive] under `<prefix>/`, validated against path traversal and
-  /// mapped to absolute targets under [targetRootPath]. Mirrors the dictionary
-  /// plan's safety checks (reject absolute / `..` escapes, `p.isWithin` gate).
-  static List<MapEntry<ArchiveFile, String>> _buildTreeReapplyPlan({
-    required Archive archive,
-    required String prefix,
-    required String targetRootPath,
-  }) {
-    final Directory targetRoot = Directory(targetRootPath);
-    final String canonicalRoot = p.canonicalize(targetRoot.path);
-    final List<MapEntry<ArchiveFile, String>> plan =
-        <MapEntry<ArchiveFile, String>>[];
-    for (final ArchiveFile file in archive.files) {
-      if (!file.isFile) continue;
-      final String rawName = file.name.replaceAll(r'\', '/');
-      if (!rawName.startsWith('$prefix/')) continue;
-      final String relativePath = rawName.substring(prefix.length + 1);
-      final String normalizedRelative = p.posix.normalize(relativePath);
-      if (relativePath.isEmpty ||
-          p.posix.isAbsolute(relativePath) ||
-          normalizedRelative == '..' ||
-          normalizedRelative.startsWith('../')) {
-        throw FormatException('Invalid backup content path: ${file.name}');
-      }
-      final String targetPath =
-          p.normalize(p.join(targetRoot.path, normalizedRelative));
-      final String canonicalTarget = p.canonicalize(targetPath);
-      if (canonicalTarget != canonicalRoot &&
-          !p.isWithin(canonicalRoot, canonicalTarget)) {
-        throw FormatException('Invalid backup content path: ${file.name}');
-      }
-      plan.add(MapEntry<ArchiveFile, String>(file, targetPath));
-    }
-    return plan;
-  }
-
-  static String _importTmpPath(String root) => '$root.import-tmp';
-  static String _importOldPath(String root) => '$root.import-old';
-
-  /// Removes any stale `.import-tmp` / `.import-old` siblings left by a prior
-  /// import that crashed mid-swap. Called on entry to every prepare so a stale
-  /// `.import-old` can never be mistaken for a valid rollback target by a later
-  /// import (review W1).
-  static Future<void> _clearImportLeftovers(String targetRootPath) async {
-    for (final String path in <String>[
-      _importTmpPath(targetRootPath),
-      _importOldPath(targetRootPath),
-    ]) {
-      final Directory d = Directory(path);
-      if (await d.exists()) await d.delete(recursive: true);
-    }
-  }
-
-  /// PHASE 1 of the content-tree restore: write every file under `<prefix>/`
-  /// into the sibling `<root>.import-tmp` (NO swap yet). Returns true when there
-  /// is something staged to commit; false when the backup carries no files under
-  /// [prefix] (db-only / audio-less backup) so the existing tree is left alone.
-  ///
-  /// Splitting write (slow, GB-scale, failure-prone) from the swap (fast rename)
-  /// lets the caller stage ALL trees before committing ANY — a write failure
-  /// then swaps nothing and leaves every existing tree intact (review W2).
-  /// 该归档实际使用的书树前缀：任一条目落在新前缀（[_booksPrefix]）下即用新，
-  /// 否则回退旧前缀 [_legacyBooksPrefix]（旧 Hibiki app 导出的备份/迁移归档）。
-  /// 一份归档只会有一代前缀，不存在混排。`@visibleForTesting`：读侧回退是
-  /// 跨版本契约，测试直接对两代归档断言。
-  @visibleForTesting
-  static String archiveBooksPrefix(Archive archive) {
-    for (final ArchiveFile file in archive) {
-      if (file.name.startsWith('$_booksPrefix/')) return _booksPrefix;
-    }
-    return _legacyBooksPrefix;
-  }
-
-  static Future<bool> _prepareTreeReapply(
-    String zipPath,
-    Archive archive,
-    String prefix,
-    String targetRootPath, {
-    void Function(int deltaBytes)? onBytes,
-  }) async {
-    final String tmpRoot = _importTmpPath(targetRootPath);
-    final List<MapEntry<ArchiveFile, String>> plan = _buildTreeReapplyPlan(
-      archive: archive,
-      prefix: prefix,
-      targetRootPath: tmpRoot,
-    );
-    await _clearImportLeftovers(targetRootPath);
-    if (plan.isEmpty) return false;
-
-    final Directory tmpDir = Directory(tmpRoot);
-    await tmpDir.create(recursive: true);
-    try {
-      await _extractEntriesStreaming(
-        zipPath: zipPath,
-        entries: plan
-            .map((MapEntry<ArchiveFile, String> e) =>
-                MapEntry<String, String>(e.key.name, e.value))
-            .toList(),
-        onBytes: onBytes,
-      );
-    } catch (_) {
-      if (await tmpDir.exists()) await tmpDir.delete(recursive: true);
-      rethrow; // nothing swapped; existing tree untouched
-    }
-    return true;
-  }
-
-  /// PHASE 2: swap the staged `<root>.import-tmp` into place. tmp and target are
-  /// siblings → rename is atomic on the same filesystem. Caller invokes this for
-  /// each prepared tree back-to-back; only the (rare) rename failure between two
-  /// trees leaves a cross-tree half-state, which is far smaller than the old
-  /// write-between-swaps window.
-  static Future<void> _commitPreparedTree(String targetRootPath) async {
-    final String asideRoot = _importOldPath(targetRootPath);
-    final Directory aside = Directory(asideRoot);
-    final Directory target = Directory(targetRootPath);
-    final Directory tmpDir = Directory(_importTmpPath(targetRootPath));
-    // Every swap rename retries transient Windows FS-busy (errno 5/32/145): an
-    // antivirus/indexer scanning the freshly-written tree briefly locks it, so
-    // a bare rename fails with "拒绝访问" even though nothing is really wrong.
-    Future<void> renameDir(Directory dir, String to) =>
-        renameDirectoryWithRetry(
-          rename: () => dir.rename(to),
-          sleep: (int ms) => Future<void>.delayed(Duration(milliseconds: ms)),
-          isWindows: Platform.isWindows,
-        );
-    if (await aside.exists()) await aside.delete(recursive: true);
-    if (await target.exists()) await renameDir(target, asideRoot);
-    try {
-      await renameDir(tmpDir, targetRootPath);
-    } catch (_) {
-      // Roll back: put the old tree back if the new one didn't land.
-      if (await aside.exists() && !await target.exists()) {
-        await renameDir(aside, targetRootPath);
-      }
-      rethrow;
-    }
-    if (await aside.exists()) await aside.delete(recursive: true);
-  }
-
-  /// Drops a staged-but-not-committed `<root>.import-tmp` (idempotent).
-  static Future<void> _abortPreparedTree(String targetRootPath) async {
-    final Directory tmpDir = Directory(_importTmpPath(targetRootPath));
-    if (await tmpDir.exists()) await tmpDir.delete(recursive: true);
-  }
-
-  /// Rebases every stored absolute path carried by the backup DB (which points
-  /// at the SOURCE device's roots) onto THIS device's roots, in the fixed
-  /// content → fonts → local-audio → videos order shared by the overwrite and
-  /// merge imports. Custom-font config and local-audio DB paths are content
-  /// too (their files come from the backup). Each underlying rebase is a no-op
-  /// when the meta carries no matching source root (legacy backup) or the new
-  /// root is null — e.g. a keep-settings import whose preserved local paths
-  /// aren't under the source root, or an unticked import category.
-  static Future<void> _rebaseAllPaths({
-    required String dbDirectory,
-    required BackupMeta meta,
-    required String? newBooksRoot,
-    required String? newAudiobooksRoot,
-    required String? newFontsRoot,
-    required String? newLocalAudioRoot,
-    required String? newVideosRoot,
-  }) async {
-    await _rebaseContentPaths(
-      dbDirectory: dbDirectory,
-      meta: meta,
-      newBooksRoot: newBooksRoot,
-      newAudiobooksRoot: newAudiobooksRoot,
-    );
-    await _rebaseFontPaths(
-      dbDirectory: dbDirectory,
-      meta: meta,
-      newFontsRoot: newFontsRoot,
-    );
-    await _rebaseLocalAudioPaths(
-      dbDirectory: dbDirectory,
-      meta: meta,
-      newLocalAudioRoot: newLocalAudioRoot,
-    );
-    await _rebaseVideoPaths(
-      dbDirectory: dbDirectory,
-      meta: meta,
-      newVideosRoot: newVideosRoot,
-    );
-  }
-
-  /// Rebases the imported DB's stored absolute content paths from the backup's
-  /// source roots ([BackupMeta.booksRoot] / [BackupMeta.audiobooksRoot]) onto
-  /// this device's [newBooksRoot] / [newAudiobooksRoot]. No-op for a legacy
-  /// backup (meta has no roots). Cover paths can live under EITHER tree (epub
-  /// covers in hoshi_books, audiobook covers in audiobooks), so they try both.
-  /// EPUB 解包目录在本机的**确定性回退**。
-  ///
-  /// [rebasePath] 靠「老根前缀」做字符串替换。一旦备份记录的
-  /// [BackupMeta.booksRoot] 与行里的真实前缀对不上，前缀匹配会失败并**静默原样
-  /// 返回**导出设备的绝对路径——库看着导入成功，每本书却都「找不到书籍文件」。
-  /// 真实踩中的形态：跨包名迁移时导出端把书根名写成改名前的旧名（`hoshi_books`），
-  /// 而行里是 `fushi_books`，于是 rebase 全程无声失效，四本书的 `extract_dir`
-  /// 仍指向老包私有目录 `/data/user/0/<老包名>/...`——那是另一个应用的沙箱，
-  /// 新包永远读不到，尽管文件早已解包到本机书根下。
-  ///
-  /// 解包落点本身是确定的（`<booksRoot>/<bookKey>`），所以不必去猜老根：rebase
-  /// 结果在本机不存在、而该确定位置存在时，用后者。**原路径有效时一律不动**，
-  /// 普通备份恢复的行为不变。
-  static String _resolveExtractDirOnDevice(
-      String rebased, String bookKey, String newBooksRoot) {
-    if (rebased.isNotEmpty && Directory(rebased).existsSync()) return rebased;
-    if (bookKey.isEmpty) return rebased;
-    final String byKey = p.join(newBooksRoot, bookKey);
-    if (Directory(byKey).existsSync()) return byKey;
-    return rebased;
-  }
-
-  static Future<void> _rebaseContentPaths({
-    required String dbDirectory,
-    required BackupMeta meta,
-    required String? newBooksRoot,
-    required String? newAudiobooksRoot,
-  }) async {
-    final String? oldBooks = meta.booksRoot;
-    final String? oldAudio = meta.audiobooksRoot;
-    final bool canBooks = oldBooks != null && newBooksRoot != null;
-    final bool canAudio = oldAudio != null && newAudiobooksRoot != null;
-    if (!canBooks && !canAudio) return;
-
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      if (canBooks) {
-        for (final EpubBookRow b in await db.getAllEpubBooks()) {
-          await db.updateEpubBookContentPaths(
-            b.bookKey,
-            epubPath: rebasePath(b.epubPath, oldBooks, newBooksRoot),
-            extractDir: _resolveExtractDirOnDevice(
-              rebasePath(b.extractDir, oldBooks, newBooksRoot),
-              b.bookKey,
-              newBooksRoot,
-            ),
-            coverPath: b.coverPath == null
-                ? null
-                : _rebaseEither(b.coverPath!, oldBooks, newBooksRoot, oldAudio,
-                    newAudiobooksRoot),
-          );
-        }
-      }
-      if (canAudio) {
-        for (final AudiobookRow a in await db.getAllAudiobooks()) {
-          await db.updateAudiobookPaths(
-            a.bookKey,
-            audioRoot: a.audioRoot == null
-                ? null
-                : rebasePath(a.audioRoot!, oldAudio, newAudiobooksRoot),
-            audioPathsJson: _rebaseAudioPathsJson(
-                a.audioPathsJson, oldAudio, newAudiobooksRoot, a.bookKey),
-            alignmentPath:
-                rebasePath(a.alignmentPath, oldAudio, newAudiobooksRoot),
-          );
-        }
-        // BUG-1575: srt_books carries its OWN copy of the audio paths and was
-        // never rebased here, while the merge engine inserts its rows column
-        // for column (audio_paths_json / audio_root / srt_path / cover_path all
-        // verbatim from the source device). Result on a cross-root import: the
-        // paired `audiobooks` row resolved but the `srt_book` row still pointed
-        // at the SOURCE root, so the shelf saw a broken audiobook -- subtitles
-        // (parsed cues live in `audio_cues`, no path) but no audio.
-        //
-        // All four columns live under ONE directory `<audiobooksRoot>/<uid>`
-        // (see SyncAssetPackageService.importAudioDatabasePackage and
-        // kPathRebaseColumns), so cover_path is rebased against the AUDIOBOOKS
-        // root first. It still falls back to the books mapping via
-        // _rebaseEither, because an epub-backed srt row (bookKey non-empty) may
-        // have adopted the epub's cover under the books root.
-        for (final SrtBookRow srt in await db.getAllSrtBooks()) {
-          await db.updateSrtBookPaths(
-            srt.uid,
-            audioRoot: srt.audioRoot == null
-                ? null
-                : rebasePath(srt.audioRoot!, oldAudio, newAudiobooksRoot),
-            audioPathsJson: _rebaseAudioPathsJson(
-                srt.audioPathsJson, oldAudio, newAudiobooksRoot, srt.uid),
-            srtPath: rebasePath(srt.srtPath, oldAudio, newAudiobooksRoot),
-            coverPath: srt.coverPath == null
-                ? null
-                : _rebaseEither(srt.coverPath!, oldAudio, newAudiobooksRoot,
-                    oldBooks, newBooksRoot),
-          );
-        }
-      }
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Rebases every path inside a persisted `audioPathsJson` string list from
-  /// [oldRoot] onto [newRoot]. A malformed value (corrupt row, not a JSON
-  /// string-list) must not abort the whole import -- it is returned verbatim
-  /// and the failure is logged with [rowKey] (review W3). Shared by the
-  /// `audiobooks` and `srt_books` rebases so the two can never drift.
-  static String? _rebaseAudioPathsJson(
-    String? json,
-    String oldRoot,
-    String newRoot,
-    String rowKey,
-  ) {
-    if (json == null) return null;
-    try {
-      final dynamic decoded = jsonDecode(json);
-      if (decoded is! List) return json;
-      return jsonEncode(decoded
-          .whereType<String>()
-          .map((String s) => rebasePath(s, oldRoot, newRoot))
-          .toList());
-    } catch (e) {
-      debugPrint(
-          'BackupService: skipped rebasing audioPathsJson for $rowKey: $e');
-      return json;
-    }
-  }
-
-  /// Rebases the imported DB's stored custom-font paths from the backup's
-  /// [BackupMeta.fontsRoot] onto this device's [newFontsRoot]. The canonical
-  /// `font_catalog` carries paths, while `font_targets` only carries catalog
-  /// ids/order/enabled rows; legacy shadow lists also carry paths. Every stored
-  /// file-font path is rebased (system fonts and unrelated paths untouched).
-  /// No-op when either root is null.
-  static Future<void> _rebaseFontPaths({
-    required String dbDirectory,
-    required BackupMeta meta,
-    required String? newFontsRoot,
-  }) async {
-    final String? oldFonts = meta.fontsRoot;
-    if (oldFonts == null || newFontsRoot == null) return;
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      final Map<String, String> prefs = await db.getAllPrefs();
-      final String? catalog = prefs[_fontCatalogPrefKey];
-      if (catalog != null) {
-        final String rebasedCatalog = rebaseFontCatalogJson(
-          catalog,
-          oldFonts,
-          newFontsRoot,
-        );
-        if (rebasedCatalog != catalog) {
-          await db.setPref(_fontCatalogPrefKey, rebasedCatalog);
-        }
-      }
-      for (final String key in _legacyFontPrefKeys) {
-        final String? raw = prefs[key];
-        if (raw == null) continue;
-        final String rebased = rebaseFontListJson(raw, oldFonts, newFontsRoot);
-        if (rebased != raw) await db.setPref(key, rebased);
-      }
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Re-homes the imported DB's stored local-audio paths onto THIS device's
-  /// support directory [newLocalAudioRoot] by FILENAME, for BOTH the canonical
-  /// `local_audio_dbs` pref AND the typed `audio_source_configs` pref (its
-  /// localAudio entries). Keeping both in lock-step preserves the
-  /// typed-config <-> local_audio_dbs join (AppModel.audioSourceConfigs matches
-  /// by path); re-homing only one side would split them and drop the typed
-  /// source (TODO-1171). Gated on [BackupMeta.localAudioRoot] being non-null —
-  /// i.e. the localAudio category was packed, so the `.db` files actually
-  /// crossed over and this device's restored DB is a real, openable database
-  /// (a db-only backup carries no audio files, and runtime resolution via
-  /// [LocalAudioManager.resolveInternalPath] covers playback there without
-  /// touching stored prefs; opening the DB in that isolation case is neither
-  /// needed nor safe — mirrors the sibling content/font rebasers). Preserves
-  /// each pref's PrefCodec tag (`s:`/`j:` in production, untagged in some
-  /// tests). Also logs any loopback remoteAudio source as a cross-machine
-  /// hazard so the failure is visible, never silent.
-  static Future<void> _rebaseLocalAudioPaths({
-    required String dbDirectory,
-    required BackupMeta meta,
-    required String? newLocalAudioRoot,
-  }) async {
-    if (meta.localAudioRoot == null || newLocalAudioRoot == null) return;
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      final Map<String, String> prefs = await db.getAllPrefs();
-      await _normalizePrefInPlace(
-        db,
-        prefs,
-        _localAudioDbsPrefKey,
-        (String body) => normalizeLocalAudioDbsJson(body, newLocalAudioRoot),
-      );
-      await _normalizePrefInPlace(
-        db,
-        prefs,
-        _audioSourceConfigsPrefKey,
-        (String body) =>
-            normalizeAudioSourceConfigsJson(body, newLocalAudioRoot),
-      );
-      _warnLoopbackAudioSources(prefs[_audioSourceConfigsPrefKey]);
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  /// Reads [key] from [prefs], runs the tag-aware [transform] on its stored
-  /// value, and writes it back when it changed. No-op when the key is absent or
-  /// the value is unchanged.
-  static Future<void> _normalizePrefInPlace(
-    FushiDatabase db,
-    Map<String, String> prefs,
-    String key,
-    String Function(String storedValue) transform,
-  ) async {
-    final String? raw = prefs[key];
-    if (raw == null) return;
-    final String next = transform(raw);
-    if (next == raw) return;
-    await db.setPref(key, next);
-  }
-
-  /// Logs (never silently drops) any imported remoteAudio source that points at
-  /// a loopback host — it resolved on the source device but points at THIS new
-  /// machine after import, so it needs a manual re-point. The audio-source
-  /// management UI surfaces the same hazard as a per-row warning (TODO-1171).
-  static void _warnLoopbackAudioSources(String? rawConfigs) {
-    if (rawConfigs == null) return;
-    try {
-      final dynamic decoded = jsonDecode(splitPrefTag(rawConfigs).body);
-      if (decoded is! List) return;
-      for (final dynamic e in decoded) {
-        if (e is! Map) continue;
-        if (e['kind'] != AudioSourceKind.remoteAudio.wireName) continue;
-        final Object? url = e['url'];
-        if (url is String && AudioSourceConfig.isLoopbackAudioUrl(url)) {
-          debugPrint(
-            '[fushi-audio] imported remote audio source points at a loopback '
-            'host and will not resolve on this device until re-pointed: $url',
-          );
-        }
-      }
-    } catch (_) {
-      // diagnostic only; never abort import on a malformed pref
-    }
-  }
-
-  static Future<void> _rebaseVideoPaths({
-    required String dbDirectory,
-    required BackupMeta meta,
-    required String? newVideosRoot,
-  }) async {
-    if (newVideosRoot == null || meta.videoFiles.isEmpty) return;
-    final FushiDatabase db = FushiDatabase(dbDirectory);
-    try {
-      for (final VideoBookRow row in await db.allVideoBooks()) {
-        final String videoPath =
-            _rebaseVideoPath(row.videoPath, meta.videoFiles, newVideosRoot);
-        final String? playlistJson = _rebaseVideoPlaylistJson(
-          row.playlistJson,
-          meta.videoFiles,
-          newVideosRoot,
-        );
-        if (videoPath == row.videoPath && playlistJson == row.playlistJson) {
-          continue;
-        }
-        await db.customStatement(
-          'UPDATE video_books SET video_path = ?, playlist_json = ? '
-          'WHERE book_uid = ?',
-          <Object?>[videoPath, playlistJson, row.bookUid],
-        );
-      }
-      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
-    } finally {
-      await db.close();
-    }
-  }
-
-  static String _rebaseVideoPath(
-    String oldPath,
-    Map<String, String> sourcePathToArchiveRelative,
-    String newVideosRoot,
-  ) {
-    final String? relativePath = sourcePathToArchiveRelative[oldPath];
-    if (relativePath == null) return oldPath;
-    return _reappliedVideoPath(newVideosRoot, relativePath);
-  }
-
-  static String? _rebaseVideoPlaylistJson(
-    String? playlistJson,
-    Map<String, String> sourcePathToArchiveRelative,
-    String newVideosRoot,
-  ) {
-    if (playlistJson == null || playlistJson.isEmpty) return playlistJson;
-    try {
-      final dynamic decoded = jsonDecode(playlistJson);
-      if (decoded is! List) return playlistJson;
-      bool changed = false;
-      final List<dynamic> rewritten = decoded.map<dynamic>((dynamic entry) {
-        if (entry is! Map) return entry;
-        final Map<String, dynamic> row = Map<String, dynamic>.from(entry);
-        final Object? path = row['path'];
-        if (path is! String) return row;
-        final String rebased =
-            _rebaseVideoPath(path, sourcePathToArchiveRelative, newVideosRoot);
-        if (rebased != path) {
-          row['path'] = rebased;
-          changed = true;
-        }
-        return row;
-      }).toList();
-      return changed ? jsonEncode(rewritten) : playlistJson;
-    } catch (_) {
-      return playlistJson;
-    }
-  }
-
-  static String _reappliedVideoPath(
-    String videosRoot,
-    String archiveRelativePath,
-  ) {
-    final String relative = archiveRelativePath.replaceAll(r'\', '/');
-    final String normalizedRelative = p.posix.normalize(relative);
-    if (relative.isEmpty ||
-        p.posix.isAbsolute(relative) ||
-        normalizedRelative == '..' ||
-        normalizedRelative.startsWith('../')) {
-      throw FormatException('Invalid backup video path: $archiveRelativePath');
-    }
-    final String targetPath =
-        p.normalize(p.join(videosRoot, normalizedRelative));
-    final String canonicalRoot = p.canonicalize(videosRoot);
-    final String canonicalTarget = p.canonicalize(targetPath);
-    if (canonicalTarget != canonicalRoot &&
-        !p.isWithin(canonicalRoot, canonicalTarget)) {
-      throw FormatException('Invalid backup video path: $archiveRelativePath');
-    }
-    return targetPath;
-  }
-
-  /// Rebases [path] trying the (oldA -> newA) mapping first, then
-  /// (oldB -> newB). A cover written under either tree resolves; one not under
-  /// either is returned unchanged. Either pair may be null (that category was
-  /// not part of the backup) -- a null pair is simply skipped, so callers do
-  /// not need a special case for it.
-  static String _rebaseEither(
-    String path,
-    String? oldA,
-    String? newA,
-    String? oldB,
-    String? newB,
-  ) {
-    if (oldA != null && newA != null) {
-      final String viaA = rebasePath(path, oldA, newA);
-      if (viaA != path) return viaA;
-    }
-    if (oldB != null && newB != null) {
-      return rebasePath(path, oldB, newB);
-    }
-    return path;
-  }
-
-  static Future<void> _safeDelete(String path) async {
-    try {
-      final f = File(path);
-      if (f.existsSync()) await f.delete();
-    } catch (_) {
-      // Best-effort cleanup; a leftover sidecar/bak is harmless and swept later.
-    }
-  }
-
-  /// Total uncompressed byte size of every content entry in [archive] (the DB +
-  /// packed trees + local-audio DBs), excluding the tiny meta json. Used as the
-  /// denominator for the import progress bar. Read from the central directory,
-  /// so it never decompresses anything. Never returns 0 (avoids /0).
-  static int _totalContentBytes(Archive archive) {
-    int total = 0;
-    for (final ArchiveFile f in archive.files) {
-      if (!f.isFile) continue;
-      if (f.name == _metaName) continue;
-      total += f.size;
-    }
-    return total > 0 ? total : 1;
-  }
-
-  /// TODO-1183: determinate progress across every streamed byte. Total is the
-  /// sum of all content entry sizes ([_totalContentBytes]); each streamed
-  /// chunk advances the bar, clamped at 1.0. Returns the `onBytes` callback
-  /// shared by the overwrite- and merge-import extraction helpers.
-  static void Function(int deltaBytes) _archiveByteProgress(
-    Archive archive,
-    void Function(double progress)? onProgress,
-  ) {
-    final int totalBytes = _totalContentBytes(archive);
-    int writtenBytes = 0;
-    return (int deltaBytes) {
-      writtenBytes += deltaBytes;
-      final double fraction = writtenBytes / totalBytes;
-      onProgress?.call(fraction > 1.0 ? 1.0 : fraction);
-    };
-  }
-
-  /// Parses the source-device manifest (`backup_meta.json`) carried by
-  /// [archive]. Null for a legacy backup without one (or an unparseable one).
-  /// Only the tiny meta entry is materialized.
-  static BackupMeta? _readBackupMeta(Archive archive) {
-    final ArchiveFile? metaFile = archive.findFile(_metaName);
-    if (metaFile == null) return null;
-    return BackupMeta.tryParse(utf8.decode(metaFile.content as List<int>));
-  }
-
-  // ── TODO-1183: streaming, off-UI-isolate backup extraction ───────────────
-  //
-  // The import/merge paths used to `dest.writeAsBytes(archiveFile.content)`,
-  // which decodes a whole archive entry into ONE Uint8List. A full-data backup's
-  // local-audio DB alone can be many GB, so that single allocation OOM-killed the
-  // app mid-import (TODO-1183); even when it fit, the synchronous write froze the
-  // UI isolate for the whole copy (progress bar stuck → looked like a hang).
-  //
-  // Extraction now runs on a BACKGROUND isolate and STREAMS each entry to disk in
-  // bounded chunks (never materializing a whole entry), reporting bytes written
-  // through a port so the overlay shows real progress. Only pure file IO +
-  // archive decoding runs in the isolate (no sqlite / platform channels), so it
-  // is isolate-safe — the DB work stays on the caller's isolate. archive 3.6.1's
-  // `ArchiveFile.writeContent` is NOT usable here: for a `decodeBuffer`-produced
-  // file it still fully materializes (`_content is FileContent` → `.content` →
-  // `toUint8List()`), so we stream the raw file-backed window directly instead.
-
-  /// Sent by the extract worker once every planned entry has been written.
-  static const String _extractDoneToken = '__fushi_backup_extract_done__';
-
-  /// Streams the entries in [entries] (archive entry name → absolute dest path)
-  /// out of the zip at [zipPath] on a background isolate. [onBytes] is invoked on
-  /// THIS isolate with each chunk's byte count as it lands, so callers accumulate
-  /// determinate progress. Throws (on this isolate) if the worker reports an
-  /// error, preserving the caller's existing try/catch crash-safety.
-  static Future<void> _extractEntriesStreaming({
-    required String zipPath,
-    required List<MapEntry<String, String>> entries,
-    void Function(int deltaBytes)? onBytes,
-  }) async {
-    if (entries.isEmpty) return;
-    final ReceivePort port = ReceivePort();
-    final Completer<void> completer = Completer<void>();
-    Isolate? isolate;
-    port.listen((dynamic message) {
-      if (message is int) {
-        onBytes?.call(message);
-      } else if (message == _extractDoneToken) {
-        if (!completer.isCompleted) completer.complete();
-        port.close();
-      } else {
-        // Worker failure ('errorText') or an uncaught isolate error
-        // ([error, stack]): fail the future so the caller's rollback runs.
-        if (!completer.isCompleted) {
-          completer.completeError(
-            StateError('Backup extraction failed: $message'),
-          );
-        }
-        port.close();
-      }
-    });
-    isolate = await Isolate.spawn(
-      _backupExtractWorker,
-      _BackupExtractRequest(zipPath, entries, port.sendPort),
-      onError: port.sendPort,
-    );
-    try {
-      await completer.future;
-    } finally {
-      isolate.kill(priority: Isolate.immediate);
-    }
-  }
-
-  /// Background-isolate entry point for [_extractEntriesStreaming]. Re-opens the
-  /// zip by path (the decoded [Archive] from the caller's isolate cannot cross
-  /// the boundary), then streams each requested entry to disk, reporting progress
-  /// and terminal status through the [SendPort].
-  static void _backupExtractWorker(_BackupExtractRequest request) {
-    final SendPort port = request.sendPort;
-    InputFileStream? input;
-    try {
-      input = InputFileStream(request.zipPath);
-      final Archive archive = ZipDecoder().decodeBuffer(input);
-      final Map<String, ArchiveFile> byName = <String, ArchiveFile>{
-        for (final ArchiveFile file in archive.files) file.name: file,
-      };
-      for (final MapEntry<String, String> entry in request.entries) {
-        final ArchiveFile? file = byName[entry.key];
-        if (file == null) {
-          throw StateError('Backup archive missing entry: ${entry.key}');
-        }
-        _streamArchiveFileToDisk(file, entry.value, port);
-      }
-      port.send(_extractDoneToken);
-    } catch (error, stack) {
-      port.send('$error\n$stack');
-    } finally {
-      input?.closeSync();
-    }
-  }
-
-  /// Streams one [file]'s uncompressed bytes to [destPath] without buffering the
-  /// whole entry. Hibiki backups are written STORE (see
-  /// [_writeBackupZipInIsolate]) so the raw window IS the uncompressed data and is
-  /// copied in bounded 4 MB chunks (each chunk's size reported via [port]); a
-  /// DEFLATE entry (small metadata / test fixtures — never a multi-GB file in
-  /// practice) is inflated streaming.
-  static void _streamArchiveFileToDisk(
-    ArchiveFile file,
-    String destPath,
-    SendPort port,
-  ) {
-    File(destPath).parent.createSync(recursive: true);
-    final OutputFileStream output = OutputFileStream(destPath);
-    try {
-      final InputStreamBase? raw = file.rawContent;
-      if (raw != null && !file.isCompressed) {
-        const int chunkSize = 4 * 1024 * 1024; // 4 MB peak heap per chunk
-        final int total = raw.length;
-        int written = 0;
-        while (written < total) {
-          final int want =
-              (total - written) < chunkSize ? (total - written) : chunkSize;
-          final Uint8List bytes = raw.readBytes(want).toUint8List();
-          if (bytes.isEmpty) break;
-          output.writeBytes(bytes);
-          written += bytes.length;
-          port.send(bytes.length);
-        }
-      } else if (raw != null && file.compressionType == ArchiveFile.DEFLATE) {
-        Inflate.stream(raw, output);
-        port.send(file.size);
-      } else {
-        // Last resort (already-materialized content): write buffered bytes.
-        output.writeBytes(file.content as List<int>);
-        port.send(file.size);
-      }
-    } finally {
-      output.closeSync();
-    }
-  }
-
   /// 导出对话框预填的建议文件名（**纯写侧**）。
   ///
   /// 改名安全的前提是读侧从不按文件名识别备份：导入用的是 `allowedExtensions:
@@ -4489,137 +1973,4 @@ class BackupService {
     final String date = FushiTimeFormat.dayKey(DateTime.now());
     return 'fushi-backup-$date.fushi.zip';
   }
-
-  // ── 旧名兼容转发（命名统一 §1-H：备份动词按用户视角统一 create/restore）────
-  //
-  // 用户视角的「创建备份 / 恢复备份」此前在代码里叫 export/import*，与 DB 内部
-  // 子步骤的 restore* 撞词。顶层 API 改名后保留下列 @Deprecated 转发（外部/并行
-  // 分支调用点平滑迁移）；内部子步骤已全部 restore*→reapply*，无转发。
-
-  /// 旧名兼容：已改名 [createBackup]。
-  @Deprecated('已改名 createBackup（用户视角动词），请改用新名')
-  Future<BackupMeta> exportBackup(
-    String outputPath, {
-    Set<BackupCategory>? categories,
-    Set<String>? bookKeys,
-    Set<String>? videoKeys,
-  }) =>
-      createBackup(
-        outputPath,
-        categories: categories,
-        bookKeys: bookKeys,
-        videoKeys: videoKeys,
-      );
-
-  /// 旧名兼容：已改名 [restoreBackup]。
-  @Deprecated('已改名 restoreBackup（用户视角动词），请改用新名')
-  static Future<void> importBackupFiles({
-    required String dbDirectory,
-    required String zipPath,
-    bool importSettings = true,
-    Set<BackupCategory>? categories,
-    String? dictionaryResourceDirectory,
-    String? booksRootDirectory,
-    String? audiobooksRootDirectory,
-    String? fontsRootDirectory,
-    String? videosRootDirectory,
-    void Function(double progress)? onProgress,
-  }) =>
-      restoreBackup(
-        dbDirectory: dbDirectory,
-        zipPath: zipPath,
-        importSettings: importSettings,
-        categories: categories,
-        dictionaryResourceDirectory: dictionaryResourceDirectory,
-        booksRootDirectory: booksRootDirectory,
-        audiobooksRootDirectory: audiobooksRootDirectory,
-        fontsRootDirectory: fontsRootDirectory,
-        videosRootDirectory: videosRootDirectory,
-        onProgress: onProgress,
-      );
-
-  /// 旧名兼容：已改名 [mergeRestoreBackup]。
-  @Deprecated('已改名 mergeRestoreBackup（用户视角动词），请改用新名')
-  static Future<void> mergeImportBackupFiles({
-    required String dbDirectory,
-    required String zipPath,
-    Set<BackupCategory>? categories,
-    String? dictionaryResourceDirectory,
-    String? booksRootDirectory,
-    String? audiobooksRootDirectory,
-    String? fontsRootDirectory,
-    String? videosRootDirectory,
-    void Function(double progress)? onProgress,
-  }) =>
-      mergeRestoreBackup(
-        dbDirectory: dbDirectory,
-        zipPath: zipPath,
-        categories: categories,
-        dictionaryResourceDirectory: dictionaryResourceDirectory,
-        booksRootDirectory: booksRootDirectory,
-        audiobooksRootDirectory: audiobooksRootDirectory,
-        fontsRootDirectory: fontsRootDirectory,
-        videosRootDirectory: videosRootDirectory,
-        onProgress: onProgress,
-      );
-
-  /// 旧名兼容：已改名 [summarizeBackupEntries]（入参是归档条目名列表而非
-  /// `Archive` 对象，旧名易误导）。
-  @Deprecated('已改名 summarizeBackupEntries，请改用新名')
-  static BackupContentSummary summarizeBackupArchive(
-    Iterable<String> archiveFileNames,
-    BackupMeta? meta, {
-    int? dbVideoBookCount,
-    int? dbAudiobookCount,
-  }) =>
-      summarizeBackupEntries(
-        archiveFileNames,
-        meta,
-        dbVideoBookCount: dbVideoBookCount,
-        dbAudiobookCount: dbAudiobookCount,
-      );
-
-  /// 旧名兼容：已改名 [summarizeBackupFile]。
-  @Deprecated('已改名 summarizeBackupFile，请改用新名')
-  Future<BackupContentSummary> summarizeBackupZip(String zipPath) =>
-      summarizeBackupFile(zipPath);
-
-  /// 旧名兼容：已改名 [summarizeLiveContent]（摘要对象是**现库内容**而非任何
-  /// 备份文件，与上两者本就不同义，旧名 Export 前缀掩盖了这一点）。
-  @Deprecated('已改名 summarizeLiveContent，请改用新名')
-  Future<BackupContentSummary> summarizeExportContent() =>
-      summarizeLiveContent();
-
-  /// 旧名兼容：已改名 [previewMergeRestore]。
-  @Deprecated('已改名 previewMergeRestore，请改用新名')
-  static Future<BackupMergePreview?> previewMergeImport({
-    required FushiDatabase liveDb,
-    required String dbDirectory,
-    required String zipPath,
-  }) =>
-      previewMergeRestore(
-        liveDb: liveDb,
-        dbDirectory: dbDirectory,
-        zipPath: zipPath,
-      );
-
-  /// 旧名兼容：已改名 [recoverMergeRestore]。
-  @Deprecated('已改名 recoverMergeRestore，请改用新名')
-  static Future<bool> recoverMergeImport(String dbDirectory) =>
-      recoverMergeRestore(dbDirectory);
-
-  /// 旧名兼容：已改名 [recoverPendingRestore]。
-  @Deprecated('已改名 recoverPendingRestore，请改用新名')
-  static Future<void> recoverPendingImport(String dbDirectory) =>
-      recoverPendingRestore(dbDirectory);
-}
-
-/// Sendable request for the background extract worker (records with a `List` and
-/// a `SendPort` cross the isolate boundary fine). Kept a top-level class rather
-/// than an anonymous record for a clearer worker signature.
-class _BackupExtractRequest {
-  const _BackupExtractRequest(this.zipPath, this.entries, this.sendPort);
-  final String zipPath;
-  final List<MapEntry<String, String>> entries;
-  final SendPort sendPort;
 }

--- a/fushi/lib/src/sync/backup_service/fs_retry.part.dart
+++ b/fushi/lib/src/sync/backup_service/fs_retry.part.dart
@@ -1,0 +1,83 @@
+part of '../backup_service.dart';
+
+// Windows 文件系统忙重试（B1 从 BackupService 拆出）：目录删除 / 改名的有界重试。
+
+/// Whether a Windows OS error code is a transient filesystem-busy condition
+/// that clears once an external handle is released. The recursive delete of
+/// the export's temp dir runs right after [_stripCredentials] /
+/// [_stripDictionaryState] closed their sqlite connections; on Windows the OS
+/// (and Defender / search-indexer scanning the just-written `hibiki.db` copy)
+/// can keep a handle open for a brief window after `close()` returns, so the
+/// delete fails with ERROR_ACCESS_DENIED(5), ERROR_SHARING_VIOLATION(32) or
+/// ERROR_DIR_NOT_EMPTY(145, a child file still locked). Same family as the
+/// dictionary-import rename lock (BUG-050).
+bool _isWindowsTransientFsBusy(int? code) =>
+    code == 5 || code == 32 || code == 145;
+
+/// Pure, dependency-injected core of [_deleteDirectoryIfPresent]: deletes a
+/// directory tree, tolerating both a vanished tree ([PathNotFoundException]:
+/// already cleaned up) and -- on Windows only -- a transient filesystem-busy
+/// error (see [_isWindowsTransientFsBusy]) via a bounded, backing-off retry
+/// that gives the lingering external handle time to release.
+///
+/// A non-Windows error, or a Windows error that is NOT transient FS-busy, is
+/// rethrown immediately (never swallowed -- a real cleanup failure must
+/// surface). If every attempt hits transient FS-busy the last exception is
+/// rethrown rather than silently leaving the temp tree on disk. POSIX deletes
+/// succeed on the first attempt and never enter the retry branch.
+@visibleForTesting
+Future<void> deleteDirectoryWithRetry({
+  required Future<bool> Function() exists,
+  required Future<void> Function() delete,
+  required Future<void> Function(int delayMs) sleep,
+  required bool isWindows,
+  int maxAttempts = 10,
+}) async {
+  for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      if (await exists()) {
+        await delete();
+      }
+      return;
+    } on PathNotFoundException {
+      // Cleanup is already satisfied if the temp tree vanished between the
+      // existence check and deletion.
+      return;
+    } on FileSystemException catch (e) {
+      final int? code = e.osError?.errorCode;
+      final bool transient = isWindows && _isWindowsTransientFsBusy(code);
+      if (!transient || attempt == maxAttempts) rethrow;
+      await sleep(50 * attempt); // backoff: 50ms,100ms,... let handle drop
+    }
+  }
+}
+
+/// Retries a directory [rename] that hits a transient Windows filesystem-busy
+/// error (access denied / sharing violation — see [_isWindowsTransientFsBusy])
+/// with a bounded backoff. The content-tree swap renames a freshly-EXTRACTED
+/// `.import-tmp` into place; on Windows an antivirus / indexer scanning the
+/// just-written tree briefly holds handles, so the immediate rename can fail
+/// with `errno 5` (the "备份导入失败: Rename failed … 拒绝访问" the user hit).
+/// A non-Windows error, or a non-transient Windows error, is rethrown at once.
+/// The longer cap than the delete retry (backoff to ~1s/attempt) gives a big
+/// multi-GB tree's scan time to finish.
+@visibleForTesting
+Future<void> renameDirectoryWithRetry({
+  required Future<void> Function() rename,
+  required Future<void> Function(int delayMs) sleep,
+  required bool isWindows,
+  int maxAttempts = 20,
+}) async {
+  for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await rename();
+      return;
+    } on FileSystemException catch (e) {
+      final int? code = e.osError?.errorCode;
+      final bool transient = isWindows && _isWindowsTransientFsBusy(code);
+      if (!transient || attempt == maxAttempts) rethrow;
+      // backoff: 100ms,200ms,... capped at 1s → ~15s total over 20 attempts.
+      await sleep((100 * attempt).clamp(100, 1000));
+    }
+  }
+}

--- a/fushi/lib/src/sync/backup_service/path_rebase.part.dart
+++ b/fushi/lib/src/sync/backup_service/path_rebase.part.dart
@@ -1,0 +1,415 @@
+part of '../backup_service.dart';
+
+// 备份包落地后的路径 rebase 族（B1 从 BackupService 拆出）：全是无状态函数，
+// 只被 restoreBackup / mergeRestoreBackup 调用。
+
+/// Rebases every stored absolute path carried by the backup DB (which points
+/// at the SOURCE device's roots) onto THIS device's roots, in the fixed
+/// content → fonts → local-audio → videos order shared by the overwrite and
+/// merge imports. Custom-font config and local-audio DB paths are content
+/// too (their files come from the backup). Each underlying rebase is a no-op
+/// when the meta carries no matching source root (legacy backup) or the new
+/// root is null — e.g. a keep-settings import whose preserved local paths
+/// aren't under the source root, or an unticked import category.
+Future<void> _rebaseAllPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newBooksRoot,
+  required String? newAudiobooksRoot,
+  required String? newFontsRoot,
+  required String? newLocalAudioRoot,
+  required String? newVideosRoot,
+}) async {
+  await _rebaseContentPaths(
+    dbDirectory: dbDirectory,
+    meta: meta,
+    newBooksRoot: newBooksRoot,
+    newAudiobooksRoot: newAudiobooksRoot,
+  );
+  await _rebaseFontPaths(
+    dbDirectory: dbDirectory,
+    meta: meta,
+    newFontsRoot: newFontsRoot,
+  );
+  await _rebaseLocalAudioPaths(
+    dbDirectory: dbDirectory,
+    meta: meta,
+    newLocalAudioRoot: newLocalAudioRoot,
+  );
+  await _rebaseVideoPaths(
+    dbDirectory: dbDirectory,
+    meta: meta,
+    newVideosRoot: newVideosRoot,
+  );
+}
+
+/// Rebases the imported DB's stored absolute content paths from the backup's
+/// source roots ([BackupMeta.booksRoot] / [BackupMeta.audiobooksRoot]) onto
+/// this device's [newBooksRoot] / [newAudiobooksRoot]. No-op for a legacy
+/// backup (meta has no roots). Cover paths can live under EITHER tree (epub
+/// covers in hoshi_books, audiobook covers in audiobooks), so they try both.
+/// EPUB 解包目录在本机的**确定性回退**。
+///
+/// [rebasePath] 靠「老根前缀」做字符串替换。一旦备份记录的
+/// [BackupMeta.booksRoot] 与行里的真实前缀对不上，前缀匹配会失败并**静默原样
+/// 返回**导出设备的绝对路径——库看着导入成功，每本书却都「找不到书籍文件」。
+/// 真实踩中的形态：跨包名迁移时导出端把书根名写成改名前的旧名（`hoshi_books`），
+/// 而行里是 `fushi_books`，于是 rebase 全程无声失效，四本书的 `extract_dir`
+/// 仍指向老包私有目录 `/data/user/0/<老包名>/...`——那是另一个应用的沙箱，
+/// 新包永远读不到，尽管文件早已解包到本机书根下。
+///
+/// 解包落点本身是确定的（`<booksRoot>/<bookKey>`），所以不必去猜老根：rebase
+/// 结果在本机不存在、而该确定位置存在时，用后者。**原路径有效时一律不动**，
+/// 普通备份恢复的行为不变。
+String _resolveExtractDirOnDevice(
+    String rebased, String bookKey, String newBooksRoot) {
+  if (rebased.isNotEmpty && Directory(rebased).existsSync()) return rebased;
+  if (bookKey.isEmpty) return rebased;
+  final String byKey = p.join(newBooksRoot, bookKey);
+  if (Directory(byKey).existsSync()) return byKey;
+  return rebased;
+}
+
+Future<void> _rebaseContentPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newBooksRoot,
+  required String? newAudiobooksRoot,
+}) async {
+  final String? oldBooks = meta.booksRoot;
+  final String? oldAudio = meta.audiobooksRoot;
+  final bool canBooks = oldBooks != null && newBooksRoot != null;
+  final bool canAudio = oldAudio != null && newAudiobooksRoot != null;
+  if (!canBooks && !canAudio) return;
+
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    if (canBooks) {
+      for (final EpubBookRow b in await db.getAllEpubBooks()) {
+        await db.updateEpubBookContentPaths(
+          b.bookKey,
+          epubPath: rebasePath(b.epubPath, oldBooks, newBooksRoot),
+          extractDir: _resolveExtractDirOnDevice(
+            rebasePath(b.extractDir, oldBooks, newBooksRoot),
+            b.bookKey,
+            newBooksRoot,
+          ),
+          coverPath: b.coverPath == null
+              ? null
+              : _rebaseEither(b.coverPath!, oldBooks, newBooksRoot, oldAudio,
+                  newAudiobooksRoot),
+        );
+      }
+    }
+    if (canAudio) {
+      for (final AudiobookRow a in await db.getAllAudiobooks()) {
+        await db.updateAudiobookPaths(
+          a.bookKey,
+          audioRoot: a.audioRoot == null
+              ? null
+              : rebasePath(a.audioRoot!, oldAudio, newAudiobooksRoot),
+          audioPathsJson: _rebaseAudioPathsJson(
+              a.audioPathsJson, oldAudio, newAudiobooksRoot, a.bookKey),
+          alignmentPath:
+              rebasePath(a.alignmentPath, oldAudio, newAudiobooksRoot),
+        );
+      }
+      // BUG-1575: srt_books carries its OWN copy of the audio paths and was
+      // never rebased here, while the merge engine inserts its rows column
+      // for column (audio_paths_json / audio_root / srt_path / cover_path all
+      // verbatim from the source device). Result on a cross-root import: the
+      // paired `audiobooks` row resolved but the `srt_book` row still pointed
+      // at the SOURCE root, so the shelf saw a broken audiobook -- subtitles
+      // (parsed cues live in `audio_cues`, no path) but no audio.
+      //
+      // All four columns live under ONE directory `<audiobooksRoot>/<uid>`
+      // (see SyncAssetPackageService.importAudioDatabasePackage and
+      // kPathRebaseColumns), so cover_path is rebased against the AUDIOBOOKS
+      // root first. It still falls back to the books mapping via
+      // _rebaseEither, because an epub-backed srt row (bookKey non-empty) may
+      // have adopted the epub's cover under the books root.
+      for (final SrtBookRow srt in await db.getAllSrtBooks()) {
+        await db.updateSrtBookPaths(
+          srt.uid,
+          audioRoot: srt.audioRoot == null
+              ? null
+              : rebasePath(srt.audioRoot!, oldAudio, newAudiobooksRoot),
+          audioPathsJson: _rebaseAudioPathsJson(
+              srt.audioPathsJson, oldAudio, newAudiobooksRoot, srt.uid),
+          srtPath: rebasePath(srt.srtPath, oldAudio, newAudiobooksRoot),
+          coverPath: srt.coverPath == null
+              ? null
+              : _rebaseEither(srt.coverPath!, oldAudio, newAudiobooksRoot,
+                  oldBooks, newBooksRoot),
+        );
+      }
+    }
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Rebases every path inside a persisted `audioPathsJson` string list from
+/// [oldRoot] onto [newRoot]. A malformed value (corrupt row, not a JSON
+/// string-list) must not abort the whole import -- it is returned verbatim
+/// and the failure is logged with [rowKey] (review W3). Shared by the
+/// `audiobooks` and `srt_books` rebases so the two can never drift.
+String? _rebaseAudioPathsJson(
+  String? json,
+  String oldRoot,
+  String newRoot,
+  String rowKey,
+) {
+  if (json == null) return null;
+  try {
+    final dynamic decoded = jsonDecode(json);
+    if (decoded is! List) return json;
+    return jsonEncode(decoded
+        .whereType<String>()
+        .map((String s) => rebasePath(s, oldRoot, newRoot))
+        .toList());
+  } catch (e) {
+    debugPrint(
+        'BackupService: skipped rebasing audioPathsJson for $rowKey: $e');
+    return json;
+  }
+}
+
+/// Rebases the imported DB's stored custom-font paths from the backup's
+/// [BackupMeta.fontsRoot] onto this device's [newFontsRoot]. The canonical
+/// `font_catalog` carries paths, while `font_targets` only carries catalog
+/// ids/order/enabled rows; legacy shadow lists also carry paths. Every stored
+/// file-font path is rebased (system fonts and unrelated paths untouched).
+/// No-op when either root is null.
+Future<void> _rebaseFontPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newFontsRoot,
+}) async {
+  final String? oldFonts = meta.fontsRoot;
+  if (oldFonts == null || newFontsRoot == null) return;
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    final Map<String, String> prefs = await db.getAllPrefs();
+    final String? catalog = prefs[_fontCatalogPrefKey];
+    if (catalog != null) {
+      final String rebasedCatalog = rebaseFontCatalogJson(
+        catalog,
+        oldFonts,
+        newFontsRoot,
+      );
+      if (rebasedCatalog != catalog) {
+        await db.setPref(_fontCatalogPrefKey, rebasedCatalog);
+      }
+    }
+    for (final String key in _legacyFontPrefKeys) {
+      final String? raw = prefs[key];
+      if (raw == null) continue;
+      final String rebased = rebaseFontListJson(raw, oldFonts, newFontsRoot);
+      if (rebased != raw) await db.setPref(key, rebased);
+    }
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Re-homes the imported DB's stored local-audio paths onto THIS device's
+/// support directory [newLocalAudioRoot] by FILENAME, for BOTH the canonical
+/// `local_audio_dbs` pref AND the typed `audio_source_configs` pref (its
+/// localAudio entries). Keeping both in lock-step preserves the
+/// typed-config <-> local_audio_dbs join (AppModel.audioSourceConfigs matches
+/// by path); re-homing only one side would split them and drop the typed
+/// source (TODO-1171). Gated on [BackupMeta.localAudioRoot] being non-null —
+/// i.e. the localAudio category was packed, so the `.db` files actually
+/// crossed over and this device's restored DB is a real, openable database
+/// (a db-only backup carries no audio files, and runtime resolution via
+/// [LocalAudioManager.resolveInternalPath] covers playback there without
+/// touching stored prefs; opening the DB in that isolation case is neither
+/// needed nor safe — mirrors the sibling content/font rebasers). Preserves
+/// each pref's PrefCodec tag (`s:`/`j:` in production, untagged in some
+/// tests). Also logs any loopback remoteAudio source as a cross-machine
+/// hazard so the failure is visible, never silent.
+Future<void> _rebaseLocalAudioPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newLocalAudioRoot,
+}) async {
+  if (meta.localAudioRoot == null || newLocalAudioRoot == null) return;
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    final Map<String, String> prefs = await db.getAllPrefs();
+    await _normalizePrefInPlace(
+      db,
+      prefs,
+      _localAudioDbsPrefKey,
+      (String body) => normalizeLocalAudioDbsJson(body, newLocalAudioRoot),
+    );
+    await _normalizePrefInPlace(
+      db,
+      prefs,
+      _audioSourceConfigsPrefKey,
+      (String body) => normalizeAudioSourceConfigsJson(body, newLocalAudioRoot),
+    );
+    _warnLoopbackAudioSources(prefs[_audioSourceConfigsPrefKey]);
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+/// Reads [key] from [prefs], runs the tag-aware [transform] on its stored
+/// value, and writes it back when it changed. No-op when the key is absent or
+/// the value is unchanged.
+Future<void> _normalizePrefInPlace(
+  FushiDatabase db,
+  Map<String, String> prefs,
+  String key,
+  String Function(String storedValue) transform,
+) async {
+  final String? raw = prefs[key];
+  if (raw == null) return;
+  final String next = transform(raw);
+  if (next == raw) return;
+  await db.setPref(key, next);
+}
+
+/// Logs (never silently drops) any imported remoteAudio source that points at
+/// a loopback host — it resolved on the source device but points at THIS new
+/// machine after import, so it needs a manual re-point. The audio-source
+/// management UI surfaces the same hazard as a per-row warning (TODO-1171).
+void _warnLoopbackAudioSources(String? rawConfigs) {
+  if (rawConfigs == null) return;
+  try {
+    final dynamic decoded = jsonDecode(splitPrefTag(rawConfigs).body);
+    if (decoded is! List) return;
+    for (final dynamic e in decoded) {
+      if (e is! Map) continue;
+      if (e['kind'] != AudioSourceKind.remoteAudio.wireName) continue;
+      final Object? url = e['url'];
+      if (url is String && AudioSourceConfig.isLoopbackAudioUrl(url)) {
+        debugPrint(
+          '[fushi-audio] imported remote audio source points at a loopback '
+          'host and will not resolve on this device until re-pointed: $url',
+        );
+      }
+    }
+  } catch (_) {
+    // diagnostic only; never abort import on a malformed pref
+  }
+}
+
+Future<void> _rebaseVideoPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newVideosRoot,
+}) async {
+  if (newVideosRoot == null || meta.videoFiles.isEmpty) return;
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    for (final VideoBookRow row in await db.allVideoBooks()) {
+      final String videoPath =
+          _rebaseVideoPath(row.videoPath, meta.videoFiles, newVideosRoot);
+      final String? playlistJson = _rebaseVideoPlaylistJson(
+        row.playlistJson,
+        meta.videoFiles,
+        newVideosRoot,
+      );
+      if (videoPath == row.videoPath && playlistJson == row.playlistJson) {
+        continue;
+      }
+      await db.customStatement(
+        'UPDATE video_books SET video_path = ?, playlist_json = ? '
+        'WHERE book_uid = ?',
+        <Object?>[videoPath, playlistJson, row.bookUid],
+      );
+    }
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
+String _rebaseVideoPath(
+  String oldPath,
+  Map<String, String> sourcePathToArchiveRelative,
+  String newVideosRoot,
+) {
+  final String? relativePath = sourcePathToArchiveRelative[oldPath];
+  if (relativePath == null) return oldPath;
+  return _reappliedVideoPath(newVideosRoot, relativePath);
+}
+
+String? _rebaseVideoPlaylistJson(
+  String? playlistJson,
+  Map<String, String> sourcePathToArchiveRelative,
+  String newVideosRoot,
+) {
+  if (playlistJson == null || playlistJson.isEmpty) return playlistJson;
+  try {
+    final dynamic decoded = jsonDecode(playlistJson);
+    if (decoded is! List) return playlistJson;
+    bool changed = false;
+    final List<dynamic> rewritten = decoded.map<dynamic>((dynamic entry) {
+      if (entry is! Map) return entry;
+      final Map<String, dynamic> row = Map<String, dynamic>.from(entry);
+      final Object? path = row['path'];
+      if (path is! String) return row;
+      final String rebased =
+          _rebaseVideoPath(path, sourcePathToArchiveRelative, newVideosRoot);
+      if (rebased != path) {
+        row['path'] = rebased;
+        changed = true;
+      }
+      return row;
+    }).toList();
+    return changed ? jsonEncode(rewritten) : playlistJson;
+  } catch (_) {
+    return playlistJson;
+  }
+}
+
+String _reappliedVideoPath(
+  String videosRoot,
+  String archiveRelativePath,
+) {
+  final String relative = archiveRelativePath.replaceAll(r'\', '/');
+  final String normalizedRelative = p.posix.normalize(relative);
+  if (relative.isEmpty ||
+      p.posix.isAbsolute(relative) ||
+      normalizedRelative == '..' ||
+      normalizedRelative.startsWith('../')) {
+    throw FormatException('Invalid backup video path: $archiveRelativePath');
+  }
+  final String targetPath = p.normalize(p.join(videosRoot, normalizedRelative));
+  final String canonicalRoot = p.canonicalize(videosRoot);
+  final String canonicalTarget = p.canonicalize(targetPath);
+  if (canonicalTarget != canonicalRoot &&
+      !p.isWithin(canonicalRoot, canonicalTarget)) {
+    throw FormatException('Invalid backup video path: $archiveRelativePath');
+  }
+  return targetPath;
+}
+
+/// Rebases [path] trying the (oldA -> newA) mapping first, then
+/// (oldB -> newB). A cover written under either tree resolves; one not under
+/// either is returned unchanged. Either pair may be null (that category was
+/// not part of the backup) -- a null pair is simply skipped, so callers do
+/// not need a special case for it.
+String _rebaseEither(
+  String path,
+  String? oldA,
+  String? newA,
+  String? oldB,
+  String? newB,
+) {
+  if (oldA != null && newA != null) {
+    final String viaA = rebasePath(path, oldA, newA);
+    if (viaA != path) return viaA;
+  }
+  if (oldB != null && newB != null) {
+    return rebasePath(path, oldB, newB);
+  }
+  return path;
+}

--- a/fushi/lib/src/sync/backup_service/restore.part.dart
+++ b/fushi/lib/src/sync/backup_service/restore.part.dart
@@ -177,7 +177,7 @@ class BackupRestoreService {
           dbAudiobookCount: dbAudiobookCount);
     } catch (e, st) {
       debugPrint(
-          'BackupService.summarizeBackupFile failed for $zipPath: $e\n$st');
+          'BackupRestoreService.summarizeBackupFile failed for $zipPath: $e\n$st');
       return const BackupContentSummary();
     } finally {
       await input?.close();
@@ -217,7 +217,7 @@ class BackupRestoreService {
         db.dispose();
       }
     } catch (e, st) {
-      debugPrint('BackupService._peekContentRowCounts failed: $e\n$st');
+      debugPrint('BackupRestoreService._peekContentRowCounts failed: $e\n$st');
       return null;
     } finally {
       try {
@@ -251,7 +251,7 @@ class BackupRestoreService {
     String bakPath,
   ) async {
     if (!File(bakPath).existsSync()) {
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+      debugPrint('BackupRestoreService._reapplyDeviceLocalTablesFromBak: '
           'pre-restore.bak missing — local pairing/baselines could not be '
           'preserved on import.');
       return false;
@@ -260,7 +260,7 @@ class BackupRestoreService {
     try {
       hasSqliteHeader = await _hasSqliteHeader(bakPath);
     } catch (e, st) {
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+      debugPrint('BackupRestoreService._reapplyDeviceLocalTablesFromBak: '
           'pre-restore.bak could not be inspected: $e\n$st');
       return false;
     }
@@ -268,7 +268,7 @@ class BackupRestoreService {
       // A few low-level restore callers intentionally swap opaque fixture
       // bytes rather than a Hibiki database. Such a snapshot cannot contain
       // device-local rows, so there is nothing to retry or retain.
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+      debugPrint('BackupRestoreService._reapplyDeviceLocalTablesFromBak: '
           'pre-restore.bak is not a SQLite database; no local tables to '
           'preserve.');
       return true;
@@ -293,7 +293,7 @@ class BackupRestoreService {
     } catch (e, st) {
       // Best-effort preservation: a corrupt/unreadable imported DB must not
       // abort the whole restore (the primary overwrite already landed).
-      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak failed: '
+      debugPrint('BackupRestoreService._reapplyDeviceLocalTablesFromBak failed: '
           '$e\n$st');
       return false;
     } finally {
@@ -529,7 +529,7 @@ class BackupRestoreService {
     ];
     if (keys.isEmpty) return;
     if (!File(bakPath).existsSync()) {
-      debugPrint('BackupService._reapplyExcludedContentRegistry: '
+      debugPrint('BackupRestoreService._reapplyExcludedContentRegistry: '
           'pre-restore.bak missing — local favorites/fonts/audio registry could '
           'not be preserved for a category-excluded backup.');
       return;
@@ -551,7 +551,7 @@ class BackupRestoreService {
       await db.customStatement('DETACH DATABASE crbak');
       await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
     } catch (e, st) {
-      debugPrint('BackupService._reapplyExcludedContentRegistry failed: '
+      debugPrint('BackupRestoreService._reapplyExcludedContentRegistry failed: '
           '$e\n$st');
     } finally {
       try {
@@ -588,7 +588,7 @@ class BackupRestoreService {
       // A null result tells the UI "invalid backup". Surface the real reason
       // (corrupt zip / read error / OOM) so it is not silently indistinguishable
       // from a genuinely malformed archive (review W4).
-      debugPrint('BackupService.validateBackup failed for $zipPath: $e\n$st');
+      debugPrint('BackupRestoreService.validateBackup failed for $zipPath: $e\n$st');
       return null;
     } finally {
       await input?.close();
@@ -983,7 +983,7 @@ class BackupRestoreService {
         await _safeDelete(sidecar.path);
         await _safeDelete(bakPath);
       } else {
-        debugPrint('BackupService.restoreBackup: device-local tables were not '
+        debugPrint('BackupRestoreService.restoreBackup: device-local tables were not '
             'reapplied; retaining restore sidecar and pre-restore.bak for '
             'startup recovery.');
       }
@@ -1245,7 +1245,7 @@ class BackupRestoreService {
     } catch (e, st) {
       // Never block the import on a preview failure — fall back to a generic
       // confirm dialog.
-      debugPrint('BackupService.previewMergeRestore failed: $e\n$st');
+      debugPrint('BackupRestoreService.previewMergeRestore failed: $e\n$st');
       return null;
     } finally {
       await _safeDelete(tmpSrc);
@@ -1299,7 +1299,7 @@ class BackupRestoreService {
         await _safeDelete('$mergeSrc-shm');
       }
     } catch (e, st) {
-      debugPrint('BackupService.recoverMergeRestore failed: $e\n$st');
+      debugPrint('BackupRestoreService.recoverMergeRestore failed: $e\n$st');
     }
     await _safeDelete(p.join(dbDirectory, _mergeSrcName));
     await _safeDelete(p.join(dbDirectory, '$_mergeSrcName-wal'));
@@ -1361,17 +1361,17 @@ class BackupRestoreService {
       // pre-restore DB snapshot can still rescue device-local tables. Preserve
       // the historical behavior of dropping an irreparably corrupt marker once
       // that table replay succeeds.
-      debugPrint('BackupService.recoverPendingRestore: corrupt sidecar: '
+      debugPrint('BackupRestoreService.recoverPendingRestore: corrupt sidecar: '
           '$e\n$st');
       sidecarStateApplied = true;
     } on TypeError catch (e, st) {
-      debugPrint('BackupService.recoverPendingRestore: invalid sidecar shape: '
+      debugPrint('BackupRestoreService.recoverPendingRestore: invalid sidecar shape: '
           '$e\n$st');
       sidecarStateApplied = true;
     } catch (e, st) {
       // Database/filesystem failures are retryable. Keep both artifacts so the
       // next startup can replay the same idempotent operations.
-      debugPrint('BackupService.recoverPendingRestore failed: $e\n$st');
+      debugPrint('BackupRestoreService.recoverPendingRestore failed: $e\n$st');
       return;
     }
 
@@ -1380,7 +1380,7 @@ class BackupRestoreService {
       final bool deviceLocalTablesReapplied =
           await _reapplyDeviceLocalTablesFromBak(dbDirectory, bakPath);
       if (!deviceLocalTablesReapplied) {
-        debugPrint('BackupService.recoverPendingRestore: retaining sidecar and '
+        debugPrint('BackupRestoreService.recoverPendingRestore: retaining sidecar and '
             'pre-restore.bak because device-local table replay did not finish.');
         return;
       }
@@ -1401,7 +1401,7 @@ class BackupRestoreService {
       // surface it loudly rather than silently dropping the user's settings.
       // (Normal flow restores inline while bak definitely exists; reaching here
       // means a crash + external deletion of bak before the next launch.)
-      debugPrint('BackupService._reapplySettingsLayer: pre-restore.bak missing '
+      debugPrint('BackupRestoreService._reapplySettingsLayer: pre-restore.bak missing '
           '— local settings/profiles could not be preserved on import.');
       return;
     }
@@ -1457,7 +1457,7 @@ class BackupRestoreService {
       // bak is the only copy of this device's settings/profiles after the
       // overwrite. Missing it means a crash + external deletion before this ran;
       // surface loudly rather than silently wiping the layer to empty.
-      debugPrint('BackupService._reapplyExcludedSettingsLayers: '
+      debugPrint('BackupRestoreService._reapplyExcludedSettingsLayers: '
           'pre-restore.bak missing — local settings/profiles could not be '
           'preserved for a settings/profiles-excluded backup.');
       return;
@@ -1517,7 +1517,7 @@ class BackupRestoreService {
       // bak is the only copy of this device's dictionary rows after the
       // overwrite. Missing it means a crash + external deletion before this
       // ran; surface loudly rather than silently dropping the dictionaries.
-      debugPrint('BackupService._reapplyDictionaryTablesFromBak: '
+      debugPrint('BackupRestoreService._reapplyDictionaryTablesFromBak: '
           'pre-restore.bak missing — local dictionaries could not be '
           'preserved on import.');
       return;
@@ -1567,7 +1567,7 @@ class BackupRestoreService {
     } catch (e, st) {
       // Current DB unreadable/corrupt: nothing to preserve. Import the backup
       // as-is rather than aborting — a broken local DB shouldn't block restore.
-      debugPrint('BackupService._readDeviceLocalPrefs failed: $e\n$st');
+      debugPrint('BackupRestoreService._readDeviceLocalPrefs failed: $e\n$st');
       return const <String, String>{};
     } finally {
       try {

--- a/fushi/lib/src/sync/backup_service/restore.part.dart
+++ b/fushi/lib/src/sync/backup_service/restore.part.dart
@@ -1,0 +1,2050 @@
+part of '../backup_service.dart';
+
+/// 备份的恢复 / 合并 / 预览 / 崩溃恢复 / 读包摘要（B1 从 [BackupService] 分家）。
+///
+/// 全部 static：恢复侧不需要导出侧的实例状态（库目录等都是参数）。共用的常量与
+/// 纯 helper 在主文件顶层，`_rebase*` 族在 path_rebase.part.dart。
+class BackupRestoreService {
+  BackupRestoreService._();
+
+  /// Predicate for the keep-THIS-device-settings restore ([_reapplySettingsLayer],
+  /// the `importSettings=false` overwrite path). Restores from bak every pref row
+  /// EXCEPT the ones that are CONTENT and must follow the imported backup:
+  ///   - `audiobook_pos_*`      -> reading progress (the `progress` category)
+  ///   - `favorite_sentences`   -> favorites content (travels)
+  ///   - `local_audio_dbs` / `audio_source_configs` -> audio-source registry that
+  ///     points at the imported local-audio `.db` files (BUG-780: the old
+  ///     `NOT LIKE 'audiobook_pos_%'` restored these from THIS device, wiping the
+  ///     backup's registration so the `.db` files landed but no source was
+  ///     registered → imported local audio silently stopped working).
+  ///   - font catalog + legacy font prefs -> font registry (the `fonts` category)
+  ///   - `*override_title://*`  -> 用户给书改的名字是内容，跟着导入的备份走
+  ///     （BUG-1488；与 [settingsPrefPredicate] 的内容/设置切分保持对称）
+  /// UNLIKE [settingsPrefPredicate] this KEEPS `sync_*` restored from bak: the
+  /// keep-settings path writes no `{'mode':'prefs'}` sidecar and never calls
+  /// [_applyPreservedConfig], so this wholesale restore is the ONLY place the
+  /// device's own (never-exported) sync config is preserved — excluding `sync_*`
+  /// here would drop it. Same content-vs-settings split as the export strip and
+  /// [_reapplyExcludedSettingsLayers], so the two restore paths stay symmetric.
+  static final String _keepDeviceSettingsPrefPredicate =
+      _buildKeepDeviceSettingsPrefPredicate();
+
+  static String _buildKeepDeviceSettingsPrefPredicate() {
+    final List<String> contentRegistryKeys = <String>[
+      _favoriteSentencesPrefKey,
+      _localAudioDbsPrefKey,
+      _audioSourceConfigsPrefKey,
+      _fontCatalogPrefKey,
+      ..._legacyFontPrefKeys,
+    ];
+    final String notIn = contentRegistryKeys
+        .map((String k) => "'${k.replaceAll("'", "''")}'")
+        .join(', ');
+    return "key NOT LIKE 'audiobook_pos_%' AND key NOT IN ($notIn) "
+        'AND $_notOverrideTitleSql';
+  }
+
+  /// Sidecar file holding this device's sync config across an import. Written
+  /// BEFORE the destructive DB overwrite so a crash mid-import is recoverable
+  /// (a startup sweep re-applies it). Deleted once the import completes.
+  static const String _preserveSidecar = '$_dbName.sync-preserve.json';
+
+  /// Item counts per file-tree category present in a backup's [archiveFileNames]
+  /// (posix or windows separators). Pure over the name list + [meta] so it is
+  /// trivially unit-testable and never opens the archive body / DB (TODO-1358).
+  ///
+  /// Counting unit per category: dictionaries / books / audiobooks = distinct
+  /// first path segment under the prefix (one directory each); fonts = font
+  /// files; videos = packed video files ([BackupMeta.videoFiles], else leaf
+  /// files); localAudio = `local_audio_<n>.db` files (the `-wal`/`-shm` siblings
+  /// are not separate databases).
+  static BackupContentSummary summarizeBackupEntries(
+    Iterable<String> archiveFileNames,
+    BackupMeta? meta, {
+    int? dbVideoBookCount,
+    int? dbAudiobookCount,
+  }) {
+    final Set<String> dictDirs = <String>{};
+    final Set<String> bookDirs = <String>{};
+    final Set<String> audioDirs = <String>{};
+    int fontFiles = 0;
+    int videoFiles = 0;
+    int localAudioDbs = 0;
+    for (final String raw in archiveFileNames) {
+      final String name = raw.replaceAll(r'\', '/');
+      final String? dictSeg =
+          _firstSegmentUnder(name, _dictionaryResourcesPrefix);
+      if (dictSeg != null) {
+        dictDirs.add(dictSeg);
+        continue;
+      }
+      final String? bookSeg = _firstSegmentUnder(name, _booksPrefix) ??
+          _firstSegmentUnder(name, _legacyBooksPrefix);
+      if (bookSeg != null) {
+        bookDirs.add(bookSeg);
+        continue;
+      }
+      final String? audioSeg = _firstSegmentUnder(name, _audiobooksPrefix);
+      if (audioSeg != null) {
+        audioDirs.add(audioSeg);
+        continue;
+      }
+      if (name.startsWith('$_fontsPrefix/')) {
+        if (name.length > _fontsPrefix.length + 1) fontFiles++;
+        continue;
+      }
+      if (name.startsWith('$_videosPrefix/')) {
+        if (name.length > _videosPrefix.length + 1) videoFiles++;
+        continue;
+      }
+      if (name.startsWith('$_localAudioPrefix/')) {
+        final String base = name.substring(_localAudioPrefix.length + 1);
+        if (_localAudioDbOnly.hasMatch(base)) localAudioDbs++;
+      }
+    }
+    // Video presence is decided by DB rows, NOT packed files: videos live in the
+    // overwrite DB blob and restore wholesale, so a files-only count would hide a
+    // streaming-video (no file) or old-backup video and import it uninvited
+    // (BUG-779). Priority: meta.videoBookCount (authoritative row count, new
+    // backups) → dbVideoBookCount (a DB-blob peek for old backups lacking the
+    // field) → packed-file fallback (legacy).
+    final int videoCount = meta?.videoBookCount ??
+        dbVideoBookCount ??
+        (meta != null && meta.videoFiles.isNotEmpty
+            ? meta.videoFiles.length
+            : videoFiles);
+    // Audiobooks decided by DB rows too (BUG-781), same priority chain: the
+    // audiobooks table rides the overwrite blob, so a files-only count would hide
+    // a row-only / old backup and import ghost audiobooks un-skippably.
+    final int audiobookCount =
+        meta?.audiobookCount ?? dbAudiobookCount ?? audioDirs.length;
+    final Map<BackupCategory, int> counts = <BackupCategory, int>{
+      if (dictDirs.isNotEmpty) BackupCategory.dictionary: dictDirs.length,
+      if (bookDirs.isNotEmpty) BackupCategory.books: bookDirs.length,
+      if (audiobookCount > 0) BackupCategory.audiobooks: audiobookCount,
+      if (fontFiles > 0) BackupCategory.fonts: fontFiles,
+      if (videoCount > 0) BackupCategory.videos: videoCount,
+      if (localAudioDbs > 0) BackupCategory.localAudio: localAudioDbs,
+    };
+    return BackupContentSummary(counts: counts, present: counts.keys.toSet());
+  }
+
+  /// First path segment directly under `<prefix>/` in [posixName], or null when
+  /// [posixName] is not under [prefix].
+  static String? _firstSegmentUnder(String posixName, String prefix) {
+    final String withSlash = '$prefix/';
+    if (!posixName.startsWith(withSlash)) return null;
+    final String rest = posixName.substring(withSlash.length);
+    if (rest.isEmpty) return null;
+    final int slash = rest.indexOf('/');
+    return slash < 0 ? rest : rest.substring(0, slash);
+  }
+
+  /// Reads a backup ZIP's central directory (never its file bodies) and returns
+  /// the "what's inside" manifest for the import dialog (TODO-1358). Streams like
+  /// [validateBackup]; returns an empty summary on any read error.
+  static Future<BackupContentSummary> summarizeBackupFile(
+      String zipPath) async {
+    InputFileStream? input;
+    try {
+      input = InputFileStream(zipPath);
+      final Archive archive = ZipDecoder().decodeBuffer(input);
+      final BackupMeta? meta = _readBackupMeta(archive);
+      final List<String> names = archive.files
+          .where((ArchiveFile f) => f.isFile)
+          .map((ArchiveFile f) => f.name)
+          .toList();
+      // Old backups (no video/audiobook row count in meta) that packed NO video
+      // or audiobook FILES would otherwise hide those categories even though the
+      // DB blob carries their rows → they import uninvited & un-skippable
+      // (BUG-779 video / BUG-781 audiobooks). Peek the DB blob for the row counts
+      // so the dialog can still offer the toggles. New backups carry the counts
+      // in meta, so the (one-time) peek is skipped for them.
+      int? dbVideoBookCount;
+      int? dbAudiobookCount;
+      final ArchiveFile? dbEntry = _findDbEntry(archive);
+      final bool needPeek =
+          (meta?.videoBookCount == null || meta?.audiobookCount == null) &&
+              dbEntry != null;
+      if (needPeek) {
+        final ({int videos, int audiobooks})? peek =
+            await _peekContentRowCounts(zipPath, dbEntry.name);
+        dbVideoBookCount = peek?.videos;
+        dbAudiobookCount = peek?.audiobooks;
+      }
+      return summarizeBackupEntries(names, meta,
+          dbVideoBookCount: dbVideoBookCount,
+          dbAudiobookCount: dbAudiobookCount);
+    } catch (e, st) {
+      debugPrint(
+          'BackupService.summarizeBackupFile failed for $zipPath: $e\n$st');
+      return const BackupContentSummary();
+    } finally {
+      await input?.close();
+    }
+  }
+
+  /// Streams the backup's main-DB blob (entry [dbEntryName]; the small metadata
+  /// DB — media lives in separate zip entries) to a temp file and returns its
+  /// `video_books` and `audiobooks` row counts, or null on any failure. Used by
+  /// [summarizeBackupFile] to offer the video / audiobooks import toggles for
+  /// OLD backups that predate [BackupMeta.videoBookCount] /
+  /// [BackupMeta.audiobookCount] (BUG-779 / BUG-781). Reuses the isolate-backed
+  /// [_extractEntriesStreaming] so a large metadata DB never materializes on
+  /// the UI isolate.
+  static Future<({int videos, int audiobooks})?> _peekContentRowCounts(
+    String zipPath,
+    String dbEntryName,
+  ) async {
+    final Directory tmp =
+        await Directory.systemTemp.createTemp('fushi_content_peek_');
+    final String dbTmp = p.join(tmp.path, _dbName);
+    try {
+      await _extractEntriesStreaming(
+        zipPath: zipPath,
+        entries: <MapEntry<String, String>>[
+          MapEntry<String, String>(dbEntryName, dbTmp),
+        ],
+      );
+      final sqlite.Database db =
+          sqlite.sqlite3.open(dbTmp, mode: sqlite.OpenMode.readOnly);
+      try {
+        return (
+          videos: _countTableIfPresent(db, 'video_books'),
+          audiobooks: _countTableIfPresent(db, 'audiobooks'),
+        );
+      } finally {
+        db.dispose();
+      }
+    } catch (e, st) {
+      debugPrint('BackupService._peekContentRowCounts failed: $e\n$st');
+      return null;
+    } finally {
+      try {
+        await tmp.delete(recursive: true);
+      } catch (_) {
+        // Best-effort temp cleanup; a leftover temp dir is harmless.
+      }
+    }
+  }
+
+  /// `SELECT COUNT(*)` of [table] on an open read-only sqlite [db], or 0 when the
+  /// table is absent (older-schema backup blob).
+  static int _countTableIfPresent(sqlite.Database db, String table) {
+    final sqlite.ResultSet has = db.select(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      <Object?>[table],
+    );
+    if (has.isEmpty) return 0;
+    return db.select('SELECT COUNT(*) AS c FROM $table').first['c'] as int;
+  }
+
+  /// Restores [_deviceLocalTables] from [bakPath] (this device's pre-import
+  /// snapshot) into the freshly-overwritten DB in [dbDirectory] (BUG-816). The
+  /// backup carries these tables EMPTY by design (`_stripCredentials`), so
+  /// without this the overwrite would wipe this device's LAN pairings and sync
+  /// baselines. Runs inline during import while both DBs are at the current
+  /// schema (bak is a copy of the live DB), so `SELECT *` columns align. No-op
+  /// (logged) if bak is gone.
+  static Future<bool> _reapplyDeviceLocalTablesFromBak(
+    String dbDirectory,
+    String bakPath,
+  ) async {
+    if (!File(bakPath).existsSync()) {
+      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+          'pre-restore.bak missing — local pairing/baselines could not be '
+          'preserved on import.');
+      return false;
+    }
+    late final bool hasSqliteHeader;
+    try {
+      hasSqliteHeader = await _hasSqliteHeader(bakPath);
+    } catch (e, st) {
+      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+          'pre-restore.bak could not be inspected: $e\n$st');
+      return false;
+    }
+    if (!hasSqliteHeader) {
+      // A few low-level restore callers intentionally swap opaque fixture
+      // bytes rather than a Hibiki database. Such a snapshot cannot contain
+      // device-local rows, so there is nothing to retry or retain.
+      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak: '
+          'pre-restore.bak is not a SQLite database; no local tables to '
+          'preserve.');
+      return true;
+    }
+    FushiDatabase? db;
+    try {
+      db = FushiDatabase(dbDirectory);
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS devbak");
+      await db.transaction(() async {
+        for (final String t in _deviceLocalTables) {
+          await db!.customStatement('DELETE FROM $t');
+        }
+        for (final String t in _deviceLocalTablesParentFirst) {
+          await _insertDeviceLocalTableFromBak(db!, t);
+        }
+      });
+      await db.customStatement('DETACH DATABASE devbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+      return true;
+    } catch (e, st) {
+      // Best-effort preservation: a corrupt/unreadable imported DB must not
+      // abort the whole restore (the primary overwrite already landed).
+      debugPrint('BackupService._reapplyDeviceLocalTablesFromBak failed: '
+          '$e\n$st');
+      return false;
+    } finally {
+      try {
+        await db?.close();
+      } catch (_) {/* db may have failed to open */}
+    }
+  }
+
+  static Future<bool> _hasSqliteHeader(String path) async {
+    const List<int> expected = <int>[
+      0x53,
+      0x51,
+      0x4c,
+      0x69,
+      0x74,
+      0x65,
+      0x20,
+      0x66,
+      0x6f,
+      0x72,
+      0x6d,
+      0x61,
+      0x74,
+      0x20,
+      0x33,
+      0x00,
+    ];
+    final RandomAccessFile file = await File(path).open();
+    try {
+      if (await file.length() < expected.length) return false;
+      final List<int> actual = await file.read(expected.length);
+      for (int index = 0; index < expected.length; index++) {
+        if (actual[index] != expected[index]) return false;
+      }
+      return true;
+    } finally {
+      await file.close();
+    }
+  }
+
+  static Future<void> _insertDeviceLocalTableFromBak(
+    FushiDatabase db,
+    String table,
+  ) async {
+    switch (table) {
+      case 'video_download_jobs':
+        await _insertVideoDownloadJobsFromBak(db);
+      case 'video_download_subscriptions':
+        await _insertVideoDownloadSubscriptionsFromBak(db);
+      default:
+        await db.customStatement(
+          'INSERT INTO $table SELECT * FROM devbak.$table',
+        );
+    }
+  }
+
+  /// Rebind a local job only when the imported DB still has the same semantic
+  /// source/collection. Numeric ids are device-local autoincrements and may
+  /// collide with an unrelated row from the backup device, so id existence by
+  /// itself is not sufficient. A missing target is nulled and the job becomes
+  /// actionable instead of aborting the whole FK-checked restore.
+  static Future<void> _insertVideoDownloadJobsFromBak(
+    FushiDatabase db,
+  ) async {
+    final List<String> columns = await _tableColumns(db, 'video_download_jobs');
+    const String sourceLookup =
+        'SELECT current_source.id FROM media_sources AS current_source '
+        'JOIN devbak.media_sources AS old_source '
+        'ON current_source.media_kind = old_source.media_kind '
+        'AND current_source.transport = old_source.transport '
+        'AND current_source.root_path = old_source.root_path '
+        'WHERE old_source.id = j.target_source_id '
+        'ORDER BY current_source.id LIMIT 1';
+    const String collectionLookup = 'SELECT current_collection.id '
+        'FROM media_collections AS current_collection '
+        'JOIN devbak.media_collections AS old_collection '
+        'ON current_collection.name = old_collection.name '
+        'AND current_collection.collection_type = '
+        'old_collection.collection_type '
+        'WHERE old_collection.id = j.collection_id '
+        'ORDER BY current_collection.id LIMIT 1';
+    const String sourceMissing =
+        'j.target_source_id IS NOT NULL AND NOT EXISTS ($sourceLookup)';
+    const String collectionMissing =
+        'j.collection_id IS NOT NULL AND NOT EXISTS ($collectionLookup)';
+    const String referenceMissing =
+        '(($sourceMissing) OR ($collectionMissing))';
+    const String attentionMessage =
+        'needsAttention: restored target source or collection is unavailable '
+        'on this device';
+    final List<String> selectExpressions = columns.map((String column) {
+      switch (column) {
+        case 'target_source_id':
+          return 'CASE WHEN j.target_source_id IS NULL THEN NULL '
+              'ELSE ($sourceLookup) END';
+        case 'collection_id':
+          return 'CASE WHEN j.collection_id IS NULL THEN NULL '
+              'ELSE ($collectionLookup) END';
+        case 'lifecycle':
+          return "CASE WHEN $referenceMissing THEN 'needsAttention' "
+              'ELSE j.lifecycle END';
+        case 'claimed_by':
+        case 'claim_expires_at':
+          return 'NULL';
+        case 'next_attempt_at':
+          return 'CASE WHEN $referenceMissing THEN NULL '
+              'ELSE j.next_attempt_at END';
+        case 'last_error':
+          return 'CASE WHEN $referenceMissing THEN CASE '
+              'WHEN j.last_error IS NULL OR j.last_error = \'\' '
+              "THEN '$attentionMessage' "
+              "ELSE j.last_error || '; $attentionMessage' END "
+              'ELSE j.last_error END';
+        default:
+          return 'j.${_quoteIdentifier(column)}';
+      }
+    }).toList(growable: false);
+    await db.customStatement(
+      'INSERT INTO video_download_jobs '
+      '(${columns.map(_quoteIdentifier).join(', ')}) '
+      'SELECT ${selectExpressions.join(', ')} '
+      'FROM devbak.video_download_jobs AS j',
+    );
+  }
+
+  /// Subscriptions have no lifecycle field. Missing local targets are surfaced
+  /// by disabling the schedule, clearing its lease, and persisting the same
+  /// `needsAttention:` marker consumed by the task UI.
+  static Future<void> _insertVideoDownloadSubscriptionsFromBak(
+    FushiDatabase db,
+  ) async {
+    final List<String> columns =
+        await _tableColumns(db, 'video_download_subscriptions');
+    const String sourceLookup =
+        'SELECT current_source.id FROM media_sources AS current_source '
+        'JOIN devbak.media_sources AS old_source '
+        'ON current_source.media_kind = old_source.media_kind '
+        'AND current_source.transport = old_source.transport '
+        'AND current_source.root_path = old_source.root_path '
+        'WHERE old_source.id = s.target_source_id '
+        'ORDER BY current_source.id LIMIT 1';
+    const String collectionLookup = 'SELECT current_collection.id '
+        'FROM media_collections AS current_collection '
+        'JOIN devbak.media_collections AS old_collection '
+        'ON current_collection.name = old_collection.name '
+        'AND current_collection.collection_type = '
+        'old_collection.collection_type '
+        'WHERE old_collection.id = s.collection_id '
+        'ORDER BY current_collection.id LIMIT 1';
+    const String sourceMissing =
+        's.target_source_id IS NOT NULL AND NOT EXISTS ($sourceLookup)';
+    const String collectionMissing =
+        's.collection_id IS NOT NULL AND NOT EXISTS ($collectionLookup)';
+    const String referenceMissing =
+        '(($sourceMissing) OR ($collectionMissing))';
+    const String attentionMessage =
+        'needsAttention: restored target source or collection is unavailable '
+        'on this device';
+    final List<String> selectExpressions = columns.map((String column) {
+      switch (column) {
+        case 'target_source_id':
+          return 'CASE WHEN s.target_source_id IS NULL THEN NULL '
+              'ELSE ($sourceLookup) END';
+        case 'collection_id':
+          return 'CASE WHEN s.collection_id IS NULL THEN NULL '
+              'ELSE ($collectionLookup) END';
+        case 'enabled':
+          return 'CASE WHEN $referenceMissing THEN 0 ELSE s.enabled END';
+        case 'next_check_at':
+          return 'CASE WHEN $referenceMissing THEN NULL '
+              'ELSE s.next_check_at END';
+        case 'claimed_by':
+        case 'claim_expires_at':
+          return 'NULL';
+        case 'last_error':
+          return 'CASE WHEN $referenceMissing THEN CASE '
+              'WHEN s.last_error IS NULL OR s.last_error = \'\' '
+              "THEN '$attentionMessage' "
+              "ELSE s.last_error || '; $attentionMessage' END "
+              'ELSE s.last_error END';
+        default:
+          return 's.${_quoteIdentifier(column)}';
+      }
+    }).toList(growable: false);
+    await db.customStatement(
+      'INSERT INTO video_download_subscriptions '
+      '(${columns.map(_quoteIdentifier).join(', ')}) '
+      'SELECT ${selectExpressions.join(', ')} '
+      'FROM devbak.video_download_subscriptions AS s',
+    );
+  }
+
+  static Future<List<String>> _tableColumns(
+    FushiDatabase db,
+    String table,
+  ) async {
+    final List<QueryRow> rows =
+        await db.customSelect('PRAGMA table_info($table)').get();
+    return rows
+        .map((QueryRow row) => row.read<String>('name'))
+        .toList(growable: false);
+  }
+
+  static String _quoteIdentifier(String value) =>
+      '"${value.replaceAll('"', '""')}"';
+
+  /// BUG-816: restores the content-registry preference rows from [bakPath] when
+  /// the backup EXCLUDED their owning category, so an overwrite import of a
+  /// books / fonts / localAudio-excluded backup never wipes this device's
+  /// favorites / font registry / local-audio registry to empty. Mirror of
+  /// [_stripExcludedContentRegistry]. `audio_source_configs` is restored whole
+  /// from bak (the device keeps its own audio setup when localAudio was
+  /// excluded), which subsumes the export-side B-filter. No-op (logged) if bak
+  /// is gone.
+  static Future<void> _reapplyExcludedContentRegistry(
+    String dbDirectory,
+    String bakPath, {
+    required bool reapplyFavorites,
+    required bool reapplyFonts,
+    required bool reapplyLocalAudio,
+  }) async {
+    final List<String> keys = <String>[
+      if (reapplyFavorites) _favoriteSentencesPrefKey,
+      if (reapplyFonts) ...<String>[
+        _fontCatalogPrefKey,
+        ..._legacyFontPrefKeys
+      ],
+      if (reapplyLocalAudio) ...<String>[
+        _localAudioDbsPrefKey,
+        _audioSourceConfigsPrefKey,
+      ],
+    ];
+    if (keys.isEmpty) return;
+    if (!File(bakPath).existsSync()) {
+      debugPrint('BackupService._reapplyExcludedContentRegistry: '
+          'pre-restore.bak missing — local favorites/fonts/audio registry could '
+          'not be preserved for a category-excluded backup.');
+      return;
+    }
+    FushiDatabase? db;
+    try {
+      db = FushiDatabase(dbDirectory);
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      final String inList =
+          keys.map((String k) => "'${k.replaceAll("'", "''")}'").join(', ');
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS crbak");
+      await db.transaction(() async {
+        await db!
+            .customStatement('DELETE FROM preferences WHERE key IN ($inList)');
+        await db.customStatement('INSERT INTO preferences '
+            'SELECT * FROM crbak.preferences WHERE key IN ($inList)');
+      });
+      await db.customStatement('DETACH DATABASE crbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (e, st) {
+      debugPrint('BackupService._reapplyExcludedContentRegistry failed: '
+          '$e\n$st');
+    } finally {
+      try {
+        await db?.close();
+      } catch (_) {/* db may have failed to open */}
+    }
+  }
+
+  /// 归档里主库条目的解析（读侧唯一入口）：新备份条目名是 [_dbName]（fushi.db），
+  /// 老 Hibiki 时代的备份 / Android 迁移压缩包条目名是
+  /// [legacyHibikiDatabaseFileName]（hibiki.db）。旧条目名属于「读旧数据的迁移
+  /// 代码」豁免；写侧（导出/提取目标路径）永远只落新名。
+  static ArchiveFile? _findDbEntry(Archive archive) =>
+      archive.findFile(_dbName) ??
+      archive.findFile(legacyHibikiDatabaseFileName);
+
+  /// Validate a backup ZIP. Returns metadata if valid.
+  ///
+  /// Streams the central directory via [InputFileStream] instead of reading the
+  /// whole archive into memory — a full-data backup can be many GB (book + audio
+  /// trees), so there is no size cap and the whole file must never be buffered.
+  /// Only the small `backup_meta.json` entry is decompressed; the db presence
+  /// check is metadata-only.
+  static Future<BackupMeta?> validateBackup(String zipPath) async {
+    InputFileStream? input;
+    try {
+      input = InputFileStream(zipPath);
+      final archive = ZipDecoder().decodeBuffer(input);
+      final BackupMeta? meta = _readBackupMeta(archive);
+      if (meta == null) return null;
+      if (_findDbEntry(archive) == null) return null;
+      return meta;
+    } catch (e, st) {
+      // A null result tells the UI "invalid backup". Surface the real reason
+      // (corrupt zip / read error / OOM) so it is not silently indistinguishable
+      // from a genuinely malformed archive (review W4).
+      debugPrint('BackupService.validateBackup failed for $zipPath: $e\n$st');
+      return null;
+    } finally {
+      await input?.close();
+    }
+  }
+
+  /// Settings-layer tables restored from THIS device when [restoreBackup]
+  /// runs with importSettings=false. Order matters: `profiles` first (FK target
+  /// of the rest). `preferences` is handled separately (audiobook positions are
+  /// content and follow the backup). No content table FKs into these, and
+  /// `book_profiles.bookUid` is plain text, so a wholesale swap is FK-safe.
+  static const List<String> _settingsLayerTables = <String>[
+    'profiles',
+    'profile_settings',
+    'media_type_profiles',
+    'book_profiles',
+  ];
+
+  /// Restore a backup (overwrite mode), replacing the current database files.
+  /// 用户视角的「恢复备份」顶层入口；merge 模式见 [mergeRestoreBackup]，内部
+  /// 子步骤一律 reapply* 动词（restore 保留给本顶层语义）。
+  ///
+  /// This is a static method because the database must already be closed
+  /// before calling — the caller is responsible for closing the DB first.
+  ///
+  /// [importSettings] (default true = full restore):
+  /// - true: everything comes from the backup, EXCEPT device-local sync config
+  ///   ([SyncRepository.deviceLocalPrefKeys]) which is always preserved (the
+  ///   backup has none — they're stripped on export — so a naive swap would log
+  ///   you out). Re-applied immediately; crash-recoverable via the sidecar.
+  /// - false: keep THIS device's settings layer (preferences + profiles +
+  ///   bindings = fonts/appearance/reading/profiles); only CONTENT comes from
+  ///   the backup. Done inline: opening the imported DB migrates it to the
+  ///   current schema, then the settings layer is copied back from
+  ///   pre-restore.bak (both at current schema → column-aligned, FK-safe). The
+  ///   sidecar + bak written before the overwrite are a crash-recovery net so
+  ///   [recoverPendingRestore] can finish the restore if this crashes mid-way.
+  static Future<void> restoreBackup({
+    required String dbDirectory,
+    required String zipPath,
+    bool importSettings = true,
+    Set<BackupCategory>? categories,
+    String? dictionaryResourceDirectory,
+    String? booksRootDirectory,
+    String? audiobooksRootDirectory,
+    String? fontsRootDirectory,
+    String? videosRootDirectory,
+    void Function(double progress)? onProgress,
+  }) async {
+    final dbPath = p.join(dbDirectory, _dbName);
+    // Stream the central directory instead of buffering the whole (GB-scale)
+    // archive in memory. Each entry's bytes are read lazily on `.content`; the
+    // stream stays open until every read completes (closed in `finally`).
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      final archive = ZipDecoder().decodeBuffer(input);
+      final ArchiveFile? dbFile = _findDbEntry(archive);
+      if (dbFile == null) throw StateError('No $_dbName in backup archive');
+
+      // TODO-1183: determinate progress across every streamed byte.
+      final void Function(int deltaBytes) reportBytes =
+          _archiveByteProgress(archive, onProgress);
+
+      // Parse the source-device content roots so book/audio paths can be
+      // rebased onto this device after the trees are restored.
+      final BackupMeta? meta = _readBackupMeta(archive);
+      // TODO-1193: a backup that unticked `settings` / `profiles` carries an
+      // EMPTY settings / profiles layer BY CHOICE. On an overwrite import the DB
+      // is replaced wholesale, so without a guard those empty layers would WIPE
+      // this device's settings/profiles. Detect the choice from the meta and
+      // preserve the LOCAL layer from bak below (mirrors BUG-454's dictionary
+      // preserve-on-absent). importSettings=false already keeps the whole
+      // settings layer from bak, so it is inherently safe.
+      final bool backupSettingsExcluded =
+          meta?.excludedCategories.contains(BackupCategory.settings.name) ??
+              false;
+      final bool backupProfilesExcluded =
+          meta?.excludedCategories.contains(BackupCategory.profiles.name) ??
+              false;
+      // BUG-816: content-registry prefs (favorites / fonts / local-audio) travel
+      // EMPTY when their owning category was unticked, so an overwrite import
+      // must preserve THIS device's rows from bak instead of wiping them.
+      final bool backupBooksExcluded =
+          meta?.excludedCategories.contains(BackupCategory.books.name) ?? false;
+      final bool backupFontsExcluded =
+          meta?.excludedCategories.contains(BackupCategory.fonts.name) ?? false;
+      final bool backupLocalAudioExcluded =
+          meta?.excludedCategories.contains(BackupCategory.localAudio.name) ??
+              false;
+
+      final String? dictionaryReapplyDirectory = dictionaryResourceDirectory;
+      List<MapEntry<ArchiveFile, String>>? dictionaryReapplyPlan;
+      if (dictionaryReapplyDirectory != null) {
+        dictionaryReapplyPlan = _buildDictionaryReapplyPlan(
+          archive: archive,
+          dictionaryResourceDirectory: dictionaryReapplyDirectory,
+        );
+      }
+      // BUG-454: a backup exported WITHOUT the dictionary category carries no
+      // `dictionaryResources/` files AND has its dictionary DB rows stripped on
+      // export (`_stripDictionaryState`). Detecting "the backup has no
+      // dictionary files" lets the overwrite import PRESERVE this device's
+      // existing dictionaries (metadata rows + resource files) instead of
+      // wiping them — the backup simply didn't include that category, the same
+      // selective-preserve contract the device-local sync prefs already follow.
+      final bool backupHasDictionaries = archive.files.any((ArchiveFile f) =>
+          f.isFile &&
+          f.name
+              .replaceAll(r'\', '/')
+              .startsWith('$_dictionaryResourcesPrefix/'));
+
+      // TODO-1358: honour a per-category IMPORT selection (overwrite path only;
+      // merge always combines everything). A null [categories] restores every
+      // category the backup carries (legacy). Unticking a category on import:
+      //  - dictionary -> treat as if the backup carries no dictionaries so the
+      //    BUG-454 path preserves THIS device dictionaries (re-seated from bak).
+      //  - audiobooks / fonts / videos / localAudio -> skip restoring those files
+      //    (and skip rebasing their paths); the DB library index still restores.
+      // Books / progress / statistics always restore (the core library index in
+      // the overwrite DB blob); settings / profiles stay governed by
+      // [importSettings].
+      bool wants(BackupCategory c) =>
+          categories == null || categories.contains(c);
+      final bool effectiveHasDictionaries =
+          backupHasDictionaries && wants(BackupCategory.dictionary);
+      final String? effAudiobooksRoot =
+          wants(BackupCategory.audiobooks) ? audiobooksRootDirectory : null;
+      final String? effFontsRoot =
+          wants(BackupCategory.fonts) ? fontsRootDirectory : null;
+      final String? effVideosRoot =
+          wants(BackupCategory.videos) ? videosRootDirectory : null;
+      final String? effLocalAudioRoot =
+          wants(BackupCategory.localAudio) ? dbDirectory : null;
+
+      final sidecar = File(p.join(dbDirectory, _preserveSidecar));
+      final String bakPath = '$dbPath.pre-restore.bak';
+      final currentDb = File(dbPath);
+      final bool haveCurrent = currentDb.existsSync();
+      bool deviceLocalTablesReapplied = !haveCurrent;
+
+      // 1) Snapshot the current DB (crash safety) + record what to preserve.
+      //    Skipped on a fresh install (no current DB) → backup applied verbatim,
+      //    so the toggle is moot there.
+      Map<String, String> preservedSync = const <String, String>{};
+      if (haveCurrent) {
+        late final Map<String, dynamic> sidecarPayload;
+        if (importSettings) {
+          preservedSync = await _readDeviceLocalPrefs(dbDirectory);
+          sidecarPayload = <String, dynamic>{
+            'mode': 'prefs',
+            'prefs': preservedSync,
+            'preserveDeviceLocalTables': true,
+            if (backupSettingsExcluded) 'preserveSettings': true,
+            if (backupProfilesExcluded) 'preserveProfiles': true,
+          };
+        } else {
+          sidecarPayload = <String, dynamic>{
+            'mode': 'settings',
+            'preserveDeviceLocalTables': true,
+          };
+        }
+        // The v78 download graph is device-local even when there are no sync
+        // preferences to preserve, so every destructive overwrite needs both
+        // artifacts. Copy the database first: a sidecar must never advertise a
+        // recoverable restore before its corresponding snapshot exists.
+        await currentDb.copy(bakPath);
+        await sidecar.writeAsString(
+          jsonEncode(sidecarPayload),
+          flush: true,
+        );
+      }
+
+      // Must delete -wal/-shm AFTER reading prefs (step 1 opened+closed a WAL
+      // connection) and BEFORE overwriting the main .db: leftover WAL frames
+      // from the old DB would otherwise be replayed against the imported file
+      // and corrupt it.
+      final walFile = File('$dbPath-wal');
+      if (walFile.existsSync()) await walFile.delete();
+      final shmFile = File('$dbPath-shm');
+      if (shmFile.existsSync()) await shmFile.delete();
+
+      // 2) Overwrite with the backup DB bytes — streamed on a background
+      //    isolate so a multi-GB DB never materializes in the heap (OOM,
+      //    TODO-1183) and never blocks the UI isolate.
+      await _extractEntriesStreaming(
+        zipPath: zipPath,
+        entries: <MapEntry<String, String>>[
+          MapEntry<String, String>(dbFile.name, dbPath),
+        ],
+        onBytes: reportBytes,
+      );
+
+      if (effectiveHasDictionaries &&
+          dictionaryReapplyPlan != null &&
+          dictionaryReapplyDirectory != null) {
+        // Backup carries dictionaries → replace this device's resources with
+        // the backup's (the DB overwrite already brought the matching rows).
+        await _reapplyDictionaryResources(
+          zipPath: zipPath,
+          reapplyPlan: dictionaryReapplyPlan,
+          dictionaryResourceDirectory: dictionaryReapplyDirectory,
+          onBytes: reportBytes,
+        );
+      } else if (!effectiveHasDictionaries &&
+          haveCurrent &&
+          dictionaryReapplyDirectory != null) {
+        // BUG-454: backup has NO dictionaries → keep this device's. The DB was
+        // just overwritten with the backup's (dictionary tables empty), so
+        // re-seat the local dictionary rows from pre-restore.bak. The resource
+        // FILES on disk were never touched (we skipped the unconditional wipe
+        // in _reapplyDictionaryResources), so rows + files stay consistent.
+        // Gated on a managed dictionary dir: the live app always supplies it;
+        // a null dir means the caller isn't managing dictionaries at all, so
+        // there is nothing to preserve (and bak may not even be a real DB in
+        // such minimal call sites).
+        await _reapplyDictionaryTablesFromBak(dbDirectory, bakPath);
+      }
+
+      // 2b) Restore the book + audiobook content trees (full-data backup).
+      //     PREPARE both (write to sibling `.import-tmp` dirs) BEFORE COMMITTING
+      //     either (fast rename-swap), so a failure during the GB-scale write
+      //     phase swaps nothing and leaves both existing trees intact — a user's
+      //     whole library must never be half-destroyed. Only runs when the
+      //     caller supplies the roots AND the backup carries that tree.
+      final List<String> toCommit = <String>[];
+      try {
+        if (booksRootDirectory != null &&
+            wants(BackupCategory.books) &&
+            await _prepareTreeReapply(zipPath, archive,
+                archiveBooksPrefix(archive), booksRootDirectory,
+                onBytes: reportBytes)) {
+          toCommit.add(booksRootDirectory);
+        }
+        if (effAudiobooksRoot != null &&
+            await _prepareTreeReapply(
+                zipPath, archive, _audiobooksPrefix, effAudiobooksRoot,
+                onBytes: reportBytes)) {
+          toCommit.add(effAudiobooksRoot);
+        }
+        if (effFontsRoot != null &&
+            await _prepareTreeReapply(
+                zipPath, archive, _fontsPrefix, effFontsRoot,
+                onBytes: reportBytes)) {
+          toCommit.add(effFontsRoot);
+        }
+        if (effVideosRoot != null &&
+            await _prepareTreeReapply(
+                zipPath, archive, _videosPrefix, effVideosRoot,
+                onBytes: reportBytes)) {
+          toCommit.add(effVideosRoot);
+        }
+      } catch (_) {
+        // A write failed: drop every staged temp dir; no tree was swapped.
+        if (booksRootDirectory != null) {
+          await _abortPreparedTree(booksRootDirectory);
+        }
+        if (effAudiobooksRoot != null) {
+          await _abortPreparedTree(effAudiobooksRoot);
+        }
+        if (effFontsRoot != null) {
+          await _abortPreparedTree(effFontsRoot);
+        }
+        if (effVideosRoot != null) {
+          await _abortPreparedTree(effVideosRoot);
+        }
+        rethrow;
+      }
+      // All writes succeeded → commit each prepared tree (fast renames).
+      for (final String root in toCommit) {
+        await _commitPreparedTree(root);
+      }
+
+      // 2c) Restore local-audio databases into the support directory. These are
+      //     individual files sharing the directory with hibiki.db, so they are
+      //     extracted file-by-file (never the destructive tree swap). When the
+      //     backup carries no localAudio/ prefix the existing local-audio DBs
+      //     are left untouched (same preserve-on-absent contract as the trees).
+      if (wants(BackupCategory.localAudio)) {
+        await _reapplyLocalAudioFiles(zipPath, archive, dbDirectory,
+            onBytes: reportBytes);
+      }
+
+      // 3) Restore what must stay on this device — inline, not deferred to
+      //    startup, so the common path never depends on bak surviving a restart.
+      if (importSettings) {
+        // TODO-1193: the backup EXCLUDED settings and/or profiles → its DB blob
+        // has those layers empty by choice. Preserve THIS device's layer from
+        // bak FIRST so the overwrite never wipes settings/profiles to empty.
+        // Runs before the sync re-apply so _applyPreservedConfig stays the
+        // authoritative last word on sync config (and clears the folder cache).
+        if ((backupSettingsExcluded || backupProfilesExcluded) && haveCurrent) {
+          await _reapplyExcludedSettingsLayers(
+            dbDirectory,
+            bakPath,
+            reapplySettings: backupSettingsExcluded,
+            reapplyProfiles: backupProfilesExcluded,
+          );
+        }
+        // Re-apply device-local sync config (preferences is schema-stable).
+        if (preservedSync.isNotEmpty) {
+          await _applyPreservedConfig(dbDirectory, preservedSync);
+        }
+      } else if (haveCurrent) {
+        // Keep this device's whole settings layer.
+        await _reapplySettingsLayer(dbDirectory);
+      }
+
+      // 3a) BUG-816: the export wipes device-local tables (LAN pairing token +
+      //     sync baselines) unconditionally, so they arrive EMPTY. Restore this
+      //     device's rows from bak on any overwrite import (both importSettings
+      //     branches) — else the overwrite would wipe the device's pairings and
+      //     baselines. No-op on a fresh install (no bak).
+      if (haveCurrent) {
+        deviceLocalTablesReapplied =
+            await _reapplyDeviceLocalTablesFromBak(dbDirectory, bakPath);
+        // BUG-816: preserve THIS device's content-registry prefs from bak when
+        // the backup excluded their owning category (books/fonts/localAudio) —
+        // runs in both importSettings branches, mirroring the export strip.
+        await _reapplyExcludedContentRegistry(
+          dbDirectory,
+          bakPath,
+          reapplyFavorites: backupBooksExcluded,
+          reapplyFonts: backupFontsExcluded,
+          reapplyLocalAudio: backupLocalAudioExcluded,
+        );
+      }
+
+      // 3b) Rebase the imported DB's stored absolute paths (which point at the
+      //     SOURCE device's roots) onto this device's roots. Books/audiobooks
+      //     are content, so they come from the backup in BOTH import modes →
+      //     always rebase. No-op for a legacy backup (meta has no roots).
+      if (meta != null) {
+        await _rebaseAllPaths(
+          dbDirectory: dbDirectory,
+          meta: meta,
+          newBooksRoot: booksRootDirectory,
+          newAudiobooksRoot: effAudiobooksRoot,
+          newFontsRoot: effFontsRoot,
+          newLocalAudioRoot: effLocalAudioRoot,
+          newVideosRoot: effVideosRoot,
+        );
+      }
+
+      // 3c) Honour the per-category IMPORT selection for the DB-content
+      //     categories the overwrite blob carries wholesale (TODO-1358). The
+      //     file categories are already gated above (skipped file restore), but
+      //     books / statistics / progress live in the swapped-in DB, so strip
+      //     the unticked ones here. Overwrite semantics: unticking = that
+      //     category's data does not end up on this device (the DB was replaced
+      //     wholesale, so there is no local layer to preserve — mirrors how the
+      //     statistics/progress strip already works on the export side).
+      if (!wants(BackupCategory.books)) {
+        // Strip every book row (+ its cascade) so no book from the backup
+        // travels; the hoshi_books tree restore was skipped above too.
+        await _retainBooks(dbDirectory, const <String>{});
+      }
+      if (!wants(BackupCategory.videos)) {
+        // Videos live in the overwrite DB blob (video_books + cascade), so
+        // unticking the video category must strip those rows too — skipping the
+        // FILE restore (effVideosRoot=null) alone left every video_books row in
+        // the swapped-in DB, so the videos imported uninvited & un-skippable even
+        // when the dialog did offer the toggle (BUG-779). Mirrors the books strip
+        // and the export-side [_retainVideos].
+        await _retainVideos(dbDirectory, const <String>{});
+      }
+      if (!wants(BackupCategory.audiobooks)) {
+        // Same class as videos (BUG-781): audiobook rows (audiobooks + audio_cues
+        // + srt shelf entry) ride the overwrite DB blob, so unticking the
+        // audiobooks category must strip them — the skipped FILE restore
+        // (effAudiobooksRoot=null) alone left ghost audiobooks (shelf + alignment
+        // rows pointing at audio that never travelled).
+        await _retainAudiobooks(dbDirectory, const <String>{});
+      }
+      if (!wants(BackupCategory.statistics) ||
+          !wants(BackupCategory.progress)) {
+        await _stripExcludedDataCategories(
+          dbDirectory,
+          stripProgress: !wants(BackupCategory.progress),
+          stripStatistics: !wants(BackupCategory.statistics),
+          // settings / profiles stay governed by the importSettings toggle and
+          // the excluded-layer preserve above — never touched by this strip.
+          stripSettings: false,
+          stripProfiles: false,
+        );
+      }
+
+      // 4) Success: drop the sidecar and the pre-restore copy (no disk leak).
+      // A failed device-local replay is recoverable at the next startup, but
+      // only while BOTH artifacts survive. The replay transaction starts with
+      // a child-first wipe and is therefore safe to run again.
+      if (deviceLocalTablesReapplied) {
+        await _safeDelete(sidecar.path);
+        await _safeDelete(bakPath);
+      } else {
+        debugPrint('BackupService.restoreBackup: device-local tables were not '
+            'reapplied; retaining restore sidecar and pre-restore.bak for '
+            'startup recovery.');
+      }
+    } finally {
+      await input.close();
+    }
+  }
+
+  /// Sidecar file marking a pending MERGE import (TODO-888). The merge runs in
+  /// one Drift transaction, so a crash leaves the DB already-consistent (the
+  /// transaction either committed or rolled back); this sidecar only drives
+  /// startup cleanup of the temp `merge-src` + `pre-merge.bak` files.
+  static const String _mergeSidecar = '$_dbName.merge-preserve.json';
+  static const String _mergeSrcName = '$_dbName.merge-src';
+
+  /// MERGE a backup into the current database instead of overwriting it
+  /// (TODO-888). The device keeps everything it has; the backup only ADDS what
+  /// is missing and MAX-unions statistics, so re-importing the same backup is
+  /// idempotent. Unlike [restoreBackup] this NEVER touches the destructive
+  /// overwrite path (`writeAsBytes`) or the two-phase tree swap; content trees
+  /// are restored copy-if-absent (existing files are never replaced or deleted).
+  ///
+  /// The caller must close the app's DB first (same contract as
+  /// [restoreBackup]); this opens its own connections. Crash safety: the
+  /// whole row merge is ONE [FushiDatabase.transaction] (rolled back on any
+  /// failure) plus a `pre-merge.bak` snapshot for manual recovery, and a
+  /// `mode:'merge'` sidecar so [recoverPendingRestore] cleans up temp files.
+  static Future<void> mergeRestoreBackup({
+    required String dbDirectory,
+    required String zipPath,
+    Set<BackupCategory>? categories,
+    String? dictionaryResourceDirectory,
+    String? booksRootDirectory,
+    String? audiobooksRootDirectory,
+    String? fontsRootDirectory,
+    String? videosRootDirectory,
+    void Function(double progress)? onProgress,
+    bool adoptSourcePreferences = false,
+  }) async {
+    // Per-category merge selection (import dialog, merge mode). null = merge
+    // every category (legacy full merge). Gates BOTH the DB row merge (via the
+    // engine) AND the content-tree copies below, so an unticked category adds
+    // nothing — neither rows nor files.
+    bool wants(BackupCategory c) =>
+        categories == null || categories.contains(c);
+    final Set<String>? enabledCategoryNames =
+        categories?.map((BackupCategory c) => c.name).toSet();
+    final String dbPath = p.join(dbDirectory, _dbName);
+    final String mergeSrcPath = p.join(dbDirectory, _mergeSrcName);
+    final String bakPath = '$dbPath.pre-merge.bak';
+    final File sidecar = File(p.join(dbDirectory, _mergeSidecar));
+
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      final Archive archive = ZipDecoder().decodeBuffer(input);
+      final ArchiveFile? dbFile = _findDbEntry(archive);
+      if (dbFile == null) throw StateError('No $_dbName in backup archive');
+
+      // TODO-1183: determinate progress across every streamed byte.
+      final void Function(int deltaBytes) reportBytes =
+          _archiveByteProgress(archive, onProgress);
+
+      final BackupMeta? meta = _readBackupMeta(archive);
+
+      // 1) Extract the backup DB to a sibling temp file (NEVER overwrite the
+      //    live DB). Drop any stale merge-src/-wal/-shm from a prior crash.
+      await _safeDelete(mergeSrcPath);
+      await _safeDelete('$mergeSrcPath-wal');
+      await _safeDelete('$mergeSrcPath-shm');
+      await _extractEntriesStreaming(
+        zipPath: zipPath,
+        entries: <MapEntry<String, String>>[
+          MapEntry<String, String>(dbFile.name, mergeSrcPath),
+        ],
+        onBytes: reportBytes,
+      );
+
+      // 2) Migrate the backup DB up to the current schema so its columns align
+      //    with the live DB for the ATTACH-based row merge. (Its schemaVersion
+      //    is <= current — validated by the caller.) Opening + closing
+      //    FushiDatabase on its file runs onUpgrade if needed.
+      final FushiDatabase srcMigrate = FushiDatabase.atFile(mergeSrcPath);
+      try {
+        await srcMigrate.customStatement('PRAGMA user_version');
+      } finally {
+        await srcMigrate.close();
+      }
+      await _safeDelete('$mergeSrcPath-wal');
+      await _safeDelete('$mergeSrcPath-shm');
+
+      // 3) Snapshot the live DB for manual recovery + drop the crash-cleanup
+      //    sidecar BEFORE mutating the live DB.
+      final File currentDb = File(dbPath);
+      if (currentDb.existsSync()) {
+        await currentDb.copy(bakPath);
+      }
+      await sidecar.writeAsString(jsonEncode(<String, dynamic>{
+        'mode': 'merge',
+        'mergeSrc': mergeSrcPath,
+      }));
+
+      // 4) Open the live DB, ATTACH the backup, run the whole row merge in one
+      //    transaction (rolled back on any failure -> DB unchanged).
+      final FushiDatabase db = FushiDatabase(dbDirectory);
+      try {
+        final String safeSrc =
+            mergeSrcPath.replaceAll(r'\', '/').replaceAll("'", "''");
+        await db.customStatement("ATTACH DATABASE '$safeSrc' AS mergesrc");
+        try {
+          // TODO-1261: only import video rows whose file travelled (or streaming
+          // URLs) so a backup never lands a dead "empty video" shell. The carried
+          // set is the exact video files packed by export (meta.videoFiles keys).
+          await BackupMergeEngine(
+            db,
+            carriedVideoSourcePaths:
+                meta?.videoFiles.keys.toSet() ?? const <String>{},
+            enabledCategoryNames: enabledCategoryNames,
+            adoptSourcePreferences: adoptSourcePreferences,
+          ).merge();
+        } finally {
+          await db.customStatement('DETACH DATABASE mergesrc');
+        }
+        await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+      } finally {
+        await db.close();
+      }
+
+      // 5) Restore content trees COPY-IF-ABSENT (never delete/replace existing
+      //    files — the device's own library must stay intact). Each tree is
+      //    gated by its category so an unticked category copies no files (its
+      //    rows were likewise skipped by the engine above).
+      if (dictionaryResourceDirectory != null &&
+          wants(BackupCategory.dictionary)) {
+        await _copyTreeIfAbsent(zipPath, archive, _dictionaryResourcesPrefix,
+            dictionaryResourceDirectory,
+            onBytes: reportBytes);
+      }
+      if (booksRootDirectory != null && wants(BackupCategory.books)) {
+        await _copyTreeIfAbsent(
+            zipPath, archive, archiveBooksPrefix(archive), booksRootDirectory,
+            onBytes: reportBytes);
+      }
+      if (audiobooksRootDirectory != null && wants(BackupCategory.audiobooks)) {
+        await _copyTreeIfAbsent(
+            zipPath, archive, _audiobooksPrefix, audiobooksRootDirectory,
+            onBytes: reportBytes);
+      }
+      if (fontsRootDirectory != null && wants(BackupCategory.fonts)) {
+        await _copyTreeIfAbsent(
+            zipPath, archive, _fontsPrefix, fontsRootDirectory,
+            onBytes: reportBytes);
+      }
+      if (videosRootDirectory != null && wants(BackupCategory.videos)) {
+        await _copyTreeIfAbsent(
+            zipPath, archive, _videosPrefix, videosRootDirectory,
+            onBytes: reportBytes);
+      }
+      // Local-audio DBs are copy-if-absent into the support directory (never
+      // overwrite the device's own local_audio_*.db files).
+      if (wants(BackupCategory.localAudio)) {
+        await _reapplyLocalAudioFiles(zipPath, archive, dbDirectory,
+            overwrite: false, onBytes: reportBytes);
+      }
+
+      // 6) Rebase the newly-merged backup rows' stored paths onto this device's
+      //    roots. Device-local rows aren't under the backup's source root, so
+      //    rebasePath leaves them untouched (a no-op for them).
+      if (meta != null) {
+        await _rebaseAllPaths(
+          dbDirectory: dbDirectory,
+          meta: meta,
+          newBooksRoot: booksRootDirectory,
+          newAudiobooksRoot: audiobooksRootDirectory,
+          newFontsRoot: fontsRootDirectory,
+          newLocalAudioRoot: dbDirectory,
+          newVideosRoot: videosRootDirectory,
+        );
+      }
+
+      // 7) Success: drop the merge-src temp, the bak, and the sidecar.
+      await _safeDelete(mergeSrcPath);
+      await _safeDelete('$mergeSrcPath-wal');
+      await _safeDelete('$mergeSrcPath-shm');
+      await _safeDelete(bakPath);
+      await _safeDelete(sidecar.path);
+    } finally {
+      await input.close();
+    }
+  }
+
+  /// Temp filename for the preview-only extracted backup DB (TODO-1195 part B).
+  static const String _mergePreviewSrcName = '$_dbName.merge-preview-src';
+
+  /// Read-only estimate of what a MERGE import of [zipPath] would change on this
+  /// device, for the import confirm dialog (TODO-1195 part B). Extracts ONLY the
+  /// backup's main-DB entry to a temp file, migrates it to the current schema,
+  /// ATTACHes it to the still-open [liveDb] and runs [BackupMergeEngine.preview]
+  /// (no mutation, no transaction), then detaches and cleans up. Best-effort:
+  /// any failure returns null so the caller shows a generic dialog and the
+  /// import is never blocked by a preview problem. The content trees are NOT
+  /// extracted (only row counts matter), so this stays cheap even for a
+  /// multi-GB backup.
+  static Future<BackupMergePreview?> previewMergeRestore({
+    required FushiDatabase liveDb,
+    required String dbDirectory,
+    required String zipPath,
+  }) async {
+    final String tmpSrc = p.join(dbDirectory, _mergePreviewSrcName);
+    try {
+      final InputFileStream input = InputFileStream(zipPath);
+      final Archive archive;
+      try {
+        archive = ZipDecoder().decodeBuffer(input);
+      } finally {
+        await input.close();
+      }
+      final ArchiveFile? dbFile = _findDbEntry(archive);
+      if (dbFile == null) return null;
+
+      // TODO-1261: the merge only materialises REACHABLE video rows (streaming
+      // or a local file the backup carried), so the preview must count with the
+      // same predicate. The carried set is the packed video files (meta.videoFiles).
+      final BackupMeta? meta = _readBackupMeta(archive);
+      final Set<String> carriedVideoSourcePaths =
+          meta?.videoFiles.keys.toSet() ?? const <String>{};
+
+      await _safeDelete(tmpSrc);
+      await _safeDelete('$tmpSrc-wal');
+      await _safeDelete('$tmpSrc-shm');
+      await _extractEntriesStreaming(
+        zipPath: zipPath,
+        entries: <MapEntry<String, String>>[
+          MapEntry<String, String>(dbFile.name, tmpSrc),
+        ],
+      );
+
+      // Migrate the extracted DB up to the current schema so its columns align
+      // for the ATTACH-based COUNT queries (same contract as the real merge).
+      final FushiDatabase srcMigrate = FushiDatabase.atFile(tmpSrc);
+      try {
+        await srcMigrate.customStatement('PRAGMA user_version');
+      } finally {
+        await srcMigrate.close();
+      }
+      await _safeDelete('$tmpSrc-wal');
+      await _safeDelete('$tmpSrc-shm');
+
+      final String safeSrc = tmpSrc.replaceAll(r'\', '/').replaceAll("'", "''");
+      await liveDb.customStatement("ATTACH DATABASE '$safeSrc' AS previewsrc");
+      try {
+        return await BackupMergeEngine(
+          liveDb,
+          srcAlias: 'previewsrc',
+          carriedVideoSourcePaths: carriedVideoSourcePaths,
+        ).preview();
+      } finally {
+        await liveDb.customStatement('DETACH DATABASE previewsrc');
+      }
+    } catch (e, st) {
+      // Never block the import on a preview failure — fall back to a generic
+      // confirm dialog.
+      debugPrint('BackupService.previewMergeRestore failed: $e\n$st');
+      return null;
+    } finally {
+      await _safeDelete(tmpSrc);
+      await _safeDelete('$tmpSrc-wal');
+      await _safeDelete('$tmpSrc-shm');
+    }
+  }
+
+  /// Copies every file under `<prefix>/` in [archive] into [targetRootPath],
+  /// SKIPPING any whose destination already exists (the merge-import invariant:
+  /// never delete or overwrite the device's own content). Reuses the same path
+  /// traversal safety checks as the overwrite path's [_buildTreeReapplyPlan].
+  static Future<void> _copyTreeIfAbsent(
+    String zipPath,
+    Archive archive,
+    String prefix,
+    String targetRootPath, {
+    void Function(int deltaBytes)? onBytes,
+  }) async {
+    final List<MapEntry<ArchiveFile, String>> plan = _buildTreeReapplyPlan(
+      archive: archive,
+      prefix: prefix,
+      targetRootPath: targetRootPath,
+    );
+    final List<MapEntry<String, String>> toWrite = <MapEntry<String, String>>[];
+    for (final MapEntry<ArchiveFile, String> entry in plan) {
+      if (await File(entry.value).exists()) continue; // copy-if-absent
+      toWrite.add(MapEntry<String, String>(entry.key.name, entry.value));
+    }
+    await _extractEntriesStreaming(
+      zipPath: zipPath,
+      entries: toWrite,
+      onBytes: onBytes,
+    );
+  }
+
+  /// Cleans up a crashed/finished MERGE import's temp files (TODO-888). Returns
+  /// true when a merge sidecar was present (and was handled), false otherwise.
+  /// The DB itself is untouched: the merge transaction is all-or-nothing, so the
+  /// live DB is already consistent regardless of when a crash happened.
+  static Future<bool> recoverMergeRestore(String dbDirectory) async {
+    final File sidecar = File(p.join(dbDirectory, _mergeSidecar));
+    if (!sidecar.existsSync()) return false;
+    try {
+      final Map<String, dynamic> decoded =
+          jsonDecode(await sidecar.readAsString()) as Map<String, dynamic>;
+      final Object? mergeSrc = decoded['mergeSrc'];
+      if (mergeSrc is String) {
+        await _safeDelete(mergeSrc);
+        await _safeDelete('$mergeSrc-wal');
+        await _safeDelete('$mergeSrc-shm');
+      }
+    } catch (e, st) {
+      debugPrint('BackupService.recoverMergeRestore failed: $e\n$st');
+    }
+    await _safeDelete(p.join(dbDirectory, _mergeSrcName));
+    await _safeDelete(p.join(dbDirectory, '$_mergeSrcName-wal'));
+    await _safeDelete(p.join(dbDirectory, '$_mergeSrcName-shm'));
+    await _safeDelete(p.join(dbDirectory, '$_dbName.pre-merge.bak'));
+    await _safeDelete(sidecar.path);
+    return true;
+  }
+
+  /// Finish a pending import at startup, before any sync code reads prefs.
+  /// Handles both: (a) re-applying device-local sync prefs if a full-restore
+  /// import crashed mid-way; (b) restoring this device's settings layer for a
+  /// keep-settings import. No-op when no sidecar is present.
+  static Future<void> recoverPendingRestore(String dbDirectory) async {
+    // MERGE import (TODO-888) leaves its own sidecar. The row merge ran in ONE
+    // Drift transaction, so the live DB is already consistent whether or not we
+    // crashed (the transaction either committed or rolled back) — there is
+    // NOTHING to apply to the DB, only leftover temp files to sweep. Handle it
+    // first + return so a 'merge' marker can never fall through to the legacy
+    // bare-map prefs path and get mis-applied. (recoverMergeRestore is reused by
+    // tests; keep the sweep there.)
+    if (await recoverMergeRestore(dbDirectory)) return;
+
+    final sidecar = File(p.join(dbDirectory, _preserveSidecar));
+    if (!sidecar.existsSync()) return;
+    final String bakPath = p.join(dbDirectory, '$_dbName.pre-restore.bak');
+    bool sidecarStateApplied = false;
+    bool shouldReapplyDeviceLocalTables = false;
+    try {
+      final raw = await sidecar.readAsString();
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      shouldReapplyDeviceLocalTables =
+          decoded['preserveDeviceLocalTables'] == true;
+      if (decoded['mode'] == 'settings') {
+        await _reapplySettingsLayer(dbDirectory);
+      } else {
+        // 'prefs' mode, or a legacy bare-map sidecar (no 'mode' field).
+        // TODO-1193: preserve the LOCAL settings/profiles layer from bak first
+        // (a settings/profiles-excluded backup crashed mid-import), then re-apply
+        // device-local sync config — same order as the inline path.
+        final bool preserveSettings = decoded['preserveSettings'] == true;
+        final bool preserveProfiles = decoded['preserveProfiles'] == true;
+        if (preserveSettings || preserveProfiles) {
+          await _reapplyExcludedSettingsLayers(
+            dbDirectory,
+            p.join(dbDirectory, '$_dbName.pre-restore.bak'),
+            reapplySettings: preserveSettings,
+            reapplyProfiles: preserveProfiles,
+          );
+        }
+        final Map<String, dynamic> prefsRaw =
+            (decoded['prefs'] as Map<String, dynamic>?) ?? decoded;
+        final prefs = prefsRaw.map((k, v) => MapEntry(k, v as String));
+        if (prefs.isNotEmpty) await _applyPreservedConfig(dbDirectory, prefs);
+      }
+      sidecarStateApplied = true;
+    } on FormatException catch (e, st) {
+      // A malformed marker cannot describe settings/prefs, but the independent
+      // pre-restore DB snapshot can still rescue device-local tables. Preserve
+      // the historical behavior of dropping an irreparably corrupt marker once
+      // that table replay succeeds.
+      debugPrint('BackupService.recoverPendingRestore: corrupt sidecar: '
+          '$e\n$st');
+      sidecarStateApplied = true;
+    } on TypeError catch (e, st) {
+      debugPrint('BackupService.recoverPendingRestore: invalid sidecar shape: '
+          '$e\n$st');
+      sidecarStateApplied = true;
+    } catch (e, st) {
+      // Database/filesystem failures are retryable. Keep both artifacts so the
+      // next startup can replay the same idempotent operations.
+      debugPrint('BackupService.recoverPendingRestore failed: $e\n$st');
+      return;
+    }
+
+    if (!sidecarStateApplied) return;
+    if (shouldReapplyDeviceLocalTables) {
+      final bool deviceLocalTablesReapplied =
+          await _reapplyDeviceLocalTablesFromBak(dbDirectory, bakPath);
+      if (!deviceLocalTablesReapplied) {
+        debugPrint('BackupService.recoverPendingRestore: retaining sidecar and '
+            'pre-restore.bak because device-local table replay did not finish.');
+        return;
+      }
+    }
+    await _safeDelete(sidecar.path);
+    await _safeDelete(bakPath);
+  }
+
+  /// Restores the settings layer (preferences + profiles + bindings) from
+  /// pre-restore.bak into the freshly-imported DB, keeping the backup's content.
+  /// Runs at startup, so both DBs are at the current schema → `SELECT *` columns
+  /// align. audiobook positions are content and stay from the backup.
+  static Future<void> _reapplySettingsLayer(String dbDirectory) async {
+    final String bakPath = p.join(dbDirectory, '$_dbName.pre-restore.bak');
+    if (!File(bakPath).existsSync()) {
+      // bak is the only copy of this device's settings layer (the main DB was
+      // already overwritten with the backup). If it's gone we cannot restore —
+      // surface it loudly rather than silently dropping the user's settings.
+      // (Normal flow restores inline while bak definitely exists; reaching here
+      // means a crash + external deletion of bak before the next launch.)
+      debugPrint('BackupService._reapplySettingsLayer: pre-restore.bak missing '
+          '— local settings/profiles could not be preserved on import.');
+      return;
+    }
+    final db = FushiDatabase(dbDirectory);
+    try {
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS bak");
+      await db.transaction(() async {
+        // preferences: keep this device's SETTINGS from bak, but let CONTENT
+        // prefs (audiobook positions, favorites, local-audio / audio-source
+        // registry, font registry) follow the imported backup — see
+        // [_keepDeviceSettingsPrefPredicate]. `sync_*` stays restored from bak
+        // (device-local, never exported), which this predicate keeps.
+        await db.customStatement(
+            'DELETE FROM preferences WHERE $_keepDeviceSettingsPrefPredicate');
+        await db.customStatement(
+            'INSERT INTO preferences SELECT * FROM bak.preferences '
+            'WHERE $_keepDeviceSettingsPrefPredicate');
+        // profiles before its FK dependents.
+        for (final String t in _settingsLayerTables) {
+          await db.customStatement('DELETE FROM $t');
+          await db.customStatement('INSERT INTO $t SELECT * FROM bak.$t');
+        }
+      });
+      await db.customStatement('DETACH DATABASE bak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// Restores ONLY the excluded settings and/or profiles layers from [bakPath]
+  /// (this device's pre-import snapshot) into the freshly-overwritten DB, so a
+  /// backup that UNTICKED the `settings` / `profiles` category never wipes this
+  /// device's settings/profiles to empty (TODO-1193). The exact mirror of the
+  /// export strip:
+  ///  - [reapplySettings]: the pure-settings preference rows
+  ///    ([settingsPrefPredicate]) — progress / favorites / content-registry /
+  ///    sync prefs stay from the backup (they are content or handled elsewhere).
+  ///  - [reapplyProfiles]: the four profile-layer tables (child-first DELETE
+  ///    then parent-first INSERT for FK-safety).
+  /// Runs while both DBs are at the current schema (bak is a copy of the live
+  /// DB), so `SELECT *` columns align. No-op (logged) if bak is gone.
+  static Future<void> _reapplyExcludedSettingsLayers(
+    String dbDirectory,
+    String bakPath, {
+    required bool reapplySettings,
+    required bool reapplyProfiles,
+  }) async {
+    if (!reapplySettings && !reapplyProfiles) return;
+    if (!File(bakPath).existsSync()) {
+      // bak is the only copy of this device's settings/profiles after the
+      // overwrite. Missing it means a crash + external deletion before this ran;
+      // surface loudly rather than silently wiping the layer to empty.
+      debugPrint('BackupService._reapplyExcludedSettingsLayers: '
+          'pre-restore.bak missing — local settings/profiles could not be '
+          'preserved for a settings/profiles-excluded backup.');
+      return;
+    }
+    final FushiDatabase db = FushiDatabase(dbDirectory);
+    try {
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS setbak");
+      await db.transaction(() async {
+        if (reapplySettings) {
+          await db.customStatement(
+              'DELETE FROM preferences WHERE $settingsPrefPredicate');
+          await db.customStatement(
+              'INSERT INTO preferences SELECT * FROM setbak.preferences '
+              'WHERE $settingsPrefPredicate');
+        }
+        if (reapplyProfiles) {
+          // Child-first DELETE so an enforced FK to `profiles` never blocks the
+          // wipe; parent-first INSERT ([_settingsLayerTables]) so children land
+          // after their profile row.
+          for (final String t in _profilesLayerTablesChildFirst) {
+            await db.customStatement('DELETE FROM $t');
+          }
+          for (final String t in _settingsLayerTables) {
+            await db.customStatement('INSERT INTO $t SELECT * FROM setbak.$t');
+          }
+        }
+      });
+      await db.customStatement('DETACH DATABASE setbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// Tables holding this device's imported dictionaries. Re-seated from
+  /// pre-restore.bak when a backup that carries NO dictionaries is imported in
+  /// overwrite mode (BUG-454), so an unselected-dictionary backup never wipes
+  /// the device's dictionary library. `dictionary_metadata` is the queryable
+  /// dictionary set; `dictionary_history` is its recent-lookup list. Neither is
+  /// FK-targeted by content tables, so a wholesale per-table swap is FK-safe.
+  static const List<String> _dictionaryLayerTables = <String>[
+    'dictionary_metadata',
+    'dictionary_history',
+  ];
+
+  /// Restores [_dictionaryLayerTables] from [bakPath] (this device's pre-import
+  /// snapshot) into the freshly-overwritten DB in [dbDirectory]. Runs inline
+  /// during import while both DBs are at the current schema (bak is a copy of
+  /// the live DB), so `SELECT *` columns align. No-op (logged) if bak is gone.
+  static Future<void> _reapplyDictionaryTablesFromBak(
+    String dbDirectory,
+    String bakPath,
+  ) async {
+    if (!File(bakPath).existsSync()) {
+      // bak is the only copy of this device's dictionary rows after the
+      // overwrite. Missing it means a crash + external deletion before this
+      // ran; surface loudly rather than silently dropping the dictionaries.
+      debugPrint('BackupService._reapplyDictionaryTablesFromBak: '
+          'pre-restore.bak missing — local dictionaries could not be '
+          'preserved on import.');
+      return;
+    }
+    final FushiDatabase db = FushiDatabase(dbDirectory);
+    try {
+      final String safeBak =
+          bakPath.replaceAll(r'\', '/').replaceAll("'", "''");
+      await db.customStatement("ATTACH DATABASE '$safeBak' AS dictbak");
+      await db.transaction(() async {
+        for (final String t in _dictionaryLayerTables) {
+          await db.customStatement('DELETE FROM $t');
+          await db.customStatement('INSERT INTO $t SELECT * FROM dictbak.$t');
+        }
+      });
+      await db.customStatement('DETACH DATABASE dictbak');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// Reads this device's device-local / credential prefs from the DB in
+  /// [dbDirectory] so an import can write them back afterwards.
+  ///
+  /// Filters by [PrefRedactionPolicy] rather than enumerating
+  /// [SyncRepository.deviceLocalPrefKeys]: the policy also matches by prefix and
+  /// shape (`media_source_secret_<id>` is one key PER SOURCE ROW and could never
+  /// be listed), and — decisively — it is the SAME predicate the export strip
+  /// uses. Enumerating a fixed list here while the strip matched by shape is
+  /// exactly how the two sides would drift: every key the strip removed but the
+  /// list did not name would be deleted from the imported DB and never restored,
+  /// silently wiping this device's own SFTP passwords / API keys on import.
+  static Future<Map<String, String>> _readDeviceLocalPrefs(
+      String dbDirectory) async {
+    FushiDatabase? db;
+    try {
+      db = FushiDatabase(dbDirectory);
+      final all = await db.getAllPrefs();
+      final out = <String, String>{};
+      for (final MapEntry<String, String> entry in all.entries) {
+        if (PrefRedactionPolicy.isDeviceLocalOrCredential(entry.key)) {
+          out[entry.key] = entry.value;
+        }
+      }
+      return out;
+    } catch (e, st) {
+      // Current DB unreadable/corrupt: nothing to preserve. Import the backup
+      // as-is rather than aborting — a broken local DB shouldn't block restore.
+      debugPrint('BackupService._readDeviceLocalPrefs failed: $e\n$st');
+      return const <String, String>{};
+    } finally {
+      try {
+        await db?.close();
+      } catch (_) {/* db may have failed to open */}
+    }
+  }
+
+  /// Writes the preserved device-local [prefs] into the imported DB, clears the
+  /// stale (backup-origin) folder cache so the next sync rebuilds it against the
+  /// preserved backend account, then durably flushes.
+  static Future<void> _applyPreservedConfig(
+      String dbDirectory, Map<String, String> prefs) async {
+    final db = FushiDatabase(dbDirectory);
+    try {
+      for (final entry in prefs.entries) {
+        await db.setPref(entry.key, entry.value);
+      }
+      // The imported DB carries the BACKUP's folder cache (title → source
+      // account folder ids), which is wrong for the preserved local backend.
+      // BUG-1576：清**所有**通道那几格（含解耦前的旧全局键）。导入库里带的是备份
+      // 来源机的目录布局，对本机保留下来的后端账号一条都不成立。
+      await SyncRepository(db).clearAllFolderCaches();
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
+  }
+
+  static List<ArchiveFile> _dictionaryResourceFiles(Archive archive) {
+    return archive.files.where((ArchiveFile file) {
+      if (!file.isFile) return false;
+      return file.name
+          .replaceAll(r'\', '/')
+          .startsWith('$_dictionaryResourcesPrefix/');
+    }).toList();
+  }
+
+  static List<MapEntry<ArchiveFile, String>> _buildDictionaryReapplyPlan({
+    required Archive archive,
+    required String dictionaryResourceDirectory,
+  }) {
+    final Directory targetRoot = Directory(dictionaryResourceDirectory);
+    final String canonicalRoot = p.canonicalize(targetRoot.path);
+    final List<MapEntry<ArchiveFile, String>> reapplyPlan =
+        <MapEntry<ArchiveFile, String>>[];
+    for (final ArchiveFile file in _dictionaryResourceFiles(archive)) {
+      final String rawName = file.name.replaceAll(r'\', '/');
+      final String relativePath =
+          rawName.substring(_dictionaryResourcesPrefix.length + 1);
+      final String normalizedRelative = p.posix.normalize(relativePath);
+      if (relativePath.isEmpty ||
+          p.posix.isAbsolute(relativePath) ||
+          normalizedRelative == '..' ||
+          normalizedRelative.startsWith('../')) {
+        throw FormatException('Invalid dictionary resource path: ${file.name}');
+      }
+
+      final String targetPath = p.normalize(
+        p.join(targetRoot.path, normalizedRelative),
+      );
+      final String canonicalTarget = p.canonicalize(targetPath);
+      if (canonicalTarget != canonicalRoot &&
+          !p.isWithin(canonicalRoot, canonicalTarget)) {
+        throw FormatException('Invalid dictionary resource path: ${file.name}');
+      }
+      reapplyPlan.add(MapEntry<ArchiveFile, String>(file, targetPath));
+    }
+    return reapplyPlan;
+  }
+
+  static Future<void> _reapplyDictionaryResources({
+    required String zipPath,
+    required List<MapEntry<ArchiveFile, String>> reapplyPlan,
+    required String dictionaryResourceDirectory,
+    void Function(int deltaBytes)? onBytes,
+  }) async {
+    final Directory targetRoot = Directory(dictionaryResourceDirectory);
+    // 引擎常驻映射着每本词典的 hash.table / blobs.bin（native map_rd）；Windows 上
+    // 只要 view 还活着，删资源根一律 ERROR_USER_MAPPED_FILE，整个恢复流程就断在
+    // 这一行（BUG-1756）。恢复流程收尾必定重启 app（backupImportRestart），故这里
+    // 把引擎清空不需要再装回来。
+    FushiDicts.releaseAllMappings();
+    if (await targetRoot.exists()) {
+      await targetRoot.delete(recursive: true);
+    }
+    await targetRoot.create(recursive: true);
+    await _extractEntriesStreaming(
+      zipPath: zipPath,
+      entries: reapplyPlan
+          .map((MapEntry<ArchiveFile, String> e) =>
+              MapEntry<String, String>(e.key.name, e.value))
+          .toList(),
+      onBytes: onBytes,
+    );
+  }
+
+  /// Extracts the packed local-audio databases (`localAudio/<file>`) into the
+  /// support directory [dbDirectory]. Unlike the content TREES these are
+  /// individual files SHARING the directory with `hibiki.db`, so they are
+  /// written file-by-file rather than via the destructive tree swap. Only file
+  /// names matching [_localAudioFileName] are accepted (defense in depth: an
+  /// archive entry naming `hibiki.db` under `localAudio/` is rejected).
+  ///
+  /// When the backup carries no `localAudio/` entries this is a no-op, so an
+  /// audio-less backup leaves this device's local-audio DBs intact (the same
+  /// preserve-on-absent contract the content trees follow — BUG-454 family).
+  ///
+  /// [overwrite] true (overwrite import) replaces an existing same-named file;
+  /// false (merge import) keeps the device's own file (copy-if-absent).
+  static Future<void> _reapplyLocalAudioFiles(
+    String zipPath,
+    Archive archive,
+    String dbDirectory, {
+    bool overwrite = true,
+    void Function(int deltaBytes)? onBytes,
+  }) async {
+    final Directory targetRoot = Directory(dbDirectory);
+    final List<MapEntry<String, String>> plan = <MapEntry<String, String>>[];
+    for (final ArchiveFile file in archive.files) {
+      if (!file.isFile) continue;
+      final String rawName = file.name.replaceAll(r'\', '/');
+      if (!rawName.startsWith('$_localAudioPrefix/')) continue;
+      final String name = rawName.substring(_localAudioPrefix.length + 1);
+      // Reject nested paths / traversal / non-local-audio names: these files
+      // must land flat in the support dir and never escape it or clobber
+      // hibiki.db.
+      if (name.isEmpty ||
+          name.contains('/') ||
+          !_localAudioFileName.hasMatch(name)) {
+        throw FormatException('Invalid local audio backup path: ${file.name}');
+      }
+      final File dest = File(p.join(targetRoot.path, name));
+      if (!overwrite && await dest.exists()) continue; // copy-if-absent (merge)
+      plan.add(MapEntry<String, String>(file.name, dest.path));
+    }
+    await _extractEntriesStreaming(
+      zipPath: zipPath,
+      entries: plan,
+      onBytes: onBytes,
+    );
+  }
+
+  /// Files in [archive] under `<prefix>/`, validated against path traversal and
+  /// mapped to absolute targets under [targetRootPath]. Mirrors the dictionary
+  /// plan's safety checks (reject absolute / `..` escapes, `p.isWithin` gate).
+  static List<MapEntry<ArchiveFile, String>> _buildTreeReapplyPlan({
+    required Archive archive,
+    required String prefix,
+    required String targetRootPath,
+  }) {
+    final Directory targetRoot = Directory(targetRootPath);
+    final String canonicalRoot = p.canonicalize(targetRoot.path);
+    final List<MapEntry<ArchiveFile, String>> plan =
+        <MapEntry<ArchiveFile, String>>[];
+    for (final ArchiveFile file in archive.files) {
+      if (!file.isFile) continue;
+      final String rawName = file.name.replaceAll(r'\', '/');
+      if (!rawName.startsWith('$prefix/')) continue;
+      final String relativePath = rawName.substring(prefix.length + 1);
+      final String normalizedRelative = p.posix.normalize(relativePath);
+      if (relativePath.isEmpty ||
+          p.posix.isAbsolute(relativePath) ||
+          normalizedRelative == '..' ||
+          normalizedRelative.startsWith('../')) {
+        throw FormatException('Invalid backup content path: ${file.name}');
+      }
+      final String targetPath =
+          p.normalize(p.join(targetRoot.path, normalizedRelative));
+      final String canonicalTarget = p.canonicalize(targetPath);
+      if (canonicalTarget != canonicalRoot &&
+          !p.isWithin(canonicalRoot, canonicalTarget)) {
+        throw FormatException('Invalid backup content path: ${file.name}');
+      }
+      plan.add(MapEntry<ArchiveFile, String>(file, targetPath));
+    }
+    return plan;
+  }
+
+  static String _importTmpPath(String root) => '$root.import-tmp';
+  static String _importOldPath(String root) => '$root.import-old';
+
+  /// Removes any stale `.import-tmp` / `.import-old` siblings left by a prior
+  /// import that crashed mid-swap. Called on entry to every prepare so a stale
+  /// `.import-old` can never be mistaken for a valid rollback target by a later
+  /// import (review W1).
+  static Future<void> _clearImportLeftovers(String targetRootPath) async {
+    for (final String path in <String>[
+      _importTmpPath(targetRootPath),
+      _importOldPath(targetRootPath),
+    ]) {
+      final Directory d = Directory(path);
+      if (await d.exists()) await d.delete(recursive: true);
+    }
+  }
+
+  /// PHASE 1 of the content-tree restore: write every file under `<prefix>/`
+  /// into the sibling `<root>.import-tmp` (NO swap yet). Returns true when there
+  /// is something staged to commit; false when the backup carries no files under
+  /// [prefix] (db-only / audio-less backup) so the existing tree is left alone.
+  ///
+  /// Splitting write (slow, GB-scale, failure-prone) from the swap (fast rename)
+  /// lets the caller stage ALL trees before committing ANY — a write failure
+  /// then swaps nothing and leaves every existing tree intact (review W2).
+  /// 该归档实际使用的书树前缀：任一条目落在新前缀（[_booksPrefix]）下即用新，
+  /// 否则回退旧前缀 [_legacyBooksPrefix]（旧 Hibiki app 导出的备份/迁移归档）。
+  /// 一份归档只会有一代前缀，不存在混排。`@visibleForTesting`：读侧回退是
+  /// 跨版本契约，测试直接对两代归档断言。
+  @visibleForTesting
+  static String archiveBooksPrefix(Archive archive) {
+    for (final ArchiveFile file in archive) {
+      if (file.name.startsWith('$_booksPrefix/')) return _booksPrefix;
+    }
+    return _legacyBooksPrefix;
+  }
+
+  static Future<bool> _prepareTreeReapply(
+    String zipPath,
+    Archive archive,
+    String prefix,
+    String targetRootPath, {
+    void Function(int deltaBytes)? onBytes,
+  }) async {
+    final String tmpRoot = _importTmpPath(targetRootPath);
+    final List<MapEntry<ArchiveFile, String>> plan = _buildTreeReapplyPlan(
+      archive: archive,
+      prefix: prefix,
+      targetRootPath: tmpRoot,
+    );
+    await _clearImportLeftovers(targetRootPath);
+    if (plan.isEmpty) return false;
+
+    final Directory tmpDir = Directory(tmpRoot);
+    await tmpDir.create(recursive: true);
+    try {
+      await _extractEntriesStreaming(
+        zipPath: zipPath,
+        entries: plan
+            .map((MapEntry<ArchiveFile, String> e) =>
+                MapEntry<String, String>(e.key.name, e.value))
+            .toList(),
+        onBytes: onBytes,
+      );
+    } catch (_) {
+      if (await tmpDir.exists()) await tmpDir.delete(recursive: true);
+      rethrow; // nothing swapped; existing tree untouched
+    }
+    return true;
+  }
+
+  /// PHASE 2: swap the staged `<root>.import-tmp` into place. tmp and target are
+  /// siblings → rename is atomic on the same filesystem. Caller invokes this for
+  /// each prepared tree back-to-back; only the (rare) rename failure between two
+  /// trees leaves a cross-tree half-state, which is far smaller than the old
+  /// write-between-swaps window.
+  static Future<void> _commitPreparedTree(String targetRootPath) async {
+    final String asideRoot = _importOldPath(targetRootPath);
+    final Directory aside = Directory(asideRoot);
+    final Directory target = Directory(targetRootPath);
+    final Directory tmpDir = Directory(_importTmpPath(targetRootPath));
+    // Every swap rename retries transient Windows FS-busy (errno 5/32/145): an
+    // antivirus/indexer scanning the freshly-written tree briefly locks it, so
+    // a bare rename fails with "拒绝访问" even though nothing is really wrong.
+    Future<void> renameDir(Directory dir, String to) =>
+        renameDirectoryWithRetry(
+          rename: () => dir.rename(to),
+          sleep: (int ms) => Future<void>.delayed(Duration(milliseconds: ms)),
+          isWindows: Platform.isWindows,
+        );
+    if (await aside.exists()) await aside.delete(recursive: true);
+    if (await target.exists()) await renameDir(target, asideRoot);
+    try {
+      await renameDir(tmpDir, targetRootPath);
+    } catch (_) {
+      // Roll back: put the old tree back if the new one didn't land.
+      if (await aside.exists() && !await target.exists()) {
+        await renameDir(aside, targetRootPath);
+      }
+      rethrow;
+    }
+    if (await aside.exists()) await aside.delete(recursive: true);
+  }
+
+  /// Drops a staged-but-not-committed `<root>.import-tmp` (idempotent).
+  static Future<void> _abortPreparedTree(String targetRootPath) async {
+    final Directory tmpDir = Directory(_importTmpPath(targetRootPath));
+    if (await tmpDir.exists()) await tmpDir.delete(recursive: true);
+  }
+
+  static Future<void> _safeDelete(String path) async {
+    try {
+      final f = File(path);
+      if (f.existsSync()) await f.delete();
+    } catch (_) {
+      // Best-effort cleanup; a leftover sidecar/bak is harmless and swept later.
+    }
+  }
+
+  /// Total uncompressed byte size of every content entry in [archive] (the DB +
+  /// packed trees + local-audio DBs), excluding the tiny meta json. Used as the
+  /// denominator for the import progress bar. Read from the central directory,
+  /// so it never decompresses anything. Never returns 0 (avoids /0).
+  static int _totalContentBytes(Archive archive) {
+    int total = 0;
+    for (final ArchiveFile f in archive.files) {
+      if (!f.isFile) continue;
+      if (f.name == _metaName) continue;
+      total += f.size;
+    }
+    return total > 0 ? total : 1;
+  }
+
+  /// TODO-1183: determinate progress across every streamed byte. Total is the
+  /// sum of all content entry sizes ([_totalContentBytes]); each streamed
+  /// chunk advances the bar, clamped at 1.0. Returns the `onBytes` callback
+  /// shared by the overwrite- and merge-import extraction helpers.
+  static void Function(int deltaBytes) _archiveByteProgress(
+    Archive archive,
+    void Function(double progress)? onProgress,
+  ) {
+    final int totalBytes = _totalContentBytes(archive);
+    int writtenBytes = 0;
+    return (int deltaBytes) {
+      writtenBytes += deltaBytes;
+      final double fraction = writtenBytes / totalBytes;
+      onProgress?.call(fraction > 1.0 ? 1.0 : fraction);
+    };
+  }
+
+  /// Parses the source-device manifest (`backup_meta.json`) carried by
+  /// [archive]. Null for a legacy backup without one (or an unparseable one).
+  /// Only the tiny meta entry is materialized.
+  static BackupMeta? _readBackupMeta(Archive archive) {
+    final ArchiveFile? metaFile = archive.findFile(_metaName);
+    if (metaFile == null) return null;
+    return BackupMeta.tryParse(utf8.decode(metaFile.content as List<int>));
+  }
+
+  // ── TODO-1183: streaming, off-UI-isolate backup extraction ───────────────
+  //
+  // The import/merge paths used to `dest.writeAsBytes(archiveFile.content)`,
+  // which decodes a whole archive entry into ONE Uint8List. A full-data backup's
+  // local-audio DB alone can be many GB, so that single allocation OOM-killed the
+  // app mid-import (TODO-1183); even when it fit, the synchronous write froze the
+  // UI isolate for the whole copy (progress bar stuck → looked like a hang).
+  //
+  // Extraction now runs on a BACKGROUND isolate and STREAMS each entry to disk in
+  // bounded chunks (never materializing a whole entry), reporting bytes written
+  // through a port so the overlay shows real progress. Only pure file IO +
+  // archive decoding runs in the isolate (no sqlite / platform channels), so it
+  // is isolate-safe — the DB work stays on the caller's isolate. archive 3.6.1's
+  // `ArchiveFile.writeContent` is NOT usable here: for a `decodeBuffer`-produced
+  // file it still fully materializes (`_content is FileContent` → `.content` →
+  // `toUint8List()`), so we stream the raw file-backed window directly instead.
+
+  /// Sent by the extract worker once every planned entry has been written.
+  static const String _extractDoneToken = '__fushi_backup_extract_done__';
+
+  /// Streams the entries in [entries] (archive entry name → absolute dest path)
+  /// out of the zip at [zipPath] on a background isolate. [onBytes] is invoked on
+  /// THIS isolate with each chunk's byte count as it lands, so callers accumulate
+  /// determinate progress. Throws (on this isolate) if the worker reports an
+  /// error, preserving the caller's existing try/catch crash-safety.
+  static Future<void> _extractEntriesStreaming({
+    required String zipPath,
+    required List<MapEntry<String, String>> entries,
+    void Function(int deltaBytes)? onBytes,
+  }) async {
+    if (entries.isEmpty) return;
+    final ReceivePort port = ReceivePort();
+    final Completer<void> completer = Completer<void>();
+    Isolate? isolate;
+    port.listen((dynamic message) {
+      if (message is int) {
+        onBytes?.call(message);
+      } else if (message == _extractDoneToken) {
+        if (!completer.isCompleted) completer.complete();
+        port.close();
+      } else {
+        // Worker failure ('errorText') or an uncaught isolate error
+        // ([error, stack]): fail the future so the caller's rollback runs.
+        if (!completer.isCompleted) {
+          completer.completeError(
+            StateError('Backup extraction failed: $message'),
+          );
+        }
+        port.close();
+      }
+    });
+    isolate = await Isolate.spawn(
+      _backupExtractWorker,
+      _BackupExtractRequest(zipPath, entries, port.sendPort),
+      onError: port.sendPort,
+    );
+    try {
+      await completer.future;
+    } finally {
+      isolate.kill(priority: Isolate.immediate);
+    }
+  }
+
+  /// Background-isolate entry point for [_extractEntriesStreaming]. Re-opens the
+  /// zip by path (the decoded [Archive] from the caller's isolate cannot cross
+  /// the boundary), then streams each requested entry to disk, reporting progress
+  /// and terminal status through the [SendPort].
+  static void _backupExtractWorker(_BackupExtractRequest request) {
+    final SendPort port = request.sendPort;
+    InputFileStream? input;
+    try {
+      input = InputFileStream(request.zipPath);
+      final Archive archive = ZipDecoder().decodeBuffer(input);
+      final Map<String, ArchiveFile> byName = <String, ArchiveFile>{
+        for (final ArchiveFile file in archive.files) file.name: file,
+      };
+      for (final MapEntry<String, String> entry in request.entries) {
+        final ArchiveFile? file = byName[entry.key];
+        if (file == null) {
+          throw StateError('Backup archive missing entry: ${entry.key}');
+        }
+        _streamArchiveFileToDisk(file, entry.value, port);
+      }
+      port.send(_extractDoneToken);
+    } catch (error, stack) {
+      port.send('$error\n$stack');
+    } finally {
+      input?.closeSync();
+    }
+  }
+
+  /// Streams one [file]'s uncompressed bytes to [destPath] without buffering the
+  /// whole entry. Hibiki backups are written STORE (see
+  /// [_writeBackupZipInIsolate]) so the raw window IS the uncompressed data and is
+  /// copied in bounded 4 MB chunks (each chunk's size reported via [port]); a
+  /// DEFLATE entry (small metadata / test fixtures — never a multi-GB file in
+  /// practice) is inflated streaming.
+  static void _streamArchiveFileToDisk(
+    ArchiveFile file,
+    String destPath,
+    SendPort port,
+  ) {
+    File(destPath).parent.createSync(recursive: true);
+    final OutputFileStream output = OutputFileStream(destPath);
+    try {
+      final InputStreamBase? raw = file.rawContent;
+      if (raw != null && !file.isCompressed) {
+        const int chunkSize = 4 * 1024 * 1024; // 4 MB peak heap per chunk
+        final int total = raw.length;
+        int written = 0;
+        while (written < total) {
+          final int want =
+              (total - written) < chunkSize ? (total - written) : chunkSize;
+          final Uint8List bytes = raw.readBytes(want).toUint8List();
+          if (bytes.isEmpty) break;
+          output.writeBytes(bytes);
+          written += bytes.length;
+          port.send(bytes.length);
+        }
+      } else if (raw != null && file.compressionType == ArchiveFile.DEFLATE) {
+        Inflate.stream(raw, output);
+        port.send(file.size);
+      } else {
+        // Last resort (already-materialized content): write buffered bytes.
+        output.writeBytes(file.content as List<int>);
+        port.send(file.size);
+      }
+    } finally {
+      output.closeSync();
+    }
+  }
+}
+
+/// Sendable request for the background extract worker (records with a `List` and
+/// a `SendPort` cross the isolate boundary fine). Kept a top-level class rather
+/// than an anonymous record for a clearer worker signature.
+class _BackupExtractRequest {
+  const _BackupExtractRequest(this.zipPath, this.entries, this.sendPort);
+  final String zipPath;
+  final List<MapEntry<String, String>> entries;
+  final SendPort sendPort;
+}

--- a/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -66,9 +66,9 @@ String backupCategoryDescription(BackupCategory category) {
 
 /// Every content category the user can individually skip on import (TODO-1358).
 /// Both modes now honour the full set: overwrite strips the unticked category's
-/// rows/files from the swapped-in DB ([BackupService.restoreBackup]); merge
+/// rows/files from the swapped-in DB ([BackupRestoreService.restoreBackup]); merge
 /// skips its per-category engine steps + content-tree copy
-/// ([BackupService.mergeRestoreBackup]). settings / profiles stay governed
+/// ([BackupRestoreService.mergeRestoreBackup]). settings / profiles stay governed
 /// by the separate "import settings and profiles" toggle (overwrite) / kept
 /// local (merge), so they are not listed here.
 const Set<BackupCategory> importSelectableCategories = <BackupCategory>{
@@ -791,7 +791,7 @@ class _BackupImportChoice {
 
   /// Categories to RESTORE on an overwrite import (TODO-1358): every
   /// always-restored category plus the selectable ones the user kept ticked.
-  /// Forwarded to [BackupService.restoreBackup]; ignored for merge.
+  /// Forwarded to [BackupRestoreService.restoreBackup]; ignored for merge.
   final Set<BackupCategory> categories;
 }
 
@@ -897,14 +897,10 @@ Future<void> runBackupImportFlowForFile({
   BackupMergePreview? mergePreview;
   BackupContentSummary? summary;
   try {
-    final service = BackupService(
-      db: appModel.database,
-      dbDirectory: appModel.databaseDirectory.path,
-      dictionaryResourceDirectory: appModel.dictionaryResourceDirectory.path,
-      appVersion: appModel.packageInfo.version,
-    );
-
-    final BackupMeta? validated = await service.validateBackup(filePath);
+    // 校验 / 读包摘要是恢复侧的静态操作（B1 分家）：不再为此构造一个导出用的
+    // BackupService 实例。
+    final BackupMeta? validated =
+        await BackupRestoreService.validateBackup(filePath);
     // 已取消/被新一轮校验取代 → 丢弃陈旧结果（遮罩已由 cancel 退出，无需再动）。
     if (!appModel.isBackupValidatingCurrent(validatingToken)) return;
     if (validated == null) {
@@ -922,7 +918,8 @@ Future<void> runBackupImportFlowForFile({
 
     // TODO-1195 part B: best-effort merge preview for the confirm dialog.
     // Runs against the still-open live DB; null on any failure → generic UI.
-    final BackupMergePreview? preview = await BackupService.previewMergeRestore(
+    final BackupMergePreview? preview =
+        await BackupRestoreService.previewMergeRestore(
       liveDb: appModel.database,
       dbDirectory: appModel.databaseDirectory.path,
       zipPath: filePath,
@@ -932,7 +929,7 @@ Future<void> runBackupImportFlowForFile({
     // dialog (per-category counts + the restore toggles). Cheap central-dir
     // read; an empty summary just hides the manifest.
     final BackupContentSummary contentSummary =
-        await service.summarizeBackupFile(filePath);
+        await BackupRestoreService.summarizeBackupFile(filePath);
     if (!appModel.isBackupValidatingCurrent(validatingToken)) return;
     meta = validated;
     mergePreview = preview;
@@ -1001,7 +998,7 @@ Future<void> runBackupImportFlowForFile({
       // TODO-888 merge: keep this device's library + settings, only ADD what
       // the backup carries (row-level upsert + copy-if-absent content trees).
       // Never overwrites/deletes existing data, so importSettings is moot.
-      await BackupService.mergeRestoreBackup(
+      await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: appModel.databaseDirectory.path,
         zipPath: filePath,
         // Per-category merge selection (merge mode now honours the dialog's
@@ -1016,7 +1013,7 @@ Future<void> runBackupImportFlowForFile({
         onProgress: appModel.reportBackupImportProgress,
       );
     } else {
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: appModel.databaseDirectory.path,
         zipPath: filePath,
         importSettings: choice.importSettings,

--- a/fushi/test/sync/aggregate_study_segments_sync_test.dart
+++ b/fushi/test/sync/aggregate_study_segments_sync_test.dart
@@ -399,7 +399,7 @@ void main() {
         isNotEmpty,
       );
 
-      await BackupService.mergeRestoreBackup(
+      await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path,
         zipPath: zip,
       );

--- a/fushi/test/sync/backup_audiobook_import_selectable_test.dart
+++ b/fushi/test/sync/backup_audiobook_import_selectable_test.dart
@@ -90,7 +90,8 @@ void main() {
 
     test('meta.audiobookCount>0 shows audiobooks even with NO packed files',
         () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db'],
         metaWith(audiobookCount: 3),
       );
@@ -99,7 +100,8 @@ void main() {
     });
 
     test('meta.audiobookCount==0 hides audiobooks (unticked new backup)', () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db'],
         metaWith(audiobookCount: 0),
         dbAudiobookCount: 9, // authoritative meta 0 wins over any peek
@@ -108,7 +110,8 @@ void main() {
     });
 
     test('old backup (meta lacks the field) falls back to the DB peek', () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db'],
         metaWith(), // audiobookCount == null
         dbAudiobookCount: 2,
@@ -145,12 +148,8 @@ void main() {
     final String zip = p.join(src.path, 'old_backup.zip');
     File(zip).writeAsBytesSync(ZipEncoder().encode(archive)!);
 
-    final FushiDatabase dummy =
-        FushiDatabase.forTesting(NativeDatabase.memory());
-    final BackupService service =
-        BackupService(db: dummy, dbDirectory: src.path, appVersion: '1.0.0');
-    final BackupContentSummary summary = await service.summarizeBackupFile(zip);
-    await dummy.close();
+    final BackupContentSummary summary =
+        await BackupRestoreService.summarizeBackupFile(zip);
 
     expect(summary.has(BackupCategory.audiobooks), isTrue,
         reason: 'the DB-blob peek must reveal the 2 audiobook rows');
@@ -178,7 +177,7 @@ void main() {
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDbDir,
         zipPath: zip,
         categories: BackupCategory.values.toSet()
@@ -195,7 +194,7 @@ void main() {
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDbDir,
         zipPath: zip, // null categories = restore everything (incl. audiobooks)
       );

--- a/fushi/test/sync/backup_categories_test.dart
+++ b/fushi/test/sync/backup_categories_test.dart
@@ -316,7 +316,7 @@ void main() {
     final String dstVideos = p.join(dst.path, 'videos');
     Directory(dstDbDir).createSync(recursive: true);
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
       videosRootDirectory: dstVideos,
@@ -356,7 +356,7 @@ void main() {
     Directory(dstDbDir).createSync(recursive: true);
     await writeFile(p.join(dstAudio, 'keep', 'kept.mp3'), 'KEEP');
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
       booksRootDirectory: dstBooks,
@@ -497,7 +497,7 @@ void main() {
     // be rebased and the files must land flat alongside the new fushi.db.
     final String dstDbDir = p.join(dst.path, 'db');
     Directory(dstDbDir).createSync(recursive: true);
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
     );
@@ -542,7 +542,7 @@ void main() {
     // Seed the device pref BEFORE the import overwrites the DB. The overwrite
     // import keeps the backup's preferences, so this exercises only the FILE
     // preservation (the file must not be deleted by the import).
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
       booksRootDirectory: dstBooks,
@@ -589,7 +589,7 @@ void main() {
     final String dstDbDir = p.join(dst.path, 'db');
     Directory(dstDbDir).createSync(recursive: true);
     // Fresh device with no books → the backup must not add any un-openable book.
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
     );
@@ -807,7 +807,7 @@ void main() {
         name: 'LocalProfile', createdAt: 9, updatedAt: 9));
     await local.close();
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zip,
     );
@@ -842,7 +842,8 @@ void main() {
     await local.setPref('theme_mode', 'local_dark');
     await local.close();
 
-    await BackupService.restoreBackup(dbDirectory: dstDbDir, zipPath: zip);
+    await BackupRestoreService.restoreBackup(
+        dbDirectory: dstDbDir, zipPath: zip);
 
     final FushiDatabase restored = FushiDatabase(dstDbDir);
     try {

--- a/fushi/test/sync/backup_delete_retry_test.dart
+++ b/fushi/test/sync/backup_delete_retry_test.dart
@@ -6,7 +6,7 @@ import 'package:fushi/src/sync/backup_service.dart';
 /// BUG-272 守卫：备份导出在 finally 里递归删临时目录时，Windows 上 sqlite/AV
 /// 句柄的瞬时占用会把 delete 打成 ERROR_DIR_NOT_EMPTY(145) /
 /// ERROR_SHARING_VIOLATION(32) / ERROR_ACCESS_DENIED(5)。
-/// [BackupService.deleteDirectoryWithRetry] 必须对这类瞬时错误有界重试（用尽后
+/// [deleteDirectoryWithRetry] 必须对这类瞬时错误有界重试（用尽后
 /// 抛出），且只在 Windows 触发、只对瞬时码触发；非 Windows / 非瞬时码直接抛。
 void main() {
   FileSystemException winError(int code) => FileSystemException(
@@ -15,11 +15,11 @@ void main() {
         OSError('目录不是空的。', code),
       );
 
-  group('BackupService.deleteDirectoryWithRetry', () {
+  group('deleteDirectoryWithRetry', () {
     test('happy path: 目录存在，删一次成功，不重试', () async {
       int deleteCalls = 0;
       int sleepCalls = 0;
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => true,
         delete: () async => deleteCalls++,
         sleep: (_) async => sleepCalls++,
@@ -31,7 +31,7 @@ void main() {
 
     test('目录已不存在：不调 delete（早已清理）', () async {
       int deleteCalls = 0;
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => false,
         delete: () async => deleteCalls++,
         sleep: (_) async {},
@@ -41,7 +41,7 @@ void main() {
     });
 
     test('PathNotFoundException：检查与删除之间消失，吞掉不抛', () async {
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => true,
         delete: () async => throw const PathNotFoundException(
           'gone',
@@ -56,7 +56,7 @@ void main() {
     test('Windows 瞬时 errno 145 两次后成功：重试后删成功救回', () async {
       int deleteCalls = 0;
       int sleepCalls = 0;
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => true,
         delete: () async {
           deleteCalls++;
@@ -71,7 +71,7 @@ void main() {
 
     test('Windows SHARING_VIOLATION errno 32 同样被当瞬时错误重试', () async {
       int deleteCalls = 0;
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => true,
         delete: () async {
           deleteCalls++;
@@ -85,7 +85,7 @@ void main() {
 
     test('Windows ACCESS_DENIED errno 5 也是瞬时错误，重试救回', () async {
       int deleteCalls = 0;
-      await BackupService.deleteDirectoryWithRetry(
+      await deleteDirectoryWithRetry(
         exists: () async => true,
         delete: () async {
           deleteCalls++;
@@ -100,7 +100,7 @@ void main() {
     test('Windows 持续 errno 145：重试用尽后抛出（不静默吞）', () async {
       int deleteCalls = 0;
       await expectLater(
-        BackupService.deleteDirectoryWithRetry(
+        deleteDirectoryWithRetry(
           exists: () async => true,
           delete: () async {
             deleteCalls++;
@@ -119,7 +119,7 @@ void main() {
       int deleteCalls = 0;
       int sleepCalls = 0;
       await expectLater(
-        BackupService.deleteDirectoryWithRetry(
+        deleteDirectoryWithRetry(
           exists: () async => true,
           delete: () async {
             deleteCalls++;
@@ -138,7 +138,7 @@ void main() {
       int deleteCalls = 0;
       int sleepCalls = 0;
       await expectLater(
-        BackupService.deleteDirectoryWithRetry(
+        deleteDirectoryWithRetry(
           exists: () async => true,
           delete: () async {
             deleteCalls++;

--- a/fushi/test/sync/backup_device_local_leak_guard_test.dart
+++ b/fushi/test/sync/backup_device_local_leak_guard_test.dart
@@ -16,9 +16,9 @@ void main() {
     expect(f.existsSync(), isTrue, reason: 'run from the fushi/ package root');
     final String s = f.readAsStringSync();
 
-    // The device-local table registry names both tables.
-    final int listStart =
-        s.indexOf('static const List<String> _deviceLocalTables =');
+    // The device-local table registry names both tables. B1 分家后它是导出侧与
+    // 恢复侧共用的库级顶层常量（不再是 BackupService 的 static 成员）。
+    final int listStart = s.indexOf('const List<String> _deviceLocalTables =');
     expect(listStart, greaterThan(-1),
         reason: '_deviceLocalTables constant must exist');
     final int listEnd = s.indexOf('];', listStart);
@@ -58,7 +58,7 @@ void main() {
     }
 
     final int parentListStart = s.indexOf(
-      'static const List<String> _deviceLocalTablesParentFirst =',
+      'const List<String> _deviceLocalTablesParentFirst =',
     );
     expect(parentListStart, greaterThan(-1));
     final int parentListEnd = s.indexOf('];', parentListStart);

--- a/fushi/test/sync/backup_font_path_test.dart
+++ b/fushi/test/sync/backup_font_path_test.dart
@@ -218,7 +218,7 @@ void main() {
 
       expect(meta.fontsRoot, srcFontsDir.path);
 
-      final result = await service.validateBackup(zipPath);
+      final result = await BackupRestoreService.validateBackup(zipPath);
       expect(result, isNotNull);
 
       final Directory dstDir =
@@ -230,7 +230,7 @@ void main() {
         if (dstFontsDir.existsSync()) await cleanupTempDir(dstFontsDir);
       });
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDir.path,
         zipPath: zipPath,
         fontsRootDirectory: dstFontsDir.path,
@@ -347,7 +347,7 @@ void main() {
         if (dstFontsDir.existsSync()) await cleanupTempDir(dstFontsDir);
       });
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDir.path,
         zipPath: zipPath,
         fontsRootDirectory: dstFontsDir.path,

--- a/fushi/test/sync/backup_full_export_test.dart
+++ b/fushi/test/sync/backup_full_export_test.dart
@@ -98,7 +98,7 @@ void main() {
     final String dstAudio = p.join(dst.path, 'audiobooks');
     Directory(dstDbDir).createSync(recursive: true);
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: dstBooks,
@@ -152,7 +152,7 @@ void main() {
     Directory(dstDbDir).createSync(recursive: true);
     await writeFile(p.join(dstBooks, 'Existing', 'keep.epub'), 'KEEP');
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: dstBooks,
@@ -198,7 +198,7 @@ void main() {
     await writeFile(
         '$dstBooks.import-tmp${Platform.pathSeparator}junk.txt', 'x');
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: dstBooks,

--- a/fushi/test/sync/backup_import_categories_test.dart
+++ b/fushi/test/sync/backup_import_categories_test.dart
@@ -14,7 +14,7 @@ import 'temp_dir_cleanup.dart';
 /// TODO-1358: the export/import dialogs describe "what is inside" a backup and
 /// the overwrite import lets the user skip restoring individual sidecar file
 /// trees. This locks down (1) the pure archive manifest counter and (2) the
-/// per-category gating of [BackupService.restoreBackup].
+/// per-category gating of [BackupRestoreService.restoreBackup].
 void main() {
   group('summarizeBackupEntries (pure manifest)', () {
     test('counts distinct dirs / files per category, normalizing separators',
@@ -38,7 +38,7 @@ void main() {
         'localAudio/local_audio_2.db',
       ];
       final BackupContentSummary s =
-          BackupService.summarizeBackupEntries(names, null);
+          BackupRestoreService.summarizeBackupEntries(names, null);
       expect(s.countFor(BackupCategory.dictionary), 2);
       expect(s.countFor(BackupCategory.books), 2);
       expect(s.countFor(BackupCategory.audiobooks), 1);
@@ -70,7 +70,8 @@ void main() {
           '/src/c.mkv': 'uid2/1-c.mkv',
         },
       );
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['videos/uid1/1-a.mp4'],
         meta,
       );
@@ -79,7 +80,8 @@ void main() {
 
     test('db-only archive marks nothing present', () {
       final BackupContentSummary s =
-          BackupService.summarizeBackupEntries(<String>['hibiki.db'], null);
+          BackupRestoreService.summarizeBackupEntries(
+              <String>['hibiki.db'], null);
       expect(s.present, isEmpty);
       expect(s.countFor(BackupCategory.books), 0);
     });
@@ -99,21 +101,21 @@ void main() {
       final Archive archive = Archive()
         ..addFile(file('hibiki.db'))
         ..addFile(file('hoshi_books/BookA/f.html'));
-      expect(BackupService.archiveBooksPrefix(archive), 'hoshi_books');
+      expect(BackupRestoreService.archiveBooksPrefix(archive), 'hoshi_books');
     });
 
     test('archive with fushi_books/ entries uses the new prefix', () {
       final Archive archive = Archive()
         ..addFile(file('hibiki.db'))
         ..addFile(file('fushi_books/BookA/f.html'));
-      expect(BackupService.archiveBooksPrefix(archive), 'fushi_books');
+      expect(BackupRestoreService.archiveBooksPrefix(archive), 'fushi_books');
     });
 
     test(
         'archive without any books tree defaults to the legacy prefix '
         '(harmless: nothing to restore under either)', () {
       final Archive archive = Archive()..addFile(file('hibiki.db'));
-      expect(BackupService.archiveBooksPrefix(archive), 'hoshi_books');
+      expect(BackupRestoreService.archiveBooksPrefix(archive), 'hoshi_books');
     });
   });
 
@@ -187,7 +189,7 @@ void main() {
       final String dstVideos = p.join(dst.path, 'videos');
       Directory(dstDbDir).createSync(recursive: true);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDbDir,
         zipPath: zip,
         categories: <BackupCategory>{BackupCategory.books},

--- a/fushi/test/sync/backup_import_keep_settings_local_audio_test.dart
+++ b/fushi/test/sync/backup_import_keep_settings_local_audio_test.dart
@@ -85,7 +85,7 @@ void main() {
     await srcDb.close();
 
     // ── Overwrite import KEEPING this device's settings (DB already closed). ──
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       importSettings: false,

--- a/fushi/test/sync/backup_import_overwrite_category_strip_test.dart
+++ b/fushi/test/sync/backup_import_overwrite_category_strip_test.dart
@@ -74,7 +74,7 @@ void main() {
       {required Directory curRoot}) async {
     final String curDbDir = p.join(curRoot.path, 'support');
     Directory(curDbDir).createSync(recursive: true);
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
       importSettings: true,

--- a/fushi/test/sync/backup_import_preserve_test.dart
+++ b/fushi/test/sync/backup_import_preserve_test.dart
@@ -61,7 +61,7 @@ void main() {
     await srcDb.close();
 
     // ── Import the backup into this device (DB already closed) ──
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: currentDir.path,
       zipPath: zipPath,
     );
@@ -110,7 +110,7 @@ void main() {
       }),
     );
 
-    await BackupService.recoverPendingRestore(dir.path);
+    await BackupRestoreService.recoverPendingRestore(dir.path);
 
     final db2 = FushiDatabase(dir.path);
     addTearDown(db2.close);
@@ -183,7 +183,7 @@ void main() {
     await srcDb.close();
 
     // ── Overwrite-import into this device (DB closed first) ──
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: currentDir.path,
       zipPath: zipPath,
       dictionaryResourceDirectory: dictResDir.path,
@@ -259,7 +259,7 @@ void main() {
     ).createBackup(zipPath); // null categories = everything, includes dict
     await srcDb2.close();
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: currentDir.path,
       zipPath: zipPath,
       dictionaryResourceDirectory: dictResDir.path,

--- a/fushi/test/sync/backup_import_streaming_guard_test.dart
+++ b/fushi/test/sync/backup_import_streaming_guard_test.dart
@@ -12,6 +12,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'backup_service_source_corpus.dart';
+
 void main() {
   String read(String rel) {
     final File f = File(rel);
@@ -21,24 +23,31 @@ void main() {
 
   group('TODO-1183 备份导入流式落盘 / failed 态守卫', () {
     test('backup_service：导入/合并路径不再把整个条目 materialize 后 writeAsBytes', () {
-      // B1 分家：恢复 / 合并路径在 restore.part.dart；负向断言两边一起扫，正向
-      // 断言只认恢复侧。
-      final String src = read('lib/src/sync/backup_service/restore.part.dart') +
-          read('lib/src/sync/backup_service.dart');
+      // B1 分家：恢复 / 合并路径搬进了 restore.part.dart。两类断言的数据源**不同**，
+      // 不能像最初那样拼成一个串喂给两边：
+      //   · 正向（「流式基础设施在场」）只认恢复侧那一个文件。拼起来扫等于把锁松成
+      //     「库里某处有流式就行」——今天导出侧用的是 `Isolate.run(` 而不是
+      //     `Isolate.spawn(`，所以还没假绿，但那是巧合不是保证。
+      //   · 负向（「不得 materialize 整条目」）要扫**整份合并语料**（主壳 + 全部
+      //     part），否则谁把裸 writeAsBytes 写进新加的 part，这几条就真空通过。
+      final String restoreSrc =
+          read('lib/src/sync/backup_service/restore.part.dart');
+      final String corpus = readBackupServiceSource();
+
       // 旧的整条目 materialize 直写必须消失（meta.content 仍可，因为它极小）。
-      expect(src.contains('writeAsBytes(dbFile.content'), isFalse,
+      expect(corpus.contains('writeAsBytes(dbFile.content'), isFalse,
           reason: 'DB 覆盖必须流式，不得 writeAsBytes 整个 DB（OOM 根因）');
-      expect(src.contains('writeAsBytes(file.content'), isFalse,
+      expect(corpus.contains('writeAsBytes(file.content'), isFalse,
           reason: 'local_audio DB（可数 GB）必须流式落盘');
-      expect(src.contains('entry.key.content as List<int>'), isFalse,
+      expect(corpus.contains('entry.key.content as List<int>'), isFalse,
           reason: '内容树/词典资源必须流式落盘，不得整条目读进堆');
-      // 流式 + 后台 isolate 基础设施在场。
-      expect(src.contains('_extractEntriesStreaming'), isTrue);
-      expect(src.contains('OutputFileStream'), isTrue,
+      // 流式 + 后台 isolate 基础设施必须在**恢复侧**在场。
+      expect(restoreSrc.contains('_extractEntriesStreaming'), isTrue);
+      expect(restoreSrc.contains('OutputFileStream'), isTrue,
           reason: '必须用 OutputFileStream 分块落盘');
-      expect(src.contains('Isolate.spawn('), isTrue,
+      expect(restoreSrc.contains('Isolate.spawn('), isTrue,
           reason: '重解压/落盘必须在后台 isolate，避免冻结 UI isolate（进度卡死）');
-      expect(src.contains('file.rawContent'), isTrue,
+      expect(restoreSrc.contains('file.rawContent'), isTrue,
           reason:
               '走 rawContent 分块流式（archive 3.6.1 writeContent 会 materialize）');
     });

--- a/fushi/test/sync/backup_import_streaming_guard_test.dart
+++ b/fushi/test/sync/backup_import_streaming_guard_test.dart
@@ -21,7 +21,10 @@ void main() {
 
   group('TODO-1183 备份导入流式落盘 / failed 态守卫', () {
     test('backup_service：导入/合并路径不再把整个条目 materialize 后 writeAsBytes', () {
-      final String src = read('lib/src/sync/backup_service.dart');
+      // B1 分家：恢复 / 合并路径在 restore.part.dart；负向断言两边一起扫，正向
+      // 断言只认恢复侧。
+      final String src = read('lib/src/sync/backup_service/restore.part.dart') +
+          read('lib/src/sync/backup_service.dart');
       // 旧的整条目 materialize 直写必须消失（meta.content 仍可，因为它极小）。
       expect(src.contains('writeAsBytes(dbFile.content'), isFalse,
           reason: 'DB 覆盖必须流式，不得 writeAsBytes 整个 DB（OOM 根因）');
@@ -41,7 +44,7 @@ void main() {
     });
 
     test('backup_service：restoreBackup/mergeRestoreBackup 暴露 onProgress', () {
-      final String src = read('lib/src/sync/backup_service.dart');
+      final String src = read('lib/src/sync/backup_service/restore.part.dart');
       expect(src.contains('void Function(double progress)? onProgress'), isTrue,
           reason: '导入必须能把确定进度回报给遮罩');
     });

--- a/fushi/test/sync/backup_local_audio_portability_test.dart
+++ b/fushi/test/sync/backup_local_audio_portability_test.dart
@@ -135,7 +135,8 @@ void main() {
 
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
-      await BackupService.restoreBackup(dbDirectory: dstDbDir, zipPath: zip);
+      await BackupRestoreService.restoreBackup(
+          dbDirectory: dstDbDir, zipPath: zip);
 
       expect(File(p.join(dstDbDir, 'local_audio_111.db')).existsSync(), isTrue);
 
@@ -200,7 +201,8 @@ void main() {
       Directory(dstDbDir).createSync(recursive: true);
       // Fresh device (no current DB), so there is nothing to preserve from bak;
       // the imported registry is simply absent.
-      await BackupService.restoreBackup(dbDirectory: dstDbDir, zipPath: zip);
+      await BackupRestoreService.restoreBackup(
+          dbDirectory: dstDbDir, zipPath: zip);
 
       final FushiDatabase restored = FushiDatabase(dstDbDir);
       try {

--- a/fushi/test/sync/backup_merge_audio_source_restore_test.dart
+++ b/fushi/test/sync/backup_merge_audio_source_restore_test.dart
@@ -51,7 +51,7 @@ void main() {
     await seed.setPref('audio_source_configs', 'j:[]');
     await seed.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
     );
@@ -105,7 +105,7 @@ void main() {
         'j:[{"kind":"localAudio","label":"DEVICE_OWN"}]');
     await seed.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
     );

--- a/fushi/test/sync/backup_merge_category_selection_test.dart
+++ b/fushi/test/sync/backup_merge_category_selection_test.dart
@@ -77,7 +77,7 @@ void main() {
     // Every category EXCEPT statistics.
     final Set<BackupCategory> categories = BackupCategory.values.toSet()
       ..remove(BackupCategory.statistics);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
       categories: categories,
@@ -101,7 +101,7 @@ void main() {
 
     final Set<BackupCategory> categories = BackupCategory.values.toSet()
       ..remove(BackupCategory.books);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
       categories: categories,
@@ -132,7 +132,7 @@ void main() {
     final String curDbDir = p.join(curRoot.path, 'support');
     Directory(curDbDir).createSync(recursive: true);
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
       booksRootDirectory: p.join(curRoot.path, 'documents', 'fushi_books'),

--- a/fushi/test/sync/backup_merge_collection_tags_test.dart
+++ b/fushi/test/sync/backup_merge_collection_tags_test.dart
@@ -48,7 +48,7 @@ void main() {
     await src.close();
 
     // ── 合并导入 ──────────────────────────────────────────────────────────────
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
     );

--- a/fushi/test/sync/backup_merge_collection_tombstone_test.dart
+++ b/fushi/test/sync/backup_merge_collection_tombstone_test.dart
@@ -69,7 +69,7 @@ void main() {
     await src.close();
 
     // ── 合并导入 ──────────────────────────────────────────────────────────────
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
     );

--- a/fushi/test/sync/backup_merge_import_test.dart
+++ b/fushi/test/sync/backup_merge_import_test.dart
@@ -66,7 +66,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
     );
@@ -115,10 +115,10 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
     // Re-import the SAME backup again — must stay idempotent.
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -169,10 +169,10 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
     // Re-import the SAME backup again — must stay idempotent.
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -239,7 +239,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -272,9 +272,9 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -345,9 +345,9 @@ void main() {
     await src.close();
 
     // Import twice — must stay idempotent (MAX, never SUM).
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -413,9 +413,9 @@ void main() {
     await src.close();
 
     // 导两遍——幂等（MAX，绝不 SUM）。
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -498,9 +498,9 @@ void main() {
     await src.close();
 
     // 导两遍——幂等。
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -553,7 +553,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -587,7 +587,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -643,7 +643,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -722,7 +722,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -792,9 +792,9 @@ void main() {
     await src.close();
 
     // 导两遍——幂等（dedupe-UNION，绝不翻倍）。
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -857,7 +857,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -904,7 +904,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -929,7 +929,7 @@ void main() {
     final zip2 = p.join(zipDir.path, 'b2.zip');
     await _exportZip(src2, src2Dir.path, zip2);
     await src2.close();
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip2);
     final pos2 = await after.getReaderPosition(afterUid);
     expect(pos2!.sectionIndex, 9); // unchanged — older backup ignored
@@ -967,7 +967,7 @@ void main() {
     ).createBackup(zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
       booksRootDirectory: booksRoot.path,
@@ -1011,7 +1011,7 @@ void main() {
     await src.close();
 
     // Must NOT throw (FK preserved) and must skip the ghost bookmark.
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -1052,7 +1052,8 @@ void main() {
     await _zipDbWithMeta(corruptDb.path, zip);
 
     await expectLater(
-      BackupService.mergeRestoreBackup(dbDirectory: curDir.path, zipPath: zip),
+      BackupRestoreService.mergeRestoreBackup(
+          dbDirectory: curDir.path, zipPath: zip),
       throwsA(anything),
     );
 
@@ -1120,7 +1121,8 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.restoreBackup(dbDirectory: curDir.path, zipPath: zip);
+    await BackupRestoreService.restoreBackup(
+        dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
     addTearDown(after.close);
@@ -1154,7 +1156,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -1211,7 +1213,7 @@ void main() {
     await src.close();
 
     // Preview runs against the STILL-OPEN live DB (attaches, counts, detaches).
-    final preview = await BackupService.previewMergeRestore(
+    final preview = await BackupRestoreService.previewMergeRestore(
       liveDb: cur,
       dbDirectory: curDir.path,
       zipPath: zip,
@@ -1245,7 +1247,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    final preview = await BackupService.previewMergeRestore(
+    final preview = await BackupRestoreService.previewMergeRestore(
       liveDb: cur,
       dbDirectory: curDir.path,
       zipPath: zip,
@@ -1304,7 +1306,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
     );
@@ -1357,7 +1359,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
     );
@@ -1407,9 +1409,9 @@ void main() {
     await src.close();
 
     // 连续合并两次同一备份：合集不翻倍、成员不重复。
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -1464,7 +1466,7 @@ void main() {
     ).createBackup(zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
       booksRootDirectory: booksRoot.path,
@@ -1518,7 +1520,7 @@ void main() {
     ).createBackup(zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
       booksRootDirectory: booksRoot.path,
@@ -1556,7 +1558,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
       adoptSourcePreferences: true,
@@ -1588,7 +1590,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);

--- a/fushi/test/sync/backup_merge_srt_tombstone_test.dart
+++ b/fushi/test/sync/backup_merge_srt_tombstone_test.dart
@@ -85,7 +85,7 @@ void main() {
     await seed.deleteEpubBook('B1', tombstone: true);
     await seed.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
     );
@@ -147,7 +147,7 @@ void main() {
     await seed.deleteEpubBook('Other', tombstone: true); // unrelated tombstone
     await seed.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDbDir,
       zipPath: zip,
     );

--- a/fushi/test/sync/backup_rename_retry_test.dart
+++ b/fushi/test/sync/backup_rename_retry_test.dart
@@ -8,7 +8,7 @@ import 'package:fushi/src/sync/backup_service.dart';
 /// just-written tree briefly locks it, so the rename fails with
 /// ERROR_ACCESS_DENIED(5) / SHARING_VIOLATION(32) / DIR_NOT_EMPTY(145) — the
 /// "备份导入失败: Rename failed … 拒绝访问" the user hit.
-/// [BackupService.renameDirectoryWithRetry] must bounded-retry those transient
+/// [renameDirectoryWithRetry] must bounded-retry those transient
 /// codes (rethrow when exhausted), and ONLY on Windows / ONLY for transient
 /// codes (non-Windows or non-transient rethrows immediately).
 void main() {
@@ -18,11 +18,11 @@ void main() {
         OSError('拒绝访问。', code),
       );
 
-  group('BackupService.renameDirectoryWithRetry', () {
+  group('renameDirectoryWithRetry', () {
     test('happy path: 一次成功，不重试', () async {
       int renameCalls = 0;
       int sleepCalls = 0;
-      await BackupService.renameDirectoryWithRetry(
+      await renameDirectoryWithRetry(
         rename: () async => renameCalls++,
         sleep: (_) async => sleepCalls++,
         isWindows: true,
@@ -34,7 +34,7 @@ void main() {
     test('Windows 瞬时 errno 5 两次后成功：重试救回', () async {
       int renameCalls = 0;
       int sleepCalls = 0;
-      await BackupService.renameDirectoryWithRetry(
+      await renameDirectoryWithRetry(
         rename: () async {
           renameCalls++;
           if (renameCalls <= 2) throw winError(5);
@@ -49,7 +49,7 @@ void main() {
     test('Windows SHARING_VIOLATION(32) / DIR_NOT_EMPTY(145) 也当瞬时重试', () async {
       for (final int code in <int>[32, 145]) {
         int renameCalls = 0;
-        await BackupService.renameDirectoryWithRetry(
+        await renameDirectoryWithRetry(
           rename: () async {
             renameCalls++;
             if (renameCalls == 1) throw winError(code);
@@ -65,7 +65,7 @@ void main() {
       int renameCalls = 0;
       int sleepCalls = 0;
       await expectLater(
-        BackupService.renameDirectoryWithRetry(
+        renameDirectoryWithRetry(
           rename: () async {
             renameCalls++;
             throw winError(5);
@@ -82,7 +82,7 @@ void main() {
     test('Windows 非瞬时码（如 2 not found）立即抛', () async {
       int renameCalls = 0;
       await expectLater(
-        BackupService.renameDirectoryWithRetry(
+        renameDirectoryWithRetry(
           rename: () async {
             renameCalls++;
             throw winError(2);
@@ -98,7 +98,7 @@ void main() {
     test('用尽 maxAttempts 后抛出最后一个异常', () async {
       int renameCalls = 0;
       await expectLater(
-        BackupService.renameDirectoryWithRetry(
+        renameDirectoryWithRetry(
           rename: () async {
             renameCalls++;
             throw winError(5);

--- a/fushi/test/sync/backup_service_source_corpus.dart
+++ b/fushi/test/sync/backup_service_source_corpus.dart
@@ -1,0 +1,25 @@
+import '../helpers/part_corpus.dart';
+
+/// B1 分家：`backup_service.dart` 拆成主壳 + `backup_service/*.part.dart`
+/// （`fs_retry` / `path_rebase` / `restore`）。这是本仓第 5 份「主壳 + part 目录」
+/// 型语料。
+///
+/// 为什么必须接上磁盘枚举而不是各守卫自己 `read('...part.dart')`：备份/恢复域的
+/// 静态守卫里有大量**负向**断言（「不得再 materialize 整个条目」「不得裸
+/// writeAsBytes」「不得泄漏 device-local 表」）。负向断言的天然弱点是**语料少读一个
+/// 文件照样绿**——不是被禁的写法真的没了，是根本没扫到那个文件。本 PR 刚把恢复链
+/// 整体搬进 part，下一个人再往 `backup_service/` 加一个 part 时，任何硬编码文件名
+/// 的守卫都会对它失明，而且没有任何反馈。
+///
+/// 路径从磁盘枚举 + 排序（跨机器/跨次运行顺序确定），新 part 自动进语料。
+const String _backupServiceShell = 'lib/src/sync/backup_service.dart';
+const String kBackupServicePartDir = 'lib/src/sync/backup_service';
+
+/// 主壳 + 磁盘上全部 `*.part.dart`（按路径排序）。
+List<String> backupServiceFiles() => partCorpusFiles(
+      shell: _backupServiceShell,
+      partDir: kBackupServicePartDir,
+    );
+
+/// 读「备份服务合并语料」：主壳 + 全部 part 拼成单个字符串，CRLF 归一成 LF。
+String readBackupServiceSource() => readPartCorpus(backupServiceFiles());

--- a/fushi/test/sync/backup_service_source_corpus_test.dart
+++ b/fushi/test/sync/backup_service_source_corpus_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/part_corpus_disk_guard.dart';
+import 'backup_service_source_corpus.dart';
+
+/// 备份服务「合并语料」自身的守卫。
+///
+/// 备份/恢复域的静态守卫里带着这一批负向断言：「不得 materialize 整个条目再
+/// writeAsBytes」「device-local 表不得进备份包」。它们全都是「语料少读一个文件就
+/// 静默真空通过」的形状，而本域刚从单文件拆成主壳 + part 目录。
+///
+/// 路径字面量在这里**故意再写一遍**，不从语料文件导入——见
+/// `helpers/part_corpus_disk_guard.dart` 里「不要和被守对象共用同一个枚举」的说明。
+void main() {
+  group('备份服务合并语料覆盖磁盘上的全部 part', () {
+    test('主壳 + 每个 part 都在清单里、顺序确定（漏登记 = 负向断言真空通过）', () {
+      expectPartManifestMatchesDisk(
+        manifest: backupServiceFiles(),
+        shellPath: 'lib/src/sync/backup_service.dart',
+        partDirPath: 'lib/src/sync/backup_service',
+      );
+    });
+
+    test('每个 part 的内容真的进了语料（不只是路径进了清单）', () {
+      expectPartContentsInCorpus(
+        manifest: backupServiceFiles(),
+        corpus: readBackupServiceSource(),
+      );
+    });
+  });
+}

--- a/fushi/test/sync/backup_service_test.dart
+++ b/fushi/test/sync/backup_service_test.dart
@@ -89,40 +89,25 @@ void main() {
     });
 
     test('validateBackup returns null for non-zip file', () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
       final fakePath = '${tmpDir.path}/fake.zip';
       await File(fakePath).writeAsString('not a zip file');
-      final result = await service.validateBackup(fakePath);
+      final result = await BackupRestoreService.validateBackup(fakePath);
       expect(result, isNull);
     });
 
     test('validateBackup returns null for zip without metadata', () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
       final archive = Archive();
       archive.addFile(ArchiveFile('random.txt', 5, utf8.encode('hello')));
       final zipData = ZipEncoder().encode(archive)!;
       final zipPath = '${tmpDir.path}/no_meta.zip';
       await File(zipPath).writeAsBytes(zipData);
 
-      final result = await service.validateBackup(zipPath);
+      final result = await BackupRestoreService.validateBackup(zipPath);
       expect(result, isNull);
     });
 
     test('validateBackup returns null for zip with metadata but no db',
         () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
       final meta = BackupMeta(
         appVersion: '1.0.0',
         schemaVersion: 13,
@@ -138,16 +123,11 @@ void main() {
       final zipPath = '${tmpDir.path}/no_db.zip';
       await File(zipPath).writeAsBytes(zipData);
 
-      final result = await service.validateBackup(zipPath);
+      final result = await BackupRestoreService.validateBackup(zipPath);
       expect(result, isNull);
     });
 
     test('validateBackup returns metadata for valid backup zip', () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
       final meta = BackupMeta(
         appVersion: '1.0.0',
         schemaVersion: 13,
@@ -165,7 +145,7 @@ void main() {
       final zipPath = '${tmpDir.path}/valid.zip';
       await File(zipPath).writeAsBytes(zipData);
 
-      final result = await service.validateBackup(zipPath);
+      final result = await BackupRestoreService.validateBackup(zipPath);
       expect(result, isNotNull);
       expect(result!.appVersion, '1.0.0');
       expect(result.schemaVersion, 13);
@@ -174,13 +154,8 @@ void main() {
     });
 
     test('validateBackup returns null for nonexistent file', () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
-      final result =
-          await service.validateBackup('${tmpDir.path}/nonexistent.zip');
+      final result = await BackupRestoreService.validateBackup(
+          '${tmpDir.path}/nonexistent.zip');
       expect(result, isNull);
     });
 
@@ -213,7 +188,7 @@ void main() {
       final zipPath = '${tmpDir.path}/restore.zip';
       await File(zipPath).writeAsBytes(zipData);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: tmpDir.path,
         zipPath: zipPath,
       );
@@ -259,7 +234,7 @@ void main() {
         expect(meta.bookCount, 1);
 
         // Validate the produced zip
-        final result = await service.validateBackup(outputPath);
+        final result = await BackupRestoreService.validateBackup(outputPath);
         expect(result, isNotNull);
         expect(result!.bookCount, 1);
         expect(result.appVersion, '2.0.0');
@@ -419,7 +394,7 @@ void main() {
         final restoredDictDir = await Directory.systemTemp
             .createTemp('backup_dict_enabled_resources_r_');
         await File('${restoreDir.path}/fushi.db').writeAsBytes(dbBytes);
-        await BackupService.restoreBackup(
+        await BackupRestoreService.restoreBackup(
           dbDirectory: restoreDir.path,
           zipPath: outputPath,
           dictionaryResourceDirectory: restoredDictDir.path,
@@ -550,7 +525,7 @@ void main() {
           await File('${dstDictDir.path}/OldDict/media/old.png')
               .writeAsString('stale image');
 
-          await BackupService.restoreBackup(
+          await BackupRestoreService.restoreBackup(
             dbDirectory: dstDir.path,
             zipPath: outputPath,
             dictionaryResourceDirectory: dstDictDir.path,
@@ -619,7 +594,7 @@ void main() {
             .writeAsString('stale index');
 
         await expectLater(
-          BackupService.restoreBackup(
+          BackupRestoreService.restoreBackup(
             dbDirectory: dstDir.path,
             zipPath: zipPath,
             dictionaryResourceDirectory: dstDictDir.path,
@@ -680,7 +655,7 @@ void main() {
       // Restore into a fresh directory and reopen — data must survive.
       final dstDir = await Directory.systemTemp.createTemp('backup_dst_');
       try {
-        await BackupService.restoreBackup(
+        await BackupRestoreService.restoreBackup(
           dbDirectory: dstDir.path,
           zipPath: '${tmpDir.path}/round_trip.zip',
         );
@@ -706,11 +681,6 @@ void main() {
     });
 
     test('validateBackup rejects oversized files', () async {
-      final service = BackupService(
-        db: db,
-        dbDirectory: tmpDir.path,
-        appVersion: '1.0.0',
-      );
       // Create a file larger than 512 MB check
       // We can't actually create 512MB in a test, but we can verify the size
       // check path by confirming a valid small zip passes.
@@ -733,7 +703,7 @@ void main() {
       await File(zipPath).writeAsBytes(zipData);
 
       // Small file should pass
-      final result = await service.validateBackup(zipPath);
+      final result = await BackupRestoreService.validateBackup(zipPath);
       expect(result, isNotNull);
     });
   });
@@ -774,7 +744,7 @@ void main() {
       // verbatim with nothing preserved — exposing exactly what the ZIP holds.
       final dstDir = await Directory.systemTemp.createTemp('hibiki_strip_dst_');
       addTearDown(() => cleanupTempDir(dstDir));
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDir.path,
         zipPath: zipPath,
       );
@@ -849,7 +819,7 @@ void main() {
 
       final dstDir = await Directory.systemTemp.createTemp('hibiki_ns_dst_');
       addTearDown(() => cleanupTempDir(dstDir));
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
           dbDirectory: dstDir.path, zipPath: zipPath);
 
       final dstDb = FushiDatabase(dstDir.path);
@@ -912,7 +882,7 @@ void main() {
 
       final dstDir = await Directory.systemTemp.createTemp('hibiki_ps_dst_');
       addTearDown(() => cleanupTempDir(dstDir));
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
           dbDirectory: dstDir.path, zipPath: zipPath);
 
       final dstDb = FushiDatabase(dstDir.path);
@@ -964,7 +934,7 @@ void main() {
       }
       await localDb.close();
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
           dbDirectory: dstDir.path, zipPath: zipPath);
 
       final dstDb = FushiDatabase(dstDir.path);
@@ -1041,12 +1011,12 @@ void main() {
       await srcDb.close();
 
       // ── Import keeping local settings, then simulate the startup restore ──
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: curDir.path,
         zipPath: zipPath,
         importSettings: false,
       );
-      await BackupService.recoverPendingRestore(curDir.path);
+      await BackupRestoreService.recoverPendingRestore(curDir.path);
 
       final after = FushiDatabase(curDir.path);
       addTearDown(after.close);
@@ -1115,12 +1085,12 @@ void main() {
       // Import into an EMPTY dir (no current DB) with importSettings:false.
       final dstDir = await Directory.systemTemp.createTemp('hibiki_fresh_dst_');
       addTearDown(() => cleanupTempDir(dstDir));
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDir.path,
         zipPath: zipPath,
         importSettings: false,
       );
-      await BackupService.recoverPendingRestore(dstDir.path);
+      await BackupRestoreService.recoverPendingRestore(dstDir.path);
 
       final after = FushiDatabase(dstDir.path);
       addTearDown(after.close);
@@ -1146,7 +1116,8 @@ void main() {
       await File('${dir.path}/fushi.db.sync-preserve.json')
           .writeAsString(jsonEncode(<String, dynamic>{'mode': 'settings'}));
 
-      await BackupService.recoverPendingRestore(dir.path); // must not throw
+      await BackupRestoreService.recoverPendingRestore(
+          dir.path); // must not throw
 
       final after = FushiDatabase(dir.path);
       addTearDown(after.close);

--- a/fushi/test/sync/backup_share_sanitization_test.dart
+++ b/fushi/test/sync/backup_share_sanitization_test.dart
@@ -327,7 +327,7 @@ void main() {
           ]));
       await cur0.close();
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: curDbDir,
         zipPath: zip,
         importSettings: true,

--- a/fushi/test/sync/backup_srt_path_rebase_test.dart
+++ b/fushi/test/sync/backup_srt_path_rebase_test.dart
@@ -11,7 +11,7 @@ import 'temp_dir_cleanup.dart';
 /// BUG-1575：合并/覆盖导入必须把 `srt_books` 的四列路径 rebase 到本机根。
 ///
 /// 真实故障：用户把互联下载来的 6 本 SRT 有声书经 hibiki → fushi 改名迁移
-/// （`MigrationImporter` → `BackupService.mergeRestoreBackup`）带过来，合并引擎
+/// （`MigrationImporter` → `BackupRestoreService.mergeRestoreBackup`）带过来，合并引擎
 /// 逐列原样 INSERT `srt_books`，而 `_rebaseContentPaths` 只遍历 `epub_books` /
 /// `audiobooks` → srt 行带着**旧数据根**进了新库 = 有字幕没声音（cue 存在
 /// `audio_cues`，不带路径）。
@@ -86,7 +86,7 @@ void main() {
     final String dstAudio = p.join(dst.path, 'audiobooks');
     Directory(dstDbDir).createSync(recursive: true);
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: dstBooks,
@@ -124,7 +124,7 @@ void main() {
     final String dstAudio = p.join(dst.path, 'audiobooks');
     Directory(dstDbDir).createSync(recursive: true);
 
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: p.join(dst.path, 'fushi_books'),
@@ -159,7 +159,7 @@ void main() {
     final String dstAudio = p.join(dst.path, 'audiobooks');
     Directory(dstDbDir).createSync(recursive: true);
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: dstDbDir,
       zipPath: zipPath,
       booksRootDirectory: p.join(dst.path, 'fushi_books'),

--- a/fushi/test/sync/backup_video_import_selectable_test.dart
+++ b/fushi/test/sync/backup_video_import_selectable_test.dart
@@ -93,7 +93,8 @@ void main() {
         );
 
     test('meta.videoBookCount>0 shows videos even with NO packed files', () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db', 'backup_meta.json'],
         metaWith(videoBookCount: 3),
       );
@@ -102,7 +103,8 @@ void main() {
     });
 
     test('meta.videoBookCount==0 hides videos (unticked new backup)', () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db'],
         metaWith(videoBookCount: 0),
         dbVideoBookCount: 9, // authoritative meta 0 must win over any peek
@@ -111,7 +113,8 @@ void main() {
     });
 
     test('old backup (meta lacks the field) falls back to the DB peek', () {
-      final BackupContentSummary s = BackupService.summarizeBackupEntries(
+      final BackupContentSummary s =
+          BackupRestoreService.summarizeBackupEntries(
         <String>['hibiki.db'],
         metaWith(), // videoBookCount == null
         dbVideoBookCount: 2,
@@ -157,12 +160,8 @@ void main() {
     final String zip = p.join(src.path, 'old_backup.zip');
     File(zip).writeAsBytesSync(ZipEncoder().encode(archive)!);
 
-    final FushiDatabase dummy =
-        FushiDatabase.forTesting(NativeDatabase.memory());
-    final BackupService service =
-        BackupService(db: dummy, dbDirectory: src.path, appVersion: '1.0.0');
-    final BackupContentSummary summary = await service.summarizeBackupFile(zip);
-    await dummy.close();
+    final BackupContentSummary summary =
+        await BackupRestoreService.summarizeBackupFile(zip);
 
     expect(summary.has(BackupCategory.videos), isTrue,
         reason: 'the DB-blob peek must reveal the 2 video rows');
@@ -198,7 +197,7 @@ void main() {
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDbDir,
         zipPath: zip,
         categories: BackupCategory.values.toSet()
@@ -215,7 +214,7 @@ void main() {
       final String dstDbDir = p.join(dst.path, 'db');
       Directory(dstDbDir).createSync(recursive: true);
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: dstDbDir,
         zipPath: zip, // null categories = restore everything (incl. videos)
       );

--- a/fushi/test/sync/backup_video_reachability_test.dart
+++ b/fushi/test/sync/backup_video_reachability_test.dart
@@ -52,7 +52,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final after = FushiDatabase(curDir.path);
@@ -91,7 +91,7 @@ void main() {
 
     final curVideos = await _tempDir('vr_curvid_');
     addTearDown(() => cleanupTempDir(curVideos));
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
       dbDirectory: curDir.path,
       zipPath: zip,
       videosRootDirectory: curVideos.path,
@@ -121,7 +121,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    final preview = await BackupService.previewMergeRestore(
+    final preview = await BackupRestoreService.previewMergeRestore(
       liveDb: cur,
       dbDirectory: curDir.path,
       zipPath: zip,
@@ -156,11 +156,7 @@ void main() {
     final zip = p.join(zipDir.path, 'b.zip');
     await _exportZip(src, srcDir.path, zip);
 
-    final meta = await BackupService(
-      db: src,
-      dbDirectory: srcDir.path,
-      appVersion: '2.0.0',
-    ).validateBackup(zip);
+    final meta = await BackupRestoreService.validateBackup(zip);
     await src.close();
 
     expect(meta != null, true);

--- a/fushi/test/sync/book_rename_cross_device_test.dart
+++ b/fushi/test/sync/book_rename_cross_device_test.dart
@@ -140,7 +140,7 @@ void main() {
 
     // 「不勾 settings 导出」= 按该谓词删掉 preferences 行。
     await db.customStatement(
-      'DELETE FROM preferences WHERE ${BackupService.settingsPrefPredicate}',
+      'DELETE FROM preferences WHERE $settingsPrefPredicate',
     );
 
     final Map<String, String> rest = await db.getAllPrefs();

--- a/fushi/test/sync/favorite_sentence_merge_import_test.dart
+++ b/fushi/test/sync/favorite_sentence_merge_import_test.dart
@@ -85,10 +85,10 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
     // Re-import the SAME backup -> must stay idempotent (no duplicates).
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final FushiDatabase after = FushiDatabase(curDir.path);
@@ -140,7 +140,7 @@ void main() {
     await _exportZip(src, srcDir.path, zip);
     await src.close();
 
-    await BackupService.mergeRestoreBackup(
+    await BackupRestoreService.mergeRestoreBackup(
         dbDirectory: curDir.path, zipPath: zip);
 
     final FushiDatabase after = FushiDatabase(curDir.path);

--- a/fushi/test/sync/temp_dir_cleanup.dart
+++ b/fushi/test/sync/temp_dir_cleanup.dart
@@ -13,11 +13,10 @@ import 'package:fushi/src/sync/backup_service.dart';
 /// non-deterministically when many sync suites run in parallel (TODO-1011).
 ///
 /// Routes through the production-grade
-/// [BackupService.deleteDirectoryWithRetry] (BUG-272) so the teardown matches
+/// [deleteDirectoryWithRetry] (BUG-272) so the teardown matches
 /// the bounded, backing-off cleanup the app itself uses, instead of failing on
 /// a transient handle release. A genuine non-transient failure still surfaces.
-Future<void> cleanupTempDir(Directory dir) =>
-    BackupService.deleteDirectoryWithRetry(
+Future<void> cleanupTempDir(Directory dir) => deleteDirectoryWithRetry(
       exists: dir.exists,
       delete: () => dir.delete(recursive: true),
       sleep: (int ms) => Future<void>.delayed(Duration(milliseconds: ms)),

--- a/fushi/test/sync/video_download_backup_restore_test.dart
+++ b/fushi/test/sync/video_download_backup_restore_test.dart
@@ -159,7 +159,7 @@ void main() {
 
     final Directory restoredDirectory =
         Directory(p.join(root.path, 'fresh-restored'));
-    await BackupService.restoreBackup(
+    await BackupRestoreService.restoreBackup(
       dbDirectory: restoredDirectory.path,
       zipPath: zipPath,
     );
@@ -202,7 +202,7 @@ void main() {
       await seedDownloadGraph(before, withLocalReferences: true);
       await before.close();
 
-      await BackupService.restoreBackup(
+      await BackupRestoreService.restoreBackup(
         dbDirectory: currentDirectory.path,
         zipPath: zipPath,
       );
@@ -294,7 +294,7 @@ void main() {
       final List<int> sqliteHeader =
           (await File(bakPath).readAsBytes()).take(16).toList(growable: false);
       await File(bakPath).writeAsBytes(sqliteHeader, flush: true);
-      await BackupService.recoverPendingRestore(currentDirectory.path);
+      await BackupRestoreService.recoverPendingRestore(currentDirectory.path);
       expect(File(sidecarPath).existsSync(), isTrue);
       expect(File(bakPath).existsSync(), isTrue);
 
@@ -313,12 +313,12 @@ void main() {
 
       await File(bakPath).delete();
       await File(repairBakPath).copy(bakPath);
-      await BackupService.recoverPendingRestore(currentDirectory.path);
+      await BackupRestoreService.recoverPendingRestore(currentDirectory.path);
       expect(File(sidecarPath).existsSync(), isFalse);
       expect(File(bakPath).existsSync(), isFalse);
 
       // A second startup must be a no-op rather than duplicating graph rows.
-      await BackupService.recoverPendingRestore(currentDirectory.path);
+      await BackupRestoreService.recoverPendingRestore(currentDirectory.path);
 
       final FushiDatabase recovered = FushiDatabase(currentDirectory.path);
       addTearDown(recovered.close);


### PR DESCRIPTION
## 同步/互联重构 PR4 · B1：`backup_service.dart` 导出 / 恢复分家

系列计划：`docs/plans/2026-09-06-sync-interconnect-refactor.md`（PR1 #1239、PR2 #1240、PR3 #1241）。**零行为变化**（除删掉 9 个 `@Deprecated` 死转发）。

### 改了什么
4625 行、一个纯 static 类混着 ≥9 种关心点，导出与导入/合并同住。按**调用方向**拆成一个库 + 三个 part（私有 helper 零改名、零可见性重写）：

| 文件 | 内容 |
|---|---|
| `backup_service.dart`（库，1.98k 行） | 顶层：`BackupCategory` / `BackupMeta` / `BackupContentSummary` / `rebasePath` 等原有公共类型与纯函数；**两侧共用的常量与 helper 提到库级顶层**（`_dbName`、各前缀、pref key、`_deviceLocalTables`、`_statisticsTables`、`_stripExcludedDataCategories`、`_retain{Books,Videos,Audiobooks}`、`settingsPrefPredicate` + builder）——引用处一字不改。`BackupService`（导出侧实例类）：`createBackup` / `summarizeLiveContent` / `defaultFilename` + VACUUM/复制、isolate 写 ZIP、剥密钥、按类别删行、收集文件树。 |
| `backup_service/restore.part.dart`（2.05k 行） | 新类 `BackupRestoreService`（全 static）：`restoreBackup` / `mergeRestoreBackup` / `previewMergeRestore` / `recoverMergeRestore` / `recoverPendingRestore` / `validateBackup` / `summarizeBackupFile` / `summarizeBackupEntries` / `archiveBooksPrefix` + 流式解包、设备本地表回填、崩溃恢复、设置层回填。`validateBackup` / `summarizeBackupFile` 原是不碰任何实例字段的实例方法，进恢复类后改 `static`。`_BackupExtractRequest` 随流式解包走。 |
| `backup_service/path_rebase.part.dart`（419 行） | `_rebase*` 十三个函数整族，无状态，只被 restore / merge 调用。 |
| `backup_service/fs_retry.part.dart`（85 行） | `deleteDirectoryWithRetry` / `renameDirectoryWithRetry` 顶层函数 + `_isWindowsTransientFsBusy`。 |

- 拆分由脚本按成员边界（花括号深度解析）搬运，每个成员的文本逐字不变；归属映射来自对整个文件的调用图分析（哪些 helper 只被导出侧 / 只被恢复侧 / 两侧可达）。
- **调用点直接改，不留转发外壳**：lib 5 处（`app_model.dart` 的 `recoverPendingImport` → `BackupRestoreService.recoverPendingRestore`、`migration_import_page.dart`、`backup.part.dart` 5 处——其中导入流程不再为了 `validateBackup` 构造一个导出用的 `BackupService` 实例）+ test 26 个文件 148 处。
- 删除 9 个 `@Deprecated` 转发（`exportBackup` / `importBackupFiles` / `mergeImportBackupFiles` / `summarizeBackupArchive` / `summarizeBackupZip` / `summarizeExportContent` / `previewMergeImport` / `recoverMergeImport` / `recoverPendingImport`）：除 `recoverPendingImport` 一处调用外全无调用方，那一处已改到目标方法。

### 守卫（有意重钉）
- `test/sync/backup_device_local_leak_guard_test.dart`：`_deviceLocalTables` / `_deviceLocalTablesParentFirst` 现在是库级顶层 `const`，锚点去掉 `static`。
- `test/sync/backup_import_streaming_guard_test.dart`：流式解包 / `Isolate.spawn` / `rawContent` / `onProgress` 正向断言改扫 `restore.part.dart`；「不得 materialize 后 writeAsBytes」负向断言两个文件一起扫。
- `test/media/db_source_pref_key_test.dart`（六个 `src:reader_fushi:*` 字面量）与 `test/tools/fushi_rename_guard_test.dart`（`hoshi_books` 只许在 `backup_service.dart`）：两个常量都留在主文件顶层，守卫不动、仍绿。

### 测试
- 全部 `test/sync/backup_*_test.dart`（26 个，含 1600 行的 `backup_merge_import_test`）+ `video_download_backup_restore` / `favorite_sentence_merge_import` / `aggregate_study_segments_sync` / `book_rename_cross_device` / `media/db_source_pref_key` / `tools/fushi_rename_guard`：全绿。
- 全量 `flutter analyze`：No issues。
- `git diff --stat`：删 3253 / 加 560（搬家 + 新文件；净减 = 9 个死转发 + 去掉的 `static`/缩进）。

https://claude.ai/code/session_01WPbEes8famqLCXoUjHNLPn
