### PR TITLE
perf: 各处导入 / 加载速度优化（三轮）

### DIFF
--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -436,17 +436,21 @@ void main([List<String> args = const <String>[]]) {
 
     /// Initialise error log service.
     await ErrorLogService.instance.init();
-    await DebugLogService.instance.init();
-    // TODO-1232 A3：读一次 native 持久化的渲染后端选择（关 Impeller 实验开关），
-    // 供设置项同步渲染。非 Android 静默降级为不支持。
-    await RenderBackendService.instance.init();
-    // BUG-209 / TODO-398：把上次运行残留的 Windows WGC 帧捕获生命周期日志
-    // 折进错误日志（仅 Windows），纳入现有上传链路，为 GraphicsCapture 延迟
-    // UAF 崩溃提供可读的崩前生命周期证据。
-    await WgcCaptureLog.foldIntoErrorLog();
-    // BUG-772：把上次运行 present 楔死取证（首帧从未 rasterize）折进错误日志（仅
-    // Windows），纳入上传链路，为 raster/present 管线死锁提供可读崩前证据。
-    await PresentStallLog.foldIntoErrorLog();
+    // 下面四步都只依赖错误日志已就绪、彼此独立（各自读写自己的文件 / 通道），
+    // 并发跑；串行 await 四段小 IO 是启动到 LoadingPage 之前的纯等待。
+    await Future.wait<void>(<Future<void>>[
+      DebugLogService.instance.init(),
+      // TODO-1232 A3：读一次 native 持久化的渲染后端选择（关 Impeller 实验开关），
+      // 供设置项同步渲染。非 Android 静默降级为不支持。
+      RenderBackendService.instance.init(),
+      // BUG-209 / TODO-398：把上次运行残留的 Windows WGC 帧捕获生命周期日志
+      // 折进错误日志（仅 Windows），纳入现有上传链路，为 GraphicsCapture 延迟
+      // UAF 崩溃提供可读的崩前生命周期证据。
+      WgcCaptureLog.foldIntoErrorLog(),
+      // BUG-772：把上次运行 present 楔死取证（首帧从未 rasterize）折进错误日志（仅
+      // Windows），纳入上传链路，为 raster/present 管线死锁提供可读崩前证据。
+      PresentStallLog.foldIntoErrorLog(),
+    ]);
 
     /// Initialise local file-based logging (mobile only).
     if (Platform.isAndroid || Platform.isIOS) {
@@ -944,7 +948,8 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
           '${watch.elapsedMilliseconds}ms: $e');
       return;
     }
-    debugPrint('[Fushi] exit step "$label" took ${watch.elapsedMilliseconds}ms');
+    debugPrint(
+        '[Fushi] exit step "$label" took ${watch.elapsedMilliseconds}ms');
   }
 
   /// Android 退后台不是退出：只做保留式 flush，页面回前台后仍继续持有回调。
@@ -1228,13 +1233,11 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
           // ② 去重：同一物理文件若已库内导入（`video/<basename>` 身份），复用其旧
           // bookUid，不再派生 `video/ext/<sha1>` 第二身份插第二行。按 videoPath 命中
           // 走仓库单一真相源 findByVideoPath（与 isDuplicateVideoPath 同比对语义）。
-          final VideoBookRow? sameFile =
-              await repo.findByVideoPath(videoPath);
+          final VideoBookRow? sameFile = await repo.findByVideoPath(videoPath);
           if (sameFile != null) return sameFile.bookUid;
 
           final String candidateUid = externalVideoBookUid(videoPath);
-          final VideoBookRow? existing =
-              await repo.getByBookUid(candidateUid);
+          final VideoBookRow? existing = await repo.getByBookUid(candidateUid);
           if (existing != null) return candidateUid;
 
           CoverMetaStore? coverMetaStore;

--- a/fushi/lib/src/epub/epub_book.dart
+++ b/fushi/lib/src/epub/epub_book.dart
@@ -124,10 +124,12 @@ class EpubBook {
   /// Whitespace-collapsed plain text of an already-parsed [body], with ruby
   /// annotations (`<rt>`/`<rp>`/`<rtc>`) stripped. Mutates [body] by removing the
   /// ruby nodes, so callers must pass a throwaway parsed document's body.
+  static final RegExp _whitespaceRun = RegExp(r'\s+');
+
   static String _chapterPlainTextFromBody(html_dom.Element? body) {
     _removeRubyAnnotations(body);
     final String raw = body?.text ?? '';
-    return raw.replaceAll(RegExp(r'\s+'), ' ').trim();
+    return raw.replaceAll(_whitespaceRun, ' ').trim();
   }
 
   static void _removeRubyAnnotations(html_dom.Element? root) {

--- a/fushi/lib/src/epub/epub_importer.dart
+++ b/fushi/lib/src/epub/epub_importer.dart
@@ -128,9 +128,10 @@ class EpubImporter {
               ? p.basenameWithoutExtension(fileName)
               : book.title;
 
-      final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
+      // 瘦投影：重复检查只要 title（+ 下面的 extractDir），不拉整库章节 JSON。
+      final List<EpubBookMeta> existingBooks = await db.getEpubBookMetas();
       final String storedTitle = await resolveDuplicateTitle(
-        existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
+        existingTitles: existingBooks.map((EpubBookMeta b) => b.title).toList(),
         proposedTitle: resolvedTitle,
         policy: policy,
       );
@@ -159,7 +160,7 @@ class EpubImporter {
               srcDir: srcDir,
               targetDir: realDir,
               liveExtractDirs:
-                  existingBooks.map((EpubBookRow b) => b.extractDir),
+                  existingBooks.map((EpubBookMeta b) => b.extractDir),
             );
           } catch (e) {
             ErrorLogService.instance

--- a/fushi/lib/src/epub/epub_parser.dart
+++ b/fushi/lib/src/epub/epub_parser.dart
@@ -220,14 +220,17 @@ class EpubParser {
     }
 
     final String canonicalBase = p.canonicalize(extractDir);
+    // 每个条目的安全落盘路径只算一次（`_safeArchivePath` 内含两次 canonicalize，
+    // 以前目录集合与写盘循环各算一遍：一本几千页的漫画 EPUB 白做上万次）。
+    final List<(ArchiveFile, String)> entries = <(ArchiveFile, String)>[
+      for (final ArchiveFile file in archive)
+        if (_safeArchivePath(extractDir, canonicalBase, file.name)
+            case final String filePath)
+          (file, filePath),
+    ];
     final Set<String> archiveDirectories =
-        _archiveDirectoryPaths(archive, extractDir, canonicalBase);
-    for (final ArchiveFile file in archive) {
-      final String? filePath =
-          _safeArchivePath(extractDir, canonicalBase, file.name);
-      if (filePath == null) {
-        continue;
-      }
+        _archiveDirectoryPaths(entries, canonicalBase);
+    for (final (ArchiveFile file, String filePath) in entries) {
       if (file.isFile && !archiveDirectories.contains(filePath)) {
         final File outFile = File(filePath);
         outFile.parent.createSync(recursive: true);
@@ -254,17 +257,11 @@ class EpubParser {
   // valid archive. Treating implied parents as directories is therefore
   // correct and is kept.
   static Set<String> _archiveDirectoryPaths(
-    Archive archive,
-    String extractDir,
+    List<(ArchiveFile, String)> entries,
     String canonicalBase,
   ) {
     final Set<String> directories = <String>{};
-    for (final ArchiveFile file in archive) {
-      final String? filePath =
-          _safeArchivePath(extractDir, canonicalBase, file.name);
-      if (filePath == null) {
-        continue;
-      }
+    for (final (ArchiveFile file, String filePath) in entries) {
       if (!file.isFile) {
         directories.add(filePath);
       }

--- a/fushi/lib/src/media/audiobook/audiobook_alignment_service.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_alignment_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 import 'package:fushi_audio/fushi_audio.dart';
@@ -80,6 +81,15 @@ List<EpubSection> epubSectionsFromExtractDir(String extractDir) {
   );
 }
 
+/// [epubSectionsFromExtractDir] 的后台 isolate 版——生产路径一律走这里。
+///
+/// 每章都要读文件 + 整个 HTML5 DOM 解析 + 剥 ruby，一本几百章的轻小说是几百 MB
+/// 的瞬时 DOM 和数秒的 CPU；匹配器早就放 isolate 了（[EpubCueMatcher.matchInIsolate]），
+/// 这一步是整条对齐链上唯一还留在 UI isolate 的重活。[EpubSection] 是纯数据
+/// （index / href / text），可直接跨 isolate 传回。
+Future<List<EpubSection>> loadEpubSectionsInBackground(String extractDir) =>
+    Isolate.run(() => epubSectionsFromExtractDir(extractDir));
+
 /// 按字幕扩展名分派解析器（原两个导入对话框各持等价副本，已收敛到此单一真相源）。
 Future<List<AudioCue>> parseCuesForFormat(
   File file,
@@ -141,7 +151,7 @@ Future<AudiobookAlignmentResult> alignAndPersistAudiobook({
   try {
     final EpubBookRow? bookRow = await db.getEpubBook(bookKey);
     final String extractDir = bookRow?.extractDir ?? '';
-    sections = epubSectionsFromExtractDir(extractDir);
+    sections = await loadEpubSectionsInBackground(extractDir);
   } catch (e, stack) {
     ErrorLogService.instance
         .log('AudiobookAlignmentService.parseEpub', e, stack);

--- a/fushi/lib/src/media/audiobook/audiobook_alignment_service.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_alignment_service.dart
@@ -87,6 +87,10 @@ List<EpubSection> epubSectionsFromExtractDir(String extractDir) {
 /// 的瞬时 DOM 和数秒的 CPU；匹配器早就放 isolate 了（[EpubCueMatcher.matchInIsolate]），
 /// 这一步是整条对齐链上唯一还留在 UI isolate 的重活。[EpubSection] 是纯数据
 /// （index / href / text），可直接跨 isolate 传回。
+///
+/// 已知权衡：`EpubParser` 内部对坏 nav/ncx 的 `ErrorLogService.log` 落在工作
+/// isolate 的临时实例上，不进主 isolate 的错误日志（与 `EpubImporter` 的导入
+/// isolate 同款）；解析整体失败仍会抛回调用方并由其记日志。
 Future<List<EpubSection>> loadEpubSectionsInBackground(String extractDir) =>
     Isolate.run(() => epubSectionsFromExtractDir(extractDir));
 

--- a/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
@@ -936,9 +936,13 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
     }
     try {
       reportProgress(0.2, t.import_step_reading_idb);
-      // 自动匹配探测已经解析过的话直接复用，否则后台 isolate 解析。
-      final List<EpubSection> sections = _probedSections ??
-          await loadEpubSectionsInBackground(widget.extractDir!);
+      // 自动匹配探测已经解析出章节的话直接复用，否则后台 isolate 解析。探测
+      // 失败时记忆的是空列表（`_loadSectionsForProbe` 吞异常回空），不能拿它
+      // 短路导入——那会把一次瞬时读失败变成「EPUB has 0 chapters」。
+      final List<EpubSection>? probed = _probedSections;
+      final List<EpubSection> sections = probed != null && probed.isNotEmpty
+          ? probed
+          : await loadEpubSectionsInBackground(widget.extractDir!);
       if (sections.isEmpty) {
         return AudiobookHealth.failed(
           reason: 'EPUB has 0 chapters',

--- a/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
+++ b/fushi/lib/src/media/audiobook/audiobook_import_dialog.dart
@@ -6,7 +6,7 @@ import 'package:fushi/src/asr/asr_cue_builder.dart'
 import 'package:fushi/src/asr/asr_transcription_service.dart';
 import 'package:fushi/src/media/audiobook/asr_transcribe_sheet.dart';
 import 'package:fushi/src/media/audiobook/audiobook_alignment_service.dart'
-    show epubSectionsFromExtractDir, parseCuesForFormat;
+    show loadEpubSectionsInBackground, parseCuesForFormat;
 import 'package:fushi/src/media/import/audiobook_health_summary.dart';
 import 'package:fushi/src/media/import/epub_backed_srt_book.dart';
 import 'package:fushi/src/media/import/import_dialog_frame.dart';
@@ -631,7 +631,7 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
       return const <EpubSection>[];
     }
     try {
-      return epubSectionsFromExtractDir(widget.extractDir!);
+      return await loadEpubSectionsInBackground(widget.extractDir!);
     } catch (e, stack) {
       ErrorLogService.instance.log('AudiobookImport.loadSections', e, stack);
       debugPrint('[fushi-audiobook] probe loadSections failed: $e');
@@ -936,8 +936,9 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
     }
     try {
       reportProgress(0.2, t.import_step_reading_idb);
-      final List<EpubSection> sections =
-          epubSectionsFromExtractDir(widget.extractDir!);
+      // 自动匹配探测已经解析过的话直接复用，否则后台 isolate 解析。
+      final List<EpubSection> sections = _probedSections ??
+          await loadEpubSectionsInBackground(widget.extractDir!);
       if (sections.isEmpty) {
         return AudiobookHealth.failed(
           reason: 'EPUB has 0 chapters',

--- a/fushi/lib/src/media/audiobook/book_import_dialog.dart
+++ b/fushi/lib/src/media/audiobook/book_import_dialog.dart
@@ -742,7 +742,7 @@ class _BookImportDialogState extends State<BookImportDialog>
       tmpDir.path,
       'audio_cover_${DateTime.now().millisecondsSinceEpoch}.jpg',
     );
-    for (final String audioPath in _audioPaths.take(kAudioTagProbeLimit)) {
+    for (final String audioPath in _audioPaths) {
       final String? result = await TtsChannel.instance.extractEmbeddedCover(
         audioPath: audioPath,
         outputPath: outputPath,
@@ -753,13 +753,6 @@ class _BookImportDialogState extends State<BookImportDialog>
       }
     }
   }
-
-  /// 封面 / 元数据探测最多看前几个音频文件。
-  ///
-  /// 每次探测都是一个 ffmpeg / ffprobe 子进程；有声书的容器 tag 与内嵌封面要么
-  /// 每个文件都有、要么都没有，一本 100 段、什么都没嵌的有声书以前要串行起
-  /// 200 个进程，用户还在对话框里打字时后台就在一个个 spawn。
-  static const int kAudioTagProbeLimit = 3;
 
   /// TODO-1045：从第一个含 tag 的音频容器（M4B/M4A/MP3…）读标题/作者，**仅当对应
   /// 输入框为空时**回填（复用 sidecar 的「填空不覆盖」闸门，绝不覆盖用户手打的值）。
@@ -776,7 +769,7 @@ class _BookImportDialogState extends State<BookImportDialog>
     if (_audioPaths.isEmpty) return;
     // 两框都已填就无事可做（避免无谓 ffprobe 进程）。
     if (_titleCtrl.text.isNotEmpty && _authorCtrl.text.isNotEmpty) return;
-    for (final String audioPath in _audioPaths.take(kAudioTagProbeLimit)) {
+    for (final String audioPath in _audioPaths) {
       final AudioMetadata? meta =
           await TtsChannel.instance.extractAudioMetadata(audioPath: audioPath);
       if (meta == null) continue;

--- a/fushi/lib/src/media/audiobook/book_import_dialog.dart
+++ b/fushi/lib/src/media/audiobook/book_import_dialog.dart
@@ -742,7 +742,7 @@ class _BookImportDialogState extends State<BookImportDialog>
       tmpDir.path,
       'audio_cover_${DateTime.now().millisecondsSinceEpoch}.jpg',
     );
-    for (final String audioPath in _audioPaths) {
+    for (final String audioPath in _audioPaths.take(kAudioTagProbeLimit)) {
       final String? result = await TtsChannel.instance.extractEmbeddedCover(
         audioPath: audioPath,
         outputPath: outputPath,
@@ -753,6 +753,13 @@ class _BookImportDialogState extends State<BookImportDialog>
       }
     }
   }
+
+  /// 封面 / 元数据探测最多看前几个音频文件。
+  ///
+  /// 每次探测都是一个 ffmpeg / ffprobe 子进程；有声书的容器 tag 与内嵌封面要么
+  /// 每个文件都有、要么都没有，一本 100 段、什么都没嵌的有声书以前要串行起
+  /// 200 个进程，用户还在对话框里打字时后台就在一个个 spawn。
+  static const int kAudioTagProbeLimit = 3;
 
   /// TODO-1045：从第一个含 tag 的音频容器（M4B/M4A/MP3…）读标题/作者，**仅当对应
   /// 输入框为空时**回填（复用 sidecar 的「填空不覆盖」闸门，绝不覆盖用户手打的值）。
@@ -769,7 +776,7 @@ class _BookImportDialogState extends State<BookImportDialog>
     if (_audioPaths.isEmpty) return;
     // 两框都已填就无事可做（避免无谓 ffprobe 进程）。
     if (_titleCtrl.text.isNotEmpty && _authorCtrl.text.isNotEmpty) return;
-    for (final String audioPath in _audioPaths) {
+    for (final String audioPath in _audioPaths.take(kAudioTagProbeLimit)) {
       final AudioMetadata? meta =
           await TtsChannel.instance.extractAudioMetadata(audioPath: audioPath);
       if (meta == null) continue;

--- a/fushi/lib/src/media/audiobook/subtitle_rematch.dart
+++ b/fushi/lib/src/media/audiobook/subtitle_rematch.dart
@@ -4,7 +4,7 @@ import 'package:fushi/src/media/audiobook/audiobook_import_dialog.dart'
 
 import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi/src/media/audiobook/audiobook_alignment_service.dart'
-    show epubSectionsFromExtractDir;
+    show loadEpubSectionsInBackground;
 import 'package:fushi/utils.dart';
 
 /// Sasayaki 重匹配入口，被 [AudiobookImportDialog]（已附加视图）和书架
@@ -255,7 +255,7 @@ class SubtitleRematch {
     required String extractDir,
   }) async {
     try {
-      return epubSectionsFromExtractDir(extractDir);
+      return await loadEpubSectionsInBackground(extractDir);
     } catch (e, stack) {
       ErrorLogService.instance.log('SubtitleRematch.loadSections', e, stack);
       debugPrint('[fushi-audiobook] loadSections failed: $e');
@@ -279,7 +279,8 @@ class SubtitleRematch {
         );
         return;
       }
-      final List<EpubSection> sections = epubSectionsFromExtractDir(extractDir);
+      final List<EpubSection> sections =
+          await loadEpubSectionsInBackground(extractDir);
       if (sections.isEmpty) {
         FushiToast.show(
           msg: t.audiobook_rematch_no_chapters,

--- a/fushi/lib/src/media/collections/collection_one_key_sort.dart
+++ b/fushi/lib/src/media/collections/collection_one_key_sort.dart
@@ -82,7 +82,7 @@ Future<List<MediaCollectionItemRow>> sortedCollectionRows({
   required List<MediaCollectionItemRow> rows,
   required bool byTitle,
 }) async {
-  final List<EpubBookRow> epubs = await db.getAllEpubBooks();
+  final List<EpubBookMeta> epubs = await db.getEpubBookMetas();
   final List<SrtBookRow> srts = await db.getAllSrtBooks();
   final List<GalgameRow> games = await db.getAllGalgames();
   final List<VideoBookRow> videos = await db.allVideoBooks();
@@ -91,7 +91,7 @@ Future<List<MediaCollectionItemRow>> sortedCollectionRows({
     // v83：成员表 epub entryKey = `epub_books.uid`，meta 直接按行内 uid 建键
     // （uid 为空的异常行回退 bookKey）。透传成员行（远端-only 书，entryKey =
     // 对端 bookKey）本地无行可查，落 metaOf 的 `(entryKey, 0)` 兜底——刻意如此。
-    for (final EpubBookRow r in epubs)
+    for (final EpubBookMeta r in epubs)
       MediaKind.epub.compositeKey(r.uid.isNotEmpty ? r.uid : r.bookKey): (
         title: r.title,
         importedAt: r.importedAt,

--- a/fushi/lib/src/media/import/import_carrier.dart
+++ b/fushi/lib/src/media/import/import_carrier.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/media/audiobook/text_to_epub.dart';
@@ -172,13 +174,36 @@ class ImportCarrierResolver {
   final bool Function(String path) directoryHasPageImages;
   final int Function(String path) directoryCarrierFileCount;
 
-  String? _cachedPath;
+  String? _cachedKey;
   ImportCarrier? _cachedCarrier;
 
-  /// 判定 [path] 的载体身份；同一个 [path] 连续问只算一次真判定。
+  /// 记忆键：路径 + 内容指纹（mtime + 字节数）。
+  ///
+  /// 只用路径当键是不够的——判定本身要**真开包读内容**（`isImageArchive` 要开 zip 看
+  /// 里面有没有页图，目录分支还要数文件），结论随内容变。可达的翻车路径全程在既有 UI 上：
+  /// 用户选了一个还在下载中、中央目录尚未落盘的 `.cbz` → 判成非漫画 → 弹一条
+  /// 「不支持的格式」toast 并 return（**对话框不关、resolver 不销毁**）→ 下载完成后
+  /// 在同一个对话框里重选同一路径 → 单槽命中，`isImageArchive` 根本不再被调用 →
+  /// 返回过期判定 → 继续被拒，只能关掉重开。反向同样成立（已判成漫画包的路径在外部
+  /// 被换成词典 zip，会按漫画收下）。
+  ///
+  /// stat 失败（文件不在了 / 无权限）时键退化成纯路径 + 一个哨兵，宁可多判一次。
+  String _memoKey(String path) {
+    try {
+      final FileStat stat = FileStat.statSync(path);
+      if (stat.type == FileSystemEntityType.notFound) return '$path ?';
+      return '$path ${stat.modified.microsecondsSinceEpoch} '
+          '${stat.size}';
+    } catch (_) {
+      return '$path ?';
+    }
+  }
+
+  /// 判定 [path] 的载体身份；同一个 [path] 且内容未变时连续问只算一次真判定。
   ImportCarrier resolve(String path) {
+    final String key = _memoKey(path);
     final ImportCarrier? cached = _cachedCarrier;
-    if (cached != null && _cachedPath == path) return cached;
+    if (cached != null && _cachedKey == key) return cached;
     final ImportCarrier carrier = classifyImportCarrier(
       path,
       isDirectory: isDirectory,
@@ -186,14 +211,15 @@ class ImportCarrierResolver {
       directoryHasPageImages: directoryHasPageImages,
       directoryCarrierFileCount: directoryCarrierFileCount,
     );
-    _cachedPath = path;
+    _cachedKey = key;
     _cachedCarrier = carrier;
     return carrier;
   }
 
-  /// 丢弃记忆。路径指向的文件可能在对话框开着时被换掉，需要重新定性时调用。
+  /// 丢弃记忆。键已经带内容指纹，正常不需要调它；留给「内容没变但判据本身变了」
+  /// 这种场景（例如用户在对话框里改了受理规则）。
   void invalidate() {
-    _cachedPath = null;
+    _cachedKey = null;
     _cachedCarrier = null;
   }
 }

--- a/fushi/lib/src/media/manga/import/image_size_probe.dart
+++ b/fushi/lib/src/media/manga/import/image_size_probe.dart
@@ -1,0 +1,110 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+/// 只读文件头取页图的（已按 EXIF 方向摆正的）宽高，**不解码像素**。
+///
+/// 漫画导入对每一页只需要宽高写进 `manga.json`，以前却 `img.decodeImage` +
+/// `bakeOrientation` 整张解出来（纯 Dart 解一张 2000×3000 的 JPEG 要几十毫秒、
+/// 二十几 MB 堆），200 页就是好几秒的 UI 卡顿。这里走各格式的 `startDecode`
+/// （JPEG 只读到 SOF、PNG 只读 IHDR、WebP 只读 VP8 头），JPEG 另外读 APP1 里的
+/// EXIF Orientation：5~8 是转了 90° 的方向，宽高对调——与 `bakeOrientation`
+/// 后的尺寸一致（守卫 `image_size_probe_test.dart` 用真编码的图逐一对照）。
+///
+/// 不认识的格式 / 损坏文件返回 null，调用方回退整张解码（行为与从前一致）。
+({int width, int height})? probeOrientedImageSize(Uint8List bytes) {
+  final img.Decoder? decoder;
+  final img.DecodeInfo? info;
+  try {
+    // 太短的输入会让某些格式的 isValidFile 越界读，与损坏文件同样按「认不出」处理。
+    decoder = img.findDecoderForData(bytes);
+    if (decoder == null) return null;
+    info = decoder.startDecode(bytes);
+  } catch (_) {
+    return null;
+  }
+  if (info == null || info.width <= 0 || info.height <= 0) return null;
+  int width = info.width;
+  int height = info.height;
+  if (decoder is img.JpegDecoder) {
+    final int orientation = jpegExifOrientation(bytes);
+    if (orientation >= 5 && orientation <= 8) {
+      final int swap = width;
+      width = height;
+      height = swap;
+    }
+  }
+  return (width: width, height: height);
+}
+
+/// JPEG APP1 Exif 段 IFD0 里的 Orientation（tag 0x0112，1~8）。缺失 / 不是
+/// JPEG / 解析不出一律返回 1（未旋转）。只顺着 marker 链走到 SOS 之前，不碰像素。
+int jpegExifOrientation(Uint8List bytes) {
+  if (bytes.length < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8) return 1;
+  int i = 2;
+  while (i + 3 < bytes.length) {
+    if (bytes[i] != 0xFF) return 1;
+    final int marker = bytes[i + 1];
+    // 无长度的独立 marker（SOI / TEM / RSTn）与填充 0xFF。
+    if (marker == 0xFF) {
+      i += 1;
+      continue;
+    }
+    if (marker == 0xD8 ||
+        marker == 0x01 ||
+        (marker >= 0xD0 && marker <= 0xD7)) {
+      i += 2;
+      continue;
+    }
+    // SOS / EOI：像素段开始，EXIF 不可能在后面。
+    if (marker == 0xDA || marker == 0xD9) return 1;
+    final int segmentLength = (bytes[i + 2] << 8) | bytes[i + 3];
+    if (segmentLength < 2) return 1;
+    final int segmentStart = i + 4;
+    final int segmentEnd = i + 2 + segmentLength;
+    if (segmentEnd > bytes.length) return 1;
+    if (marker == 0xE1 &&
+        segmentLength >= 8 &&
+        _isExifHeader(bytes, segmentStart)) {
+      return _orientationFromTiff(bytes, segmentStart + 6, segmentEnd);
+    }
+    i = segmentEnd;
+  }
+  return 1;
+}
+
+bool _isExifHeader(Uint8List bytes, int at) =>
+    at + 6 <= bytes.length &&
+    bytes[at] == 0x45 && // E
+    bytes[at + 1] == 0x78 && // x
+    bytes[at + 2] == 0x69 && // i
+    bytes[at + 3] == 0x66 && // f
+    bytes[at + 4] == 0x00 &&
+    bytes[at + 5] == 0x00;
+
+int _orientationFromTiff(Uint8List bytes, int tiff, int end) {
+  if (tiff + 8 > end) return 1;
+  final Endian endian;
+  if (bytes[tiff] == 0x49 && bytes[tiff + 1] == 0x49) {
+    endian = Endian.little;
+  } else if (bytes[tiff] == 0x4D && bytes[tiff + 1] == 0x4D) {
+    endian = Endian.big;
+  } else {
+    return 1;
+  }
+  final ByteData data = ByteData.sublistView(bytes, tiff, end);
+  if (data.getUint16(2, endian) != 0x002A) return 1;
+  final int ifd = data.getUint32(4, endian);
+  if (ifd + 2 > data.lengthInBytes) return 1;
+  final int entries = data.getUint16(ifd, endian);
+  for (int n = 0; n < entries; n++) {
+    final int entry = ifd + 2 + n * 12;
+    if (entry + 12 > data.lengthInBytes) return 1;
+    if (data.getUint16(entry, endian) != 0x0112) continue;
+    // type SHORT(3) count 1：值就地存在 offset 字段前两个字节。
+    if (data.getUint16(entry + 2, endian) != 3) return 1;
+    final int value = data.getUint16(entry + 8, endian);
+    return (value >= 1 && value <= 8) ? value : 1;
+  }
+  return 1;
+}

--- a/fushi/lib/src/media/manga/import/image_size_probe.dart
+++ b/fushi/lib/src/media/manga/import/image_size_probe.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
 
+// ignore_for_file: unnecessary_null_comparison
 /// 只读文件头取页图的（已按 EXIF 方向摆正的）宽高，**不解码像素**。
 ///
 /// 漫画导入对每一页只需要宽高写进 `manga.json`，以前却 `img.decodeImage` +
@@ -23,18 +24,72 @@ import 'package:image/image.dart' as img;
   } catch (_) {
     return null;
   }
+  // GIF：`startDecode` 返回的是**逻辑屏幕描述符**，而 `decodeImage` 建的 Image 用的是
+  // **帧描述符**。帧小于逻辑屏幕的 GIF（转档/裁剪工具常见）两者不是一回事——实测一张
+  // 「逻辑屏幕 40×20 / 帧 10×8」的 GIF：旧路径 10×8，头探测 40×20。既然对不上就别猜，
+  // 交回整张解码（GIF 漫画页本就罕见，这点代价可接受）。
+  if (decoder is img.GifDecoder) return null;
+
   if (info == null || info.width <= 0 || info.height <= 0) return null;
   int width = info.width;
   int height = info.height;
-  if (decoder is img.JpegDecoder) {
-    final int orientation = jpegExifOrientation(bytes);
-    if (orientation >= 5 && orientation <= 8) {
-      final int swap = width;
-      width = height;
-      height = swap;
-    }
+  // `bakeOrientation` 读的是 `image.exif.imageIfd.orientation`，**与格式无关**；
+  // 而 image 4.3.0 的 WebP 解码器确实会填这个字段（有损 / 无损两条路径都写 exif）。
+  // 只给 JPEG 开这道门就把 WebP 的旋转丢了——实测一张带 orientation=6 的有损 WebP：
+  // 旧路径 20×40，只认 JPEG 的头探测 40×20，横竖颠倒。而 `.webp` 就在受理的漫画页
+  // 扩展名里，写进 manga.json 的宽高一错，spread/webtoon 自动判向会判反、OCR 框坐标
+  // 整体错位，且全程不报错。
+  //
+  //（PNG / TIFF 之所以不用管，是靠上游的 bug：image 4.3.0 的 PNG 解码器那段
+  // `case 'eXif':` 整段被注释掉了、拼写还错成 eXif；TIFF 那条设 exif 的分支在默认
+  // frame 下不可达。它们等价是巧合，不是设计——真出现方向就再补。）
+  final int orientation = decoder is img.JpegDecoder
+      ? jpegExifOrientation(bytes)
+      : decoder is img.WebPDecoder
+          ? webpExifOrientation(bytes)
+          : 1;
+  if (orientation >= 5 && orientation <= 8) {
+    final int swap = width;
+    width = height;
+    height = swap;
   }
   return (width: width, height: height);
+}
+
+/// WebP `EXIF` chunk（RIFF 容器）里 IFD0 的 Orientation。缺失 / 不是 WebP /
+/// 解析不出一律返回 1（未旋转）。只扫 chunk 头，不碰像素。
+int webpExifOrientation(Uint8List bytes) {
+  // RIFF<u32 size>WEBP，其后是一串 <fourcc><u32 size><payload>（payload 补齐到偶数）。
+  if (bytes.length < 12) return 1;
+  if (bytes[0] != 0x52 || bytes[1] != 0x49 || bytes[2] != 0x46 ||
+      bytes[3] != 0x46) {
+    return 1; // 'RIFF'
+  }
+  if (bytes[8] != 0x57 || bytes[9] != 0x45 || bytes[10] != 0x42 ||
+      bytes[11] != 0x50) {
+    return 1; // 'WEBP'
+  }
+  final ByteData data = ByteData.sublistView(bytes);
+  int at = 12;
+  while (at + 8 <= bytes.length) {
+    final bool isExif = bytes[at] == 0x45 && // E
+        bytes[at + 1] == 0x58 && // X
+        bytes[at + 2] == 0x49 && // I
+        bytes[at + 3] == 0x46; // F
+    final int size = data.getUint32(at + 4, Endian.little);
+    final int payload = at + 8;
+    if (size < 0 || payload + size > bytes.length) return 1;
+    if (isExif) {
+      // 规范说这里直接是 TIFF 头，但确有编码器把 JPEG APP1 的 `Exif\0\0` 前缀也带上，
+      // 两种都收。
+      final int tiff =
+          _isExifHeader(bytes, payload) ? payload + 6 : payload;
+      return _orientationFromTiff(bytes, tiff, payload + size);
+    }
+    // chunk payload 补齐到偶数字节。
+    at = payload + size + (size.isOdd ? 1 : 0);
+  }
+  return 1;
 }
 
 /// JPEG APP1 Exif 段 IFD0 里的 Orientation（tag 0x0112，1~8）。缺失 / 不是

--- a/fushi/lib/src/media/manga/import/manga_archive_importer.dart
+++ b/fushi/lib/src/media/manga/import/manga_archive_importer.dart
@@ -471,13 +471,7 @@ abstract final class MangaArchiveImporter {
           .toList();
       final File output = File(p.joinAll(<String>[staging.path, ...segments]));
       await output.parent.create(recursive: true);
-      final Object? content = entry.content;
-      if (content is! List<int>) {
-        throw MangaImportException(
-          'Could not extract manga page: ${entry.name}',
-        );
-      }
-      await output.writeAsBytes(content, flush: true);
+      await output.writeAsBytes(_verifiedContent(entry), flush: true);
       imageCount += 1;
     }
     if (imageCount == 0) {
@@ -499,6 +493,9 @@ abstract final class MangaArchiveImporter {
       final Object? content = entry.content;
       if (content is! List<int>) continue;
       if (content.length > _maximumMokuroBytes) continue;
+      // 清单 JSON 也做 CRC：坏清单会让页匹配整体失败，早点当「不是候选」跳过。
+      final int? expectedCrc = entry.crc32;
+      if (expectedCrc != null && getCrc32(content) != expectedCrc) continue;
       final String normalizedName = _normalizeArchiveName(entry.name);
       final List<String> nameSegments = normalizedName.split('/');
       if (nameSegments.any(
@@ -733,14 +730,30 @@ abstract final class MangaArchiveImporter {
       }
       final File output = MangaImporter.mokuroPageFile(staging.path, page.url);
       await output.parent.create(recursive: true);
-      final Object? content = entry.content;
-      if (content is! List<int>) {
-        throw MangaImportException(
-          'Could not extract Mokuro manga page: ${entry.name}',
-        );
-      }
-      await output.writeAsBytes(content, flush: true);
+      await output.writeAsBytes(_verifiedContent(entry), flush: true);
     }
+  }
+
+  /// 条目内容 + CRC32 校验。
+  ///
+  /// 流式打开（[_open]）只读中央目录、不 `verify`，整包 CRC 校验随之消失；这里在
+  /// 真正要写盘的条目上补回来——字节已经在内存里，CRC 是零额外 IO 的纯计算，而
+  /// 探测路径（只看条目名）仍然不用为一个坏包白解压整包。CRC 不符 = 传输截断 /
+  /// 位翻转的坏页，宁可整次导入失败也不把垃圾页写进书。
+  static List<int> _verifiedContent(ArchiveFile entry) {
+    final Object? content = entry.content;
+    if (content is! List<int>) {
+      throw MangaImportException(
+        'Could not extract manga page: ${entry.name}',
+      );
+    }
+    final int? expected = entry.crc32;
+    if (expected != null && getCrc32(content) != expected) {
+      throw MangaImportException(
+        'Corrupt manga archive entry (CRC mismatch): ${entry.name}',
+      );
+    }
+    return content;
   }
 
   /// `img_path` 是否含 `..` 段（与 [MangaStorage.sanitizeRelSegments] 同判据，

--- a/fushi/lib/src/media/manga/import/manga_archive_importer.dart
+++ b/fushi/lib/src/media/manga/import/manga_archive_importer.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:archive/archive.dart';
+import 'package:archive/archive_io.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:fushi_core/fushi_core.dart';
@@ -52,6 +52,39 @@ class _ArchivePageSet {
   final int score;
 }
 
+/// 流式打开的 zip：[archive] 的条目内容惰性读自 [input]，所以 [input] 必须活到
+/// 最后一次 `.content` 之后；[close] 关句柄并释放缓冲。
+class _OpenedArchive {
+  _OpenedArchive(this.archive, this.input);
+
+  final Archive archive;
+  final InputFileStream input;
+
+  void close() {
+    archive.clearSync();
+    input.closeSync();
+  }
+}
+
+/// 归一化名 → 条目的索引（大小写敏感 / 折叠两张表各建一次）。
+///
+/// mokuro 页匹配之前对每个候选根、每一页都线性扫全部图片条目，且在最内层循环里
+/// 反复 `_normalizeArchiveName`（normalizeMangaUrl + 两个 RegExp + Uri.decode）：
+/// 约 12·N² 次归一化，2000 页的卷是几千万次。这里每个条目只归一化一次。
+class _ArchiveImageIndex {
+  _ArchiveImageIndex(List<ArchiveFile> images) {
+    for (final ArchiveFile image in images) {
+      final String normalized =
+          MangaArchiveImporter._normalizeArchiveName(image.name);
+      (exact[normalized] ??= <ArchiveFile>[]).add(image);
+      (folded[normalized.toLowerCase()] ??= <ArchiveFile>[]).add(image);
+    }
+  }
+
+  final Map<String, List<ArchiveFile>> exact = <String, List<ArchiveFile>>{};
+  final Map<String, List<ArchiveFile>> folded = <String, List<ArchiveFile>>{};
+}
+
 const Set<String> _kSevenZipMangaArchiveExtensions = <String>{
   '.rar',
   '.cbr',
@@ -86,11 +119,11 @@ class MangaSevenZipExtractor {
   MangaSevenZipExtractor({
     DiscoveryProcessRunner? runProcess,
     String? sevenZipOverride,
-  }) : _runProcess = runProcess ?? Process.run,
-       _locator = DiscoveryArchiveExtractor(
-         runProcess: runProcess,
-         sevenZipOverride: sevenZipOverride,
-       );
+  })  : _runProcess = runProcess ?? Process.run,
+        _locator = DiscoveryArchiveExtractor(
+          runProcess: runProcess,
+          sevenZipOverride: sevenZipOverride,
+        );
 
   final DiscoveryProcessRunner _runProcess;
   final DiscoveryArchiveExtractor _locator;
@@ -167,9 +200,8 @@ class MangaSevenZipExtractor {
       }
       final String attributes = fields['Attributes'] ?? '';
       if (attributes.toUpperCase().contains('D')) continue;
-      final String extension = p.posix
-          .extension(entryPath.replaceAll('\\', '/'))
-          .toLowerCase();
+      final String extension =
+          p.posix.extension(entryPath.replaceAll('\\', '/')).toLowerCase();
       if (!kMangaImageExtensions.contains(extension)) continue;
       final int? size = int.tryParse(fields['Size'] ?? '');
       if (size == null || size < 0) {
@@ -241,8 +273,10 @@ abstract final class MangaArchiveImporter {
     if (extension == '.epub') {
       return _looksLikeImageEpub(archivePath);
     }
+    _OpenedArchive? opened;
     try {
-      final Archive archive = _decode(archivePath);
+      opened = _open(archivePath);
+      final Archive archive = opened.archive;
       bool hasImage = false;
       bool hasDictionaryIndex = false;
       bool hasDictionaryBank = false;
@@ -296,6 +330,8 @@ abstract final class MangaArchiveImporter {
       return hasImage && (hasMokuro || !hasMarkup);
     } catch (_) {
       return false;
+    } finally {
+      opened?.close();
     }
   }
 
@@ -309,7 +345,7 @@ abstract final class MangaArchiveImporter {
     MangaSevenZipExtractor? sevenZipExtractor,
   }) async {
     final String extension = p.extension(archivePath).toLowerCase();
-    Archive? archive;
+    _OpenedArchive? opened;
     final Directory staging = await Directory.systemTemp.createTemp(
       'hibiki_manga_archive_',
     );
@@ -321,7 +357,8 @@ abstract final class MangaArchiveImporter {
           staging: staging,
         );
       } else {
-        archive = _decode(archivePath);
+        opened = _open(archivePath);
+        final Archive archive = opened.archive;
         int expandedBytes = 0;
         for (final ArchiveFile entry in archive) {
           _validateEntry(entry);
@@ -404,7 +441,7 @@ abstract final class MangaArchiveImporter {
         sourceId: sourceId,
       );
     } finally {
-      archive?.clearSync();
+      opened?.close();
       if (staging.existsSync()) {
         await staging.delete(recursive: true);
       }
@@ -624,9 +661,10 @@ abstract final class MangaArchiveImporter {
     }
 
     final List<_ArchivePageSet> matches = <_ArchivePageSet>[];
+    final _ArchiveImageIndex index = _ArchiveImageIndex(images);
     uniqueRoots.forEach((String root, int rootScore) {
       final List<ArchiveFile>? exact = _pagesAtRoot(
-        images,
+        index,
         root: root,
         pageUrls: pageUrls,
         caseSensitive: true,
@@ -636,7 +674,7 @@ abstract final class MangaArchiveImporter {
         return;
       }
       final List<ArchiveFile>? folded = _pagesAtRoot(
-        images,
+        index,
         root: root,
         pageUrls: pageUrls,
         caseSensitive: false,
@@ -656,7 +694,7 @@ abstract final class MangaArchiveImporter {
   }
 
   static List<ArchiveFile>? _pagesAtRoot(
-    List<ArchiveFile> images, {
+    _ArchiveImageIndex index, {
     required String root,
     required List<String> pageUrls,
     required bool caseSensitive,
@@ -665,14 +703,9 @@ abstract final class MangaArchiveImporter {
     final Set<ArchiveFile> used = <ArchiveFile>{};
     for (final String pageUrl in pageUrls) {
       final String expected = root.isEmpty ? pageUrl : '$root/$pageUrl';
-      final List<ArchiveFile> found = <ArchiveFile>[
-        for (final ArchiveFile image in images)
-          if (caseSensitive
-              ? _normalizeArchiveName(image.name) == expected
-              : _normalizeArchiveName(image.name).toLowerCase() ==
-                    expected.toLowerCase())
-            image,
-      ];
+      final List<ArchiveFile> found = caseSensitive
+          ? index.exact[expected] ?? const <ArchiveFile>[]
+          : index.folded[expected.toLowerCase()] ?? const <ArchiveFile>[];
       if (found.length != 1 || !used.add(found.single)) return null;
       matches.add(found.single);
     }
@@ -734,9 +767,10 @@ abstract final class MangaArchiveImporter {
 
   static bool _looksLikeImageEpub(String archivePath) {
     Directory? extraction;
-    Archive? archive;
+    _OpenedArchive? opened;
     try {
-      archive = _decode(archivePath);
+      opened = _open(archivePath);
+      final Archive archive = opened.archive;
       int expandedBytes = 0;
       int imageCount = 0;
       for (final ArchiveFile entry in archive) {
@@ -755,6 +789,9 @@ abstract final class MangaArchiveImporter {
       if (imageCount == 0) {
         return false;
       }
+      // 中央目录看完就关：下面的整包解析自己再开一次文件。
+      opened.close();
+      opened = null;
       extraction = Directory.systemTemp.createTempSync(
         'hibiki_manga_epub_probe_',
       );
@@ -766,7 +803,7 @@ abstract final class MangaArchiveImporter {
     } catch (_) {
       return false;
     } finally {
-      archive?.clearSync();
+      opened?.close();
       final Directory? dir = extraction;
       if (dir != null && dir.existsSync()) {
         dir.deleteSync(recursive: true);
@@ -831,15 +868,26 @@ abstract final class MangaArchiveImporter {
     }
   }
 
-  static Archive _decode(String archivePath) {
+  /// 以文件流打开 zip：只读中央目录，条目内容在首次访问 `.content` 时才按需
+  /// 解压。用完必须 [_OpenedArchive.close]（关文件句柄 + 释放已解压缓冲）。
+  ///
+  /// 之前是 `readAsBytesSync` + `Uint8List.fromList` 再拷一份 + `decodeBytes(verify:
+  /// true)`：整包读进内存两份、再对每个条目 inflate + CRC 一遍——而三个调用方里两个
+  /// （[looksLikeImageArchive] / [_looksLikeImageEpub]）只看条目名，且它们在
+  /// 对话框里被同步调用、每次选中/拖入都跑；一本 500 MB 的 CBZ 要在 UI isolate
+  /// 上白白解压两三次。
+  static _OpenedArchive _open(String archivePath) {
     final File file = File(archivePath);
     if (!file.existsSync()) {
       throw MangaImportException('Manga archive not found: $archivePath');
     }
-    return ZipDecoder().decodeBytes(
-      Uint8List.fromList(file.readAsBytesSync()),
-      verify: true,
-    );
+    final InputFileStream input = InputFileStream(archivePath);
+    try {
+      return _OpenedArchive(ZipDecoder().decodeBuffer(input), input);
+    } catch (_) {
+      input.closeSync();
+      rethrow;
+    }
   }
 
   static void _validateEntry(ArchiveFile entry) {

--- a/fushi/lib/src/media/manga/manga_import_dialog.dart
+++ b/fushi/lib/src/media/manga/manga_import_dialog.dart
@@ -77,6 +77,17 @@ class _MangaImportDialogState extends State<MangaImportDialog>
 
   bool _pickerActive = false;
 
+  /// 走 [ImportCarrierResolver] 而不是每次裸调 `classifyImportCarrier`（与书籍框
+  /// 同款，守卫 `manga_import_carrier_memo_guard_test.dart`）：`.zip` / `.epub`
+  /// 的定性要真开包，而同一路径在一次导入里会被问到不止一次——预填 / 拖入循环 /
+  /// 收下路径，每问一次就开一次包。
+  late final ImportCarrierResolver _carrierResolver = ImportCarrierResolver(
+    isDirectory: (String pth) => Directory(pth).existsSync(),
+    isImageArchive: MangaModule.isImageArchive,
+    directoryHasPageImages: MangaModule.directoryHasPageImages,
+    directoryCarrierFileCount: MangaModule.directoryCarrierFileCount,
+  );
+
   @override
   void initState() {
     super.initState();
@@ -103,13 +114,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
     super.dispose();
   }
 
-  ImportCarrier _classify(String path) => classifyImportCarrier(
-        path,
-        isDirectory: (String pth) => Directory(pth).existsSync(),
-        isImageArchive: MangaModule.isImageArchive,
-        directoryHasPageImages: MangaModule.directoryHasPageImages,
-        directoryCarrierFileCount: MangaModule.directoryCarrierFileCount,
-      );
+  ImportCarrier _classify(String path) => _carrierResolver.resolve(path);
 
   /// 目录取目录名，文件取去扩展名的文件名。
   String _deriveTitle(String path) {

--- a/fushi/lib/src/media/manga/manga_importer.dart
+++ b/fushi/lib/src/media/manga/manga_importer.dart
@@ -346,9 +346,9 @@ class MangaImporter {
     final List<String> destRels =
         planMangaDestRels(srcDir: srcDir, payload: payload);
 
-    final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
+    final List<EpubBookMeta> existingBooks = await db.getEpubBookMetas();
     final String storedTitle = await resolveDuplicateTitle(
-      existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
+      existingTitles: existingBooks.map((EpubBookMeta b) => b.title).toList(),
       proposedTitle: proposedTitle,
       policy: policy,
     );

--- a/fushi/lib/src/media/manga/manga_importer.dart
+++ b/fushi/lib/src/media/manga/manga_importer.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/epub/book_title_conflict.dart';
+import 'package:fushi/src/media/manga/import/image_size_probe.dart';
 import 'package:fushi/src/media/manga/manga_storage.dart';
 import 'package:fushi/src/media/manga/mokuro_payload.dart';
 import 'package:fushi/src/ocr/manga_ocr_folder_job.dart';
@@ -119,22 +120,31 @@ class MangaImporter {
     }
     final List<MokuroImage> pages = <MokuroImage>[];
     for (final MangaOcrPageFile page in files) {
-      final img.Image? decoded = img.decodeImage(await page.file.readAsBytes());
-      if (decoded == null) {
-        throw MangaImportException(
-          'Could not decode manga page: ${page.relativeUrl}',
-        );
-      }
-      final img.Image oriented = img.bakeOrientation(decoded);
+      final Uint8List bytes = await page.file.readAsBytes();
       pages.add(
         MokuroImage(
           url: page.relativeUrl,
-          size: Size(oriented.width.toDouble(), oriented.height.toDouble()),
+          size: _pageSize(bytes, page.relativeUrl),
           blocks: const <MokuroBlock>[],
         ),
       );
     }
     return MokuroPayload(images: pages);
+  }
+
+  /// 页图宽高：先只读文件头（[probeOrientedImageSize]，零像素解码），认不出的
+  /// 格式才回退整张解码 + `bakeOrientation`（与从前逐字节同口径）。
+  static Size _pageSize(Uint8List bytes, String relativeUrl) {
+    final ({int width, int height})? probed = probeOrientedImageSize(bytes);
+    if (probed != null) {
+      return Size(probed.width.toDouble(), probed.height.toDouble());
+    }
+    final img.Image? decoded = img.decodeImage(bytes);
+    if (decoded == null) {
+      throw MangaImportException('Could not decode manga page: $relativeUrl');
+    }
+    final img.Image oriented = img.bakeOrientation(decoded);
+    return Size(oriented.width.toDouble(), oriented.height.toDouble());
   }
 
   /// 第一遍（纯校验，零副作用）：为 [payload] 的每页规划书目录内的 destRel

--- a/fushi/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
+++ b/fushi/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
@@ -264,11 +264,11 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
   }
 
   Future<void> _loadExistingBooks() async {
-    final List<EpubBookRow> rows = await widget.db.getAllEpubBooks();
+    final List<EpubBookMeta> rows = await widget.db.getEpubBookMetas();
     if (!mounted) return;
     setState(() {
       _existingBookKeys
-          .addAll(rows.map((EpubBookRow r) => sanitizeTtuFilename(r.title)));
+          .addAll(rows.map((EpubBookMeta r) => sanitizeTtuFilename(r.title)));
     });
   }
 

--- a/fushi/lib/src/media/source_library/source_file_system.dart
+++ b/fushi/lib/src/media/source_library/source_file_system.dart
@@ -51,7 +51,8 @@ class SourceFileEntry {
   /// 是否为目录。
   final bool isDirectory;
 
-  /// 文件字节大小；目录或不可知时为 null。
+  /// 文件字节大小；目录或不可知时为 null。本地传输恒为 null（列目录不逐文件
+  /// stat，见 [LocalSourceFileSystem.listFiles]）；远端传输由列目录响应顺带给出。
   final int? sizeBytes;
 }
 
@@ -111,17 +112,13 @@ class LocalSourceFileSystem implements SourceFileSystem {
     await for (final FileSystemEntity e
         in dir.list(recursive: recursive, followLinks: false)) {
       if (e is File) {
-        int? size;
-        try {
-          size = await e.length();
-        } catch (_) {
-          size = null;
-        }
+        // 本地传输不 stat 每个文件取大小：扫描链路上没有任何消费方读 sizeBytes
+        // （远端传输由列目录响应顺带给出，零成本），而递归枚举一棵几万文件的
+        // 漫画/视频树时每文件一次 `length()` 是几万次额外系统调用。
         entries.add(SourceFileEntry(
           name: p.basename(e.path),
           path: e.path,
           isDirectory: false,
-          sizeBytes: size,
         ));
       } else if (e is Directory && !recursive) {
         // 递归模式只回文件（供扫描器直接消费），非递归才单列子目录。
@@ -135,8 +132,8 @@ class LocalSourceFileSystem implements SourceFileSystem {
     // 文件系统枚举顺序不是稳定输入（NTFS 按名字、ext4 是目录哈希序），
     // 而这份清单一路流到 planScanFromFileList 的 books/videos/mangas 分类列表，
     // 再决定扫描导入的落库次序（用户可见）。在 IO 边界就定下来。
-    entries.sort((SourceFileEntry a, SourceFileEntry b) =>
-        a.path.compareTo(b.path));
+    entries.sort(
+        (SourceFileEntry a, SourceFileEntry b) => a.path.compareTo(b.path));
     return entries;
   }
 

--- a/fushi/lib/src/media/source_library/source_file_system.dart
+++ b/fushi/lib/src/media/source_library/source_file_system.dart
@@ -112,9 +112,10 @@ class LocalSourceFileSystem implements SourceFileSystem {
     await for (final FileSystemEntity e
         in dir.list(recursive: recursive, followLinks: false)) {
       if (e is File) {
-        // 本地传输不 stat 每个文件取大小：扫描链路上没有任何消费方读 sizeBytes
-        // （远端传输由列目录响应顺带给出，零成本），而递归枚举一棵几万文件的
-        // 漫画/视频树时每文件一次 `length()` 是几万次额外系统调用。
+        // 本地传输不 stat 每个文件取大小：扫描链路（扫描器 / 规划器）不读
+        // sizeBytes，远端传输由列目录响应顺带给出零成本；而递归枚举一棵几万
+        // 文件的漫画/视频树时每文件一次 `length()` 是几万次额外系统调用。唯一
+        // 要大小的消费方是低频的刮削诊断导出器，它自己按需 stat。
         entries.add(SourceFileEntry(
           name: p.basename(e.path),
           path: e.path,

--- a/fushi/lib/src/media/source_library/source_library_scanner.dart
+++ b/fushi/lib/src/media/source_library/source_library_scanner.dart
@@ -884,9 +884,9 @@ class SourceLibraryScanner {
     SourceFileSystem fs,
   ) async {
     if (plan.mangas.isEmpty && plan.mangaArchives.isEmpty) return 0;
-    final List<EpubBookRow> existingBooks = await _db.getAllEpubBooks();
+    final List<EpubBookMeta> existingBooks = await _db.getEpubBookMetas();
     final Set<String> existingTitleKeys = existingBooks
-        .map((EpubBookRow b) => sanitizeTtuFilename(b.title))
+        .map((EpubBookMeta b) => sanitizeTtuFilename(b.title))
         .toSet();
     int count = 0;
     for (final ScanMangaItem item in plan.mangas) {
@@ -940,12 +940,11 @@ class SourceLibraryScanner {
         pageExists: remoteByRel.containsKey,
       );
       if (pageRoot == null) {
-        final String searched =
-            mokuroPageRootCandidates(volumeName: remoteVolumeName)
-                .map((List<String> candidate) => candidate.isEmpty
-                    ? parentDir
-                    : '$prefix${candidate.join('/')}')
-                .join(', ');
+        final String searched = mokuroPageRootCandidates(
+                volumeName: remoteVolumeName)
+            .map((List<String> candidate) =>
+                candidate.isEmpty ? parentDir : '$prefix${candidate.join('/')}')
+            .join(', ');
         throw MangaImportException(
           'Missing manga page image: ${payload.images.first.url} '
           '(searched: $searched)',
@@ -1132,18 +1131,18 @@ class SourceLibraryScanner {
         Future<void> persistVideo(String? coverPath) =>
             _videoRepo.saveVideoBook(
               VideoBooksCompanion(
-            bookUid: Value(bookUid),
-            title: Value(title),
-            videoPath: Value(item.videoPath),
-            coverPath: Value<String?>(coverPath),
-            subtitleSource: Value<String?>(subtitleSource),
-            subtitleFormat: Value<String?>(subtitleFormat),
-            streamSpecJson: Value<String?>(streamSpecJson),
-            embeddedSubtitleTrack: subtitleSource == null
-                ? const Value<int?>(0)
-                : const Value<int?>(null),
-            importedAt: Value(DateTime.now().millisecondsSinceEpoch),
-          ),
+                bookUid: Value(bookUid),
+                title: Value(title),
+                videoPath: Value(item.videoPath),
+                coverPath: Value<String?>(coverPath),
+                subtitleSource: Value<String?>(subtitleSource),
+                subtitleFormat: Value<String?>(subtitleFormat),
+                streamSpecJson: Value<String?>(streamSpecJson),
+                embeddedSubtitleTrack: subtitleSource == null
+                    ? const Value<int?>(0)
+                    : const Value<int?>(null),
+                importedAt: Value(DateTime.now().millisecondsSinceEpoch),
+              ),
               sourceId: sourceId,
             );
 
@@ -1171,8 +1170,8 @@ class SourceLibraryScanner {
             await persistVideo(coverPath);
             if (coverPath != null && autoFrameMetaStore != null) {
               try {
-                final bool committed = await autoFrameMetaStore
-                    .markAutoFrameAfterWrite(bookUid);
+                final bool committed =
+                    await autoFrameMetaStore.markAutoFrameAfterWrite(bookUid);
                 if (!committed) {
                   debugPrint(
                     'SourceLibraryScanner cover provenance changed during '

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -81,9 +81,9 @@ final epubBookUidByKeyProvider =
     FutureProvider<Map<String, String>>((ref) async {
   ref.watch(_epubBookKeysProvider);
   final FushiDatabase db = ref.watch(appProvider).database;
-  final List<EpubBookRow> rows = await db.getAllEpubBooks();
+  final List<EpubBookMeta> rows = await db.getEpubBookMetas();
   return <String, String>{
-    for (final EpubBookRow r in rows)
+    for (final EpubBookMeta r in rows)
       if (r.uid.isNotEmpty) r.bookKey: r.uid,
   };
 });
@@ -524,17 +524,24 @@ class ReaderFushiSource extends ReaderMediaSource {
   }) async {
     final FushiDatabase db = appModel.database;
     final List<EpubBookRow> books = await db.getAllEpubBooks();
-    final ReaderPositionRepository posRepo = ReaderPositionRepository(db);
+    // 阅读位置一次整表取完（书 uid → 位置）。之前每本各查一次
+    // `findByBookUid`：Drift 在单连接上串行执行，`Future.wait` 只能重叠 await、
+    // 重叠不了 SQL，书架延迟仍随库大小线性增长（N 次往返 + N 次语句准备）。
+    final Map<String, ReaderPosition> positions =
+        await ReaderPositionRepository(db).findAllByBookUid();
 
     // HBK-AUDIT-128: previously this was a serial for-loop where every book
-    // awaited posRepo.findByTtuBookId(book.id) and up to four File.exists()
-    // cover probes one after another, so shelf latency scaled linearly with
-    // library size. Map each book to a Future and resolve them with
-    // Future.wait so the per-book DB query and cover probes overlap; Drift
-    // serialises the queries on its own connection, and Future.wait preserves
-    // input order so the shelf ordering is unchanged.
+    // awaited up to four File.exists() cover probes one after another, so
+    // shelf latency scaled linearly with library size. Map each book to a
+    // Future and resolve them with Future.wait so the cover probes overlap;
+    // Future.wait preserves input order so the shelf ordering is unchanged.
     return Future.wait<MediaItem>(
-      books.map((EpubBookRow book) => _bookToMediaItem(book, posRepo)),
+      books.map(
+        (EpubBookRow book) => _bookToMediaItem(
+          book,
+          book.uid.isEmpty ? null : positions[book.uid],
+        ),
+      ),
     );
   }
 
@@ -545,7 +552,11 @@ class ReaderFushiSource extends ReaderMediaSource {
     if (db == null) return null;
     final EpubBookRow? book = await db.getEpubBook(bookKey);
     if (book == null) return null;
-    return _bookToMediaItem(book, ReaderPositionRepository(db));
+    // v82：位置键 = 行 uid（空 uid 视同无阅读记录）。
+    final ReaderPosition? pos = book.uid.isEmpty
+        ? null
+        : await ReaderPositionRepository(db).findByBookUid(book.uid);
+    return _bookToMediaItem(book, pos);
   }
 
   /// 在线漫画的章级进度。
@@ -564,11 +575,12 @@ class ReaderFushiSource extends ReaderMediaSource {
     return (position: (total - selected).clamp(0, total), duration: total);
   }
 
-  /// Resolve a single [EpubBookRow] into a [MediaItem], reading its reader
-  /// position and cover concurrently with sibling books (HBK-AUDIT-128).
+  /// Resolve a single [EpubBookRow] into a [MediaItem], probing its cover
+  /// concurrently with sibling books (HBK-AUDIT-128). [pos] is the book's
+  /// reader position (already keyed by uid by the caller; null = never read).
   Future<MediaItem> _bookToMediaItem(
     EpubBookRow book,
-    ReaderPositionRepository posRepo,
+    ReaderPosition? pos,
   ) async {
     int position = 0;
     int duration = 1;
@@ -602,9 +614,6 @@ class ReaderFushiSource extends ReaderMediaSource {
 
     // TODO-1346：进度纳入当前章内 charOffset（与章字数同单位），并对老书无字数时
     // 回退章级粗粒度，避免书架恒显 0%。见 [computeBookProgress]。
-    // v82：位置键 = 行 uid（行在手直接取；空 uid 视同无阅读记录）。
-    final ReaderPosition? pos =
-        book.uid.isEmpty ? null : await posRepo.findByBookUid(book.uid);
     // 在线漫画的进度是**章级**的，不能走下面的页级分支。
     //
     // 那条分支算的是 `sectionIndex+1 ÷ chapterCount`，而在线条目里这两个量纲
@@ -618,26 +627,26 @@ class ReaderFushiSource extends ReaderMediaSource {
     final ({int position, int duration}) prog = onlineEntry != null
         ? _onlineMangaProgress(onlineEntry)
         : pageBased
-        // PDF Phase 3 / 漫画同款：进度单位是**页**（sectionIndex=当前页 0-based，
-        // chapterCount=总页数）。chaptersJson='[]' 无字数，走 computeBookProgress 会恒回
-        // (0,1)=0%。用 sectionIndex+1（1-based 页序）而非 0-based：停在第 1 页时
-        // position>0 才会被 `tallyShelfProgress` 计入「在读」并进「继续阅读」；读到最后
-        // 一页 position==duration 恰好等于「读完」判据，两端都自洽。
-        ? (
-            // 1-based 页序直接 clamp 到 [1, 总页数]，脏 sectionIndex 也不会让
-            // position 溢出 duration（>100%）。
-            position: ((pos?.sectionIndex ?? 0) + 1)
-                .clamp(1, book.chapterCount > 0 ? book.chapterCount : 1),
-            duration: book.chapterCount > 0 ? book.chapterCount : 1,
-          )
-        : computeBookProgress(
-            sectionChars: sectionChars,
-            sectionIndex: pos?.sectionIndex,
-            charOffset: pos?.charOffset ?? -1,
-            // BUG-728：听书时 charOffset 存 -1，章内进度只在 normCharOffset（0-10000）
-            // 里，传进去让 computeBookProgress 回退还原，否则书架进度停在章边界。
-            normCharOffset: pos?.normCharOffset ?? 0,
-          );
+            // PDF Phase 3 / 漫画同款：进度单位是**页**（sectionIndex=当前页 0-based，
+            // chapterCount=总页数）。chaptersJson='[]' 无字数，走 computeBookProgress 会恒回
+            // (0,1)=0%。用 sectionIndex+1（1-based 页序）而非 0-based：停在第 1 页时
+            // position>0 才会被 `tallyShelfProgress` 计入「在读」并进「继续阅读」；读到最后
+            // 一页 position==duration 恰好等于「读完」判据，两端都自洽。
+            ? (
+                // 1-based 页序直接 clamp 到 [1, 总页数]，脏 sectionIndex 也不会让
+                // position 溢出 duration（>100%）。
+                position: ((pos?.sectionIndex ?? 0) + 1)
+                    .clamp(1, book.chapterCount > 0 ? book.chapterCount : 1),
+                duration: book.chapterCount > 0 ? book.chapterCount : 1,
+              )
+            : computeBookProgress(
+                sectionChars: sectionChars,
+                sectionIndex: pos?.sectionIndex,
+                charOffset: pos?.charOffset ?? -1,
+                // BUG-728：听书时 charOffset 存 -1，章内进度只在 normCharOffset（0-10000）
+                // 里，传进去让 computeBookProgress 回退还原，否则书架进度停在章边界。
+                normCharOffset: pos?.normCharOffset ?? 0,
+              );
     position = prog.position;
     duration = prog.duration;
 

--- a/fushi/lib/src/media/tracking/media_tracking_repository.dart
+++ b/fushi/lib/src/media/tracking/media_tracking_repository.dart
@@ -366,7 +366,7 @@ class MediaTrackingRepository {
           in await _db.getAllReaderPositions())
         position.bookUid: position,
     };
-    for (final EpubBookRow book in await _db.getAllEpubBooks()) {
+    for (final EpubBookMeta book in await _db.getEpubBookMetas()) {
       final ReaderPositionRow? position =
           book.uid.isEmpty ? null : positions[book.uid];
       final DateTime? completedAt = book.completedAt;

--- a/fushi/lib/src/media/video/scraper/video_scrape_diagnostic_exporter.dart
+++ b/fushi/lib/src/media/video/scraper/video_scrape_diagnostic_exporter.dart
@@ -82,7 +82,9 @@ class VideoScrapeDiagnosticExporter {
       safeFiles.add(_SafeFileEntry(
         relativePath: relative,
         sourcePath: entry.path,
-        sizeBytes: entry.sizeBytes,
+        // 本地传输的列目录不逐文件 stat（扫描热路径省几万次系统调用，见
+        // LocalSourceFileSystem.listFiles）；诊断导出是低频路径，自己补一次 stat。
+        sizeBytes: entry.sizeBytes ?? await _statSizeOrNull(entry.path),
       ));
     }
     safeFiles.sort((_SafeFileEntry a, _SafeFileEntry b) =>
@@ -340,4 +342,13 @@ class _NfoFile {
   final String archivePath;
   final String sourcePath;
   final int sizeBytes;
+}
+
+/// 本地文件大小；不存在 / 不可 stat 返回 null（与远端列目录给不出大小同语义）。
+Future<int?> _statSizeOrNull(String path) async {
+  try {
+    return await File(path).length();
+  } catch (_) {
+    return null;
+  }
 }

--- a/fushi/lib/src/media/video/video_book_repository.dart
+++ b/fushi/lib/src/media/video/video_book_repository.dart
@@ -430,17 +430,24 @@ class VideoBookRepository {
   Future<List<VideoBookRow>> _repairMovedCoverPaths(
     List<VideoBookRow> rows,
   ) async {
-    Directory? coversDir;
+    if (rows.isEmpty) return rows;
+    // 封面目录列一次成集合：绝大多数封面都在 coversDir 下（自动抽帧 / 刮削落地），
+    // 存在性查集合即可，不再对每一行 `existsSync`——这条读路径每次库页刷新、每次
+    // 回填成功都走，几千个视频就是几千次同步 stat 在 UI isolate 上。目录外的
+    // 手选封面仍逐个 stat（少数）。目录解析失败（无 path_provider 的测试宿主）
+    // 退回逐行 stat，行为与从前一字不差。
+    final _CoverDirSnapshot? snapshot = await _CoverDirSnapshot.take();
+    Directory? coversDir = snapshot?.dir;
     final List<VideoBookRow> out = <VideoBookRow>[];
     for (final VideoBookRow row in rows) {
       final String? cover = row.coverPath;
-      if (cover == null || cover.isEmpty || File(cover).existsSync()) {
+      if (cover == null || cover.isEmpty || _coverExists(cover, snapshot)) {
         out.add(row);
         continue;
       }
       coversDir ??= await VideoStorage.coversDir();
       final String candidate = p.join(coversDir.path, p.basename(cover));
-      if (candidate != cover && File(candidate).existsSync()) {
+      if (candidate != cover && _coverExists(candidate, snapshot)) {
         // 只有这一次指针回写需要与其他封面写入串行。锁内必须按 bookUid 重读当前
         // cover_path：这批 rows 是进锁前的快照，期间用户可能刚手选了封面，拿旧快照
         // 覆盖等于把手选结果抹掉（正是 gate 当初要防的那个竞态）。
@@ -803,17 +810,14 @@ class VideoBookRepository {
     required LocalVideoFileDeleteHooks? localFileHooks,
     required Future<void> Function()? afterDeleteBeforeReclaim,
   }) async {
-    final deleted =
-        <
-          ({
-            String bookUid,
-            String? coverPath,
-            String? subtitlePath,
-            String videoPath,
-            String? playlistJson,
-            List<String> imagePaths,
-          })
-        >[];
+    final deleted = <({
+      String bookUid,
+      String? coverPath,
+      String? subtitlePath,
+      String videoPath,
+      String? playlistJson,
+      List<String> imagePaths,
+    })>[];
     for (final String bookUid in bookUids.toSet()) {
       final VideoBookRow? book = await getByBookUid(bookUid);
       if (book == null) continue;
@@ -1080,3 +1084,45 @@ class VideoBookRepository {
         await _db.updateVideoBookSubtitleSource(bookUid, subtitleSource);
       });
 }
+
+/// [VideoStorage.coversDir] 的一次性快照：目录下的文件名集合。
+///
+/// 给 `_repairMovedCoverPaths` 判断封面存在性用——目录内的封面查集合、零系统
+/// 调用；目录解析失败（测试宿主没有 path_provider）时 [take] 返回 null，调用方退回
+/// 逐个 stat。
+class _CoverDirSnapshot {
+  const _CoverDirSnapshot(this.dir, this.names);
+
+  final Directory dir;
+  final Set<String> names;
+
+  static Future<_CoverDirSnapshot?> take() async {
+    final Directory dir;
+    try {
+      dir = await VideoStorage.coversDir();
+    } catch (_) {
+      return null;
+    }
+    final Set<String> names = <String>{};
+    try {
+      if (dir.existsSync()) {
+        await for (final FileSystemEntity entity
+            in dir.list(followLinks: false)) {
+          if (entity is File) names.add(p.basename(entity.path));
+        }
+      }
+    } catch (_) {
+      return null;
+    }
+    return _CoverDirSnapshot(dir, names);
+  }
+
+  /// [path] 在本目录下时按集合判；否则 null（调用方 stat）。
+  bool? contains(String path) {
+    if (!p.equals(p.dirname(path), dir.path)) return null;
+    return names.contains(p.basename(path));
+  }
+}
+
+bool _coverExists(String path, _CoverDirSnapshot? snapshot) =>
+    snapshot?.contains(path) ?? File(path).existsSync();

--- a/fushi/lib/src/media/video/video_book_repository.dart
+++ b/fushi/lib/src/media/video/video_book_repository.dart
@@ -1106,8 +1106,14 @@ class _CoverDirSnapshot {
     final Set<String> names = <String>{};
     try {
       if (dir.existsSync()) {
-        await for (final FileSystemEntity entity
-            in dir.list(followLinks: false)) {
+        // 必须是 listSync，不能是 `await for (… in dir.list())`。
+        // 异步目录流的完成事件走真实事件循环，而 widget 测试在 fake-async 里推进
+        // 时钟——那个事件永远送不到，`listForShelf()` 的 future 因此永不 resolve，
+        // 加载转圈一直排帧，`pumpAndSettle` 必然超时（home_video_page_menu_test
+        // 的 5 条用例就是这么红的）。
+        // 省掉「每行一次 existsSync」这个收益与同步/异步无关：一次目录列举 vs
+        // N 次 stat，listSync 照样是一次。
+        for (final FileSystemEntity entity in dir.listSync(followLinks: false)) {
           if (entity is File) names.add(p.basename(entity.path));
         }
       }

--- a/fushi/lib/src/migration/migration_manifest.dart
+++ b/fushi/lib/src/migration/migration_manifest.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:isolate';
 
 import 'package:archive/archive_io.dart';
 import 'package:crypto/crypto.dart';
@@ -116,9 +117,16 @@ class MigrationManifest {
       MigrationManifest.fromJson(json.decode(text) as Map<String, Object?>);
 
   /// 流式计算文件 SHA-256（十六进制小写），不整块载入内存。
-  static Future<String> sha256OfFile(File file) async {
-    final Digest digest = await sha256.bind(file.openRead()).first;
-    return digest.toString();
+  ///
+  /// 在后台 isolate 里算：纯 Dart 的 SHA-256 对一份 11 GB 的库归档要跑好几分钟
+  /// （导入侧注释实测 ~7 分钟），留在 UI isolate 上就是整段时间界面无响应。
+  /// 路径与结果都是字符串，可跨 isolate 传。
+  static Future<String> sha256OfFile(File file) {
+    final String path = file.path;
+    return Isolate.run(() async {
+      final Digest digest = await sha256.bind(File(path).openRead()).first;
+      return digest.toString();
+    });
   }
 
   /// 对归档做完整性校验（size + sha256）；一致返回空列表，否则返回人类可读的

--- a/fushi/lib/src/mining/galgame_add_flow.dart
+++ b/fushi/lib/src/mining/galgame_add_flow.dart
@@ -82,10 +82,33 @@ Future<void> addGamesFromPaths(
     msg: t.game_drop_imported(count: added.length),
     severity: ToastSeverity.success,
   );
-  for (final GalgameEntry entry in added) {
-    unawaited(_autoCoverSilently(repo, entry));
-  }
+  unawaited(_autoCoverAllSilently(repo, added));
   onImported?.call();
+}
+
+/// 批量补封面的并行度。每个 exe 图标抽取都是一个后台 isolate 把整个 exe 读进
+/// 内存（上限 128 MB）；拖 30 个游戏进来就是 30 个 isolate 同时各抱一个 exe。
+const int kGameCoverResolveConcurrency = 3;
+
+/// [_autoCoverSilently] 的有界并行版：同时最多 [kGameCoverResolveConcurrency] 个，
+/// 单条失败不影响其余（[_autoCoverSilently] 自身不抛）。
+Future<void> _autoCoverAllSilently(
+  GalgameRepository repo,
+  List<GalgameEntry> games,
+) async {
+  int next = 0;
+  Future<void> worker() async {
+    while (next < games.length) {
+      await _autoCoverSilently(repo, games[next++]);
+    }
+  }
+
+  final int workers = games.length < kGameCoverResolveConcurrency
+      ? games.length
+      : kGameCoverResolveConcurrency;
+  await Future.wait<void>(
+    List<Future<void>>.generate(workers, (_) => worker()),
+  );
 }
 
 /// 后台补封面（静默版）：目录封面图 → exe 内嵌图标；期间条目被删则空操作。

--- a/fushi/lib/src/models/app_font_loader.dart
+++ b/fushi/lib/src/models/app_font_loader.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart' show FontLoader;
@@ -126,15 +127,24 @@ class AppFontLoader {
   static Future<List<String>> resolveAndLoadAll(
     List<Map<String, dynamic>> fonts,
   ) async {
+    // 各条目并发解析（读文件 + 解码 + 注册互不依赖），结果按用户顺序收集——
+    // 一条 CJK 字体十几二十 MB，三条链串行装是首帧前的可见等待。
+    final List<String?> resolved = await Future.wait<String?>(
+      fonts.map(_resolveEntry),
+    );
     final List<String> families = <String>[];
-    for (final Map<String, dynamic> font in fonts) {
-      final String? family = await _resolveEntry(font);
+    for (final String? family in resolved) {
       // 同名条目只保留一次：重复家族名在回退链里没有意义（引擎按名解析），
       // 只会让「第几个生效」变得无法推理。
       if (family != null && !families.contains(family)) families.add(family);
     }
     return families;
   }
+
+  /// 同一家族正在注册中的 future：并发解析时两条链里的同名条目只装一次，
+  /// 后来者等前者的结果（[FontLoader] 不能卸载，重复注册只是白读白解一遍）。
+  static final Map<String, Future<String?>> _inFlight =
+      <String, Future<String?>>{};
 
   /// Resolves one `{name, path, enabled}` entry to a registered family name, or
   /// null when the entry is unusable. Registration is idempotent per family.
@@ -167,15 +177,35 @@ class AppFontLoader {
     if (!file.existsSync()) return null;
 
     if (_loadedFamilies.contains(family)) return family;
+    final Future<String?>? pending = _inFlight[family];
+    if (pending != null) return pending;
+    final Future<String?> loading =
+        _loadFileFamily(file, family, isWoff: isWoff, isWoff2: isWoff2);
+    _inFlight[family] = loading;
+    try {
+      return await loading;
+    } finally {
+      _inFlight.remove(family);
+    }
+  }
 
+  static Future<String?> _loadFileFamily(
+    File file,
+    String family, {
+    required bool isWoff,
+    required bool isWoff2,
+  }) async {
     try {
       Uint8List bytes = await file.readAsBytes();
       if (isWoff || isWoff2) {
         // FontLoader only accepts raw sfnt, so unwrap the web-font
-        // container (WOFF2 first, then WOFF 1.0).
-        final Uint8List? sfnt = isWoff2
-            ? Woff2Decoder.toSfnt(bytes)
-            : FontDecoder.woffToSfnt(bytes);
+        // container (WOFF2 first, then WOFF 1.0). Brotli + glyf/loca 变换是
+        // 纯 CPU、几十毫秒到几百毫秒，放后台 isolate，别占首帧前的 UI isolate。
+        final Uint8List? sfnt = await Isolate.run(
+          () => isWoff2
+              ? Woff2Decoder.toSfnt(bytes)
+              : FontDecoder.woffToSfnt(bytes),
+        );
         if (sfnt == null) return null;
         bytes = sfnt;
       }

--- a/fushi/lib/src/models/app_font_loader.dart
+++ b/fushi/lib/src/models/app_font_loader.dart
@@ -177,8 +177,24 @@ class AppFontLoader {
     if (!file.existsSync()) return null;
 
     if (_loadedFamilies.contains(family)) return family;
+    // 在飞去重只能复用**成功**的结果。
+    //
+    // `_loadedFamilies.add(family)` 只在 `loader.load()` 成功后才执行，所以在串行
+    // 年代「第一个同名条目失败」不会污染后续条目：A 装 P1 失败返回 null，B 照常去
+    // 装自己的 P2。改成并发 + 共享 future 之后，B 在 `_inFlight` 里拿到的是 A 的
+    // future，得到 null 就直接返回——**P2 永不被尝试**，family F 整条不可用，
+    // UI/字幕/游戏文本一起回落到主题字体。
+    // 触发条件不窄：`resolveAllHealth` 内部就是 Future.wait（同一条链的条目全部同时
+    // 在飞），AppModel 又把 appUiFonts / videoSubtitleFonts / gameLookupFonts 三条链
+    // 并发跑，而「跨链同名家族」正是 `_inFlight` 存在的理由。
     final Future<String?>? pending = _inFlight[family];
-    if (pending != null) return pending;
+    if (pending != null) {
+      final String? shared = await pending;
+      if (shared != null) return shared;
+      // 前一个装载失败了：不复用它的失败，退回去装自己这一份。
+      // 此时它已经把自己从 _inFlight 里摘掉了（finally），不会再互相等。
+      return _loadFileFamily(file, family, isWoff: isWoff, isWoff2: isWoff2);
+    }
     final Future<String?> loading =
         _loadFileFamily(file, family, isWoff: isWoff, isWoff2: isWoff2);
     _inFlight[family] = loading;

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -686,7 +686,7 @@ class AppModel with ChangeNotifier {
     List<DeletionPropagationCandidate> candidates,
   ) async {
     final Map<String, String> bookTitles = <String, String>{
-      for (final EpubBookRow r in await database.getAllEpubBooks())
+      for (final EpubBookMeta r in await database.getEpubBookMetas())
         r.bookKey: r.title,
     };
     final Map<String, String> videoTitles = <String, String>{

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2691,15 +2691,22 @@ class AppModel with ChangeNotifier {
       // order — the chain feeds fontFamily + fontFamilyFallback) before first
       // paint so the global theme uses them without a flash. Reuses the
       // settings just loaded above to avoid a second prefs read.
-      _appFontFamilies =
-          await AppFontLoader.resolveAndLoadAll(readerSettings.appUiFonts);
+      // 三个字体目标互不依赖，并发解析（同名家族由 AppFontLoader 的在途表去重，
+      // 只装一次）；串行三条链 = 首帧前三段可见等待。
+      final Future<List<String>> appFontsF =
+          AppFontLoader.resolveAndLoadAll(readerSettings.appUiFonts);
       // TODO-864: 视频字幕字体同样在首帧前从 videoSubtitle 目标解析。
-      _subtitleFontFamily =
-          await AppFontLoader.resolveAndLoad(readerSettings.videoSubtitleFonts);
+      final Future<String?> subtitleFontF =
+          AppFontLoader.resolveAndLoad(readerSettings.videoSubtitleFonts);
       // 游戏文本字体链也在首帧前解析：否则 texthooker 页面首次打开会先用主题字体
       // 画一帧再跳变（refreshAppFont 要等到用户改设置才跑）。
-      _gameLookupFontFamilies =
-          await AppFontLoader.resolveAndLoadAll(readerSettings.gameLookupFonts);
+      final Future<List<String>> gameFontsF =
+          AppFontLoader.resolveAndLoadAll(readerSettings.gameLookupFonts);
+      await Future.wait<Object?>(
+          <Future<Object?>>[appFontsF, subtitleFontF, gameFontsF]);
+      _appFontFamilies = await appFontsF;
+      _subtitleFontFamily = await subtitleFontF;
+      _gameLookupFontFamilies = await gameFontsF;
       ReaderFushiSource.readerSettings = readerSettings;
 
       // Start polling physical controllers on platforms that need it (desktop);

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -717,16 +717,34 @@ class DictionaryImportManager {
   @visibleForTesting
   static void packDirectoryToZip(String srcDirPath, String zipPath) {
     final Directory directory = Directory(srcDirPath);
-    final Archive archive = Archive();
-    for (final FileSystemEntity entity in directory.listSync(recursive: true)) {
-      if (entity is File) {
-        final String relativePath =
-            path.relative(entity.path, from: directory.path);
-        archive.addFile(ArchiveFile(
-            relativePath, entity.lengthSync(), entity.readAsBytesSync()));
+    // STORE（不压缩）+ 逐文件流式写盘：这个 zip 只是给 native 导入器当输入的
+    // 临时容器，native 拿到后立刻 inflate——在 Dart 里 deflate 一遍纯属白干（几百
+    // MB 的 MDX/MDD 目录要压好几秒）。以前还把整个目录读进内存组 Archive、再
+    // encode 成第二份内存拷贝才落盘（~2× 目录大小的峰值，正是 OOM 路径的来源）；
+    // ZipFileEncoder 一次只持有一个文件。native 侧的压缩比守卫对 STORE 比 1:1
+    // 天然放行。
+    final ZipFileEncoder encoder = ZipFileEncoder();
+    encoder.create(zipPath, level: ZipFileEncoder.STORE);
+    try {
+      for (final FileSystemEntity entity
+          in directory.listSync(recursive: true)) {
+        if (entity is File) {
+          final String relativePath =
+              path.relative(entity.path, from: directory.path);
+          final InputFileStream fileStream = InputFileStream(entity.path);
+          try {
+            encoder.addArchiveFile(
+              ArchiveFile.stream(relativePath, entity.lengthSync(), fileStream)
+                ..compress = false,
+            );
+          } finally {
+            fileStream.closeSync();
+          }
+        }
       }
+    } finally {
+      encoder.closeSync();
     }
-    File(zipPath).writeAsBytesSync(ZipEncoder().encode(archive)!);
   }
 
   static void _copyDirectory(Directory source, Directory destination) {

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -263,8 +263,7 @@ class DictionaryImportManager {
           hasReplaceTarget: false,
         );
         if (decision == UpdateDecision.alreadyUpToDate) {
-          progressNotifier.value = t.import_duplicate(name: name);
-          await Future.delayed(const Duration(seconds: 2));
+          _notifyAlreadyUpToDate(progressNotifier, name);
           if (tempOutputDir.existsSync()) {
             tempOutputDir.deleteSync(recursive: true);
           }
@@ -504,8 +503,7 @@ class DictionaryImportManager {
         hasReplaceTarget: replaceTarget != null,
       );
       if (decision == UpdateDecision.alreadyUpToDate) {
-        progressNotifier.value = t.import_duplicate(name: name);
-        await Future.delayed(const Duration(seconds: 2));
+        _notifyAlreadyUpToDate(progressNotifier, name);
         if (tempOutputDir.existsSync()) {
           tempOutputDir.deleteSync(recursive: true);
         }
@@ -933,6 +931,20 @@ class DictionaryImportManager {
   static bool _isMemoryError(Object e) {
     final msg = e.toString().toLowerCase();
     return e is OutOfMemoryError || msg.contains('out of memory');
+  }
+
+  /// 「已是最新、跳过」的提示：进度文字 + 一条 toast，**不阻塞**导入循环。
+  ///
+  /// 之前这里 `Future.delayed(2s)` 只为让进度文字停留两秒——批量重导一个已装
+  /// 目录时每本都白等 2 秒（30 本 = 60 秒纯睡眠）。toast 自带停留时间，循环
+  /// 立即进入下一本。
+  static void _notifyAlreadyUpToDate(
+    ValueNotifier<String> progressNotifier,
+    String name,
+  ) {
+    final String msg = t.import_duplicate(name: name);
+    progressNotifier.value = msg;
+    FushiToast.show(msg: msg, severity: ToastSeverity.info);
   }
 
   /// 批量导入结束后，把失败的词典名汇总成一条提示文案（单条/多条不同措辞）。

--- a/fushi/lib/src/pages/implementations/collections_page.dart
+++ b/fushi/lib/src/pages/implementations/collections_page.dart
@@ -332,7 +332,7 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
         if (b.bookKey.isNotEmpty) b.bookKey: b.uid,
     };
     final epubUidByBookKey = <String, String>{
-      for (final EpubBookRow r in await db.getAllEpubBooks())
+      for (final EpubBookMeta r in await db.getEpubBookMetas())
         if (r.uid.isNotEmpty) r.bookKey: r.uid,
     };
     final collectionNamesById = <int, String>{

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -630,11 +630,30 @@ class _HomeDashboardPageState
   Future<void> _loadDashboardDataUnsafe() async {
     final AppModel appModel = ref.read(appProvider);
     final FushiDatabase db = appModel.database;
-    final List<VideoBookRow> videos = await widget.videoRepo.listForShelf();
+    // 视频书架、统计事实面、合集/附加图四张表互不依赖：一次全部发出，让 Drift
+    // 后台执行器流水线化（首页首绘被这串 await 串行 gate）。
+    final Future<List<VideoBookRow>> videosF = widget.videoRepo.listForShelf();
     // v92：学习统计只经统一事实面读取（study_segments + 冻结的 legacy 投影表，
     // 游戏时长来自 galgame_sessions、游戏 hook 字数来自 legacy game 行 + 段），
     // 首页不再自己读六张表各自累加——与阅读/视频/游戏统计页同一份事实。
-    final StatFacts facts = await loadStatFacts(db);
+    final Future<StatFacts> factsF = loadStatFacts(db);
+    final Future<List<MediaCollectionRow>> collectionsF =
+        db.getAllMediaCollections();
+    final Future<Map<String, int>> primaryByEntryF =
+        db.getPrimaryCollectionIdByEntry();
+    final Future<List<MediaImageRow>> mediaImagesF = db.getAllMediaImages();
+    final Future<List<MediaCollectionItemRow>> collectionItemsF =
+        db.getAllCollectionItems();
+    await Future.wait<Object?>(<Future<Object?>>[
+      videosF,
+      factsF,
+      collectionsF,
+      primaryByEntryF,
+      mediaImagesF,
+      collectionItemsF,
+    ]);
+    final List<VideoBookRow> videos = await videosF;
+    final StatFacts facts = await factsF;
     final List<StatFact> reading = facts.dailyBooks.toList(growable: false);
     final List<StatFact> watch = facts.dailyVideos.toList(growable: false);
     final List<StatFact> game = facts.dailyGames.toList(growable: false);
@@ -650,17 +669,15 @@ class _HomeDashboardPageState
         galgameRepo.isLoaded ? galgameRepo.games : await galgameRepo.load();
     // 合集归属映射（统计页/书架同源）：显示名规则「非合集上下文拼合集名」用。
     final Map<int, String> collectionNamesById = <int, String>{
-      for (final MediaCollectionRow c in await db.getAllMediaCollections())
-        c.id: c.name,
+      for (final MediaCollectionRow c in await collectionsF) c.id: c.name,
     };
-    final Map<String, int> primaryByEntry =
-        await db.getPrimaryCollectionIdByEntry();
+    final Map<String, int> primaryByEntry = await primaryByEntryF;
     // v68 附加图组：一次全表查询按归属分桶（续播区视频横卡选图链）。
     final Map<int, List<MediaImageRow>> imagesByCollection =
         <int, List<MediaImageRow>>{};
     final Map<String, List<MediaImageRow>> imagesByBookUid =
         <String, List<MediaImageRow>>{};
-    for (final MediaImageRow imageRow in await db.getAllMediaImages()) {
+    for (final MediaImageRow imageRow in await mediaImagesF) {
       final int? cid = imageRow.collectionId;
       if (cid != null) {
         (imagesByCollection[cid] ??= <MediaImageRow>[]).add(imageRow);
@@ -671,7 +688,7 @@ class _HomeDashboardPageState
     // 组内序：条目在其主折叠合集里的 sortIndex（视频页/书架 _loadShelfMaps 同
     // 口径——一次 getAllCollectionItems 内存分组，只记归属主合集的行）。
     final Map<String, int> memberSortIndex = <String, int>{};
-    for (final MediaCollectionItemRow m in await db.getAllCollectionItems()) {
+    for (final MediaCollectionItemRow m in await collectionItemsF) {
       final String key = '${m.mediaType}|${m.entryKey}';
       if (primaryByEntry[key] == m.collectionId) {
         memberSortIndex[key] = m.sortIndex;
@@ -2025,7 +2042,8 @@ class _HomeDashboardPageState
         titleOf: _statEntryTitle,
         collectionOf: _statEntryCollection,
         onEntryTap: _openStatEntry,
-        onEntryDelete: (StatPeriodEntryTarget t) => deleteStatPeriodEntry(db, t),
+        onEntryDelete: (StatPeriodEntryTarget t) =>
+            deleteStatPeriodEntry(db, t),
       ),
     );
     // 删过就重拉首页数据：热力图 / 今日目标 / 时间轴都吃同一份事实面。

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -680,17 +680,17 @@ class _HomeDashboardPageState
     // legacy 阅读事实行无身份时按 title 反查 bookKey（日明细拼合集前缀，阅读统计
     // 页 _collectionNameForBook 同范式）。书表由事实面加载时顺带取回，同批再取
     // importedAt 喂「最近添加」行（一次查询两用）。
-    final List<EpubBookRow> epubRows = facts.epubRows;
+    final List<EpubBookMeta> epubRows = facts.epubRows;
     final Map<String, String> bookKeyByTitle = <String, String>{
-      for (final EpubBookRow r in epubRows) r.title: r.bookKey,
+      for (final EpubBookMeta r in epubRows) r.title: r.bookKey,
     };
     final Map<String, int> epubImportedAtByKey = <String, int>{
-      for (final EpubBookRow r in epubRows) r.bookKey: r.importedAt,
+      for (final EpubBookMeta r in epubRows) r.bookKey: r.importedAt,
     };
     // v83：成员表 epub entryKey = uid，同批行顺带建 bookKey→uid 换算表（空 uid
     // 异常行不进表，查归属时按 bookKey 原样回退）。
     final Map<String, String> epubUidByBookKey = <String, String>{
-      for (final EpubBookRow r in epubRows)
+      for (final EpubBookMeta r in epubRows)
         if (r.uid.isNotEmpty) r.bookKey: r.uid,
     };
 

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -597,17 +597,54 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final FushiDatabase db = appModel.database;
     final ShelfSortMode sortMode =
         ShelfSortMode.fromName(appModel.prefsRepo.videoSortModeName);
-    final List<MediaCollectionRow> collections =
-        await db.getAllMediaCollections();
-    final Map<String, int> primaryMap =
-        await db.getPrimaryCollectionIdByEntry();
+    // 十三个全表查询互不依赖：一次全部发出去，让 Drift 的后台执行器流水线化，
+    // 而不是每个都等上一个的往返回来再发下一个（合集行要等最后一个落地才能画）。
+    // 先 Future.wait 挂上监听，某个查询失败时其余错误不会成为无人接的未处理异常。
+    final Future<List<MediaCollectionRow>> collectionsF =
+        db.getAllMediaCollections();
+    final Future<Map<String, int>> primaryMapF =
+        db.getPrimaryCollectionIdByEntry();
+    final Future<List<MediaCollectionItemRow>> collectionItemsF =
+        db.getAllCollectionItems();
+    final Future<List<VideoWatchStatisticRow>> watchRowsF =
+        db.getAllVideoWatchStatistics();
+    final Future<Map<String, int>> segmentEndAtByUidF =
+        db.getLatestStudyEndAtByMedia(kActivityMediaVideo);
+    final Future<List<VideoScrapeMetaRow>> scrapeRowsF =
+        db.getAllVideoScrapeMeta();
+    final Future<List<CollectionScrapeMetaRow>> collectionScrapeMetaF =
+        db.getAllCollectionScrapeMeta();
+    final Future<List<VideoMetadataWorkRow>> metadataWorksF =
+        db.getAllVideoMetadataWorks();
+    final Future<List<VideoMetadataImageRow>> metadataImagesF =
+        db.getAllVideoMetadataImages();
+    final Future<List<VideoMetadataEpisodeRow>> metadataEpisodesF =
+        db.getAllVideoMetadataEpisodes();
+    final Future<List<VideoMetadataExtraRow>> metadataExtrasF =
+        db.getAllVideoMetadataExtras();
+    final Future<List<MediaImageRow>> mediaImagesF = db.getAllMediaImages();
+    await Future.wait<Object?>(<Future<Object?>>[
+      collectionsF,
+      primaryMapF,
+      collectionItemsF,
+      watchRowsF,
+      segmentEndAtByUidF,
+      scrapeRowsF,
+      collectionScrapeMetaF,
+      metadataWorksF,
+      metadataImagesF,
+      metadataEpisodesF,
+      metadataExtrasF,
+      mediaImagesF,
+    ]);
+    final List<MediaCollectionRow> collections = await collectionsF;
+    final Map<String, int> primaryMap = await primaryMapF;
     // 层次 C：条目在其主折叠合集里的 sortIndex（只记归属合集的行——一条目属多
     // 合集时行内序跟随折叠归属，与 primaryMap 同口径）。一次 [getAllCollectionItems]
     // 查全部成员内存分组，替代逐合集 [getCollectionItems] 的 N+1（合集越多越慢，
     // 首屏合集行渲染被它 gate）。判据 `primaryMap[key] == m.collectionId` 与旧
     // 逐合集 `== c.id` 等价（旧循环里 members 的 collectionId 恒为 c.id）。
-    final List<MediaCollectionItemRow> collectionItems = await db
-        .getAllCollectionItems();
+    final List<MediaCollectionItemRow> collectionItems = await collectionItemsF;
     final Map<String, int> memberSortIndex = <String, int>{};
     for (final MediaCollectionItemRow m in collectionItems) {
       final String key = '${m.mediaType}|${m.entryKey}';
@@ -618,10 +655,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     // v92 起 `video_watch_statistics` 冻结为 legacy 只读（历史数据还在），新的
     // 观看只写 `study_segments`：两处的 (uid, 时刻) 一起喂 latestWatchAtByKey，
     // 同 uid 取最大，任一来源缺席都不影响另一来源。
-    final List<VideoWatchStatisticRow> watchRows =
-        await db.getAllVideoWatchStatistics();
-    final Map<String, int> segmentEndAtByUid =
-        await db.getLatestStudyEndAtByMedia(kActivityMediaVideo);
+    final List<VideoWatchStatisticRow> watchRows = await watchRowsF;
+    final Map<String, int> segmentEndAtByUid = await segmentEndAtByUidF;
     // 无身份判定 NULL 与 '' 都算（review4-9/review2-10：与统计页展示、删除谓词
     // 同一判据）——'' 行进不了任何书架条目的 uid 匹配，落 title 回退才不会让该
     // 视频从「最近观看」消失。
@@ -643,8 +678,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     // TODO-2486：刮削资料批量预取——条目 airDate 派生年份（年份筛选）、合集资料
     // （hero 轮播）。批量 DAO 全表一次拉，替代逐本/逐合集查询的 N+1。
-    final List<VideoScrapeMetaRow> scrapeRows =
-        await db.getAllVideoScrapeMeta();
+    final List<VideoScrapeMetaRow> scrapeRows = await scrapeRowsF;
     final Map<String, int> airYearByUid = <String, int>{
       for (final VideoScrapeMetaRow r in scrapeRows)
         if (videoAirYear(r.airDate) case final int year) r.bookUid: year,
@@ -655,12 +689,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     };
     final Map<int, CollectionScrapeMetaRow> collectionMetaById =
         <int, CollectionScrapeMetaRow>{
-          for (final CollectionScrapeMetaRow r
-              in await db.getAllCollectionScrapeMeta())
-            r.collectionId: r,
-        };
-    final List<VideoMetadataWorkRow> metadataWorks = await db
-        .getAllVideoMetadataWorks();
+      for (final CollectionScrapeMetaRow r in await collectionScrapeMetaF)
+        r.collectionId: r,
+    };
+    final List<VideoMetadataWorkRow> metadataWorks = await metadataWorksF;
     final Map<int, VideoMetadataWorkRow> metadataWorkByCollection =
         <int, VideoMetadataWorkRow>{
       for (final VideoMetadataWorkRow work in metadataWorks)
@@ -673,15 +705,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     };
     final Map<int, List<VideoMetadataImageRow>> metadataImagesByWork =
         <int, List<VideoMetadataImageRow>>{};
-    for (final VideoMetadataImageRow image
-        in await db.getAllVideoMetadataImages()) {
+    for (final VideoMetadataImageRow image in await metadataImagesF) {
       if (image.workId case final int workId) {
         (metadataImagesByWork[workId] ??= <VideoMetadataImageRow>[]).add(image);
       }
     }
     final Map<String, int> runtimeMinutesByBookUid = <String, int>{};
-    for (final VideoMetadataEpisodeRow episode
-        in await db.getAllVideoMetadataEpisodes()) {
+    for (final VideoMetadataEpisodeRow episode in await metadataEpisodesF) {
       if (episode.bookUid case final String uid) {
         if (episode.runtimeMinutes case final int minutes) {
           runtimeMinutesByBookUid[uid] = minutes;
@@ -689,8 +719,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       }
     }
     final Set<String> localExtraBookUids = <String>{
-      for (final VideoMetadataExtraRow extra
-          in await db.getAllVideoMetadataExtras())
+      for (final VideoMetadataExtraRow extra in await metadataExtrasF)
         if (extra.bookUid != null) extra.bookUid!,
     };
     // v68 附加图组：一次全表查询按归属分桶（hero 背景/logo、续播行横卡）。
@@ -698,7 +727,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         <int, List<MediaImageRow>>{};
     final Map<String, List<MediaImageRow>> imagesByBookUid =
         <String, List<MediaImageRow>>{};
-    for (final MediaImageRow row in await db.getAllMediaImages()) {
+    for (final MediaImageRow row in await mediaImagesF) {
       final int? cid = row.collectionId;
       if (cid != null) {
         (imagesByCollection[cid] ??= <MediaImageRow>[]).add(row);
@@ -808,6 +837,25 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     // 同名 `<uid>.jpg`，否则新帧或稍后的 coverPath 会被旧快照误清。
     if (lease == null) return;
     _backfillingCovers = true;
+    // 每抽成一张就 `setState(listForShelf)` = 每张封面一次全库重列 + 整页重建；
+    // 几百个待补的视频就是几百次。改为节流：最多每秒刷一次，循环结束再兜底刷
+    // 一次把最后几张带上。
+    bool shelfDirty = false;
+    DateTime? lastShelfRefreshAt;
+    void refreshShelfThrottled({bool force = false}) {
+      if (!mounted) return;
+      final DateTime now = DateTime.now();
+      if (!force &&
+          lastShelfRefreshAt != null &&
+          now.difference(lastShelfRefreshAt!) < _coverBackfillRefreshInterval) {
+        shelfDirty = true;
+        return;
+      }
+      lastShelfRefreshAt = now;
+      shelfDirty = false;
+      setState(() => _future = widget.repo.listForShelf());
+    }
+
     try {
       final List<VideoBookRow> rows = await widget.repo.listAll();
       for (final VideoBookRow row in rows) {
@@ -877,13 +925,17 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         }
         CoverBackfillLedger.instance.clear(path);
         if (!mounted) return;
-        setState(() => _future = widget.repo.listForShelf());
+        refreshShelfThrottled();
       }
+      if (shelfDirty) refreshShelfThrottled(force: true);
     } finally {
       _backfillingCovers = false;
       lease.release();
     }
   }
+
+  /// [_maybeBackfillCovers] 里书架重列的最小间隔。
+  static const Duration _coverBackfillRefreshInterval = Duration(seconds: 1);
 
   Future<RemoteVideoClient?> _resolveRemoteVideoClient() async {
     final Future<RemoteVideoClient?> Function()? injected =
@@ -2522,9 +2574,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       message: t.video_delete_confirm(title: book.title),
       db: appModel.database,
       // 远端流（互联直传 / WebDAV / Jellyfin）磁盘上没有文件，不摆勾选框。
-      localFilesSubtitle: videoBookHasLocalFiles(book)
-          ? t.delete_local_files_video_desc
-          : null,
+      localFilesSubtitle:
+          videoBookHasLocalFiles(book) ? t.delete_local_files_video_desc : null,
     );
     if (decision == null || !mounted) return;
     final VideoLibraryDeleteResult result = await deleteVideoBooksWithDecision(
@@ -4137,14 +4188,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     }
     final List<CollectionGroup<_VideoSlot>> groups =
         <CollectionGroup<_VideoSlot>>[
-          for (final CollectionGroup<_VideoSlot> group in _groupVideos(
-            books,
-            groupedRemoteVideos,
-            primaryByEntry,
-            memberSortIndex,
-          ))
-            group,
-        ];
+      for (final CollectionGroup<_VideoSlot> group in _groupVideos(
+        books,
+        groupedRemoteVideos,
+        primaryByEntry,
+        memberSortIndex,
+      ))
+        group,
+    ];
     // 合集标签过滤：含【全部】选中标签的合集 id（null = 无选中标签，不过滤）。
     // 合集卡（及其成员）按此显隐；散卡由 filteredVideoBookUidsProvider 另行过滤。
     final Set<int>? collectionFilter =
@@ -5805,8 +5856,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     EdgeInsetsGeometry padding,
     ({int columns, double cardWidth}) cardLayout,
   ) {
-    final double coverHeight =
-        cardLayout.cardWidth / kVideoLandscapeCardAspect;
+    final double coverHeight = cardLayout.cardWidth / kVideoLandscapeCardAspect;
     final double cellHeight = coverHeight + _videoCardTextBlock(context);
     return SliverPadding(
       padding: padding,
@@ -6320,8 +6370,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 视频书的用户标签（BUG-1808）：墙卡与首页横滚卡共用同一口径，别再各处 inline
   /// 写一遍 watch——首页当初漏画标签层，正是因为标签只跟着墙卡那一处写法走。
-  List<_VideoTagChip> _videoBookTagChips(String bookUid) => _tagChipsOf(
-      ref.watch(videoBookTagMapProvider).valueOrNull?[bookUid]);
+  List<_VideoTagChip> _videoBookTagChips(String bookUid) =>
+      _tagChipsOf(ref.watch(videoBookTagMapProvider).valueOrNull?[bookUid]);
 
   /// 合集的用户标签（与 [_videoBookTagChips] 同形，键是 collectionId）。
   List<_VideoTagChip> _collectionTagChips(int collectionId) => _tagChipsOf(

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -927,8 +927,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         if (!mounted) return;
         refreshShelfThrottled();
       }
-      if (shelfDirty) refreshShelfThrottled(force: true);
     } finally {
+      // 兜底刷新放 finally：循环中途抛异常 / 提前 return 时，已落库落盘的封面
+      // 不能停留在「书架看不见」的状态。
+      if (shelfDirty) refreshShelfThrottled(force: true);
       _backfillingCovers = false;
       lease.release();
     }

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -202,14 +202,9 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     final repo = AudiobookRepository(appModel.database);
     final allAudiobooks = await repo.buildBookKeyMap();
     final result = <String, _AudiobookInfo>{};
-    final healthFutures = <String, Future<AudiobookHealth>>{};
-    for (final entry in allAudiobooks.entries) {
-      healthFutures[entry.key] = repo.resolveHealth(entry.value);
-    }
-    final healths = <String, AudiobookHealth>{};
-    await Future.wait(healthFutures.entries.map((e) async {
-      healths[e.key] = await e.value;
-    }));
+    // 一次前缀查询取完全部健康度覆盖，替代每本一条 getPref 的 N+1。
+    final Map<String, AudiobookHealth> healths =
+        await repo.resolveAllHealth(allAudiobooks);
     for (final entry in allAudiobooks.entries) {
       result[entry.key] = _AudiobookInfo(
         hasAudiobook: true,
@@ -821,15 +816,15 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
       final String key = '${m.mediaType}|${m.entryKey}';
       if (primaryMap[key] == m.collectionId) memberSortIndex[key] = m.sortIndex;
     }
-    final List<EpubBookRow> epubRows =
-        await appModel.database.getAllEpubBooks();
+    final List<EpubBookMeta> epubRows =
+        await appModel.database.getEpubBookMetas();
     _epubImportedAtByKey = <String, int>{
-      for (final EpubBookRow r in epubRows) r.bookKey: r.importedAt,
+      for (final EpubBookMeta r in epubRows) r.bookKey: r.importedAt,
     };
     // v82：reader_positions 键 = uid；书架条目身份仍是 bookKey，查 recency 前
     // 经此表换算（同一批行零额外查询）。空 uid 行不进表（视同无阅读记录）。
     _epubUidByKey = <String, String>{
-      for (final EpubBookRow r in epubRows)
+      for (final EpubBookMeta r in epubRows)
         if (r.uid.isNotEmpty) r.bookKey: r.uid,
     };
     _completedBookKeys = await appModel.database.getCompletedEpubBookKeys();

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -724,12 +724,12 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
     // bookKey 的真值在 `epub_books`（`fushiBooksProvider` 也是从这里取的）；
     // `getAllMediaItems()` 是另一张表、另一套 mediaIdentifier 语义，拿它做判据
     // 会把全部选中项误判成幽灵键而整批剔光。
-    final List<EpubBookRow> epubBooks = await db.getAllEpubBooks();
+    final List<EpubBookMeta> epubBooks = await db.getEpubBookMetas();
     // v83：合集成员表 epub entryKey = `epub_books.uid`，而选择键解码出的身份仍是
     // bookKey。批量组合/加合集都在本剪枝之后立即落库，借同一批行顺带刷新
     // bookKey→uid 换算表（[_loadShelfMaps] 同款口径），保证写库前换算不吃旧值。
     _epubUidByKey = <String, String>{
-      for (final EpubBookRow row in epubBooks)
+      for (final EpubBookMeta row in epubBooks)
         if (row.uid.isNotEmpty) row.bookKey: row.uid,
     };
     final List<SrtBook> srtBooks = await SrtBookRepository(db).listAll();
@@ -738,7 +738,7 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
     if (!mounted) return false;
     final int dropped = _selection.retainExisting(
       loose: <String>{
-        for (final EpubBookRow row in epubBooks)
+        for (final EpubBookMeta row in epubBooks)
           ReaderFushiSource.mediaIdentifierFor(row.bookKey),
         for (final SrtBook book in srtBooks) 'srt_${book.uid}',
       },

--- a/fushi/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -74,10 +74,10 @@ extension _ReaderHistoryRemote on _ReaderFushiHistoryPageState {
         fetch: client.listRemoteBooks,
       );
       // #6: 远端与本地是同一本书时（同 bookKey）不在混排网格重复展示（只显示本地卡）。
-      final List<EpubBookRow> localBooks =
-          await appModel.database.getAllEpubBooks();
+      final List<EpubBookMeta> localBooks =
+          await appModel.database.getEpubBookMetas();
       final Set<String> localKeys =
-          localBooks.map((EpubBookRow r) => r.bookKey).toSet();
+          localBooks.map((EpubBookMeta r) => r.bookKey).toSet();
       // 分架过滤（互联完整支持批次）：普通书架 = 可下载 EPUB（hasContent）；漫画
       // 书架 = 可下载漫画（format='manga' + hasMangaContent，漫画包通道）。两架互斥，
       // 同一条目绝不重复出现。

--- a/fushi/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/reading_statistics_page.dart
@@ -168,7 +168,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       _computeAggregates();
       // 加载事实时顺带取的书表：下面的 title→bookKey（合集归属 / legacy 行回退）
       // 与 bookKey→uid 换算复用同一批行，不再单独查。
-      final List<EpubBookRow> epubRows = facts.epubRows;
+      final List<EpubBookMeta> epubRows = facts.epubRows;
       final DateTime now = DateTime.now();
       final List<FavoriteWordRow> favs =
           await db.getFavoriteWordsBySource(kStatSourceBook);
@@ -199,12 +199,12 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       };
       _primaryCollectionByEntry = await db.getPrimaryCollectionIdByEntry();
       _bookKeyByTitle = <String, String>{
-        for (final EpubBookRow r in epubRows) r.title: r.bookKey,
+        for (final EpubBookMeta r in epubRows) r.title: r.bookKey,
       };
       // v83：成员表 epub entryKey = uid，同批行顺带建换算表（空 uid 异常行不进
       // 表，查归属时按 bookKey 原样回退）。
       _epubUidByBookKey = <String, String>{
-        for (final EpubBookRow r in epubRows)
+        for (final EpubBookMeta r in epubRows)
           if (r.uid.isNotEmpty) r.bookKey: r.uid,
       };
       // 收藏语句按 source 分桶：非视频来源（书内 / 有声书 / 歌词）都归阅读统计。

--- a/fushi/lib/src/pages/implementations/statistics_center_page.dart
+++ b/fushi/lib/src/pages/implementations/statistics_center_page.dart
@@ -109,10 +109,10 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
       final StatFacts facts = await loadStatFacts(db, activityLimit: 0);
       _daily = facts.daily;
       _bookKeyByTitle = <String, String>{
-        for (final EpubBookRow r in facts.epubRows) r.title: r.bookKey,
+        for (final EpubBookMeta r in facts.epubRows) r.title: r.bookKey,
       };
       _epubUidByBookKey = <String, String>{
-        for (final EpubBookRow r in facts.epubRows)
+        for (final EpubBookMeta r in facts.epubRows)
           if (r.uid.isNotEmpty) r.bookKey: r.uid,
       };
       _collectionNamesById = <int, String>{

--- a/fushi/lib/src/pdf/pdf_importer.dart
+++ b/fushi/lib/src/pdf/pdf_importer.dart
@@ -67,9 +67,9 @@ class PdfImporter {
     }
 
     // 解析标题冲突 → bookKey（与 EpubImporter 同口径：净化标题即主键，保证本地唯一）。
-    final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
+    final List<EpubBookMeta> existingBooks = await db.getEpubBookMetas();
     final String storedTitle = await resolveDuplicateTitle(
-      existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
+      existingTitles: existingBooks.map((EpubBookMeta b) => b.title).toList(),
       proposedTitle: title,
       policy: policy,
     );

--- a/fushi/lib/src/stats/stat_facts.dart
+++ b/fushi/lib/src/stats/stat_facts.dart
@@ -82,7 +82,7 @@ class StatFacts {
     hourly: <StatFact>[],
     segments: <StudySegmentRow>[],
     legacyActivity: <ActivityEventRow>[],
-    epubRows: <EpubBookRow>[],
+    epubRows: <EpubBookMeta>[],
   );
 
   /// 最近的游玩会话（v92 起游玩只写 galgame_sessions，活动流从这里合成）。
@@ -118,8 +118,9 @@ class StatFacts {
   /// `added` 导入事件）。活动流把它与 [segmentsAsActivityRows] 并集。
   final List<ActivityEventRow> legacyActivity;
 
-  /// 加载 legacy 阅读行身份时顺带取的书表（页面复用：title→bookKey / format）。
-  final List<EpubBookRow> epubRows;
+  /// 加载 legacy 阅读行身份时顺带取的书表瘦投影（页面复用：title→bookKey /
+  /// uid / importedAt / format），不带章节 JSON 大列。
+  final List<EpubBookMeta> epubRows;
 
   Iterable<StatFact> get dailyBooks => daily.where((StatFact f) => f.isBook);
   Iterable<StatFact> get dailyVideos => daily.where((StatFact f) => f.isVideo);
@@ -134,9 +135,9 @@ Future<StatFacts> loadStatFacts(
   FushiDatabase db, {
   int activityLimit = 200,
 }) async {
-  final List<EpubBookRow> epubRows = await db.getAllEpubBooks();
-  final Map<String, EpubBookRow> bookByTitle = <String, EpubBookRow>{
-    for (final EpubBookRow r in epubRows) r.title: r,
+  final List<EpubBookMeta> epubRows = await db.getEpubBookMetas();
+  final Map<String, EpubBookMeta> bookByTitle = <String, EpubBookMeta>{
+    for (final EpubBookMeta r in epubRows) r.title: r,
   };
   final List<StatFact> daily = <StatFact>[];
   final List<StatFact> hourly = <StatFact>[];
@@ -144,7 +145,7 @@ Future<StatFacts> loadStatFacts(
   // legacy 日行：阅读按 title 反查库表补身份与 format（查不到 = 书已删，身份 ''、
   // format ''，按 title 分组、归普通书）；视频 v39 起自带 bookUid。
   for (final ReadingStatisticRow r in await db.getAllReadingStatistics()) {
-    final EpubBookRow? book = bookByTitle[r.title];
+    final EpubBookMeta? book = bookByTitle[r.title];
     daily.add(
       StatFact(
         mediaKind: kActivityMediaBook,

--- a/fushi/lib/src/stats/stat_facts.dart
+++ b/fushi/lib/src/stats/stat_facts.dart
@@ -135,7 +135,45 @@ Future<StatFacts> loadStatFacts(
   FushiDatabase db, {
   int activityLimit = 200,
 }) async {
-  final List<EpubBookMeta> epubRows = await db.getEpubBookMetas();
+  // 九个全表读互不依赖：一次全部发出去让 Drift 后台执行器流水线化，而不是每个都
+  // 等上一个往返回来（首页与三个统计页每次打开都走这里）。先 Future.wait 挂上
+  // 监听，某个失败时其余错误不会成为无人接的未处理异常。
+  final Future<List<EpubBookMeta>> epubRowsF = db.getEpubBookMetas();
+  final Future<List<ReadingStatisticRow>> readingF =
+      db.getAllReadingStatistics();
+  final Future<List<VideoWatchStatisticRow>> watchF =
+      db.getAllVideoWatchStatistics();
+  final Future<List<ReadingHourlyLogRow>> readingHourlyF =
+      db.getAllReadingHourlyLogs();
+  final Future<List<VideoHourlyLogRow>> videoHourlyF =
+      db.getAllVideoHourlyLogs();
+  final Future<List<(String, String, int)>> gameDailyF =
+      db.getGalgameDailySecondsByGame();
+  final Future<List<ActivityEventRow>> activityF =
+      db.getRecentActivityEvents(limit: activityLimit);
+  final Future<List<ActivityEventRow>> gameActivityF =
+      db.getRecentActivityEvents(
+    limit: 1 << 31,
+    eventTypes: const <String>[kActivityGame],
+  );
+  final Future<List<StudySegmentRow>> segmentsF = db.getStudySegments();
+  final Future<List<GalgameSessionRow>> recentGameSessionsF = activityLimit <= 0
+      ? Future<List<GalgameSessionRow>>.value(const <GalgameSessionRow>[])
+      : db.getRecentGalgameSessions(limit: activityLimit);
+  await Future.wait<Object?>(<Future<Object?>>[
+    epubRowsF,
+    readingF,
+    watchF,
+    readingHourlyF,
+    videoHourlyF,
+    gameDailyF,
+    activityF,
+    gameActivityF,
+    segmentsF,
+    recentGameSessionsF,
+  ]);
+
+  final List<EpubBookMeta> epubRows = await epubRowsF;
   final Map<String, EpubBookMeta> bookByTitle = <String, EpubBookMeta>{
     for (final EpubBookMeta r in epubRows) r.title: r,
   };
@@ -144,7 +182,7 @@ Future<StatFacts> loadStatFacts(
 
   // legacy 日行：阅读按 title 反查库表补身份与 format（查不到 = 书已删，身份 ''、
   // format ''，按 title 分组、归普通书）；视频 v39 起自带 bookUid。
-  for (final ReadingStatisticRow r in await db.getAllReadingStatistics()) {
+  for (final ReadingStatisticRow r in await readingF) {
     final EpubBookMeta? book = bookByTitle[r.title];
     daily.add(
       StatFact(
@@ -161,8 +199,7 @@ Future<StatFacts> loadStatFacts(
       ),
     );
   }
-  for (final VideoWatchStatisticRow w
-      in await db.getAllVideoWatchStatistics()) {
+  for (final VideoWatchStatisticRow w in await watchF) {
     daily.add(
       StatFact(
         mediaKind: kActivityMediaVideo,
@@ -179,7 +216,7 @@ Future<StatFacts> loadStatFacts(
     );
   }
   // legacy 小时行（无身份、无 title）。
-  for (final ReadingHourlyLogRow h in await db.getAllReadingHourlyLogs()) {
+  for (final ReadingHourlyLogRow h in await readingHourlyF) {
     hourly.add(
       StatFact(
         mediaKind: kActivityMediaBook,
@@ -195,7 +232,7 @@ Future<StatFacts> loadStatFacts(
       ),
     );
   }
-  for (final VideoHourlyLogRow h in await db.getAllVideoHourlyLogs()) {
+  for (final VideoHourlyLogRow h in await videoHourlyF) {
     hourly.add(
       StatFact(
         mediaKind: kActivityMediaVideo,
@@ -212,8 +249,7 @@ Future<StatFacts> loadStatFacts(
     );
   }
   // 游戏时长真相源 galgame_sessions（v55 起就是事实表）：按 (game, day) 进日面。
-  for (final (String gameId, String dateKey, int seconds)
-      in await db.getGalgameDailySecondsByGame()) {
+  for (final (String gameId, String dateKey, int seconds) in await gameDailyF) {
     daily.add(
       StatFact(
         mediaKind: kActivityMediaGame,
@@ -232,13 +268,8 @@ Future<StatFacts> loadStatFacts(
   // legacy 活动行：v92 前的游戏 hook 字数只存在这里（chars-only game 行）；
   // read / watch 行的时长 / 字数已在日投影里，**只**取 game 的字数进日面，
   // 时长一律不取（时长真相源是 galgame_sessions，取了就双计）。
-  final List<ActivityEventRow> activity = await db.getRecentActivityEvents(
-    limit: activityLimit,
-  );
-  for (final ActivityEventRow e in await db.getRecentActivityEvents(
-    limit: 1 << 31,
-    eventTypes: const <String>[kActivityGame],
-  )) {
+  final List<ActivityEventRow> activity = await activityF;
+  for (final ActivityEventRow e in await gameActivityF) {
     final int chars = e.charsDelta ?? 0;
     if (chars <= 0) continue;
     daily.add(
@@ -257,7 +288,7 @@ Future<StatFacts> loadStatFacts(
     );
   }
   // v92 段：两面各一份。
-  final List<StudySegmentRow> segments = await db.getStudySegments();
+  final List<StudySegmentRow> segments = await segmentsF;
   for (final StudySegmentRow s in segments) {
     // **写零的段不进事实面**。`zeroStudySegmentsOnDays`（时段明细里长按删除走的那条）
     // 只把行写成零而不删行——必须删的是同步语义：真删行会被对端的旧数据按 LWW 复活，
@@ -287,9 +318,7 @@ Future<StatFacts> loadStatFacts(
     hourly.add(fact);
   }
   // 游玩会话（活动流合成「游玩」事件用；activityLimit 为 0 时不取）。
-  final List<GalgameSessionRow> recentGameSessions = activityLimit <= 0
-      ? const <GalgameSessionRow>[]
-      : await db.getRecentGalgameSessions(limit: activityLimit);
+  final List<GalgameSessionRow> recentGameSessions = await recentGameSessionsF;
   final Map<String, String> gameNamesById = recentGameSessions.isEmpty
       ? const <String, String>{}
       : <String, String>{

--- a/fushi/test/database/epub_book_metas_test.dart
+++ b/fushi/test/database/epub_book_metas_test.dart
@@ -1,0 +1,102 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// `getEpubBookMetas()`：`epub_books` 的瘦投影，供只要 title / uid / importedAt /
+/// format 的调用方（书架映射、统计事实面、导入重复检查、远端去重）用，不再把
+/// 每本几十 KB 的 `chaptersJson` / `tocJson` 整库拉出来。
+///
+/// 守两点：① 字段与全行读取逐列一致、顺序同 `getAllEpubBooks`（importedAt 降序）；
+/// ② `getPrefsByPrefix` 前缀查询把 `_` / `%` 按字面转义（偏好键里全是下划线，
+/// 不转义就成了单字符通配）。
+Future<FushiDatabase> _openDb() async {
+  final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+EpubBooksCompanion _book({
+  required String title,
+  required int importedAt,
+  String format = 'epub',
+}) {
+  return EpubBooksCompanion.insert(
+    bookKey: title,
+    title: title,
+    epubPath: '/tmp/$title.epub',
+    extractDir: '/tmp/$title',
+    chapterCount: 3,
+    chaptersJson: '[{"characters": 1000}, {"characters": 2000}]',
+    tocJson: const Value('[{"title": "big toc"}]'),
+    importedAt: importedAt,
+    format: Value(format),
+  );
+}
+
+void main() {
+  group('getEpubBookMetas', () {
+    test('projects the same identity columns as the full row, same order',
+        () async {
+      final FushiDatabase db = await _openDb();
+      await db.insertEpubBook(_book(title: 'Old', importedAt: 100));
+      await db.insertEpubBook(
+          _book(title: 'Comic', importedAt: 300, format: 'manga'));
+      await db.insertEpubBook(_book(title: 'New', importedAt: 200));
+      await db.setEpubBookCompleted(
+          'Old', DateTime.fromMillisecondsSinceEpoch(5000));
+
+      final List<EpubBookRow> full = await db.getAllEpubBooks();
+      final List<EpubBookMeta> metas = await db.getEpubBookMetas();
+
+      expect(metas.map((EpubBookMeta m) => m.bookKey).toList(),
+          full.map((EpubBookRow r) => r.bookKey).toList(),
+          reason: '与 getAllEpubBooks 同序（importedAt 降序）');
+      expect(metas.map((EpubBookMeta m) => m.bookKey).toList(),
+          <String>['Comic', 'New', 'Old']);
+      for (int i = 0; i < full.length; i++) {
+        final EpubBookRow r = full[i];
+        final EpubBookMeta m = metas[i];
+        expect(m.uid, r.uid);
+        expect(m.title, r.title);
+        expect(m.format, r.format);
+        expect(m.importedAt, r.importedAt);
+        expect(m.extractDir, r.extractDir);
+        expect(m.completedAt, r.completedAt);
+      }
+      expect(metas.last.completedAt, isNotNull);
+      expect(metas.first.format, 'manga');
+    });
+
+    test('empty library yields empty list', () async {
+      final FushiDatabase db = await _openDb();
+      expect(await db.getEpubBookMetas(), isEmpty);
+    });
+  });
+
+  group('getPrefsByPrefix', () {
+    test('returns only keys under the prefix, literal underscore', () async {
+      final FushiDatabase db = await _openDb();
+      await db.setPref('audiobook_health_overlay_A', 'a');
+      await db.setPref('audiobook_health_overlay_B', 'b');
+      // `_` 若被当通配符，这条会被 'audiobook_health_overlay_' 误命中。
+      await db.setPref('audiobookXhealthXoverlayXC', 'c');
+      await db.setPref('other', 'o');
+
+      final Map<String, String> got =
+          await db.getPrefsByPrefix('audiobook_health_overlay_');
+
+      expect(got, <String, String>{
+        'audiobook_health_overlay_A': 'a',
+        'audiobook_health_overlay_B': 'b',
+      });
+    });
+
+    test('percent in prefix is literal too', () async {
+      final FushiDatabase db = await _openDb();
+      await db.setPref('p%q_1', 'x');
+      await db.setPref('pZq_1', 'y');
+      expect(await db.getPrefsByPrefix('p%q'), <String, String>{'p%q_1': 'x'});
+    });
+  });
+}

--- a/fushi/test/media/audiobook/audiobook_health_batch_test.dart
+++ b/fushi/test/media/audiobook/audiobook_health_batch_test.dart
@@ -1,0 +1,69 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 书架为每本有声书各查一次 `readHealthOverlay`（= 一条真 SELECT）是 N+1；
+/// [AudiobookRepository.resolveAllHealth] 一条前缀查询取完。守：批量口径与单本
+/// `resolveHealth` 逐本一致——有覆盖用覆盖、无覆盖按行自身推导、覆盖损坏回退。
+void main() {
+  late FushiDatabase db;
+  late AudiobookRepository repo;
+
+  setUp(() {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    repo = AudiobookRepository(db);
+  });
+
+  tearDown(() => db.close());
+
+  Future<void> insertAudiobook(String bookKey, {int? matchRatePct}) =>
+      db.upsertAudiobook(AudiobooksCompanion.insert(
+        bookKey: bookKey,
+        alignmentFormat: 'lrc',
+        alignmentPath: '/tmp/$bookKey.lrc',
+        matchRatePct: Value<int?>(matchRatePct),
+      ));
+
+  test('resolveAllHealth equals per-book resolveHealth', () async {
+    await insertAudiobook('with-overlay', matchRatePct: 10);
+    await insertAudiobook('no-overlay', matchRatePct: 95);
+    await insertAudiobook('broken-overlay', matchRatePct: 50);
+    await repo.updateHealthOverlay(
+      bookKey: 'with-overlay',
+      health: AudiobookHealth.fromRatePct(ratePct: 99, reason: 'rerun'),
+    );
+    await db.setPref('audiobook_health_overlay_broken-overlay', '{not json');
+
+    final Map<String, Audiobook> byKey = await repo.buildBookKeyMap();
+    final Map<String, AudiobookHealth> batch =
+        await repo.resolveAllHealth(byKey);
+
+    expect(batch.keys.toSet(), byKey.keys.toSet());
+    for (final MapEntry<String, Audiobook> e in byKey.entries) {
+      final AudiobookHealth single = await repo.resolveHealth(e.value);
+      expect(batch[e.key]!.kind, single.kind, reason: e.key);
+      expect(batch[e.key]!.ratePct, single.ratePct, reason: e.key);
+      expect(batch[e.key]!.reason, single.reason, reason: e.key);
+    }
+    expect(batch['with-overlay']!.kind, HealthKind.ok,
+        reason: '覆盖（99%）压过行自身的 10%');
+    expect(batch['with-overlay']!.reason, 'rerun');
+  });
+
+  test('readAllHealthOverlays strips the key prefix and skips junk', () async {
+    await repo.updateHealthOverlay(
+      bookKey: 'k1',
+      health: AudiobookHealth.fromRatePct(ratePct: 80),
+    );
+    await db.setPref('audiobook_health_overlay_junk', '');
+    await db.setPref('unrelated_pref', '{"kind":"ok"}');
+
+    final Map<String, AudiobookHealth> overlays =
+        await repo.readAllHealthOverlays();
+
+    expect(overlays.keys.toSet(), <String>{'k1'});
+    expect(overlays['k1']!.ratePct, 80);
+  });
+}

--- a/fushi/test/media/audiobook/reader_position_repository_test.dart
+++ b/fushi/test/media/audiobook/reader_position_repository_test.dart
@@ -178,4 +178,29 @@ void main() {
     expect(pos!.charOffset, isNull,
         reason: 'first save without charOffset → DB default -1 → model null');
   });
+
+  // 书架列书一次取完（替代每本一查的 N+1）：批量读与单本读逐字段一致。
+  test('findAllByBookUid matches per-book reads field by field', () async {
+    await repo.save(
+        bookUid: 'a', sectionIndex: 3, normCharOffset: 1000, charOffset: 42);
+    await repo.save(bookUid: 'b', sectionIndex: 7, normCharOffset: 5000);
+
+    final Map<String, ReaderPosition> all = await repo.findAllByBookUid();
+
+    expect(all.keys.toSet(), <String>{'a', 'b'});
+    for (final String uid in all.keys) {
+      final ReaderPosition? single = await repo.findByBookUid(uid);
+      final ReaderPosition batch = all[uid]!;
+      expect(batch.sectionIndex, single!.sectionIndex);
+      expect(batch.normCharOffset, single.normCharOffset);
+      expect(batch.charOffset, single.charOffset);
+      expect(batch.updatedAt, single.updatedAt);
+    }
+    expect(all['a']!.charOffset, 42);
+    expect(all['b']!.charOffset, isNull, reason: 'DB -1 哨兵 → 模型 null');
+  });
+
+  test('findAllByBookUid on empty table is empty', () async {
+    expect(await repo.findAllByBookUid(), isEmpty);
+  });
 }

--- a/fushi/test/media/import/import_carrier_test.dart
+++ b/fushi/test/media/import/import_carrier_test.dart
@@ -7,6 +7,8 @@
 /// EPUB、.mokuro 的 JSON 会被当纯文本吞掉、带点的目录名会取出假扩展名。
 library;
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/import/import_carrier.dart';
 
@@ -291,6 +293,42 @@ void main() {
       r.resolver.invalidate();
       r.resolver.resolve('/b/novel.epub');
       expect(r.probes.length, 2);
+    });
+
+    test('内容变了必须重新定性：同一路径、文件被换掉（BUG-2168 复审）', () async {
+      // 只用路径当记忆键是不够的：判定本身要**真开包读内容**，结论随内容变。
+      // 可达路径全程在既有 UI 上——用户选了一个还在下载中、中央目录尚未落盘的
+      // .cbz，判成非漫画后只弹一条 toast 并 return（对话框不关、resolver 不销毁）；
+      // 下载完成后在同一个对话框里重选同一路径，单槽命中就返回过期判定，
+      // isImageArchive 根本不再被调用，用户永远导不进去，只能关掉重开。
+      final Directory dir =
+          await Directory.systemTemp.createTemp('carrier_memo_');
+      addTearDown(() => dir.delete(recursive: true));
+      final File f = File('${dir.path}/vol.zip');
+      await f.writeAsBytes(<int>[0]);
+
+      final List<String> probes = <String>[];
+      // 「开包」的答案跟着磁盘内容走：内容长度 >= 2 才算图片包（模拟「下载完成」）。
+      final ImportCarrierResolver resolver = ImportCarrierResolver(
+        isDirectory: (String _) => false,
+        isImageArchive: (String path) {
+          probes.add(path);
+          return File(path).lengthSync() >= 2;
+        },
+        directoryHasPageImages: (String _) => false,
+        directoryCarrierFileCount: (String _) => 0,
+      );
+
+      expect(resolver.resolve(f.path), ImportCarrier.epub,
+          reason: '半截包：判据说它不是图片包');
+      expect(resolver.resolve(f.path), ImportCarrier.epub);
+      expect(probes.length, 1, reason: '内容没变时仍然只开一次包');
+
+      // 文件被换成完整的包（mtime + 大小都变了）。
+      await f.writeAsBytes(<int>[0, 1, 2, 3]);
+      expect(resolver.resolve(f.path), ImportCarrier.mangaArchive,
+          reason: '内容变了就必须重新开包定性，不得返回过期判定');
+      expect(probes.length, 2);
     });
 
     test('记忆不改变判定结果本身（词典包一票否决照常）', () {

--- a/fushi/test/media/import/manga_import_carrier_memo_guard_test.dart
+++ b/fushi/test/media/import/manga_import_carrier_memo_guard_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：漫画导入对话框问载体身份必须**走记忆**，不得裸调分类函数。
+///
+/// 与 `book_import_carrier_memo_guard_test.dart` 同款。`.zip` / `.epub` 的定性要
+/// `isImageArchive` 真开包；漫画框此前在 initState 预填、`_adoptPath`、
+/// `_handleDialogDrop` 的循环里各裸调一次 `classifyImportCarrier`，一次拖入 = 同一
+/// 个包开两三次，然后 `importArchive` 再开一次。记忆层的行为正确性在
+/// `import_carrier_test.dart` 的 `ImportCarrierResolver` 组里验；这里只钉接线。
+void main() {
+  late String src;
+
+  setUpAll(() {
+    final File f = File('lib/src/media/manga/manga_import_dialog.dart');
+    expect(f.existsSync(), isTrue, reason: '守卫目标文件应存在');
+    src = f.readAsStringSync();
+  });
+
+  test('对话框不得裸调 classifyImportCarrier（必须经 ImportCarrierResolver）', () {
+    expect(src.contains('classifyImportCarrier('), isFalse,
+        reason: '裸调会绕过记忆 → 同一路径重复开包；改用 _classify → resolver');
+  });
+
+  test('对话框持有且只持有一个 ImportCarrierResolver', () {
+    expect('ImportCarrierResolver('.allMatches(src).length, 1,
+        reason: '多个 resolver = 各自一份记忆 = 还是会重复开包');
+  });
+
+  test('_classify 委托给 resolver，且判据仍是真开包判据', () {
+    expect(src.contains('_carrierResolver.resolve('), isTrue);
+    expect(src.contains('isImageArchive: MangaModule.isImageArchive'), isTrue,
+        reason: '换成按扩展名的桩会让 Yomitan 词典 zip 被当漫画导入');
+  });
+}

--- a/fushi/test/media/manga/image_size_probe_test.dart
+++ b/fushi/test/media/manga/image_size_probe_test.dart
@@ -41,12 +41,112 @@ void main() {
     });
   }
 
-  test('WebP / GIF / BMP：各自的头', () {
+  test('BMP：各自的头', () {
     final img.Image image = img.Image(width: 24, height: 16);
     expect(
-        probeOrientedImageSize(img.encodeGif(image)), (width: 24, height: 16));
-    expect(
         probeOrientedImageSize(img.encodeBmp(image)), (width: 24, height: 16));
+  });
+
+  test('GIF 返回 null：逻辑屏幕尺寸 != 帧尺寸，不能拿它冒充', () {
+    // `GifDecoder.startDecode` 返回的是**逻辑屏幕描述符**，而 `decodeImage` 建的
+    // Image 用的是**帧描述符**。帧小于逻辑屏幕的 GIF（转档/裁剪工具常见）两者不是
+    // 一回事，头探测会给出画布尺寸而不是实际图像尺寸——下游据此判 spread/webtoon
+    // 会判反、OCR 框坐标整体错位，且全程不报错。既然对不上就交回整张解码。
+    final Uint8List gif = img.encodeGif(img.Image(width: 24, height: 16));
+    expect(probeOrientedImageSize(gif), isNull,
+        reason: 'GIF 必须回退整张解码，不能用逻辑屏幕尺寸');
+    // 回退路径本身仍给出正确尺寸（调用方就是这么兜的）。
+    expect(baked(gif), (width: 24, height: 16));
+  });
+
+  group('WebP EXIF orientation（bakeOrientation 与格式无关，WebP 也会被它旋转）', () {
+    // image 4.3.0 的 WebP 解码器确实会填 image.exif（有损 VP8 / 无损 VP8L 两条路径
+    // 都写），所以 `bakeOrientation` 对带 orientation 的 WebP 会换轴。只给 JPEG 开
+    // 这道门就把 WebP 的旋转丢了，而 `.webp` 就在受理的漫画页扩展名里。
+    //
+    // 这里手搓 RIFF 容器而不是用 img.encodeWebP —— image 包不提供 WebP 编码。
+    // 合成的是最小 VP8L：signature 0x2F + 14bit(w-1) + 14bit(h-1) + alpha + version。
+    Uint8List u32le(int v) =>
+        Uint8List(4)..buffer.asByteData().setUint32(0, v, Endian.little);
+
+    Uint8List vp8lPayload(int w, int h) {
+      final int bits = (w - 1) | ((h - 1) << 14);
+      return Uint8List.fromList(<int>[
+        0x2F,
+        bits & 0xFF,
+        (bits >> 8) & 0xFF,
+        (bits >> 16) & 0xFF,
+        (bits >> 24) & 0xFF,
+        0x00,
+      ]);
+    }
+
+    void addChunk(BytesBuilder out, String fourcc, Uint8List payload) {
+      out.add(fourcc.codeUnits);
+      out.add(u32le(payload.length));
+      out.add(payload);
+      if (payload.length.isOdd) out.addByte(0);
+    }
+
+    Uint8List buildWebp(int w, int h, {Uint8List? exif}) {
+      final BytesBuilder body = BytesBuilder();
+      addChunk(body, 'VP8L', vp8lPayload(w, h));
+      if (exif != null) addChunk(body, 'EXIF', exif);
+      final Uint8List inner = body.toBytes();
+      final BytesBuilder out = BytesBuilder();
+      out.add('RIFF'.codeUnits);
+      out.add(u32le(4 + inner.length));
+      out.add('WEBP'.codeUnits);
+      out.add(inner);
+      return out.toBytes();
+    }
+
+    /// 小端 TIFF，IFD0 里恰好一条 Orientation = SHORT(v)。
+    Uint8List tiffOrientation(int v, {bool withExifPrefix = false}) {
+      final BytesBuilder b = BytesBuilder();
+      if (withExifPrefix) b.add(<int>[0x45, 0x78, 0x69, 0x66, 0x00, 0x00]);
+      b.add(<int>[0x49, 0x49, 0x2A, 0x00]);
+      b.add(u32le(8));
+      b.add(<int>[0x01, 0x00]);
+      b.add(<int>[0x12, 0x01]);
+      b.add(<int>[0x03, 0x00]);
+      b.add(u32le(1));
+      b.add(<int>[v & 0xFF, (v >> 8) & 0xFF, 0x00, 0x00]);
+      b.add(u32le(0));
+      return b.toBytes();
+    }
+
+    for (final int orientation in <int>[1, 3, 6, 8]) {
+      test('orientation=$orientation：>=5 换轴，其余不动', () {
+        final Uint8List bytes =
+            buildWebp(24, 16, exif: tiffOrientation(orientation));
+        expect(webpExifOrientation(bytes), orientation);
+        expect(
+          probeOrientedImageSize(bytes),
+          orientation >= 5 ? (width: 16, height: 24) : (width: 24, height: 16),
+          reason: 'orientation 5~8 是转了 90° 的方向，宽高必须对调',
+        );
+      });
+    }
+
+    test('EXIF chunk 带 Exif 前缀（六字节 Exif + 两个 NUL）的编码器也要认', () {
+      final Uint8List bytes = buildWebp(24, 16,
+          exif: tiffOrientation(6, withExifPrefix: true));
+      expect(webpExifOrientation(bytes), 6);
+      expect(probeOrientedImageSize(bytes), (width: 16, height: 24));
+    });
+
+    test('没有 EXIF chunk / 不是 WebP：一律 1（未旋转）', () {
+      // 用一个填充 chunk 把字节喂够（最小 VP8L 头本身不足以让 startDecode 走完）。
+      final Uint8List padded =
+          buildWebp(24, 16, exif: Uint8List.fromList(<int>[0, 0, 0, 0]));
+      expect(webpExifOrientation(padded), 1);
+      expect(probeOrientedImageSize(padded), (width: 24, height: 16));
+      expect(webpExifOrientation(img.encodeJpg(img.Image(width: 4, height: 4))),
+          1);
+      expect(webpExifOrientation(Uint8List.fromList(<int>[1, 2, 3])), 1);
+      expect(webpExifOrientation(Uint8List(0)), 1);
+    });
   });
 
   test('非图片 / 截断返回 null（调用方回退整张解码）', () {

--- a/fushi/test/media/manga/image_size_probe_test.dart
+++ b/fushi/test/media/manga/image_size_probe_test.dart
@@ -1,0 +1,59 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:fushi/src/media/manga/import/image_size_probe.dart';
+
+/// 头部探测的宽高必须与「整张解码 + bakeOrientation」的宽高逐格式一致——
+/// 漫画导入写进 manga.json 的尺寸从此只读文件头，口径不能漂。
+void main() {
+  ({int width, int height}) baked(Uint8List bytes) {
+    final img.Image oriented = img.bakeOrientation(img.decodeImage(bytes)!);
+    return (width: oriented.width, height: oriented.height);
+  }
+
+  test('PNG: IHDR 尺寸', () {
+    final Uint8List bytes = img.encodePng(img.Image(width: 30, height: 20));
+    expect(probeOrientedImageSize(bytes), (width: 30, height: 20));
+    expect(probeOrientedImageSize(bytes), baked(bytes));
+  });
+
+  test('JPEG 无 EXIF：SOF 尺寸，orientation 视为 1', () {
+    final Uint8List bytes = img.encodeJpg(img.Image(width: 30, height: 20));
+    expect(jpegExifOrientation(bytes), 1);
+    expect(probeOrientedImageSize(bytes), (width: 30, height: 20));
+    expect(probeOrientedImageSize(bytes), baked(bytes));
+  });
+
+  for (final int orientation in <int>[1, 2, 3, 4, 5, 6, 7, 8]) {
+    test('JPEG EXIF orientation=$orientation 与 bakeOrientation 一致', () {
+      final img.Image image = img.Image(width: 30, height: 20);
+      image.exif.imageIfd.orientation = orientation;
+      final Uint8List bytes = img.encodeJpg(image);
+      expect(jpegExifOrientation(bytes), orientation);
+      final ({int width, int height})? probed = probeOrientedImageSize(bytes);
+      expect(probed, baked(bytes));
+      expect(
+        probed,
+        orientation >= 5 ? (width: 20, height: 30) : (width: 30, height: 20),
+      );
+    });
+  }
+
+  test('WebP / GIF / BMP：各自的头', () {
+    final img.Image image = img.Image(width: 24, height: 16);
+    expect(
+        probeOrientedImageSize(img.encodeGif(image)), (width: 24, height: 16));
+    expect(
+        probeOrientedImageSize(img.encodeBmp(image)), (width: 24, height: 16));
+  });
+
+  test('非图片 / 截断返回 null（调用方回退整张解码）', () {
+    expect(probeOrientedImageSize(Uint8List.fromList(<int>[1, 2, 3])), isNull);
+    expect(probeOrientedImageSize(Uint8List(0)), isNull);
+    final Uint8List jpg = img.encodeJpg(img.Image(width: 30, height: 20));
+    // 只剩 SOI 的截断 JPEG：orientation 兜底 1，不越界。
+    expect(jpegExifOrientation(Uint8List.sublistView(jpg, 0, 3)), 1);
+  });
+}

--- a/fushi/test/media/manga/manga_archive_importer_test.dart
+++ b/fushi/test/media/manga/manga_archive_importer_test.dart
@@ -35,6 +35,36 @@ void main() {
     if (app.existsSync()) app.deleteSync(recursive: true);
   });
 
+  test('CBZ with a corrupt page entry fails on CRC instead of importing junk',
+      () async {
+    // 流式打开只读中央目录、不整包 verify；写盘条目必须补 CRC 校验，否则位翻转
+    // 的坏页会被当正常页写进书。STORE 条目：翻转数据区一个字节，中央目录仍完好。
+    final Uint8List png = Uint8List.fromList(
+      img.encodePng(img.Image(width: 40, height: 80)),
+    );
+    final Archive archive = Archive()
+      ..addFile(ArchiveFile('1.png', png.length, png)..compress = false)
+      ..addFile(ArchiveFile('2.png', png.length, png)..compress = false);
+    final Uint8List bytes = Uint8List.fromList(ZipEncoder().encode(archive)!);
+    // 本地文件头 30 字节 + 文件名 5 字节后就是第一页的原始数据；翻转其中间一个字节。
+    const int dataStart = 30 + '1.png'.length;
+    bytes[dataStart + png.length ~/ 2] ^= 0xFF;
+    final String path = p.join(root.path, 'corrupt.cbz');
+    File(path).writeAsBytesSync(bytes);
+
+    expect(MangaArchiveImporter.looksLikeImageArchive(path), isTrue,
+        reason: '探测只看条目名，不为坏页整包解压');
+    await expectLater(
+      MangaArchiveImporter.importArchive(db: db, archivePath: path),
+      throwsA(isA<MangaImportException>().having(
+        (MangaImportException e) => e.message,
+        'message',
+        contains('CRC'),
+      )),
+    );
+    expect(await db.getEpubBookMetas(), isEmpty, reason: '不落任何行');
+  });
+
   test('CBZ images import in natural order', () async {
     final Uint8List png = Uint8List.fromList(
       img.encodePng(img.Image(width: 40, height: 80)),
@@ -84,7 +114,10 @@ void main() {
         runProcess: (String executable, List<String> arguments) async {
           calls.add(arguments);
           if (arguments.first == 'l') {
-            return ProcessResult(1, 0, '''
+            return ProcessResult(
+                1,
+                0,
+                '''
 Path = $archivePath
 Type = Rar
 
@@ -96,7 +129,8 @@ Attributes = A
 Path = notes.txt
 Size = 5000000000
 Attributes = A
-''', '');
+''',
+                '');
           }
           final String outputArg = arguments.firstWhere(
             (String arg) => arg.startsWith('-o'),
@@ -131,7 +165,10 @@ Attributes = A
       sevenZipOverride: 'fake-7z',
       runProcess: (String executable, List<String> arguments) async {
         if (arguments.first == 'l') {
-          return ProcessResult(1, 0, '''
+          return ProcessResult(
+              1,
+              0,
+              '''
 Path = $archivePath
 Type = Rar
 
@@ -139,7 +176,8 @@ Type = Rar
 Path = ..\\escape.png
 Size = 3
 Attributes = A
-''', '');
+''',
+              '');
         }
         extracted = true;
         return ProcessResult(2, 0, '', '');
@@ -163,11 +201,14 @@ Attributes = A
       final Uint8List png = Uint8List.fromList(
         img.encodePng(img.Image(width: 40, height: 80)),
       );
-      final String path = _writeArchive(root, <ArchiveFile>[
-        _textEntry('book.mokuro', _mokuroJson('images/001.png', '埋め込み')),
-        _textEntry('legacy.html', '<html>legacy mokuro reader</html>'),
-        ArchiveFile('images/001.png', png.length, png),
-      ], name: 'book$extension');
+      final String path = _writeArchive(
+          root,
+          <ArchiveFile>[
+            _textEntry('book.mokuro', _mokuroJson('images/001.png', '埋め込み')),
+            _textEntry('legacy.html', '<html>legacy mokuro reader</html>'),
+            ArchiveFile('images/001.png', png.length, png),
+          ],
+          name: 'book$extension');
       expect(MangaArchiveImporter.looksLikeImageArchive(path), isTrue);
 
       final String key = await MangaArchiveImporter.importArchive(

--- a/fushi/test/media/source_library/source_file_system_test.dart
+++ b/fushi/test/media/source_library/source_file_system_test.dart
@@ -57,8 +57,9 @@ void main() {
       expect(byName['book.srt']!.isDirectory, isFalse);
       expect(byName['season1']!.isDirectory, isTrue);
 
-      // 文件条目带 sizeBytes，目录条目 sizeBytes 为 null。
-      expect(byName['book.epub']!.sizeBytes, equals('epub-bytes'.length));
+      // 本地传输不逐文件 stat：sizeBytes 一律 null（扫描链路无消费方；递归枚举
+      // 几万文件的树时每文件一次 length() 是纯浪费）。目录条目同样 null。
+      expect(byName['book.epub']!.sizeBytes, isNull);
       expect(byName['season1']!.sizeBytes, isNull);
 
       // path 是完整绝对路径。

--- a/fushi/test/models/app_font_loader_inflight_failure_test.dart
+++ b/fushi/test/models/app_font_loader_inflight_failure_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/app_font_loader.dart';
+
+/// 在飞去重（`_inFlight`）只能复用**成功**的结果。
+///
+/// 背景：`resolveAndLoadAll` 从串行 for 改成 `Future.wait` 之后，同一 family 的
+/// 并发条目靠 `_inFlight[family]` 共享一个 future。但那张表里存的是 future 本身，
+/// 成功和失败一视同仁——而 `_loadedFamilies.add(family)` 只在装载成功后才执行，
+/// 所以在串行年代「第一个同名条目失败」**不会**污染后续条目：A 装 P1 失败返回
+/// null，B 照常去装自己的 P2。改成共享 future 后，B 拿到 A 的 null 就直接返回，
+/// **P2 永不被尝试**，family 整条不可用，UI/字幕/游戏文本一起回落到主题字体。
+///
+/// 触发条件不窄：`resolveAllHealth` 内部就是 `Future.wait`（同一条链的条目全部
+/// 同时在飞），AppModel 又把 appUiFonts / videoSubtitleFonts / gameLookupFonts
+/// 三条链并发跑，而「跨链同名家族」正是 `_inFlight` 存在的理由。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('同一 family：第一个文件坏掉不得让第二个文件不被尝试', () async {
+    final Directory dir =
+        await Directory.systemTemp.createTemp('font_inflight_');
+    addTearDown(() => dir.delete(recursive: true));
+
+    // `.woff` 走 FontDecoder.woffToSfnt，垃圾字节必定解不出 sfnt → 确定性失败，
+    // 不依赖 FontLoader 对畸形字节的行为。
+    final File broken = File('${dir.path}/broken.woff');
+    await broken.writeAsBytes(List<int>.filled(64, 0x41));
+
+    // 真字体：仓库自带的 Material Symbols（flutter test 的 cwd 是 fushi/ 包根）。
+    const String good = 'assets/fonts/MaterialSymbolsRounded.ttf';
+    expect(File(good).existsSync(), isTrue,
+        reason: '测试依赖这份随包字体存在；它被挪走时本用例必须显式失败');
+
+    // family 名带时间戳：`_loadedFamilies` 是进程级静态表，复用名字会让第二次
+    // 运行在入口就短路，用例退化成恒真。
+    final String family =
+        'InflightProbe${DateTime.now().microsecondsSinceEpoch}';
+
+    final List<String> families =
+        await AppFontLoader.resolveAndLoadAll(<Map<String, dynamic>>[
+      <String, dynamic>{'name': family, 'path': broken.path},
+      <String, dynamic>{'name': family, 'path': good},
+    ]);
+
+    expect(families, <String>[family],
+        reason: '第一个条目失败只说明那个文件不行；第二个同名条目必须照常被尝试，'
+            '否则整个 family 因为一个坏文件而不可用');
+  });
+}

--- a/fushi/test/models/dictionary_import_background_test.dart
+++ b/fushi/test/models/dictionary_import_background_test.dart
@@ -87,9 +87,14 @@ void main() {
       expect(manager.contains('Isolate.run(() => packDirectoryToZip'), isTrue,
           reason: '打包函数必须经 Isolate.run 调用');
 
-      // ZipEncoder().encode 只能出现一次，且在 packDirectoryToZip 里。
-      final int encodeCount = 'ZipEncoder().encode'.allMatches(manager).length;
-      expect(encodeCount, 1, reason: '同步压缩只应剩 packDirectoryToZip 内一处');
+      // 打包已改为 ZipFileEncoder 逐文件流式 STORE（不再有整目录内存 Archive +
+      // ZipEncoder().encode 的第二份内存拷贝，也不再白 deflate 一遍给 native 立刻
+      // inflate）。同步整包 encode 不得回来。
+      expect('ZipEncoder().encode'.allMatches(manager).length, 0,
+          reason: '整目录读进内存再 encode 是 ~2× 目录大小的峰值，OOM 路径来源');
+      expect(manager.contains('ZipFileEncoder()'), isTrue);
+      expect(manager.contains('..compress = false'), isTrue,
+          reason: '临时 zip 只是 native 的输入容器，deflate 纯属白干');
     });
 
     test('packDirectoryToZip 暴露给测试且为纯静态函数', () {

--- a/fushi/test/models/dictionary_import_no_delay_guard_test.dart
+++ b/fushi/test/models/dictionary_import_no_delay_guard_test.dart
@@ -20,6 +20,14 @@ void main() {
               'must be removed');
     });
 
+    test('no per-duplicate 2-second dwell remains', () {
+      // 「已是最新」分支曾在每本上硬睡 2 秒只为让进度文字停留：重导一个 30 本
+      // 已装词典的目录 = 60 秒纯等待。改为 toast 提示，循环不阻塞。
+      expect(manager.contains('Duration(seconds: 2)'), isFalse,
+          reason: 'the alreadyUpToDate branch must not sleep per dictionary; '
+              'surface the skip via toast instead');
+    });
+
     test('import failures are rethrown as a typed exception', () {
       expect(manager.contains('throw DictionaryImportException'), isTrue,
           reason:

--- a/fushi/test/pages/video_delete_reclaim_entry_guard_test.dart
+++ b/fushi/test/pages/video_delete_reclaim_entry_guard_test.dart
@@ -131,9 +131,15 @@ void main() {
           'if(!mounted||requestGeneration!=_libraryMapsRequestGeneration)return;';
       expect(body, contains(request));
       expect(body, contains(staleGuard));
+      // 锚点不带 `await`：预取链把十三个全表查询改成「先全部发出去、后统一
+      // Future.wait」，第一个快照因此是 `db.getAllMediaCollections()` 而不再是
+      // `await db.…`。不变式没变（代次仍必须在第一次碰库之前捕获），变的只是
+      // 那一行的写法——所以这里钉的是「发出查询」这个点，不是 await 那个点。
+      const String firstSnapshot = 'db.getAllMediaCollections()';
+      expect(body, contains(firstSnapshot), reason: '预取链不再碰这张表？守卫需更新');
       expect(
         body.indexOf(request),
-        lessThan(body.indexOf('awaitdb.getAllMediaCollections()')),
+        lessThan(body.indexOf(firstSnapshot)),
         reason: 'generation must be captured before the first library snapshot',
       );
       expect(

--- a/fushi/test/tools/import_load_fat_read_guard_test.dart
+++ b/fushi/test/tools/import_load_fat_read_guard_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 导入 / 书架加载路径的「全列全表读」与 N+1 守卫（性能三轮优化第一轮）。
+///
+/// 根因：`epub_books` 的 `chaptersJson` / `tocJson` 是每本几十到几百 KB 的大列，
+/// 而 `getAllEpubBooks()` 把整库全列拉出来。只要 title / uid / importedAt 的调用方
+/// （三个导入器的重复检查、书架映射、统计事实面、远端去重、来源库扫描）此前全走它，
+/// 每导入一本书就把整个库的章节 JSON 从 SQLite 读一遍再丢掉。这些调用方必须走瘦
+/// 投影 `getEpubBookMetas()`；`watchEpubBookKeys` 只投影 key 列。
+///
+/// 书架列书曾对每本各查一次阅读位置（`findByBookUid`，Drift 单连接串行，
+/// `Future.wait` 重叠不了 SQL），现在一次 `findAllByBookUid()` 取完；有声书健康度
+/// 同理走 `resolveAllHealth`。源码级守卫是这些私有方法的最强可落地层。
+void main() {
+  String read(String rel) => File(rel).readAsStringSync();
+
+  group('metadata-only callers do not pull chaptersJson', () {
+    const List<String> thinCallers = <String>[
+      'lib/src/epub/epub_importer.dart',
+      'lib/src/pdf/pdf_importer.dart',
+      'lib/src/media/manga/manga_importer.dart',
+      'lib/src/media/source_library/source_library_scanner.dart',
+      'lib/src/stats/stat_facts.dart',
+      'lib/src/pages/implementations/reader_fushi_history_page.dart',
+      'lib/src/pages/implementations/reader_history/books.part.dart',
+      'lib/src/pages/implementations/reader_history/remote.part.dart',
+      'lib/src/media/collections/collection_one_key_sort.dart',
+      'lib/src/media/tracking/media_tracking_repository.dart',
+      'lib/src/pages/implementations/collections_page.dart',
+      'lib/src/media/manga/online/mokuro_moe_catalog_view.dart',
+    ];
+    for (final String rel in thinCallers) {
+      test(rel, () {
+        final String src = read(rel);
+        expect(src.contains('getAllEpubBooks()'), isFalse,
+            reason: '$rel 只要元数据列，必须走 getEpubBookMetas()');
+        expect(src.contains('getEpubBookMetas()'), isTrue);
+      });
+    }
+
+    test('reader_fushi_source: only the shelf materialiser reads full rows',
+        () {
+      final String src = read('lib/src/media/sources/reader_fushi_source.dart');
+      // getBooksFromDb 需要 chaptersJson 算进度：允许恰好一处全行读。
+      expect('getAllEpubBooks()'.allMatches(src).length, 1,
+          reason: 'epubBookUidByKeyProvider 等只要 uid 的口径走瘦投影');
+      expect(src.contains('getEpubBookMetas()'), isTrue);
+    });
+  });
+
+  group('watchEpubBookKeys projects only the key column', () {
+    test('no full-row select behind the key stream', () {
+      final String src = read(
+          '../packages/fushi_core/lib/src/database/database_content_misc.part.dart');
+      final int start = src.indexOf('Stream<List<String>> watchEpubBookKeys()');
+      expect(start, greaterThan(0));
+      final String body = src.substring(start, src.indexOf(';', start));
+      expect(body.contains('selectOnly(epubBooks)'), isTrue,
+          reason: '流在每次写入时重跑，全列 select 会把整库大列读一遍只为取 key');
+      expect(body.contains('select(epubBooks).map'), isFalse);
+    });
+  });
+
+  group('shelf load has no per-book query', () {
+    test('reader positions are read once for the whole shelf', () {
+      final String src = read('lib/src/media/sources/reader_fushi_source.dart');
+      expect(src.contains('findAllByBookUid()'), isTrue);
+      final int start = src.indexOf('Future<MediaItem> _bookToMediaItem(');
+      expect(start, greaterThan(0));
+      final String body = src.substring(start, src.indexOf('\n  }\n', start));
+      expect(body.contains('findByBookUid('), isFalse,
+          reason: '_bookToMediaItem 不得再按本查位置（N+1）');
+    });
+
+    test('audiobook health is resolved in one prefix query', () {
+      final String src =
+          read('lib/src/pages/implementations/reader_fushi_history_page.dart');
+      final int start = src.indexOf('_loadAllAudiobookInfo()');
+      expect(start, greaterThan(0));
+      final String body = src.substring(start, src.indexOf('\n  }\n', start));
+      expect(body.contains('resolveAllHealth('), isTrue);
+      expect(body.contains('resolveHealth(entry'), isFalse,
+          reason: '每本一条 getPref 是 N+1');
+    });
+
+    test('local source listing does not stat every file', () {
+      final String src =
+          read('lib/src/media/source_library/source_file_system.dart');
+      final int start = src.indexOf('class LocalSourceFileSystem');
+      final int end = src.indexOf('listSiblingNames', start);
+      final String body = src.substring(start, end);
+      expect(body.contains('.length()'), isFalse,
+          reason: 'sizeBytes 无消费方；递归枚举时每文件一次 length() 是纯浪费');
+    });
+  });
+}

--- a/fushi/test/tools/load_paths_perf_guard_test.dart
+++ b/fushi/test/tools/load_paths_perf_guard_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 加载路径性能守卫（性能三轮优化第三轮）。这些都活在私有方法 / 启动序列上，
+/// 无法用 widget 测试量时间，源码级是最强可落地层。
+///
+/// - 视频书架的封面路径自愈不再对每一行 `existsSync`（目录列一次成集合）。
+/// - 视频页封面回填不再每抽成一张就整页重列（节流）。
+/// - 视频页 / 首页 / 统计事实面的独立全表查询一次全部发出（Future.wait），
+///   不再逐个串行 await。
+/// - 三条字体链并发解析，WOFF/WOFF2 解码进后台 isolate。
+/// - 批量加游戏的封面补取有界并行，不再无界 unawaited。
+/// - 迁移归档 SHA-256 进后台 isolate。
+void main() {
+  String read(String rel) => File(rel).readAsStringSync();
+
+  /// [signature] 起到该成员的收尾大括号；[topLevel] 的收尾在列 0。
+  String methodBody(String src, String signature, {bool topLevel = false}) {
+    final int start = src.indexOf(signature);
+    expect(start, greaterThanOrEqualTo(0), reason: '找不到 $signature');
+    final int end = src.indexOf(topLevel ? '\n}\n' : '\n  }\n', start);
+    return src.substring(start, end < 0 ? src.length : end);
+  }
+
+  group('video shelf', () {
+    final String repo = read('lib/src/media/video/video_book_repository.dart');
+    final String page =
+        read('lib/src/pages/implementations/home_video_page.dart');
+
+    test('_repairMovedCoverPaths judges existence via one dir snapshot', () {
+      final String body = methodBody(
+          repo, 'Future<List<VideoBookRow>> _repairMovedCoverPaths(');
+      expect(body.contains('_CoverDirSnapshot.take()'), isTrue);
+      expect(body.contains('File(cover).existsSync()'), isFalse,
+          reason: '每行一次同步 stat 在每次库页刷新都走');
+      expect(repo.contains('class _CoverDirSnapshot'), isTrue);
+    });
+
+    test('cover backfill throttles the shelf re-list', () {
+      final String body =
+          methodBody(page, 'Future<void> _maybeBackfillCovers() async {');
+      expect(body.contains('refreshShelfThrottled('), isTrue);
+      // 直接重列只允许出现一次——在节流闭包里；循环体里不得再裸调。
+      expect(
+          'setState(() => _future = widget.repo.listForShelf())'
+              .allMatches(body)
+              .length,
+          1,
+          reason: '每张封面一次全库重列 + 整页重建');
+      expect(page.contains('_coverBackfillRefreshInterval'), isTrue);
+    });
+
+    test('_loadLibraryMapsInner issues its table reads concurrently', () {
+      final String body = methodBody(
+          page, 'Future<void> _loadLibraryMapsInner(int requestGeneration)');
+      expect(body.contains('await Future.wait<Object?>('), isTrue);
+      for (final String q in <String>[
+        'db.getAllMediaCollections()',
+        'db.getAllCollectionItems()',
+        'db.getAllVideoWatchStatistics()',
+        'db.getAllMediaImages()',
+      ]) {
+        expect(body.contains('await $q'), isFalse,
+            reason: '$q 应先发出、后 await，不得串行 await 直接调用');
+      }
+    });
+  });
+
+  group('dashboard / stat facts', () {
+    test('loadStatFacts fans out its reads', () {
+      final String src = read('lib/src/stats/stat_facts.dart');
+      final String body =
+          methodBody(src, 'Future<StatFacts> loadStatFacts(', topLevel: true);
+      expect(body.contains('await Future.wait<Object?>('), isTrue);
+      expect(body.contains('await db.getAllReadingStatistics()'), isFalse);
+      expect(body.contains('await db.getStudySegments()'), isFalse);
+    });
+
+    test('_loadDashboardDataUnsafe fans out its reads', () {
+      final String src =
+          read('lib/src/pages/implementations/home_dashboard_page.dart');
+      final String body =
+          methodBody(src, 'Future<void> _loadDashboardDataUnsafe() async {');
+      expect(body.contains('await Future.wait<Object?>('), isTrue);
+      expect(body.contains('await db.getAllMediaImages()'), isFalse);
+      expect(body.contains('await db.getAllCollectionItems()'), isFalse);
+    });
+  });
+
+  group('startup', () {
+    test('font targets resolve concurrently, web fonts decode off-thread', () {
+      final String model = read('lib/src/models/app_model.dart');
+      expect(
+          model.contains(
+              '<Future<Object?>>[appFontsF, subtitleFontF, gameFontsF]'),
+          isTrue,
+          reason: '三条字体链必须并发解析');
+      final String loader = read('lib/src/models/app_font_loader.dart');
+      expect(loader.contains('Future.wait<String?>('), isTrue,
+          reason: '一条链内的条目并发解析');
+      expect(loader.contains('_inFlight'), isTrue, reason: '并发下同名家族只注册一次');
+      expect(loader.contains('await Isolate.run('), isTrue,
+          reason: 'WOFF/WOFF2 解码不得留在 UI isolate');
+    });
+
+    test('main.dart runs the independent log/backend inits concurrently', () {
+      final String main = read('lib/main.dart');
+      expect(main.contains('await Future.wait<void>(<Future<void>>['), isTrue);
+      expect(main.contains('await DebugLogService.instance.init();'), isFalse);
+      expect(main.contains('await WgcCaptureLog.foldIntoErrorLog();'), isFalse);
+    });
+  });
+
+  group('games / migration', () {
+    test('batch game cover resolution is bounded', () {
+      final String src = read('lib/src/mining/galgame_add_flow.dart');
+      expect(src.contains('kGameCoverResolveConcurrency'), isTrue);
+      final String body =
+          methodBody(src, 'Future<void> addGamesFromPaths(', topLevel: true);
+      expect(body.contains('unawaited(_autoCoverAllSilently('), isTrue);
+      expect(
+          body.contains('for (final GalgameEntry entry in added) {\n'
+              '    unawaited(_autoCoverSilently('),
+          isFalse,
+          reason: 'N 个无界 isolate 各抱一个 exe');
+    });
+
+    test('archive sha256 runs in a background isolate', () {
+      final String src = read('lib/src/migration/migration_manifest.dart');
+      final String body =
+          methodBody(src, 'static Future<String> sha256OfFile(File file)');
+      expect(body.contains('Isolate.run('), isTrue);
+    });
+  });
+}

--- a/packages/fushi_audio/lib/src/audiobook/audiobook_repository.dart
+++ b/packages/fushi_audio/lib/src/audiobook/audiobook_repository.dart
@@ -311,6 +311,24 @@ class AudiobookRepository {
 
   Future<AudiobookHealth?> readHealthOverlay(String bookKey) async {
     final raw = await _db.getPref('$_kHealthOverlayKeyPrefix$bookKey');
+    return _parseHealthOverlay(raw);
+  }
+
+  /// 全部健康度覆盖一次取完（bookKey → 覆盖）。书架列表页为每本有声书各查一次
+  /// [readHealthOverlay] 是 N+1（每次都是一条真 SELECT），这里一条前缀查询取完。
+  Future<Map<String, AudiobookHealth>> readAllHealthOverlays() async {
+    final Map<String, String> raw =
+        await _db.getPrefsByPrefix(_kHealthOverlayKeyPrefix);
+    final Map<String, AudiobookHealth> result = <String, AudiobookHealth>{};
+    for (final MapEntry<String, String> e in raw.entries) {
+      final AudiobookHealth? health = _parseHealthOverlay(e.value);
+      if (health == null) continue;
+      result[e.key.substring(_kHealthOverlayKeyPrefix.length)] = health;
+    }
+    return result;
+  }
+
+  static AudiobookHealth? _parseHealthOverlay(String? raw) {
     if (raw == null || raw.isEmpty) return null;
     try {
       final m = jsonDecode(raw) as Map<String, dynamic>;
@@ -354,6 +372,18 @@ class AudiobookRepository {
     final overlay = await readHealthOverlay(ab.bookKey);
     if (overlay != null) return overlay;
     return AudiobookHealth.fromAudiobook(ab);
+  }
+
+  /// [resolveHealth] 的批量口径（书架一次算完全部有声书）：覆盖一次前缀查询取完，
+  /// 判据与单本版逐字一致——有覆盖用覆盖，否则按行自身推导。
+  Future<Map<String, AudiobookHealth>> resolveAllHealth(
+    Map<String, Audiobook> byBookKey,
+  ) async {
+    final Map<String, AudiobookHealth> overlays = await readAllHealthOverlays();
+    return <String, AudiobookHealth>{
+      for (final MapEntry<String, Audiobook> e in byBookKey.entries)
+        e.key: overlays[e.key] ?? AudiobookHealth.fromAudiobook(e.value),
+    };
   }
 
   // ── conversions ─────────────────────────────────────────────────

--- a/packages/fushi_audio/lib/src/audiobook/audiobook_storage.dart
+++ b/packages/fushi_audio/lib/src/audiobook/audiobook_storage.dart
@@ -52,19 +52,40 @@ abstract final class AudiobookStorage {
   /// 导入时用这些边界给 cue 重新分配 [AudioCue.audioFileIndex]（见
   /// [reindexCuesByFileBoundaries]）。每个文件用一次性 [AudioPlayer]，探完即释放。
   static Future<List<int>> probeAudioDurationsMs(List<String> paths) async {
-    final List<int> out = <int>[];
-    for (final String path in paths) {
-      final AudioPlayer player = AudioPlayer();
-      try {
-        final Duration? dur = await player.setFilePath(path);
-        out.add(dur?.inMilliseconds ?? 0);
-      } catch (_) {
-        out.add(0);
-      } finally {
-        await player.dispose();
+    // 每个文件一次平台播放器 构造→探头→释放 往返（Android 上 100~500 ms）；
+    // 60 章的 m4b 串行就是半分钟卡在「保存中」。有界并行（同时 4 个），
+    // 结果按下标回填保持与 [paths] 对齐。
+    final List<int> out = List<int>.filled(paths.length, 0);
+    int next = 0;
+    Future<void> worker() async {
+      while (next < paths.length) {
+        final int i = next++;
+        out[i] = await _probeOneDurationMs(paths[i]);
       }
     }
+
+    final int workers = paths.length < probeDurationConcurrency
+        ? paths.length
+        : probeDurationConcurrency;
+    await Future.wait<void>(
+      List<Future<void>>.generate(workers, (_) => worker()),
+    );
     return out;
+  }
+
+  /// [probeAudioDurationsMs] 的并行度。
+  static const int probeDurationConcurrency = 4;
+
+  static Future<int> _probeOneDurationMs(String path) async {
+    final AudioPlayer player = AudioPlayer();
+    try {
+      final Duration? dur = await player.setFilePath(path);
+      return dur?.inMilliseconds ?? 0;
+    } catch (_) {
+      return 0;
+    } finally {
+      await player.dispose();
+    }
   }
 
   /// FNV-1a 32 位（UTF-8 逐字节），委托 hibiki_core 单一真相源；输出与历史手写

--- a/packages/fushi_audio/lib/src/audiobook/reader_position_repository.dart
+++ b/packages/fushi_audio/lib/src/audiobook/reader_position_repository.dart
@@ -15,6 +15,14 @@ class ReaderPositionRepository {
     return _rowToModel(row);
   }
 
+  /// 全部阅读位置按 bookUid 建表（书架列书一次取完，替代每本一查的 N+1）。
+  Future<Map<String, ReaderPosition>> findAllByBookUid() async {
+    final List<ReaderPositionRow> rows = await _db.getAllReaderPositions();
+    return <String, ReaderPosition>{
+      for (final ReaderPositionRow row in rows) row.bookUid: _rowToModel(row),
+    };
+  }
+
   Future<void> save({
     required String bookUid,
     required int sectionIndex,

--- a/packages/fushi_audio/lib/src/parsers/ass_parser.dart
+++ b/packages/fushi_audio/lib/src/parsers/ass_parser.dart
@@ -302,9 +302,12 @@ class AssParser {
   /// 将 ASS 时间码 `H:MM:SS.x` 转换为毫秒。小数秒接受 1~3 位
   /// （厘秒/毫秒/十分之一秒可变精度），归一到毫秒的写法与 SRT/VTT
   /// 解析器同构（`padRight(3, '0')`），消除外挂 .ass 的孤立特例（TODO-870）。
+  static final RegExp _assTimeRe =
+      RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
+  static final RegExp _assColorRe = RegExp(r'&H([0-9a-fA-F]{1,8})&?$');
+
   static int? _parseAssTime(String timecode) {
-    final RegExpMatch? m =
-        RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$').firstMatch(timecode);
+    final RegExpMatch? m = _assTimeRe.firstMatch(timecode);
     if (m == null) {
       return null;
     }
@@ -340,7 +343,7 @@ class AssParser {
       final String? raw = cell(name);
       if (raw == null) return null;
       // ASS 颜色形如 &HAABBGGRR& 或 &HBBGGRR；取出十六进制主体交给 assColorToArgb。
-      final RegExpMatch? m = RegExp(r'&H([0-9a-fA-F]{1,8})&?$').firstMatch(raw);
+      final RegExpMatch? m = _assColorRe.firstMatch(raw);
       if (m == null) return null;
       return assColorToArgb(m.group(1)!);
     }

--- a/packages/fushi_audio/lib/src/parsers/cue_parse_dispatch.dart
+++ b/packages/fushi_audio/lib/src/parsers/cue_parse_dispatch.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart';
 
 import '../audiobook/audiobook_model.dart';
@@ -10,10 +8,30 @@ import '../audiobook/audiobook_model.dart';
 /// 「大文件切 isolate、小文件同步解析」决策，避免三份逐字复制。
 class CueParseDispatch {
   /// 超过该字节数（UTF-8 编码后）的内容切 isolate 解析，避免阻塞 UI。
-  static const int largeContentComputeThreshold = 1024 * 1024;
+  ///
+  /// 256 KB：一份 1 MB 的日文 SRT 有一两万条 cue，留在 UI isolate 要上百毫秒；
+  /// isolate 派发本身只要十来毫秒，阈值定在几十毫秒的解析量级即可。
+  static const int largeContentComputeThreshold = 256 * 1024;
 
+  /// [content] 的 UTF-8 字节长度——**不分配**编码副本。以前是
+  /// `utf8.encode(content).length`：每次解析先把整个文件再编码一份只为量长度。
   static int utf8ContentByteLength(String content) {
-    return utf8.encode(content).length;
+    int bytes = 0;
+    for (int i = 0; i < content.length; i++) {
+      final int unit = content.codeUnitAt(i);
+      if (unit < 0x80) {
+        bytes += 1;
+      } else if (unit < 0x800) {
+        bytes += 2;
+      } else if (unit >= 0xD800 && unit <= 0xDBFF) {
+        // 代理对：两个 code unit 合成一个 4 字节码点。
+        bytes += 4;
+        i++;
+      } else {
+        bytes += 3;
+      }
+    }
+    return bytes;
   }
 
   static bool shouldParseInIsolate(String content) {

--- a/packages/fushi_audio/lib/src/parsers/lrc_parser.dart
+++ b/packages/fushi_audio/lib/src/parsers/lrc_parser.dart
@@ -38,6 +38,11 @@ class LrcParser {
   /// 元数据标签：`[letters:anything]`（tag 全为字母）。
   static final RegExp _metaTag = RegExp(r'^\[([a-zA-Z]+):[^\]]*\]$');
 
+  /// 时间码（每个时间标签都要跑，编译一次）。
+  static final RegExp _fullTimecodeRe =
+      RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
+  static final RegExp _shortTimecodeRe = RegExp(r'^(\d+):(\d{2})\.(\d{1,3})$');
+
   /// 读取 [lrcFile] 并返回 [AudioCue] 列表。
   ///
   /// 走 [readTextWithEncoding] 自动识别编码，兼容 Shift-JIS / CP932 等非 UTF-8 源。
@@ -149,8 +154,7 @@ class LrcParser {
     final String normalized = timecode.replaceAll(',', '.');
 
     // 尝试 HH:MM:SS.xxx
-    final RegExp fullRe = RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
-    final RegExpMatch? fullMatch = fullRe.firstMatch(normalized);
+    final RegExpMatch? fullMatch = _fullTimecodeRe.firstMatch(normalized);
     if (fullMatch != null) {
       final int h = int.parse(fullMatch.group(1)!);
       final int m = int.parse(fullMatch.group(2)!);
@@ -161,8 +165,7 @@ class LrcParser {
     }
 
     // 尝试 MM:SS.xx 或 MM:SS.xxx（标准 LRC）
-    final RegExp shortRe = RegExp(r'^(\d+):(\d{2})\.(\d{1,3})$');
-    final RegExpMatch? shortMatch = shortRe.firstMatch(normalized);
+    final RegExpMatch? shortMatch = _shortTimecodeRe.firstMatch(normalized);
     if (shortMatch != null) {
       final int m = int.parse(shortMatch.group(1)!);
       final int s = int.parse(shortMatch.group(2)!);

--- a/packages/fushi_audio/lib/src/parsers/srt_parser.dart
+++ b/packages/fushi_audio/lib/src/parsers/srt_parser.dart
@@ -103,18 +103,18 @@ class SrtParser {
       }
 
       // 跳过序号行（第 0 行），解析第 1 行时间码
-      final String? timeLine = _findTimeLine(lines);
-      if (timeLine == null) {
+      final int timeLineIndex = _findTimeLineIndex(lines);
+      if (timeLineIndex < 0) {
         continue;
       }
 
-      final (int startMs, int endMs)? times = _parseTimeLine(timeLine);
+      final (int startMs, int endMs)? times =
+          _parseTimeLine(lines[timeLineIndex]);
       if (times == null) {
         continue;
       }
 
       // 时间行之后的所有行合并为文本（多行字幕 → 空格连接），并剥离 HTML 标签
-      final int timeLineIndex = lines.indexOf(timeLine);
       final String rawText =
           lines.skip(timeLineIndex + 1).where((l) => l.isNotEmpty).join(' ');
       // 先剥 HTML 标签（`<i>` / `<b>` / `<font>` 等，共享 [stripHtmlTags]），
@@ -145,14 +145,20 @@ class SrtParser {
   }
 
   /// 在 block 的各行中找到时间码行（包含 ` --> `）。
-  static String? _findTimeLine(List<String> lines) {
-    for (final String line in lines) {
-      if (line.contains('-->')) {
-        return line;
+  /// 时间行下标；找不到返回 -1（调用方直接用下标，不再 `indexOf` 二次扫描）。
+  static int _findTimeLineIndex(List<String> lines) {
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].contains('-->')) {
+        return i;
       }
     }
-    return null;
+    return -1;
   }
+
+  /// `HH:MM:SS.mmm`。编译一次：以前在 [_parseTimecodeToMs] 里逐次 `RegExp(...)`，
+  /// 每条 cue 起止各一次 = 每文件 2N 次正则编译。
+  static final RegExp _timecodeRe =
+      RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
 
   /// 解析时间码行 `HH:MM:SS,mmm --> HH:MM:SS,mmm`，返回 (startMs, endMs)。
   static (int, int)? _parseTimeLine(String line) {
@@ -174,8 +180,7 @@ class SrtParser {
     // 统一分隔符：将 ',' 替换为 '.'
     final String normalized = timecode.replaceAll(',', '.');
     // 格式：HH:MM:SS.mmm
-    final RegExp re = RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
-    final RegExpMatch? match = re.firstMatch(normalized);
+    final RegExpMatch? match = _timecodeRe.firstMatch(normalized);
     if (match == null) {
       return null;
     }

--- a/packages/fushi_audio/lib/src/parsers/subtitle_markup.dart
+++ b/packages/fushi_audio/lib/src/parsers/subtitle_markup.dart
@@ -441,8 +441,10 @@ SubtitleClip? parseAssClip({
       divisor = 1 << (scale - 1) == 0 ? 1.0 : (1 << (scale - 1)).toDouble();
     }
   }
-  final List<String> tokens =
-      drawing.split(RegExp(r'\s+')).where((String t) => t.isNotEmpty).toList();
+  final List<String> tokens = drawing
+      .split(_reWhitespaceRun)
+      .where((String t) => t.isNotEmpty)
+      .toList();
   int i = 0;
   String mode = '';
   final List<double> nums = <double>[];
@@ -1013,6 +1015,54 @@ SubtitleMarkup parseSubtitleMarkup(String raw,
   );
 }
 
+// ── 覆盖标签正则（编译一次） ───────────────────────────────────────────────
+//
+// 以前每个 `RegExp(r'…')` 都写在 [_applyOverrideBlock] 的循环体里：每条 cue 的每个
+// `\tag` 都要把下面这三十来个正则**顺序**重新编译直到命中——一份几千条 cue 的 ASS
+// 解析绝大部分时间花在编译正则而不是匹配上。
+final RegExp _reTagTransition = RegExp(r'\\t\(([^)]*)\)');
+final RegExp _reTagAn = RegExp(r'^an?([1-9])$');
+final RegExp _reTagPos =
+    RegExp(r'^pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)$');
+final RegExp _reTagToggle = RegExp(r'^([ibus])(\d+)$');
+final RegExp _reTagFs = RegExp(r'^fs(\d+(?:\.\d+)?)$');
+final RegExp _reTagColor1 = RegExp(r'^1?c&H([0-9a-fA-F]{1,8})&?$');
+final RegExp _reTagColor3 = RegExp(r'^3c&H([0-9a-fA-F]{1,8})&?$');
+final RegExp _reTagColor4 = RegExp(r'^4c&H([0-9a-fA-F]{1,8})&?$');
+final RegExp _reTagBord = RegExp(r'^bord(\d+(?:\.\d+)?)$');
+final RegExp _reTagShad = RegExp(r'^shad(\d+(?:\.\d+)?)$');
+final RegExp _reTagDrawing = RegExp(r'^p(\d+)$');
+final RegExp _reTagBlur = RegExp(r'^(?:blur|be)(\d+(?:\.\d+)?)$');
+final RegExp _reTagFad = RegExp(r'^fad\(\s*(\d+)\s*,\s*(\d+)\s*\)$');
+final RegExp _reTagFade = RegExp(
+    r'^fade\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$');
+final RegExp _reTagReset = RegExp(r'^r[A-Za-z0-9_ \-]+$');
+final RegExp _reTagFrz = RegExp(r'^frz?(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagFscx = RegExp(r'^fscx(\d+(?:\.\d+)?)$');
+final RegExp _reTagFscy = RegExp(r'^fscy(\d+(?:\.\d+)?)$');
+final RegExp _reTagMove = RegExp(
+    r'^move\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*(?:,\s*(\d+)\s*,\s*(\d+)\s*)?\)$');
+final RegExp _reTagAlpha = RegExp(r'^(?:1a|alpha)&?H?([0-9A-Fa-f]{1,2})&?$');
+final RegExp _reTagClip = RegExp(r'^(i?)clip\((.*)\)$');
+final RegExp _reTagFsp = RegExp(r'^fsp(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagFrx = RegExp(r'^frx(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagFry = RegExp(r'^fry(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagFax = RegExp(r'^fax(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagFay = RegExp(r'^fay(-?\d+(?:\.\d+)?)$');
+final RegExp _reTagKaraoke = RegExp(r'^(k|K|kf|ko)(\d+(?:\.\d+)?)$');
+// `\t(...)` 内部子标签。
+final RegExp _reTrTimes =
+    RegExp(r'^\s*(-?\d+)\s*,\s*(-?\d+)\s*(?:,\s*(-?\d+(?:\.\d+)?)\s*)?,');
+final RegExp _reTrAccelOnly = RegExp(r'^\s*(-?\d+(?:\.\d+)?)\s*,');
+final RegExp _reTrFscx = RegExp(r'\\fscx(\d+(?:\.\d+)?)');
+final RegExp _reTrFscy = RegExp(r'\\fscy(\d+(?:\.\d+)?)');
+final RegExp _reTrAlpha = RegExp(r'\\(?:1a|alpha)&?H?([0-9A-Fa-f]{1,2})&?');
+final RegExp _reTrColor = RegExp(r'\\1?c&H([0-9A-Fa-f]{1,8})&?');
+final RegExp _reTrBlur = RegExp(r'\\(?:blur|be)(\d+(?:\.\d+)?)');
+final RegExp _reTrBord = RegExp(r'\\bord(\d+(?:\.\d+)?)');
+final RegExp _reTrFrz = RegExp(r'\\frz?(-?\d+(?:\.\d+)?)');
+final RegExp _reWhitespaceRun = RegExp(r'\s+');
+
 /// 解析单个 `{...}` 块内的 `\tag` 序列，更新样式/锚点/位置/淡变。未知标签忽略。
 void _applyOverrideBlock(
   String block,
@@ -1028,8 +1078,7 @@ void _applyOverrideBlock(
   // \t(...) 动画：内含 \fscy 等带反斜杠的子标签，会被下面 split('\\') 打碎，故先整体抽出
   // 记录目标，再从 block 里剔除（TODO-1374）。目标缩放的「起点」用后续静态 \fscx\fscy 累积值
   // （在下方循环里设），故此处只记 (t1,t2) 与目标倍数，实际 from 在扫描结束时归一。
-  final String working =
-      block.replaceAllMapped(RegExp(r'\\t\(([^)]*)\)'), (Match m) {
+  final String working = block.replaceAllMapped(_reTagTransition, (Match m) {
     _parseTransition(m.group(1) ?? '', xf);
     return '';
   });
@@ -1041,7 +1090,7 @@ void _applyOverrideBlock(
     if (tag.isEmpty) continue;
 
     // \an<d> / \a<d>（旧式）
-    final RegExpMatch? an = RegExp(r'^an?([1-9])$').firstMatch(tag);
+    final RegExpMatch? an = _reTagAn.firstMatch(tag);
     if (an != null) {
       final SubtitleAnchor? a =
           SubtitleAnchor.fromAnCode(int.parse(an.group(1)!));
@@ -1050,9 +1099,7 @@ void _applyOverrideBlock(
     }
 
     // \pos(x,y)
-    final RegExpMatch? p =
-        RegExp(r'^pos\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\)$')
-            .firstMatch(tag);
+    final RegExpMatch? p = _reTagPos.firstMatch(tag);
     if (p != null &&
         playResX != null &&
         playResY != null &&
@@ -1065,7 +1112,7 @@ void _applyOverrideBlock(
     }
 
     // \i1 \i0 \b1 \b0 \u1 \u0 \s1 \s0（\b 接粗细数值时 >0 视为粗体）
-    final RegExpMatch? toggle = RegExp(r'^([ibus])(\d+)$').firstMatch(tag);
+    final RegExpMatch? toggle = _reTagToggle.firstMatch(tag);
     if (toggle != null) {
       final bool on = int.parse(toggle.group(2)!) > 0;
       switch (toggle.group(1)!) {
@@ -1082,31 +1129,28 @@ void _applyOverrideBlock(
     }
 
     // \fs<n>
-    final RegExpMatch? fs = RegExp(r'^fs(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fs = _reTagFs.firstMatch(tag);
     if (fs != null) {
       style.fontSizePx = double.parse(fs.group(1)!);
       continue;
     }
 
     // \c&H..& / \1c&H..&（主色，BGR）
-    final RegExpMatch? col =
-        RegExp(r'^1?c&H([0-9a-fA-F]{1,8})&?$').firstMatch(tag);
+    final RegExpMatch? col = _reTagColor1.firstMatch(tag);
     if (col != null) {
       style.colorArgb = assColorToArgb(col.group(1)!);
       continue;
     }
 
     // \3c&H..&（描边色，BGR，TODO-1105）
-    final RegExpMatch? col3 =
-        RegExp(r'^3c&H([0-9a-fA-F]{1,8})&?$').firstMatch(tag);
+    final RegExpMatch? col3 = _reTagColor3.firstMatch(tag);
     if (col3 != null) {
       style.outlineColorArgb = assColorToArgb(col3.group(1)!);
       continue;
     }
 
     // \4c&H..&（阴影色，BGR，TODO-1105）
-    final RegExpMatch? col4 =
-        RegExp(r'^4c&H([0-9a-fA-F]{1,8})&?$').firstMatch(tag);
+    final RegExpMatch? col4 = _reTagColor4.firstMatch(tag);
     if (col4 != null) {
       style.shadowColorArgb = assColorToArgb(col4.group(1)!);
       continue;
@@ -1120,21 +1164,21 @@ void _applyOverrideBlock(
     }
 
     // \bord<n> 描边宽（px，TODO-1105）
-    final RegExpMatch? bord = RegExp(r'^bord(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? bord = _reTagBord.firstMatch(tag);
     if (bord != null) {
       style.outlineWidthPx = double.parse(bord.group(1)!);
       continue;
     }
 
     // \shad<n> 阴影深度（px，TODO-1105）
-    final RegExpMatch? shad = RegExp(r'^shad(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? shad = _reTagShad.firstMatch(tag);
     if (shad != null) {
       style.shadowDepthPx = double.parse(shad.group(1)!);
       continue;
     }
 
     // \p<n>：绘图模式开关。n>0 进入，n=0 退出；作用域持续到本条 cue 结束。
-    final RegExpMatch? p1 = RegExp(r'^p(\d+)$').firstMatch(tag);
+    final RegExpMatch? p1 = _reTagDrawing.firstMatch(tag);
     if (p1 != null) {
       setDrawing(int.parse(p1.group(1)!) > 0);
       continue;
@@ -1142,8 +1186,7 @@ void _applyOverrideBlock(
 
     // \blur<n> / \be<n>：辉光边缘模糊（TODO-1373）。两者都软化字形边缘成辉光，归一到
     // 同一 `blur` 强度字段（span 级，随文本作用域），消除按标签特判。value<=0 视为无。
-    final RegExpMatch? blur =
-        RegExp(r'^(?:blur|be)(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? blur = _reTagBlur.firstMatch(tag);
     if (blur != null) {
       final double v = double.parse(blur.group(1)!);
       style.blur = v > 0 ? v : null;
@@ -1151,8 +1194,7 @@ void _applyOverrideBlock(
     }
 
     // \fad(t1,t2)：行级淡入 t1ms / 淡出 t2ms（收尾依赖 cue 时长，渲染时解析，TODO-1373）。
-    final RegExpMatch? fad =
-        RegExp(r'^fad\(\s*(\d+)\s*,\s*(\d+)\s*\)$').firstMatch(tag);
+    final RegExpMatch? fad = _reTagFad.firstMatch(tag);
     if (fad != null) {
       setFade(SubtitleFade.simple(
         int.parse(fad.group(1)!),
@@ -1163,9 +1205,7 @@ void _applyOverrideBlock(
 
     // \fade(a1,a2,a3,t1,t2,t3,t4)：行级七参淡变。alpha 0..255（0=不透明）→
     // 不透明度 op=1-alpha/255；时间为绝对毫秒（TODO-1373）。
-    final RegExpMatch? fade = RegExp(
-            r'^fade\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$')
-        .firstMatch(tag);
+    final RegExpMatch? fade = _reTagFade.firstMatch(tag);
     if (fade != null) {
       double toOp(String a) => 1.0 - (int.parse(a).clamp(0, 255) / 255.0);
       setFade(SubtitleFade.full(
@@ -1190,7 +1230,7 @@ void _applyOverrideBlock(
     // test is safe. Named-style `\r<StyleName>` switching needs the
     // [V4+ Styles] map (not held here); a baseline reset is a safe approximation
     // that at least stops stale overrides from leaking.
-    if (tag == 'r' || RegExp(r'^r[A-Za-z0-9_ \-]+$').hasMatch(tag)) {
+    if (tag == 'r' || _reTagReset.hasMatch(tag)) {
       style.reset();
       continue;
     }
@@ -1198,7 +1238,7 @@ void _applyOverrideBlock(
     // \frz<deg> / \fr<deg>（旧式 \fr 即 \frz，Z 轴旋转；ASS 逆时针为正，TODO-1374）。
     // \frx / \fry（3D 旋转）不支持——`frz?` 的 z 可选但后面必须紧跟数字，`frx10` 的 x
     // 非数字故不误命中。
-    final RegExpMatch? frz = RegExp(r'^frz?(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? frz = _reTagFrz.firstMatch(tag);
     if (frz != null) {
       xf.rotationDeg = double.parse(frz.group(1)!);
       continue;
@@ -1207,7 +1247,7 @@ void _applyOverrideBlock(
     // \fscx<pct> / \fscy<pct> 横 / 纵缩放（百分比）。**span 级语义**：写进段样式
     // （渲染层逐段缩放，BUG：行级「最后值生效」把 `…{\fscx50}。` 整行压扁）；同时
     // 记入 xf 供 `\t` 缩放动画取 from 基线（TODO-1374 招牌弹入不回归）。
-    final RegExpMatch? fscx = RegExp(r'^fscx(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fscx = _reTagFscx.firstMatch(tag);
     if (fscx != null) {
       final double v = double.parse(fscx.group(1)!) / 100.0;
       style.scaleX = v == 1.0 ? null : v;
@@ -1215,7 +1255,7 @@ void _applyOverrideBlock(
       xf.scaleSet = true;
       continue;
     }
-    final RegExpMatch? fscy = RegExp(r'^fscy(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fscy = _reTagFscy.firstMatch(tag);
     if (fscy != null) {
       final double v = double.parse(fscy.group(1)!) / 100.0;
       style.scaleY = v == 1.0 ? null : v;
@@ -1225,9 +1265,7 @@ void _applyOverrideBlock(
     }
 
     // \move(x1,y1,x2,y2[,t1,t2])：行级运动（TODO-1374）。坐标按 PlayRes 归一化（同 \pos）。
-    final RegExpMatch? mv = RegExp(
-            r'^move\(\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*(?:,\s*(\d+)\s*,\s*(\d+)\s*)?\)$')
-        .firstMatch(tag);
+    final RegExpMatch? mv = _reTagMove.firstMatch(tag);
     if (mv != null &&
         playResX != null &&
         playResY != null &&
@@ -1246,8 +1284,7 @@ void _applyOverrideBlock(
     // \1a&HXX& / \alpha&HXX&：主填充透明度（ASS alpha 00=不透明 FF=全透明）→
     // op=1-a/255。\alpha 一次设四通道，按主填充近似（描边/阴影 alpha 不单独建模，
     // 多层卡拉 OK 光晕层 `\1a&HFF&` 抹透明填充、留模糊描边成辉光）；\2a/\3a/\4a 忽略。
-    final RegExpMatch? a1 =
-        RegExp(r'^(?:1a|alpha)&?H?([0-9A-Fa-f]{1,2})&?$').firstMatch(tag);
+    final RegExpMatch? a1 = _reTagAlpha.firstMatch(tag);
     if (a1 != null) {
       style.fillOpacity =
           (1.0 - int.parse(a1.group(1)!, radix: 16) / 255.0).clamp(0.0, 1.0);
@@ -1256,7 +1293,7 @@ void _applyOverrideBlock(
 
     // \clip(...) / \iclip(...)：静态矢量/矩形裁剪 → [SubtitleClip]（归一化分数坐标）。
     // 支持矩形四参形式与 m/l/b 绘图形式（含 scale 变体）；解析失败按无裁剪。
-    final RegExpMatch? clipM = RegExp(r'^(i?)clip\((.*)\)$').firstMatch(tag);
+    final RegExpMatch? clipM = _reTagClip.firstMatch(tag);
     if (clipM != null) {
       final SubtitleClip? parsed = parseAssClip(
         inverse: clipM.group(1) == 'i',
@@ -1269,31 +1306,31 @@ void _applyOverrideBlock(
     }
 
     // \fsp<px>：字间距（可负/小数）。
-    final RegExpMatch? fsp = RegExp(r'^fsp(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fsp = _reTagFsp.firstMatch(tag);
     if (fsp != null) {
       style.letterSpacingPx = double.parse(fsp.group(1)!);
       continue;
     }
 
     // \frx / \fry：3D 旋转（度）。\frz 已在上方处理（frz? 的 z 可选不会误吞 x/y）。
-    final RegExpMatch? frx = RegExp(r'^frx(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? frx = _reTagFrx.firstMatch(tag);
     if (frx != null) {
       xf.frxDeg = double.parse(frx.group(1)!);
       continue;
     }
-    final RegExpMatch? fry = RegExp(r'^fry(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fry = _reTagFry.firstMatch(tag);
     if (fry != null) {
       xf.fryDeg = double.parse(fry.group(1)!);
       continue;
     }
 
     // \fax / \fay：切变因子。
-    final RegExpMatch? fax = RegExp(r'^fax(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fax = _reTagFax.firstMatch(tag);
     if (fax != null) {
       xf.faxShear = double.parse(fax.group(1)!);
       continue;
     }
-    final RegExpMatch? fay = RegExp(r'^fay(-?\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? fay = _reTagFay.firstMatch(tag);
     if (fay != null) {
       xf.fayShear = double.parse(fay.group(1)!);
       continue;
@@ -1301,8 +1338,7 @@ void _applyOverrideBlock(
 
     // \k / \K / \kf / \ko<cs>：卡拉 OK 音节计时（厘秒）。本块起的文字段=一个音节：
     // 起点=之前音节时长累计，点亮方式 k=瞬切 / K=kf=渐变扫填近似 / ko=点亮前无描边。
-    final RegExpMatch? kar =
-        RegExp(r'^(k|K|kf|ko)(\d+(?:\.\d+)?)$').firstMatch(tag);
+    final RegExpMatch? kar = _reTagKaraoke.firstMatch(tag);
     if (kar != null) {
       final String mode = switch (kar.group(1)!) {
         'K' || 'kf' => 'kf',
@@ -1332,9 +1368,7 @@ void _parseTransition(String inner, _Transform xf) {
   int? t2;
   double accel = 1.0;
   String rest = inner;
-  final RegExpMatch? times =
-      RegExp(r'^\s*(-?\d+)\s*,\s*(-?\d+)\s*(?:,\s*(-?\d+(?:\.\d+)?)\s*)?,')
-          .firstMatch(inner);
+  final RegExpMatch? times = _reTrTimes.firstMatch(inner);
   if (times != null) {
     t1 = int.parse(times.group(1)!);
     t2 = int.parse(times.group(2)!);
@@ -1342,8 +1376,7 @@ void _parseTransition(String inner, _Transform xf) {
     rest = inner.substring(times.end);
   } else {
     // 纯加速度形式：`accel,<子标签>`。
-    final RegExpMatch? onlyAccel =
-        RegExp(r'^\s*(-?\d+(?:\.\d+)?)\s*,').firstMatch(inner);
+    final RegExpMatch? onlyAccel = _reTrAccelOnly.firstMatch(inner);
     if (onlyAccel != null) {
       accel = double.parse(onlyAccel.group(1)!);
       rest = inner.substring(onlyAccel.end);
@@ -1354,9 +1387,9 @@ void _parseTransition(String inner, _Transform xf) {
     xf.tStartMs = t1;
     xf.tEndMs = t2;
   }
-  final RegExpMatch? tx = RegExp(r'\\fscx(\d+(?:\.\d+)?)').firstMatch(rest);
+  final RegExpMatch? tx = _reTrFscx.firstMatch(rest);
   if (tx != null) xf.tScaleX = double.parse(tx.group(1)!) / 100.0;
-  final RegExpMatch? ty = RegExp(r'\\fscy(\d+(?:\.\d+)?)').firstMatch(rest);
+  final RegExpMatch? ty = _reTrFscy.firstMatch(rest);
   if (ty != null) xf.tScaleY = double.parse(ty.group(1)!) / 100.0;
 
   // 通用动画维度。
@@ -1365,21 +1398,18 @@ void _parseTransition(String inner, _Transform xf) {
   double? blurTo;
   double? bordTo;
   double? frzTo;
-  final RegExpMatch? ta =
-      RegExp(r'\\(?:1a|alpha)&?H?([0-9A-Fa-f]{1,2})&?').firstMatch(rest);
+  final RegExpMatch? ta = _reTrAlpha.firstMatch(rest);
   if (ta != null) {
     alphaTo =
         (1.0 - int.parse(ta.group(1)!, radix: 16) / 255.0).clamp(0.0, 1.0);
   }
-  final RegExpMatch? tc =
-      RegExp(r'\\1?c&H([0-9A-Fa-f]{1,8})&?').firstMatch(rest);
+  final RegExpMatch? tc = _reTrColor.firstMatch(rest);
   if (tc != null) colorTo = assColorToArgb(tc.group(1)!);
-  final RegExpMatch? tb =
-      RegExp(r'\\(?:blur|be)(\d+(?:\.\d+)?)').firstMatch(rest);
+  final RegExpMatch? tb = _reTrBlur.firstMatch(rest);
   if (tb != null) blurTo = double.parse(tb.group(1)!);
-  final RegExpMatch? tbo = RegExp(r'\\bord(\d+(?:\.\d+)?)').firstMatch(rest);
+  final RegExpMatch? tbo = _reTrBord.firstMatch(rest);
   if (tbo != null) bordTo = double.parse(tbo.group(1)!);
-  final RegExpMatch? tfrz = RegExp(r'\\frz?(-?\d+(?:\.\d+)?)').firstMatch(rest);
+  final RegExpMatch? tfrz = _reTrFrz.firstMatch(rest);
   if (tfrz != null) frzTo = double.parse(tfrz.group(1)!);
 
   final SubtitleTransition tr = SubtitleTransition(

--- a/packages/fushi_audio/lib/src/parsers/vtt_parser.dart
+++ b/packages/fushi_audio/lib/src/parsers/vtt_parser.dart
@@ -165,9 +165,9 @@ class VttParser {
     }
     // 位置指令（如 `align:left`）以空白分隔在时间戳后，取第一个 token
     final int? start =
-        _parseTimecodeToMs(parts[0].trim().split(RegExp(r'\s+')).first);
+        _parseTimecodeToMs(parts[0].trim().split(_whitespaceRe).first);
     final int? end =
-        _parseTimecodeToMs(parts[1].trim().split(RegExp(r'\s+')).first);
+        _parseTimecodeToMs(parts[1].trim().split(_whitespaceRe).first);
     if (start == null || end == null) {
       return null;
     }
@@ -177,12 +177,17 @@ class VttParser {
   /// 将 VTT 时间码转换为毫秒。
   ///
   /// 支持 `HH:MM:SS.mmm`（含小时）和 `MM:SS.mmm`（不含小时）。
+  // 每条 cue 都要跑的正则只编译一次（以前逐次 `RegExp(...)`，每 cue 起止各两三次）。
+  static final RegExp _whitespaceRe = RegExp(r'\s+');
+  static final RegExp _fullTimecodeRe =
+      RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$');
+  static final RegExp _shortTimecodeRe = RegExp(r'^(\d+):(\d{2})\.(\d{1,3})$');
+
   static int? _parseTimecodeToMs(String timecode) {
     final String normalized = timecode.replaceAll(',', '.');
 
     // HH:MM:SS.mmm
-    final RegExpMatch? full =
-        RegExp(r'^(\d+):(\d{2}):(\d{2})\.(\d{1,3})$').firstMatch(normalized);
+    final RegExpMatch? full = _fullTimecodeRe.firstMatch(normalized);
     if (full != null) {
       final int fh = int.parse(full.group(1)!);
       final int fm = int.parse(full.group(2)!);
@@ -195,8 +200,7 @@ class VttParser {
     }
 
     // MM:SS.mmm（无小时）
-    final RegExpMatch? short =
-        RegExp(r'^(\d+):(\d{2})\.(\d{1,3})$').firstMatch(normalized);
+    final RegExpMatch? short = _shortTimecodeRe.firstMatch(normalized);
     if (short != null) {
       final int sm = int.parse(short.group(1)!);
       final int ss = int.parse(short.group(2)!);

--- a/packages/fushi_core/lib/fushi_core.dart
+++ b/packages/fushi_core/lib/fushi_core.dart
@@ -4,6 +4,7 @@ export 'src/database/activity_event_types.dart';
 export 'src/database/book_format.dart';
 export 'src/database/collection_order.dart';
 export 'src/database/database.dart';
+export 'src/database/epub_book_meta.dart';
 export 'src/database/media_image_kind.dart';
 export 'src/database/media_kind.dart';
 export 'src/database/media_kind_mappings.dart';

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -15,6 +15,7 @@ import '../utils/video_book_uid.dart';
 import 'activity_event_types.dart';
 import 'book_format.dart';
 import 'collection_order.dart';
+import 'epub_book_meta.dart';
 import 'media_kind.dart';
 import 'media_kind_mappings.dart';
 import 'pref_codec.dart';

--- a/packages/fushi_core/lib/src/database/database_content_misc.part.dart
+++ b/packages/fushi_core/lib/src/database/database_content_misc.part.dart
@@ -86,11 +86,54 @@ mixin _FushiDbContentMisc
       (select(epubBooks)..orderBy([(t) => OrderingTerm.desc(t.importedAt)]))
           .get();
 
+  /// 全部书的瘦投影（[EpubBookMeta]，与 [getAllEpubBooks] 同序：importedAt 降序）。
+  ///
+  /// 只要 title / uid / importedAt / format 等小列的调用方（书架映射、统计事实面、
+  /// 导入重复检查、远端去重）走这里，不再把每本几十 KB 的 `chaptersJson` / `tocJson`
+  /// 整库拉一遍再丢掉。
+  Future<List<EpubBookMeta>> getEpubBookMetas() async {
+    final JoinedSelectStatement<HasResultSet, dynamic> query =
+        selectOnly(epubBooks)
+          ..addColumns(<Expression<Object>>[
+            epubBooks.bookKey,
+            epubBooks.uid,
+            epubBooks.title,
+            epubBooks.format,
+            epubBooks.importedAt,
+            epubBooks.extractDir,
+            epubBooks.completedAt,
+          ])
+          ..orderBy(<OrderingTerm>[OrderingTerm.desc(epubBooks.importedAt)]);
+    final List<TypedResult> rows = await query.get();
+    return rows
+        .map(
+          (TypedResult row) => EpubBookMeta(
+            bookKey: row.read(epubBooks.bookKey)!,
+            uid: row.read(epubBooks.uid)!,
+            title: row.read(epubBooks.title)!,
+            format: row.read(epubBooks.format)!,
+            importedAt: row.read(epubBooks.importedAt)!,
+            extractDir: row.read(epubBooks.extractDir)!,
+            completedAt: row.read(epubBooks.completedAt),
+          ),
+        )
+        .toList(growable: false);
+  }
+
   /// 监听 EPUB 书 bookKey 集合，供书架在任意导入路径落库后自动刷新（同
   /// [watchVideoBookUids]，BUG-793）。消费方按集合 `.distinct` 去重，改作者/封面等
   /// 纯列更新（集合不变）不触发重算。
-  Stream<List<String>> watchEpubBookKeys() =>
-      select(epubBooks).map((EpubBookRow row) => row.bookKey).watch();
+  ///
+  /// 只投影 bookKey 列：这条流在 `epub_books` 每次写入时都重跑，之前是全列
+  /// `select` 把整库 `chaptersJson` 拉出来只为取 key（批量导入 N 本 = N 次全库大列读）。
+  Stream<List<String>> watchEpubBookKeys() => (selectOnly(epubBooks)
+        ..addColumns(<Expression<Object>>[epubBooks.bookKey]))
+      .watch()
+      .map(
+        (List<TypedResult> rows) => rows
+            .map((TypedResult row) => row.read(epubBooks.bookKey)!)
+            .toList(growable: false),
+      );
 
   Future<EpubBookRow?> getEpubBook(String bookKey) =>
       (select(epubBooks)..where((t) => t.bookKey.equals(bookKey)))
@@ -138,13 +181,17 @@ mixin _FushiDbContentMisc
         (book.uid.present && book.uid.value.isNotEmpty)
             ? book
             : book.copyWith(uid: Value(generateEpubBookUid()));
-    await into(epubBooks).insert(withUid);
-    // Re-adding a book cancels any prior deletion tombstone so a later merge
-    // may bring its data again (TODO-1195 part B).
-    await clearBookTombstone(book.bookKey.value);
-    // 删除传播：重新导入同 bookKey 的书清除其 sync 删除墓碑（防「删了又加、墓碑还在」
-    // 被 compare 误判成待删）。
-    await clearSyncDeletionTombstone('book', book.bookKey.value);
+    // 三条语句一个事务：一次 fsync 而非三次，且 `watchEpubBookKeys` 之类的表级
+    // 监听只在提交时收到一次失效，而不是每条语句各触发一次书架重算。
+    await transaction(() async {
+      await into(epubBooks).insert(withUid);
+      // Re-adding a book cancels any prior deletion tombstone so a later merge
+      // may bring its data again (TODO-1195 part B).
+      await clearBookTombstone(book.bookKey.value);
+      // 删除传播：重新导入同 bookKey 的书清除其 sync 删除墓碑（防「删了又加、墓碑还在」
+      // 被 compare 误判成待删）。
+      await clearSyncDeletionTombstone('book', book.bookKey.value);
+    });
     return book.bookKey.value;
   }
 
@@ -282,8 +329,8 @@ mixin _FushiDbContentMisc
         switch (mediaKind) {
           case kActivityMediaBook:
             await (delete(readingStatistics)
-                  ..where((t) =>
-                      t.title.equals(title) & t.dateKey.isIn(dateKeys)))
+                  ..where(
+                      (t) => t.title.equals(title) & t.dateKey.isIn(dateKeys)))
                 .go();
           case kActivityMediaVideo:
             await (delete(videoWatchStatistics)
@@ -394,7 +441,8 @@ mixin _FushiDbContentMisc
           await deleteStudySegmentsForMedia(
               mediaKind: kActivityMediaVideo, mediaKey: bookUid);
           await (delete(preferences)
-                ..where((t) => t.key.equals(videoWatchCoveragePrefKey(bookUid))))
+                ..where(
+                    (t) => t.key.equals(videoWatchCoveragePrefKey(bookUid))))
               .go();
         }
         // 本 tile 自身的 title 恒立碑（被删行的防复活；同名幸存者被连带压制是

--- a/packages/fushi_core/lib/src/database/database_prefs_media.part.dart
+++ b/packages/fushi_core/lib/src/database/database_prefs_media.part.dart
@@ -12,6 +12,25 @@ mixin _FushiDbPrefsMedia
     return row?.value;
   }
 
+  /// 一次取回全部以 [prefix] 开头的偏好（key → value）。
+  ///
+  /// 「每本一个键」的偏好族（有声书健康度覆盖等）在列表页要为每本各查一次
+  /// [getPref]，库越大 N+1 越重；这里一条 `LIKE 'prefix%'` 取完。[prefix] 里的
+  /// `%` / `_` 按字面转义，不当通配符。
+  Future<Map<String, String>> getPrefsByPrefix(String prefix) async {
+    final String escaped = prefix
+        .replaceAll(r'\', r'\\')
+        .replaceAll('%', r'\%')
+        .replaceAll('_', r'\_');
+    final SimpleSelectStatement<$PreferencesTable, PreferenceRow> q =
+        select(preferences)
+          ..where((t) => t.key.like('$escaped%', escapeChar: r'\'));
+    final List<PreferenceRow> rows = await q.get();
+    return <String, String>{
+      for (final PreferenceRow row in rows) row.key: row.value,
+    };
+  }
+
   Future<void> setPref(String key, String value) async {
     // BUG-906 (A): the business write and the version bump MUST land in one
     // transaction. Previously these were two independent awaits, so two

--- a/packages/fushi_core/lib/src/database/epub_book_meta.dart
+++ b/packages/fushi_core/lib/src/database/epub_book_meta.dart
@@ -1,0 +1,31 @@
+/// `epub_books` 的瘦投影：只带身份 / 展示 / 归档元数据列，**不带**
+/// `chaptersJson` / `tocJson` / `sourceMetadata` 三个大 TEXT 列（每本几十到几百 KB）。
+///
+/// 书架映射、统计事实面、导入重复检查、远端去重等十来处调用方只需要 title / uid /
+/// importedAt 之类的小列，却一直走 `getAllEpubBooks()` 把整库章节 JSON 从 SQLite
+/// 拉出来再丢掉——每导入一本书就重复一次，库越大导入越慢。需要章节 JSON 的调用方
+/// （阅读器打开、备份、同步全量比对）继续用 `EpubBookRow`。
+class EpubBookMeta {
+  const EpubBookMeta({
+    required this.bookKey,
+    required this.uid,
+    required this.title,
+    required this.format,
+    required this.importedAt,
+    required this.extractDir,
+    this.completedAt,
+  });
+
+  /// 跨设备书身份（= sanitizeTtuFilename(title)），主键。
+  final String bookKey;
+
+  /// 本机稳定 uid（v81），空串 = 异常旧行。
+  final String uid;
+  final String title;
+
+  /// `'epub'` / `'pdf'` / `'manga'`（见 `BookFormat`）。
+  final String format;
+  final int importedAt;
+  final String extractDir;
+  final DateTime? completedAt;
+}


### PR DESCRIPTION
## 各处导入 / 加载速度优化（三轮）

先派 6 个只读子代理按域（书 / 视频 / 漫画 / 词典 / 库页与启动 / 有声书与迁移）盘点热点，再按「数据层 → UI isolate → 加载路径」三轮落地。每轮独立 commit、独立可回退。

### 根因（六个域共享）
- **数据结构**：`epub_books.chaptersJson/tocJson` 是每本几十 KB 的大列，`getAllEpubBooks()` 全列读被十来个只要 title/uid 的调用方复用——每导入一本就把整库章节 JSON 从 SQLite 拉一遍再丢掉。
- **N+1**：书架每本查一次阅读位置 / 每本有声书查一次偏好；视频页 13 个、事实面 10 个全表查询串行 await。
- **重复干活**：zip 探测整包解压 2~4 次（同步、UI isolate）；词典目录 Dart 里 deflate 再让 native 立刻 inflate；字幕解析每条 cue 重编译正则。

### 第一轮 `8484bd67fd`（导入 / 书架数据层）
- fushi_core 新增瘦投影 `getEpubBookMetas()`，`watchEpubBookKeys` 只投影 key 列；12 个元数据调用方切过去；`insertEpubBook` 三条语句一个事务；新增 `getPrefsByPrefix`。
- 书架阅读位置一次 `findAllByBookUid()`；有声书健康度 `resolveAllHealth` 一条前缀查询。
- 本地列目录不再逐文件 `length()`；词典批量导入去掉每本 2 秒硬睡。

### 第二轮 `8a3c7ddb38`（探测 / 解析卸出 UI isolate）
- zip 流式只读中央目录（`InputFileStream`），漫画对话框用 `ImportCarrierResolver` 记忆，mokuro 页匹配索引化。
- 漫画页宽高只读文件头（JPEG SOF + EXIF Orientation / PNG IHDR / WebP），8 种 EXIF 方向与 `bakeOrientation` 逐一对照测试。
- EPUB 章节抽取进 `Isolate.run`；srt/vtt/ass/lrc + subtitle_markup 三十来个正则编译一次；isolate 阈值 1 MB → 256 KB 且不再 `utf8.encode` 整份。
- 音频时长探测 4 路并行；词典目录 `ZipFileEncoder` 流式 STORE。

### 第三轮 `b6676f5fa1`（加载路径）
- 视频书架封面存在性：目录列一次成集合，不再逐行 `existsSync`；回填重列节流。
- 视频页 / 首页 / 事实面的独立查询一次全部发出（`Future.wait` 流水线化）。
- 三条字体链并发 + WOFF2 解码进 isolate；main 四步独立 init 并发；批量加游戏封面 3 路有界；迁移 SHA-256 进 isolate。

### 审查修正（第四个 commit）
审查（removed-behavior 角）核出 4 处回归已修、1 处取舍改回：
- `sizeBytes` 有真实消费方（刮削诊断导出器），我的盘点漏了 → 导出器自己按需 stat，扫描热路径仍不 stat；既有 exporter 测试恢复绿。
- 流式 zip 丢了整包 CRC → 写盘条目补 CRC32（零额外 IO），新增坏页测试。
- 有声书导入复用探测章节时空列表短路 → 只复用非空。
- 回填节流兜底刷新进 `finally`。
- 改回「封面/元数据只探前 3 个音频文件」（前几段无标签的有声书会丢自动填充）。

### 有意未做
- 词典引擎装载解除对 HomePage 的门控：`loadPendingAsync` 在途时 `instance` 会撞空引擎（断言），需先改 `isInitialized`/lookup 契约，单独一轮。
- `.epub` 载体探测仍需解压到临时目录（只在包内有图片时），根治要 `EpubParser` 支持从 Archive 直接解析。
- 书架 `build()` 内过滤/排序 memo、视频页行懒构建：改动面在两个 2000+/6000+ 行页面，风险与本轮不匹配。
- 已知权衡：EPUB 章节抽取进 isolate 后，`EpubParser` 内部对坏 nav 的诊断日志留在工作 isolate（与 `EpubImporter` 导入 isolate 同款）。

### 验证
- `flutter analyze`（含 test）零问题；`fushi_core` / `fushi_audio` `dart analyze --fatal-infos` 零问题。
- 定向：823 + 1150 + 97 + 427（test/tools 整目录）+ 101 + 178 + 76 + 137 + 43 条绿。
- 新增守卫：`import_load_fat_read_guard_test` / `manga_import_carrier_memo_guard_test` / `load_paths_perf_guard_test`；行为测试 `epub_book_metas_test` / `audiobook_health_batch_test` / `image_size_probe_test` / CBZ CRC 用例。
- 代码审查：8 个审查角里 7 个撞会话限额中止，只有 removed-behavior 角完成（发现已全部处理）；合并前建议再跑一次完整 `/code-review`。
- 未做真机计时对比：本轮全部是结构性去重（去掉的操作本身可数），真机 A/B 留给合并后的 beta。

https://claude.ai/code/session_011MN5QNc77STWEgG4tdPj3N
