### PR TITLE
perf(asr): ORT 插件工作线程化 + 三级流水线 + 显存预算选桶与预热策略（#1231 合并后遗留的三个提交）

### DIFF
--- a/fushi/integration_test/asr_plugin_latency_itest.dart
+++ b/fushi/integration_test/asr_plugin_latency_itest.dart
@@ -1,0 +1,66 @@
+/// 插件往返延迟基准：小模型（silero-vad）连续 run 的平均耗时，用来量
+/// `flutter_onnxruntime` 工作线程化前后的每次调用开销（FLUTTER_ONNXRUNTIME_SYNC=1
+/// 时插件退回同步执行，可 A/B）。
+///
+///   ASR_MODEL_SEED=<含 silero_vad.onnx 的目录>
+library;
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/asr/asr_types.dart';
+import 'package:fushi/src/onnx/onnx_inference.dart';
+import 'package:fushi/src/onnx/onnx_inference_ort.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('插件往返延迟', (WidgetTester tester) async {
+    final String seed = Platform.environment['ASR_MODEL_SEED'] ?? '';
+    expect(seed, isNotEmpty);
+    final OrtOnnxSessionFactory factory = OrtOnnxSessionFactory();
+    // ignore: avoid_print
+    print(
+      '[asr-latency] gpu budget=${await factory.deviceMemoryBudgetBytes()}',
+    );
+    final OnnxSession vad = await factory.createSession(
+      p.join(seed, 'silero_vad.onnx'),
+      providers: const <OnnxExecutionProvider>[OnnxExecutionProvider.cpu],
+    );
+    final Map<String, OnnxTensor> inputs = <String, OnnxTensor>{
+      AsrModelIo.vadInputX: OnnxTensor.float32(
+        Float32List(kAsrVadWindowSamples),
+        <int>[1, kAsrVadWindowSamples],
+      ),
+      AsrModelIo.vadInputH: OnnxTensor.float32(Float32List(128), <int>[
+        2,
+        1,
+        64,
+      ]),
+      AsrModelIo.vadInputC: OnnxTensor.float32(Float32List(128), <int>[
+        2,
+        1,
+        64,
+      ]),
+    };
+    for (int i = 0; i < 20; i++) {
+      await vad.run(inputs);
+    }
+    const int n = 300;
+    final Stopwatch sw = Stopwatch()..start();
+    for (int i = 0; i < n; i++) {
+      await vad.run(inputs);
+    }
+    sw.stop();
+    // ignore: avoid_print
+    print(
+      '[asr-latency] sync=${Platform.environment['FLUTTER_ONNXRUNTIME_SYNC'] ?? '0'} '
+      'runs=$n avg=${(sw.elapsedMicroseconds / n / 1000).toStringAsFixed(2)}ms',
+    );
+    await vad.close();
+  });
+}

--- a/fushi/integration_test/asr_transcribe_e2e_itest.dart
+++ b/fushi/integration_test/asr_transcribe_e2e_itest.dart
@@ -28,6 +28,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/asr/asr_encoder_buckets.dart';
 import 'package:fushi/src/asr/asr_engine.dart';
 import 'package:fushi/src/asr/asr_model_manifest.dart';
 import 'package:fushi/src/asr/asr_model_store.dart';
@@ -51,6 +52,7 @@ String _param(String name, {String defaultValue = ''}) {
     'ASR_ONLY' => const String.fromEnvironment('ASR_ONLY'),
     'ASR_CHUNK_SECONDS' => const String.fromEnvironment('ASR_CHUNK_SECONDS'),
     'ASR_PIPELINE' => const String.fromEnvironment('ASR_PIPELINE'),
+    'ASR_BUCKETS' => const String.fromEnvironment('ASR_BUCKETS'),
     _ => '',
   };
   if (fromDefine.isNotEmpty) return fromDefine;
@@ -68,6 +70,17 @@ final String _kAudio = _param(
   defaultValue: 'test/asr/fixtures/ja_tts_16k.wav',
 );
 final String _kExpect = _param('ASR_EXPECT', defaultValue: '今日はいい天気ですね');
+
+List<AsrEncoderBucket>? _bucketsFromEnv(String spec) {
+  if (spec.isEmpty) return null;
+  return <AsrEncoderBucket>[
+    for (final String item in spec.split(','))
+      AsrEncoderBucket(
+        frames: int.parse(item.split('x')[0]),
+        batch: int.parse(item.split('x')[1]),
+      ),
+  ];
+}
 
 String _normalize(String s) =>
     s.toLowerCase().replaceAll(RegExp(r'[\s、。！？!?,.\x27"“”’]'), '');
@@ -94,6 +107,8 @@ _runOnce({
     chunkSeconds: int.tryParse(_param('ASR_CHUNK_SECONDS')) ?? 60,
     // ASR_PIPELINE=0：逐批串行解码（与三段式流水线做 A/B）。
     usePipeline: _param('ASR_PIPELINE') != '0',
+    // ASR_BUCKETS=560x32,1120x16：静态桶表覆盖（帧数x行数，按帧数递增）。
+    staticBucketsOverride: _bucketsFromEnv(_param('ASR_BUCKETS')),
   );
   await service.discard(<String>[audio], _kLang);
   final Stopwatch loadClock = Stopwatch()..start();

--- a/fushi/integration_test/asr_transcribe_e2e_itest.dart
+++ b/fushi/integration_test/asr_transcribe_e2e_itest.dart
@@ -50,6 +50,7 @@ String _param(String name, {String defaultValue = ''}) {
     'ASR_OUT' => const String.fromEnvironment('ASR_OUT'),
     'ASR_ONLY' => const String.fromEnvironment('ASR_ONLY'),
     'ASR_CHUNK_SECONDS' => const String.fromEnvironment('ASR_CHUNK_SECONDS'),
+    'ASR_PIPELINE' => const String.fromEnvironment('ASR_PIPELINE'),
     _ => '',
   };
   if (fromDefine.isNotEmpty) return fromDefine;
@@ -91,6 +92,8 @@ _runOnce({
     jobsRoot: () async => jobsRoot,
     // 缺省 60 s 让检查点/续跑路径多走几次；ASR_CHUNK_SECONDS=300 对齐生产值拿速度数。
     chunkSeconds: int.tryParse(_param('ASR_CHUNK_SECONDS')) ?? 60,
+    // ASR_PIPELINE=0：逐批串行解码（与三段式流水线做 A/B）。
+    usePipeline: _param('ASR_PIPELINE') != '0',
   );
   await service.discard(<String>[audio], _kLang);
   final Stopwatch loadClock = Stopwatch()..start();

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 73032 (4296 per locale)
+/// Strings: 73049 (4297 per locale)
 ///
-/// Built on 2026-09-06 at 04:15 UTC
+/// Built on 2026-09-06 at 06:59 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5923,6 +5923,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get onboarding_pack_paused_desc =>
       'Progress is kept on disk — resuming picks up where it stopped.';
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -15968,6 +15970,9 @@ class _StringsAr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -26240,6 +26245,9 @@ class _StringsDe extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -36565,6 +36573,9 @@ class _StringsEs extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -46924,6 +46935,9 @@ class _StringsFr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -57087,6 +57101,9 @@ class _StringsId extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -67342,6 +67359,9 @@ class _StringsIt extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -76984,6 +77004,9 @@ class _StringsJa extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -86636,6 +86659,9 @@ class _StringsKo extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -96846,6 +96872,9 @@ class _StringsNl extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -107110,6 +107139,9 @@ class _StringsPtBr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -117352,6 +117384,9 @@ class _StringsRu extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -127393,6 +127428,9 @@ class _StringsTh extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -137551,6 +137589,9 @@ class _StringsTr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -147680,6 +147721,9 @@ class _StringsVi extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 // Path: <root>
@@ -156990,6 +157034,9 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_pack_paused_desc => '进度留在磁盘上，继续下载会从中断处接着下。';
   @override
   String get onboarding_pack_mini_bar_hide => '收起';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      '运行于 ${provider} · 静态融合图';
 }
 
 // Path: <root>
@@ -166325,6 +166372,9 @@ class _StringsZhHk extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String audiobook_transcribe_running_on_static({required Object provider}) =>
+      'Running on ${provider} · fused static graph';
 }
 
 /// Flat map(s) containing all translations.
@@ -175152,6 +175202,9 @@ extension on _StringsEn {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -183974,6 +184027,9 @@ extension on _StringsAr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -192841,6 +192897,9 @@ extension on _StringsDe {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -201699,6 +201758,9 @@ extension on _StringsEs {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -210566,6 +210628,9 @@ extension on _StringsFr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -219404,6 +219469,9 @@ extension on _StringsId {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -228264,6 +228332,9 @@ extension on _StringsIt {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -237051,6 +237122,9 @@ extension on _StringsJa {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -245842,6 +245916,9 @@ extension on _StringsKo {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -254695,6 +254772,9 @@ extension on _StringsNl {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -263543,6 +263623,9 @@ extension on _StringsPtBr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -272398,6 +272481,9 @@ extension on _StringsRu {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -281225,6 +281311,9 @@ extension on _StringsTh {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -290067,6 +290156,9 @@ extension on _StringsTr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -298903,6 +298995,9 @@ extension on _StringsVi {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }
@@ -307663,6 +307758,8 @@ extension on _StringsZhCn {
         return '进度留在磁盘上，继续下载会从中断处接着下。';
       case 'onboarding_pack_mini_bar_hide':
         return '收起';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) => '运行于 ${provider} · 静态融合图';
       default:
         return null;
     }
@@ -316428,6 +316525,9 @@ extension on _StringsZhHk {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'audiobook_transcribe_running_on_static':
+        return ({required Object provider}) =>
+            'Running on ${provider} · fused static graph';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "推荐包下载已暂停",
   "onboarding_pack_download_resume": "继续下载",
   "onboarding_pack_paused_desc": "进度留在磁盘上，继续下载会从中断处接着下。",
-  "onboarding_pack_mini_bar_hide": "收起"
+  "onboarding_pack_mini_bar_hide": "收起",
+  "audiobook_transcribe_running_on_static": "运行于 $provider · 静态融合图"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4294,5 +4294,6 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "audiobook_transcribe_running_on_static": "Running on $provider · fused static graph"
 }

--- a/fushi/lib/src/asr/asr_encoder_buckets.dart
+++ b/fushi/lib/src/asr/asr_encoder_buckets.dart
@@ -18,6 +18,7 @@
 library;
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
@@ -144,8 +145,12 @@ class AsrStaticEncoderPool {
       <AsrEncoderBucket, AsrStaticEncoderSession>{};
   final Map<AsrEncoderBucket, Future<AsrStaticEncoderSession?>> _pending =
       <AsrEncoderBucket, Future<AsrStaticEncoderSession?>>{};
-  final Map<AsrEncoderBucket, String> unavailableReasons =
+  final Map<AsrEncoderBucket, String> _unavailableReasons =
       <AsrEncoderBucket, String>{};
+
+  /// 建失败 / 运行期失败的桶及原因（只读；诊断与 UI 用）。
+  late final Map<AsrEncoderBucket, String> unavailableReasons =
+      UnmodifiableMapView<AsrEncoderBucket, String>(_unavailableReasons);
   bool _closed = false;
 
   /// 能装下 [frames] 帧的最小桶；超过最大桶返回 null（走动态会话）。
@@ -166,7 +171,7 @@ class AsrStaticEncoderPool {
     if (bucket == null) return null;
     final AsrStaticEncoderSession? ready = _sessions[bucket];
     if (ready != null) return ready;
-    if (unavailableReasons.containsKey(bucket)) return null;
+    if (_unavailableReasons.containsKey(bucket)) return null;
     return _pending.putIfAbsent(bucket, () => _create(bucket));
   }
 
@@ -196,7 +201,7 @@ class AsrStaticEncoderPool {
       );
       return created;
     } catch (error, stack) {
-      unavailableReasons[bucket] = '$error';
+      _unavailableReasons[bucket] = '$error';
       developer.log(
         'ASR static encoder $bucket unavailable; falling back to dynamic '
         'session for this bucket',
@@ -232,7 +237,7 @@ class AsrStaticEncoderPool {
     Object error,
     StackTrace stack,
   ) {
-    unavailableReasons[bucket] = '$error';
+    _unavailableReasons[bucket] = '$error';
     final AsrStaticEncoderSession? s = _sessions.remove(bucket);
     developer.log(
       'ASR static encoder $bucket failed at run time; disabled, falling back '

--- a/fushi/lib/src/asr/asr_encoder_buckets.dart
+++ b/fushi/lib/src/asr/asr_encoder_buckets.dart
@@ -69,6 +69,22 @@ const int kAsrStaticMaxSegmentMs = 10000;
 /// 的 8 成，而融合图会把全部中间张量一次分配、各桶池子常驻——桶越大、桶越多，
 /// VRAM 就越容易溢出到系统内存（三桶 64/32/16 × 550/1100/2100 曾把测试进程撑到
 /// 8 GB 被系统杀掉）。
+///
+/// **为什么不加更细的短桶**（2026-09-06 A/B，同机、桶预热后、`ASR_BUCKETS` 覆盖）：
+/// 段长分布确实偏短——英语 30 分钟 71% 的段 ≤ 5 s，日语 10 分钟 99% ≤ 5 s 且大头
+/// 在 1~3 s，560 帧桶被 1~3 s 的段填得很空（日语 padding 3.25x）。但加一档 280 帧：
+///
+/// | 桶表 | 英语 30 min wall / padding | 日语 10 min wall / padding | 峰值显存（含桌面基线） |
+/// |---|---|---|---|
+/// | 560×32 + 1120×16 | 6.4 s / 2.19x | 5.2 s / 3.25x | 10.2 / 11.4 GB |
+/// | 280×64 + 560×32 + 1120×16 | 11.8 s / 2.19x | 11.1 s / 2.53x | 11.9 / 11.6 GB |
+/// | 280×48 + 560×32 + 1120×16 | 6.6 s / 2.11x | 12.2 s / 2.53x | 10.0 / 11.6 GB |
+///
+/// 英语的 padding 几乎不动：成批按最长段选桶、从最长往下取，短段在到达 280 桶之前
+/// 就被 560 桶的批顺手带走了；日语 padding 有降，但第三份常驻权重 + 中间张量把
+/// 12 GB 卡顶到溢出，wall 翻倍（280 帧桶单会话吞吐本身正常：64×280 两个模型都
+/// 120k 帧/s 以上）。桌面基线本身占 4.5 GB，两桶时本进程约 5.7 GB（英语）/
+/// 6.9 GB（日语）；padding 剩下的空间只能靠更多显存换，本机没有。
 /// 哪些执行后端真的实现了 free-dimension override —— 也就是静态桶**唯一**能带来
 /// 收益的那批。白名单不是黑名单：`freeDimensionOverrides` 只有 vendored
 /// flutter_onnxruntime 的 Windows 插件读（`third_party/flutter_onnxruntime/
@@ -230,6 +246,16 @@ class AsrStaticEncoderPool {
     await sessionFor(buckets.first.frames);
   }
 
+  /// 把全部桶建起来并等建完。只在显存预算已知且够放整张桶表时用（见
+  /// `asr_engine.dart` 的预热策略）；建失败的桶各自记原因、不抛。
+  Future<void> prewarmAll() async {
+    await Future.wait<AsrStaticEncoderSession?>(
+      <Future<AsrStaticEncoderSession?>>[
+        for (final AsrEncoderBucket b in buckets) sessionFor(b.frames),
+      ],
+    );
+  }
+
   /// 运行期发现该桶不可用（建得起来、`run` 抛错）：关掉会话、记原因，之后
   /// [sessionFor] 对该桶恒返回 null。
   void markUnavailable(
@@ -252,14 +278,14 @@ class AsrStaticEncoderPool {
     }
   }
 
+  /// 关闭已建成的桶会话。**不等**还在建的桶：建一个桶 3~8 s，用户在转录刚开始
+  /// 点取消不该干等；[_create] 见到 `_closed` 会在建成的那一刻自己把会话关掉。
   Future<void> close() async {
     _closed = true;
-    for (final Future<AsrStaticEncoderSession?> p in _pending.values.toList()) {
-      await p;
-    }
-    for (final AsrStaticEncoderSession s in _sessions.values) {
+    final List<AsrStaticEncoderSession> ready = _sessions.values.toList();
+    _sessions.clear();
+    for (final AsrStaticEncoderSession s in ready) {
       await s.session.close();
     }
-    _sessions.clear();
   }
 }

--- a/fushi/lib/src/asr/asr_encoder_buckets.dart
+++ b/fushi/lib/src/asr/asr_encoder_buckets.dart
@@ -82,6 +82,27 @@ const List<AsrEncoderBucket> kAsrGpuEncoderBuckets = <AsrEncoderBucket>[
   AsrEncoderBucket(frames: 1120, batch: 16),
 ];
 
+/// 显存吃紧时的半桶（行数减半，融合图常驻的中间张量随之减半）。
+const List<AsrEncoderBucket> kAsrGpuEncoderBucketsSmall = <AsrEncoderBucket>[
+  AsrEncoderBucket(frames: 560, batch: 16),
+  AsrEncoderBucket(frames: 1120, batch: 8),
+];
+
+const int _kGiB = 1024 * 1024 * 1024;
+
+/// 按显存预算（字节，DXGI 本进程可分配上限；null = 查不到）选桶表：
+/// - ≥ 10 GiB：[kAsrGpuEncoderBuckets]（12 GB 卡上 E2E 峰值 6.6~7.6 GB，含动态
+///   会话与贪心图）；
+/// - 6~10 GiB：[kAsrGpuEncoderBucketsSmall]；
+/// - < 6 GiB：空表——静态图溢出到系统内存后比动态会话还慢，不如不建；
+/// - null：按默认表试，建失败自会回退（非 Windows 走不到 GPU 桶）。
+List<AsrEncoderBucket> asrEncoderBucketsForBudget(int? budgetBytes) {
+  if (budgetBytes == null) return kAsrGpuEncoderBuckets;
+  if (budgetBytes >= 10 * _kGiB) return kAsrGpuEncoderBuckets;
+  if (budgetBytes >= 6 * _kGiB) return kAsrGpuEncoderBucketsSmall;
+  return const <AsrEncoderBucket>[];
+}
+
 /// 一个已建好的静态桶会话。
 class AsrStaticEncoderSession {
   const AsrStaticEncoderSession({required this.bucket, required this.session});
@@ -189,18 +210,19 @@ class AsrStaticEncoderPool {
     }
   }
 
-  /// 后台把**最小**桶建起来（不等待）：建一个会话 3~8 s，放到第一批需要时再建
-  /// 会让转录卡在那里；装载完就开始建，第一批到时通常已经好了或正在建。
+  /// 把**最小**桶建起来并等它建完。建一个会话 3~8 s：放到第一批需要时再建会让
+  /// 转录卡在那里，而不等它建完就开跑，进度与 ETA 会把建桶的停顿算成转录速度
+  /// （2026-09-06 A/B：30 分钟样本 wall 多出 ~4 s，全是第一批在等桶）。
   ///
   /// 只预热最小的那个是有意的。每个桶常驻一份编码器权重 + 融合图一次性分配的
   /// 全部中间张量（实测 E2E 峰值 6.6~7.6 GB），而显存不足时 DirectML **不抛
   /// 异常**——它溢出到主机内存，表现是 RSS 暴涨直到进程被系统杀掉，
   /// [markUnavailable] 这条回退路径根本照不到。全预热等于在任何机器上都先把
   /// 两份都占上；按需建则是「真出现长段才多占一份」。
-  /// 短素材（段都不超过最小桶）因此只会建一个会话。
-  void prewarmSmallest() {
+  /// 短素材（段都不超过最小桶）因此只会建一个会话。建失败记原因、不抛。
+  Future<void> prewarmSmallest() async {
     if (buckets.isEmpty) return;
-    unawaited(sessionFor(buckets.first.frames));
+    await sessionFor(buckets.first.frames);
   }
 
   /// 运行期发现该桶不可用（建得起来、`run` 抛错）：关掉会话、记原因，之后

--- a/fushi/lib/src/asr/asr_engine.dart
+++ b/fushi/lib/src/asr/asr_engine.dart
@@ -303,21 +303,35 @@ class AsrEngineLoader {
       // shape 收得下静态形状）、零收益、且永远不触发回退」的池子：多占两份
       // 编码器权重、x 白 pad 到桶的 T、VAD 还被砍到 10 s。
       final OnnxExecutionProvider effective = encoderResolution.effective;
-      final AsrStaticEncoderPool? staticEncoders =
-          useStaticEncoderBuckets &&
-              kAsrStaticBucketProviders.contains(effective)
-          ? AsrStaticEncoderPool(
-              factory: _factory,
-              modelPath: store.fileFor(encoderRole).path,
-              providers: <OnnxExecutionProvider>[effective],
-              logName: kAsrLogName,
-            )
-          : null;
-      // 只预热最小桶：两个桶各驻一份 fp32 编码器权重 + 融合图一次性分配的全部
-      // 中间张量，实测 E2E 峰值 6.6~7.6 GB（12 GB 卡独占）。显存不够时 DML **不
-      // 抛异常**——它溢出到主机内存，表现是 RSS 暴涨到被系统杀掉，回退机制照不到
-      // 这条路径。大桶留给真正出现长段时按需建（`sessionFor` 本来就是惰性的）。
-      staticEncoders?.prewarmSmallest();
+      AsrStaticEncoderPool? staticEncoders;
+      if (useStaticEncoderBuckets &&
+          kAsrStaticBucketProviders.contains(effective)) {
+        final int? budget = await _factory.deviceMemoryBudgetBytes();
+        final List<AsrEncoderBucket> buckets = asrEncoderBucketsForBudget(
+          budget,
+        );
+        developer.log(
+          'ASR static encoder buckets for GPU budget '
+          '${budget == null ? 'unknown' : '${budget ~/ (1024 * 1024)} MiB'}: '
+          '$buckets',
+          name: kAsrLogName,
+        );
+        if (buckets.isNotEmpty) {
+          staticEncoders = AsrStaticEncoderPool(
+            factory: _factory,
+            modelPath: store.fileFor(encoderRole).path,
+            providers: <OnnxExecutionProvider>[effective],
+            buckets: buckets,
+            logName: kAsrLogName,
+          );
+          // 只预热最小桶并等它建完：两个桶各驻一份 fp32 编码器权重 + 融合图一次性
+          // 分配的全部中间张量，实测 E2E 峰值 6.6~7.6 GB（12 GB 卡独占）。显存不够
+          // 时 DML **不抛异常**——它溢出到主机内存，表现是 RSS 暴涨到被系统杀掉，
+          // 回退机制照不到这条路径。大桶留给真正出现长段时按需建（`sessionFor`
+          // 本来就是惰性的）；等最小桶建完再开跑，进度 / ETA 才不会把建桶算进去。
+          await staticEncoders.prewarmSmallest();
+        }
+      }
       developer.log(
         'ASR engine loaded (${variant.name} encoder): $encoderResolution '
         'greedyGraph=${greedy != null} staticBuckets=${staticEncoders != null}',

--- a/fushi/lib/src/asr/asr_engine.dart
+++ b/fushi/lib/src/asr/asr_engine.dart
@@ -98,6 +98,29 @@ List<OnnxExecutionProvider> selectAsrEncoderProviders({
   return cpuOnly;
 }
 
+/// 装载时要不要把全部静态桶建好（纯函数，可测）。
+///
+/// 三个条件同时成立才全预热：
+/// - [buckets] 是全桶表（[kAsrGpuEncoderBuckets]）——半桶表本来就是预算吃紧的信号；
+/// - [budgetBytes] 已知（≥ 10 GiB 才会拿到全桶表，两桶常驻峰值 6.6~7.6 GB 实测过）；
+/// - [materialMs] 已知且 ≥ [kAsrPrewarmAllMinMaterialMs]：每桶 3~8 s 的建桶只有在
+///   素材够长时才摊得平——5 分钟片段本身只转 2~3 s，为省几百毫秒 padding 先花
+///   8 s 建大桶是净亏。
+bool shouldPrewarmAllStaticBuckets({
+  required List<AsrEncoderBucket> buckets,
+  required int? budgetBytes,
+  required int? materialMs,
+}) {
+  if (!identical(buckets, kAsrGpuEncoderBuckets)) return false;
+  if (budgetBytes == null) return false;
+  if (materialMs == null) return false;
+  return materialMs >= kAsrPrewarmAllMinMaterialMs;
+}
+
+/// 全预热的素材时长门槛：15 分钟。RTX 4070 Ti 上 30 分钟英语按需建大桶要多付
+/// ~4 s（wall 6 s → 10 s），15 分钟约多付 2 s，与提前建桶的 3~8 s 打平。
+const int kAsrPrewarmAllMinMaterialMs = 15 * 60 * 1000;
+
 /// 推荐下载 / 加载哪个编码器变体：会选到 GPU EP 就 fp32，否则 int8。
 ///
 /// fp32 比 int8 大 437 MB，只有 GPU 能把这笔磁盘换成速度；CPU 上 int8 反而更快
@@ -197,6 +220,8 @@ class AsrEngineLoader {
     required AsrAccelerationPreference preference,
     bool useGreedyGraph = true,
     bool useStaticEncoderBuckets = true,
+    List<AsrEncoderBucket>? staticBucketsOverride,
+    int? materialMs,
     int? greedyIntraOpThreads = kAsrGreedyGraphIntraOpThreads,
   }) async {
     Set<OnnxExecutionProvider> available = const <OnnxExecutionProvider>{};
@@ -307,9 +332,9 @@ class AsrEngineLoader {
       if (useStaticEncoderBuckets &&
           kAsrStaticBucketProviders.contains(effective)) {
         final int? budget = await _factory.deviceMemoryBudgetBytes();
-        final List<AsrEncoderBucket> buckets = asrEncoderBucketsForBudget(
-          budget,
-        );
+        // 桶表：基准 / 调参用的显式覆盖优先，否则按显存预算选。
+        final List<AsrEncoderBucket> buckets =
+            staticBucketsOverride ?? asrEncoderBucketsForBudget(budget);
         developer.log(
           'ASR static encoder buckets for GPU budget '
           '${budget == null ? 'unknown' : '${budget ~/ (1024 * 1024)} MiB'}: '
@@ -324,12 +349,22 @@ class AsrEngineLoader {
             buckets: buckets,
             logName: kAsrLogName,
           );
-          // 只预热最小桶并等它建完：两个桶各驻一份 fp32 编码器权重 + 融合图一次性
-          // 分配的全部中间张量，实测 E2E 峰值 6.6~7.6 GB（12 GB 卡独占）。显存不够
-          // 时 DML **不抛异常**——它溢出到主机内存，表现是 RSS 暴涨到被系统杀掉，
-          // 回退机制照不到这条路径。大桶留给真正出现长段时按需建（`sessionFor`
-          // 本来就是惰性的）；等最小桶建完再开跑，进度 / ETA 才不会把建桶算进去。
-          await staticEncoders.prewarmSmallest();
+          // 预热策略（见 [shouldPrewarmAllStaticBuckets]）：素材够长且预算够放整张
+          // 桶表时全部预热并等建完——每桶 3~8 s，留到转录中途按需建会在 GPU 队列上
+          // 把编码停住同样久，且进度 / ETA 会把停顿算成转录速度；短素材或预算不足
+          // 时只预热最小桶，大桶按需建（`sessionFor` 本来就是惰性的）。显存不够时
+          // DML **不抛异常**——它溢出到主机内存、RSS 暴涨到被系统杀掉，回退机制照
+          // 不到这条路径，所以预算这道门必须在建桶之前。
+          if (staticBucketsOverride != null ||
+              shouldPrewarmAllStaticBuckets(
+                buckets: buckets,
+                budgetBytes: budget,
+                materialMs: materialMs,
+              )) {
+            await staticEncoders.prewarmAll();
+          } else {
+            await staticEncoders.prewarmSmallest();
+          }
         }
       }
       developer.log(

--- a/fushi/lib/src/asr/asr_transcribe_isolate.dart
+++ b/fushi/lib/src/asr/asr_transcribe_isolate.dart
@@ -55,6 +55,8 @@ class AsrIsolateJobSpec {
     required this.segmenterKind,
     this.batchSize,
     this.usePipeline = true,
+    this.staticBucketsOverride,
+    this.materialMs,
   });
 
   final String storeDirPath;
@@ -67,6 +69,12 @@ class AsrIsolateJobSpec {
   final AsrSegmenterKind segmenterKind;
 
   final bool usePipeline;
+
+  /// 见 [AsrTranscriptionService.staticBucketsOverride]。
+  final List<AsrEncoderBucket>? staticBucketsOverride;
+
+  /// 素材总时长（毫秒；null = 未知），决定装载时的桶预热策略。
+  final int? materialMs;
 
   /// null = 按编码器实际落到的 EP 取 [AsrTranscriptionService.defaultBatchSizeFor]。
   final int? batchSize;
@@ -322,6 +330,8 @@ Future<void> _isolateMain(_IsolateArgs args) async {
       store: store,
       variant: spec.variant,
       preference: spec.preference,
+      staticBucketsOverride: spec.staticBucketsOverride,
+      materialMs: spec.materialMs,
     );
     args.events.send(
       _LoadedMessage(

--- a/fushi/lib/src/asr/asr_transcribe_isolate.dart
+++ b/fushi/lib/src/asr/asr_transcribe_isolate.dart
@@ -54,6 +54,7 @@ class AsrIsolateJobSpec {
     required this.chunkSeconds,
     required this.segmenterKind,
     this.batchSize,
+    this.usePipeline = true,
   });
 
   final String storeDirPath;
@@ -64,6 +65,8 @@ class AsrIsolateJobSpec {
   final String jobDirPath;
   final int chunkSeconds;
   final AsrSegmenterKind segmenterKind;
+
+  final bool usePipeline;
 
   /// null = 按编码器实际落到的 EP 取 [AsrTranscriptionService.defaultBatchSizeFor]。
   final int? batchSize;
@@ -361,6 +364,8 @@ Future<void> _isolateMain(_IsolateArgs args) async {
             sessions.encoderResolution.effective,
           ),
       chunkSeconds: spec.chunkSeconds,
+      statsProvider: () => decoder.stats,
+      usePipeline: spec.usePipeline,
     );
     job = j;
     if (pauseBeforeStart) j.requestPause();

--- a/fushi/lib/src/asr/asr_transcribe_job.dart
+++ b/fushi/lib/src/asr/asr_transcribe_job.dart
@@ -287,15 +287,20 @@ class AsrTranscribeJob {
   final AsrSegmenter segmenter;
   final AsrBatchDecoder decoder;
 
-  /// 成批的**参考**段数：一批的音频预算 = [batchSize] × [kAsrBatchReferenceSeconds]
-  /// 秒。段短时一批可以装比它多得多的段（上限 [maxBatchSegments]），段都顶到
-  /// 20 s 时恰好是 [batchSize] 段。GPU 上越大越省往返；CPU 上受内存约束。
+  /// **动态 shape 路径**的成批参考段数：一批的音频预算 = [batchSize] ×
+  /// [kAsrBatchReferenceSeconds] 秒。段短时一批可以装比它多得多的段（上限
+  /// [maxBatchSegments]），段都顶到 20 s 时恰好是 [batchSize] 段。GPU 上越大越省
+  /// 往返；CPU 上受内存约束。
+  ///
+  /// 解码器实现了 [AsrBatchShaper]（GPU 静态 shape 桶）时**本参数与下面两项都不
+  /// 生效**：一批的行数由最长段所在桶的容量决定（`batchCapFor`），攒够就发——桶
+  /// 内每行成本相同，装满最划算，音频预算和 4 倍上限在那里没有意义。
   final int batchSize;
 
-  /// 一批最多装多少段（防止全是 1 s 短句时把一批撑到几百行）。
+  /// 动态路径：一批最多装多少段（防止全是 1 s 短句时把一批撑到几百行）。
   int get maxBatchSegments => batchSize * 4;
 
-  /// [batchSize] 对应的每段参考时长（= VAD 的 maxSegment 上限）。
+  /// 动态路径：[batchSize] 对应的每段参考时长（= VAD 的 maxSegment 默认上限）。
   static const int kAsrBatchReferenceSeconds = 20;
 
   /// 每块 PCM 的时长（秒）。也是检查点粒度上限。

--- a/fushi/lib/src/asr/asr_transcribe_job.dart
+++ b/fushi/lib/src/asr/asr_transcribe_job.dart
@@ -28,6 +28,8 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/asr/asr_cue_builder.dart';
+import 'package:fushi/src/asr/asr_transducer_decoder.dart'
+    show AsrBatchFeatures, AsrDecodeStats, AsrEncodedBatch;
 import 'package:fushi/src/asr/asr_types.dart';
 
 /// 流式 VAD 切段器（`AsrVadSegmenter` 实现之）。
@@ -43,6 +45,19 @@ abstract interface class AsrSegmenter {
 /// 批量解码器（`AsrTransducerDecoder` 实现之）。
 abstract interface class AsrBatchDecoder {
   Future<List<AsrDecodedSegment>> decodeBatch(List<AsrSpeechSegment> segments);
+}
+
+/// 三段式解码器（可选实现）：fbank（Dart 同步）→ encoder（GPU）→ 搜索（CPU）
+/// 拆开后任务可以把三者叠起来：GPU 编码第 i 批时 CPU 搜索第 i-1 批、Dart 算第
+/// i+1 批的 fbank（`asr_transcribe_job.dart` 的流水线）。三段串起来必须与
+/// [AsrBatchDecoder.decodeBatch] 逐字等价。
+abstract interface class AsrPipelinedDecoder implements AsrBatchDecoder {
+  AsrBatchFeatures computeFeatures(List<AsrSpeechSegment> segments);
+  Future<AsrEncodedBatch> encode(
+    List<AsrSpeechSegment> segments, {
+    AsrBatchFeatures? features,
+  });
+  Future<List<AsrDecodedSegment>> search(AsrEncodedBatch encoded);
 }
 
 /// 解码器对成批形状的约束（可选实现）：GPU 静态 shape 桶一批**恰好** N 行，
@@ -63,10 +78,15 @@ class AsrTranscribeProgress {
     required this.speechMs,
     required this.segmentsDone,
     required this.elapsed,
+    this.decodeStats,
   });
 
   /// 当前正在处理的文件下标（0 起）。
   final int fileIndex;
+
+  /// 解码器到此刻的分阶段统计（UI 据此显示是否在跑静态融合图等）；解码器不
+  /// 提供时 null。
+  final AsrDecodeStats? decodeStats;
   final int filesTotal;
 
   /// 已处理的音频时长（毫秒，跨文件累计）。
@@ -252,6 +272,8 @@ class AsrTranscribeJob {
     this.chunkSeconds = 300,
     this.cueBuilder = const AsrCueBuilder(),
     this.progressInterval = const Duration(milliseconds: 500),
+    this.statsProvider,
+    this.usePipeline = true,
   })  : assert(audioPaths.isNotEmpty),
         assert(batchSize > 0),
         assert(chunkSeconds > 0);
@@ -282,6 +304,12 @@ class AsrTranscribeJob {
 
   /// 进度事件的最小间隔（同一块内按批次发，防止刷屏）。
   final Duration progressInterval;
+
+  /// 取解码器当前统计的钩子（进度事件随带）；null = 进度不带统计。
+  final AsrDecodeStats Function()? statsProvider;
+
+  /// 解码器支持三段式时是否走流水线（false = 逐批 decodeBatch，基准对照用）。
+  final bool usePipeline;
 
   bool _pauseRequested = false;
   bool _started = false;
@@ -420,6 +448,7 @@ class AsrTranscribeJob {
         speechMs: speechMs,
         segmentsDone: segmentsDone,
         elapsed: clock.elapsed,
+        decodeStats: statsProvider?.call(),
       );
     }
 
@@ -455,6 +484,80 @@ class AsrTranscribeJob {
             pendingSamples() >= budgetSamples;
       }
 
+      final AsrPipelinedDecoder? pipe =
+          usePipeline && decoder is AsrPipelinedDecoder
+              ? decoder as AsrPipelinedDecoder
+              : null;
+      // 流水线状态（跨 drain 调用保留，块末 drain(all: true) 冲干净）。
+      Future<AsrEncodedBatch>? inFlight;
+      List<AsrSpeechSegment>? peeked;
+      AsrBatchFeatures? peekedFeatures;
+
+      Future<void> commit(
+        List<AsrSpeechSegment> batch,
+        List<AsrDecodedSegment> decoded,
+      ) async {
+        final List<AsrTranscribedSegment> out = <AsrTranscribedSegment>[];
+        for (int k = 0; k < batch.length; k++) {
+          if (decoded[k].isEmpty) continue;
+          out.add(
+            AsrTranscribedSegment.fromDecoded(
+              audioFileIndex: fileIndex,
+              speech: batch[k],
+              decoded: decoded[k],
+            ),
+          );
+          speechMs += batch[k].lengthMs;
+        }
+        segmentsDone += out.length;
+        await _appendSegments(out);
+      }
+
+      int nextTake() {
+        final int? cap = shaper?.batchCapFor(pending.first.samples.length);
+        // 静态桶：一批就是桶的行数（桶内每行成本相同，装满最划算）。
+        return cap != null
+            ? (pending.length < cap ? pending.length : cap)
+            : pickBatchSize(
+                pending,
+                budgetSamples: budgetSamples,
+                maxSegments: maxBatchSegments,
+              );
+      }
+
+      /// 取下一批：若上一轮已经窥视过（并提前算了 fbank）且 pending 头部没变，
+      /// 就复用同一个列表对象，让 encode 认出提前算好的特征。
+      List<AsrSpeechSegment> takeBatch() {
+        final int take = nextTake();
+        final List<AsrSpeechSegment>? p = peeked;
+        peeked = null;
+        if (p != null && p.length == take) {
+          bool same = true;
+          for (int k = 0; k < take; k++) {
+            if (!identical(p[k], pending[k])) {
+              same = false;
+              break;
+            }
+          }
+          if (same) {
+            pending.removeRange(0, take);
+            return p;
+          }
+        }
+        peekedFeatures = null;
+        final List<AsrSpeechSegment> batch = pending.sublist(0, take);
+        pending.removeRange(0, take);
+        return batch;
+      }
+
+      Future<void> flushInFlight() async {
+        final Future<AsrEncodedBatch>? f = inFlight;
+        if (f == null || pipe == null) return;
+        inFlight = null;
+        final AsrEncodedBatch enc = await f;
+        await commit(enc.segments, await pipe.search(enc));
+      }
+
       Future<void> drain({required bool all}) async {
         // 按段长降序、按音频预算成批：encoder 按批内最长 pad、Loop 图每一步都
         // 带着整批算，长短混批的 padding 全是白付（2026-09-06 实测：英语朗读段
@@ -465,36 +568,43 @@ class AsrTranscribeJob {
           (AsrSpeechSegment a, AsrSpeechSegment b) =>
               b.samples.length.compareTo(a.samples.length),
         );
+        // 排序可能让窥视过的批失效（takeBatch 会按元素身份复核）。
         while (pending.isNotEmpty && (all || enoughPending())) {
-          final int? cap = shaper?.batchCapFor(pending.first.samples.length);
-          // 静态桶：一批就是桶的行数（桶内每行成本相同，装满最划算）。
-          final int take = cap != null
-              ? (pending.length < cap ? pending.length : cap)
-              : pickBatchSize(
-                  pending,
-                  budgetSamples: budgetSamples,
-                  maxSegments: maxBatchSegments,
-                );
-          final List<AsrSpeechSegment> batch = pending.sublist(0, take);
-          pending.removeRange(0, take);
-          final List<AsrDecodedSegment> decoded = await decoder.decodeBatch(
-            batch,
-          );
-          final List<AsrTranscribedSegment> out = <AsrTranscribedSegment>[];
-          for (int k = 0; k < batch.length; k++) {
-            if (decoded[k].isEmpty) continue;
-            out.add(
-              AsrTranscribedSegment.fromDecoded(
-                audioFileIndex: fileIndex,
-                speech: batch[k],
-                decoded: decoded[k],
-              ),
-            );
-            speechMs += batch[k].lengthMs;
+          final List<AsrSpeechSegment> batch = takeBatch();
+          if (pipe == null) {
+            await commit(batch, await decoder.decodeBatch(batch));
+            continue;
           }
-          segmentsDone += out.length;
-          await _appendSegments(out);
+          // 三级流水线：GPU 编码第 i 批 ‖ CPU 搜索第 i-1 批 ‖ Dart 算第 i+1 批
+          // 的 fbank。插件把 GPU 会话与 CPU 会话放在两条工作线程上，三者才真能
+          // 同时跑（2026-09-06：串行时 fbank + 搜索 + ffmpeg 占 30 分钟英语
+          // 7.2 s 里的四成，GPU 那段时间全闲着）。
+          final AsrBatchFeatures? ready = peekedFeatures;
+          peekedFeatures = null;
+          final Future<AsrEncodedBatch> encoding = pipe.encode(
+            batch,
+            features: ready,
+          );
+          Future<List<AsrDecodedSegment>>? searching;
+          AsrEncodedBatch? previous;
+          final Future<AsrEncodedBatch>? prevFuture = inFlight;
+          inFlight = null;
+          if (prevFuture != null) {
+            previous = await prevFuture;
+            searching = pipe.search(previous);
+          }
+          // 趁 GPU / CPU 会话都在忙：窥视下一批并把它的 fbank 先算出来。
+          if (pending.isNotEmpty && (all || enoughPending())) {
+            final int take = nextTake();
+            peeked = pending.sublist(0, take);
+            peekedFeatures = pipe.computeFeatures(peeked!);
+          }
+          if (searching != null) {
+            await commit(previous!.segments, await searching);
+          }
+          inFlight = encoding;
         }
+        if (all) await flushInFlight();
       }
 
       // 预取：先向流要下一块，让 ffmpeg 与本块的 VAD/解码重叠。

--- a/fushi/lib/src/asr/asr_transcription_service.dart
+++ b/fushi/lib/src/asr/asr_transcription_service.dart
@@ -135,6 +135,7 @@ class AsrTranscriptionService {
     this.segmenterKind = AsrSegmenterKind.energy,
     this.runInIsolate = true,
     this.usePipeline = true,
+    this.staticBucketsOverride,
   }) : _loader = loader ?? AsrEngineLoader(),
        _pcm = pcm ?? FfmpegAsrPcmSource(),
        _openStore = openStore ?? AsrModelStore.open,
@@ -145,8 +146,9 @@ class AsrTranscriptionService {
   final Future<AsrModelStore> Function(AsrLanguage language) _openStore;
   final Future<Directory> Function() _jobsRoot;
 
-  /// 一次 encoder 前向的段数；null 时按编码器实际落到的 EP 取
-  /// [defaultBatchSizeFor]。
+  /// 一次 encoder 前向的段数（动态 shape 路径）；null 时按编码器实际落到的 EP 取
+  /// [defaultBatchSizeFor]。GPU 静态桶路径下一批行数由桶决定，本值不生效
+  /// （见 [AsrTranscribeJob.batchSize]）。
   final int? batchSize;
   final int chunkSeconds;
   final AsrSegmenterKind segmenterKind;
@@ -158,6 +160,9 @@ class AsrTranscriptionService {
 
   /// 见 [AsrTranscribeJob.usePipeline]（基准对照用；生产恒 true）。
   final bool usePipeline;
+
+  /// 静态桶表覆盖（基准 / 调参用；生产为 null，按显存预算选表）。
+  final List<AsrEncoderBucket>? staticBucketsOverride;
 
   /// 默认批次：GPU 上 batch 越大越省逐帧 joiner 的往返（2026-09-05 真机分阶段计时
   /// 里逐帧循环是 ASR 阶段的大头，encoder 本身在 DirectML 上只占零头）；CPU 上
@@ -292,6 +297,18 @@ class AsrTranscriptionService {
     return File(p.join(p.dirname(path), AsrJobFiles.state)).existsSync();
   }
 
+  /// 全部音频的总时长（毫秒）；任一文件探不出就返回 null（策略按未知处理，
+  /// 不拿部分和冒充总长）。
+  Future<int?> _probeMaterialMs(List<String> audioPaths) async {
+    int total = 0;
+    for (final String path in audioPaths) {
+      final int? ms = await _pcm.probeDurationMs(path);
+      if (ms == null) return null;
+      total += ms;
+    }
+    return total;
+  }
+
   /// 丢弃该组音频在该语言下的全部转录进度与产物。
   Future<void> discard(List<String> audioPaths, AsrLanguage language) async {
     final Directory dir = await jobDirFor(audioPaths, language);
@@ -307,6 +324,8 @@ class AsrTranscriptionService {
   }) async {
     final AsrModelStore store = await _openStore(language);
     final Directory jobDir = await jobDirFor(audioPaths, language);
+    // 素材总时长（探测失败的文件按未知处理）：决定装载时预热几个静态桶。
+    final int? materialMs = await _probeMaterialMs(audioPaths);
     if (runInIsolate) {
       return AsrIsolateTranscription.spawn(
         AsrIsolateJobSpec(
@@ -320,6 +339,8 @@ class AsrTranscriptionService {
           segmenterKind: segmenterKind,
           batchSize: batchSize,
           usePipeline: usePipeline,
+          staticBucketsOverride: staticBucketsOverride,
+          materialMs: materialMs,
         ),
       );
     }
@@ -327,6 +348,8 @@ class AsrTranscriptionService {
       store: store,
       variant: variant,
       preference: preference,
+      staticBucketsOverride: staticBucketsOverride,
+      materialMs: materialMs,
     );
     try {
       final AsrTransducerDecoder decoder = AsrTransducerDecoder(

--- a/fushi/lib/src/asr/asr_transcription_service.dart
+++ b/fushi/lib/src/asr/asr_transcription_service.dart
@@ -134,6 +134,7 @@ class AsrTranscriptionService {
     this.chunkSeconds = 300,
     this.segmenterKind = AsrSegmenterKind.energy,
     this.runInIsolate = true,
+    this.usePipeline = true,
   }) : _loader = loader ?? AsrEngineLoader(),
        _pcm = pcm ?? FfmpegAsrPcmSource(),
        _openStore = openStore ?? AsrModelStore.open,
@@ -154,6 +155,9 @@ class AsrTranscriptionService {
   /// [AsrEngineLoader] / [AsrPcmSource] 只在该路径生效——闭包与 fake 会话过不了
   /// isolate 边界。
   final bool runInIsolate;
+
+  /// 见 [AsrTranscribeJob.usePipeline]（基准对照用；生产恒 true）。
+  final bool usePipeline;
 
   /// 默认批次：GPU 上 batch 越大越省逐帧 joiner 的往返（2026-09-05 真机分阶段计时
   /// 里逐帧循环是 ASR 阶段的大头，encoder 本身在 DirectML 上只占零头）；CPU 上
@@ -315,6 +319,7 @@ class AsrTranscriptionService {
           chunkSeconds: chunkSeconds,
           segmenterKind: segmenterKind,
           batchSize: batchSize,
+          usePipeline: usePipeline,
         ),
       );
     }
@@ -356,6 +361,8 @@ class AsrTranscriptionService {
             batchSize ??
             defaultBatchSizeFor(sessions.encoderResolution.effective),
         chunkSeconds: chunkSeconds,
+        statsProvider: () => decoder.stats,
+        usePipeline: usePipeline,
       );
       return AsrInProcessTranscription(
         sessions: sessions,

--- a/fushi/lib/src/asr/asr_transducer_decoder.dart
+++ b/fushi/lib/src/asr/asr_transducer_decoder.dart
@@ -56,6 +56,9 @@ class AsrDecodeStats {
   final Duration encoder;
   final Duration search;
 
+  /// encoder 实际算过的帧数 / 真实帧数。两条路径口径一致：都是「喂给 encoder 的
+  /// 张量面积 ÷ 各段真实帧数之和」——动态路径的面积是 batch × 批内最长，静态路径
+  /// 是桶的 N × T（含哨兵行）。1.0 = 零浪费。
   double get paddingRatio => realFrames == 0 ? 1 : paddedFrames / realFrames;
 
   AsrDecodeStats add({

--- a/fushi/lib/src/asr/asr_transducer_decoder.dart
+++ b/fushi/lib/src/asr/asr_transducer_decoder.dart
@@ -24,7 +24,7 @@ import 'package:fushi/src/asr/asr_fbank.dart';
 import 'package:fushi/src/asr/asr_greedy_graph.dart' show AsrGreedyGraphIo;
 import 'package:fushi/src/asr/asr_types.dart';
 import 'package:fushi/src/asr/asr_transcribe_job.dart'
-    show AsrBatchDecoder, AsrBatchShaper;
+    show AsrBatchDecoder, AsrBatchShaper, AsrPipelinedDecoder;
 import 'package:fushi/src/onnx/onnx_inference.dart';
 
 /// 解码器累计的分阶段耗时与帧数（诊断用，进度 UI / 集成测试打印）。
@@ -88,7 +88,8 @@ class AsrDecodeStats {
       'search=${search.inMilliseconds}ms)';
 }
 
-class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
+class AsrTransducerDecoder
+    implements AsrBatchDecoder, AsrBatchShaper, AsrPipelinedDecoder {
   AsrTransducerDecoder({
     required OnnxSession encoder,
     required OnnxSession decoder,
@@ -159,6 +160,10 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
   AsrDecodeStats get stats => _stats;
 
   /// 一次 encoder 前向 + 整批逐帧贪心解码；返回与 [segments] 等长、同序的结果。
+  ///
+  /// 等价于 `search(await encode(segments))`；行数超过静态桶容量时拆成多批。
+  /// 要把 GPU 编码、CPU 搜索与 Dart fbank 叠起来跑，用 [computeFeatures] /
+  /// [encode] / [search] 三段（`asr_transcribe_job.dart` 的流水线）。
   @override
   Future<List<AsrDecodedSegment>> decodeBatch(
     List<AsrSpeechSegment> segments,
@@ -166,48 +171,88 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
     if (segments.isEmpty) return <AsrDecodedSegment>[];
     // 静态桶的行数封顶：超过就拆成多批（任务侧已按 batchCapFor 封顶，这里只是
     // 兜底，保证直接调用者也不会把 64 行塞进 N=32 的桶）。
-    final AsrStaticEncoderPool? pool = _staticEncoders;
-    if (pool != null && segments.length > 1) {
-      int longest = 0;
-      for (final AsrSpeechSegment s in segments) {
-        if (s.samples.length > longest) longest = s.samples.length;
+    final int? cap = _capFor(segments);
+    if (cap != null && segments.length > cap) {
+      final List<AsrDecodedSegment> out = <AsrDecodedSegment>[];
+      for (int i = 0; i < segments.length; i += cap) {
+        final int end = i + cap > segments.length ? segments.length : i + cap;
+        out.addAll(await decodeBatch(segments.sublist(i, end)));
       }
-      final int? cap = pool.batchCapFor(AsrFbank.frameCount(longest));
-      if (cap != null && segments.length > cap) {
-        final List<AsrDecodedSegment> out = <AsrDecodedSegment>[];
-        for (int i = 0; i < segments.length; i += cap) {
-          final int end = i + cap > segments.length ? segments.length : i + cap;
-          out.addAll(await decodeBatch(segments.sublist(i, end)));
-        }
-        return out;
-      }
+      return out;
     }
-    final int batch = segments.length;
-    final Stopwatch clock = Stopwatch()..start();
+    return search(await encode(segments));
+  }
 
-    // 1. fbank + pad。
+  int? _capFor(List<AsrSpeechSegment> segments) {
+    final AsrStaticEncoderPool? pool = _staticEncoders;
+    if (pool == null || segments.length <= 1) return null;
+    int longest = 0;
+    for (final AsrSpeechSegment s in segments) {
+      if (s.samples.length > longest) longest = s.samples.length;
+    }
+    return pool.batchCapFor(AsrFbank.frameCount(longest));
+  }
+
+  /// 第一段：fbank（纯 Dart，同步）。流水线里趁 GPU / CPU 会话都在忙时算下一批。
+  @override
+  AsrBatchFeatures computeFeatures(List<AsrSpeechSegment> segments) {
+    final Stopwatch clock = Stopwatch()..start();
+    final int batch = segments.length;
     final List<Float32List> features = <Float32List>[];
     final Int64List frameCounts = Int64List(batch);
     int maxFrames = 0;
+    int realFrames = 0;
     for (int i = 0; i < batch; i++) {
       final Float32List f = _fbank.compute(segments[i].samples);
       features.add(f);
       final int frames = f.length ~/ kAsrFeatureDim;
       frameCounts[i] = frames;
+      realFrames += frames;
       if (frames > maxFrames) maxFrames = frames;
     }
-    if (maxFrames == 0) {
-      return List<AsrDecodedSegment>.filled(batch, AsrDecodedSegment.empty);
-    }
-    final Duration fbankTime = clock.elapsed;
-    int realFrames = 0;
-    for (int i = 0; i < batch; i++) {
-      realFrames += frameCounts[i];
-    }
+    return AsrBatchFeatures._(
+      segments: segments,
+      features: features,
+      frameCounts: frameCounts,
+      maxFrames: maxFrames,
+      realFrames: realFrames,
+      fbankTime: clock.elapsed,
+    );
+  }
 
-    // 2. encoder：有静态桶就填成桶的 [N_b, T_b, 80]——多出的行喂 pad 值、
-    //    x_lens = T_b（哨兵行，让 x_lens.max() 恒等于 T_b，见
-    //    `asr_encoder_buckets.dart` 文件头），否则按批内最长 pad 走动态会话。
+  /// 第二段：encoder 前向（GPU 会话；静态桶或动态会话）。[features] 缺省现算。
+  /// 返回后 encoder 输出已读回主机，可立刻发起下一批的 encoder 而不等搜索。
+  @override
+  Future<AsrEncodedBatch> encode(
+    List<AsrSpeechSegment> segments, {
+    AsrBatchFeatures? features,
+  }) async {
+    if (segments.isEmpty) {
+      throw ArgumentError.value(segments, 'segments', '空批');
+    }
+    final int? cap = _capFor(segments);
+    if (cap != null && segments.length > cap) {
+      throw ArgumentError.value(
+        segments.length,
+        'segments',
+        '超过静态桶容量 $cap（调用方按 batchCapFor 封顶，或用 decodeBatch）',
+      );
+    }
+    final AsrBatchFeatures feats =
+        features != null && identical(features.segments, segments)
+        ? features
+        : computeFeatures(segments);
+    final int batch = segments.length;
+    final int maxFrames = feats.maxFrames;
+    if (maxFrames == 0) {
+      return AsrEncodedBatch._empty(segments, feats.fbankTime);
+    }
+    final Stopwatch clock = Stopwatch()..start();
+
+    // encoder：有静态桶就填成桶的 [N_b, T_b, 80]——多出的行喂 pad 值、
+    // x_lens = T_b（哨兵行，让 x_lens.max() 恒等于 T_b，见
+    // `asr_encoder_buckets.dart` 文件头），否则按批内最长 pad 走动态会话。
+    final AsrStaticEncoderPool? pool = _staticEncoders;
     final AsrStaticEncoderSession? fixed = pool == null
         ? null
         : await pool.sessionFor(maxFrames);
@@ -219,14 +264,14 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
     final Int64List xLens = Int64List(rows);
     for (int i = 0; i < rows; i++) {
       final int base = i * cols * kAsrFeatureDim;
-      final Float32List? f = i < batch ? features[i] : null;
+      final Float32List? f = i < batch ? feats.features[i] : null;
       if (f != null) x.setRange(base, base + f.length, f);
       x.fillRange(
         base + (f?.length ?? 0),
         base + cols * kAsrFeatureDim,
         kFeaturePadValue,
       );
-      xLens[i] = f == null ? cols : frameCounts[i];
+      xLens[i] = f == null ? cols : feats.frameCounts[i];
     }
     // run 与**输出契约校验**必须在同一个 try 里：融合图少给一个输出 key、或回来
     // 的行数与 rows 对不上，同样是「这个静态桶跑不动」的表现形态，而且正是全新
@@ -254,9 +299,8 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
       // 这个桶标为不可用、本批回退动态会话，任务不中断；原因留在池子里。
       if (fixed == null || pool == null) rethrow;
       pool.markUnavailable(fixed.bucket, error, stack);
-      return decodeBatch(segments);
+      return encode(segments, features: feats);
     }
-    final Duration encoderTime = clock.elapsed - fbankTime;
     final int encFrames = encoderOutAll.shape[1];
     final int encDim = encoderOutAll.shape[2];
     // 只保留真实行（填充行排在后面，是连续前缀）。
@@ -267,11 +311,6 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
             0,
             batch * encFrames * encDim,
           );
-    final OnnxTensor encoderOut = OnnxTensor.float32(encData, <int>[
-      batch,
-      encFrames,
-      encDim,
-    ]);
     final List<int> encLens = List<int>.generate(batch, (int i) {
       final int len = _lengthAt(encoderLens, i);
       if (len < 0 || len > encFrames) {
@@ -281,17 +320,50 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
       }
       return len;
     });
-    final int paddedFrames = rows * cols;
+    return AsrEncodedBatch._(
+      segments: segments,
+      encData: encData,
+      encFrames: encFrames,
+      encDim: encDim,
+      encLens: encLens,
+      realFrames: feats.realFrames,
+      paddedFrames: rows * cols,
+      fbankTime: feats.fbankTime,
+      encoderTime: clock.elapsed,
+      isStatic: fixed != null,
+    );
+  }
+
+  /// 第三段：逐帧贪心搜索（CPU 会话：Loop 图或 decoder/joiner 逐帧）。
+  @override
+  Future<List<AsrDecodedSegment>> search(AsrEncodedBatch encoded) async {
+    final int batch = encoded.segments.length;
+    if (encoded.isEmpty) {
+      _stats = _stats.add(
+        segments: batch,
+        realFrames: 0,
+        paddedFrames: 0,
+        fbank: encoded.fbankTime,
+        encoder: Duration.zero,
+        search: Duration.zero,
+      );
+      return List<AsrDecodedSegment>.filled(batch, AsrDecodedSegment.empty);
+    }
+    final Stopwatch clock = Stopwatch()..start();
+    final Float32List encData = encoded.encData;
+    final int encFrames = encoded.encFrames;
+    final int encDim = encoded.encDim;
+    final List<int> encLens = encoded.encLens;
 
     void account() {
       _stats = _stats.add(
         segments: batch,
-        realFrames: realFrames,
-        paddedFrames: paddedFrames,
-        fbank: fbankTime,
-        encoder: encoderTime,
-        search: clock.elapsed - fbankTime - encoderTime,
-        static: fixed != null,
+        realFrames: encoded.realFrames,
+        paddedFrames: encoded.paddedFrames,
+        fbank: encoded.fbankTime,
+        encoder: encoded.encoderTime,
+        search: clock.elapsed,
+        static: encoded.isStatic,
       );
     }
 
@@ -299,10 +371,9 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
     if (greedy != null) {
       final List<AsrDecodedSegment> out = await _decodeWithGreedyGraph(
         greedy: greedy,
-        encoderOut: encoderOut,
-        encoderLens: encoderLens,
         encData: encData,
         encFrames: encFrames,
+        encDim: encDim,
         encLens: encLens,
         batch: batch,
       );
@@ -433,19 +504,19 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
   /// token id，-1 = 无），按帧还原 token 与时间。
   Future<List<AsrDecodedSegment>> _decodeWithGreedyGraph({
     required OnnxSession greedy,
-    required OnnxTensor encoderOut,
-    required OnnxTensor encoderLens,
     required Float32List encData,
     required int encFrames,
+    required int encDim,
     required List<int> encLens,
     required int batch,
   }) async {
     final Int64List lens = Int64List.fromList(encLens);
     final Map<String, OnnxTensor> out = await greedy.run(<String, OnnxTensor>{
-      AsrGreedyGraphIo.encoderOut: OnnxTensor.float32(
-        encData,
-        List<int>.from(encoderOut.shape),
-      ),
+      AsrGreedyGraphIo.encoderOut: OnnxTensor.float32(encData, <int>[
+        batch,
+        encFrames,
+        encDim,
+      ]),
       AsrGreedyGraphIo.encoderOutLens: OnnxTensor.int64(lens, <int>[batch]),
     });
     final OnnxTensor emitted = _require(out, AsrGreedyGraphIo.emitted);
@@ -539,4 +610,84 @@ class AsrTransducerDecoder implements AsrBatchDecoder, AsrBatchShaper {
     }
     return best;
   }
+}
+
+/// [AsrTransducerDecoder.computeFeatures] 的产物：一批段的 fbank 特征。
+class AsrBatchFeatures {
+  const AsrBatchFeatures._({
+    required this.segments,
+    required this.features,
+    required this.frameCounts,
+    required this.maxFrames,
+    required this.realFrames,
+    required this.fbankTime,
+  });
+
+  /// 测试用：不算特征的占位（fake 解码器只关心段与身份）。
+  @visibleForTesting
+  factory AsrBatchFeatures.forTest(List<AsrSpeechSegment> segments) =>
+      AsrBatchFeatures._(
+        segments: segments,
+        features: const <Float32List>[],
+        frameCounts: Int64List(0),
+        maxFrames: 0,
+        realFrames: 0,
+        fbankTime: Duration.zero,
+      );
+
+  final List<AsrSpeechSegment> segments;
+  final List<Float32List> features;
+  final Int64List frameCounts;
+  final int maxFrames;
+  final int realFrames;
+  final Duration fbankTime;
+}
+
+/// [AsrTransducerDecoder.encode] 的产物：已读回主机的 encoder 输出（只含真实行）。
+class AsrEncodedBatch {
+  const AsrEncodedBatch._({
+    required this.segments,
+    required this.encData,
+    required this.encFrames,
+    required this.encDim,
+    required this.encLens,
+    required this.realFrames,
+    required this.paddedFrames,
+    required this.fbankTime,
+    required this.encoderTime,
+    required this.isStatic,
+  });
+
+  /// 测试用：只带段列表的占位。
+  @visibleForTesting
+  factory AsrEncodedBatch.forTest(List<AsrSpeechSegment> segments) =>
+      AsrEncodedBatch._empty(segments, Duration.zero);
+
+  /// 全部段都没有一帧特征（极短静音）：搜索直接返回空结果。
+  AsrEncodedBatch._empty(List<AsrSpeechSegment> segments, Duration fbankTime)
+    : this._(
+        segments: segments,
+        encData: Float32List(0),
+        encFrames: 0,
+        encDim: 0,
+        encLens: const <int>[],
+        realFrames: 0,
+        paddedFrames: 0,
+        fbankTime: fbankTime,
+        encoderTime: Duration.zero,
+        isStatic: false,
+      );
+
+  final List<AsrSpeechSegment> segments;
+  final Float32List encData;
+  final int encFrames;
+  final int encDim;
+  final List<int> encLens;
+  final int realFrames;
+  final int paddedFrames;
+  final Duration fbankTime;
+  final Duration encoderTime;
+  final bool isStatic;
+
+  bool get isEmpty => encFrames == 0;
 }

--- a/fushi/lib/src/asr/asr_transducer_decoder.dart
+++ b/fushi/lib/src/asr/asr_transducer_decoder.dart
@@ -65,11 +65,11 @@ class AsrDecodeStats {
     required Duration fbank,
     required Duration encoder,
     required Duration search,
-    bool static = false,
+    bool usedStaticBucket = false,
   }) {
     return AsrDecodeStats(
       batches: batches + 1,
-      staticBatches: staticBatches + (static ? 1 : 0),
+      staticBatches: staticBatches + (usedStaticBucket ? 1 : 0),
       segments: this.segments + segments,
       realFrames: this.realFrames + realFrames,
       paddedFrames: this.paddedFrames + paddedFrames,
@@ -363,7 +363,7 @@ class AsrTransducerDecoder
         fbank: encoded.fbankTime,
         encoder: encoded.encoderTime,
         search: clock.elapsed,
-        static: encoded.isStatic,
+        usedStaticBucket: encoded.isStatic,
       );
     }
 

--- a/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
+++ b/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
@@ -592,10 +592,17 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
         final StringBuffer sb = StringBuffer();
         final OnnxProviderResolution? r = _resolution;
         if (r != null) {
+          // 静态融合图（GPU 桶）真在跑时告诉用户——它是「为什么这么快 / 为什么
+          // 显存涨了」的答案；桶建失败回退动态会话时这里自然不显示。
+          final bool staticGraph = (p?.decodeStats?.staticBatches ?? 0) > 0;
           sb.writeln(
-            t.audiobook_transcribe_running_on(
-              provider: _providerLabel(r.effective),
-            ),
+            staticGraph
+                ? t.audiobook_transcribe_running_on_static(
+                    provider: _providerLabel(r.effective),
+                  )
+                : t.audiobook_transcribe_running_on(
+                    provider: _providerLabel(r.effective),
+                  ),
           );
           if (r.didFallBack) {
             sb.writeln(

--- a/fushi/lib/src/onnx/onnx_inference_ort.dart
+++ b/fushi/lib/src/onnx/onnx_inference_ort.dart
@@ -230,6 +230,23 @@ class OrtOnnxSessionFactory implements OnnxSessionFactory {
   /// 探测本身失败是一条真实的降级路径（有 N 卡也会退到 CPU），不允许调用方
   /// `catch (_)` 静默吞掉——所以这里不吞异常，由调用方捕获后记进可观测的降级
   /// 说明（BUG-1163）。
+  /// GPU 显存预算（字节；DXGI 本进程可分配上限）。非 Windows、无 GPU、查询失败
+  /// 都返回 null——调用方按「未知」处理，不当成 0。
+  Future<int?> deviceMemoryBudgetBytes() async {
+    try {
+      final OrtDeviceMemoryInfo? info = await _runtime.getDeviceMemoryInfo();
+      if (info == null || info.isSoftware || info.budget <= 0) return null;
+      return info.budget;
+    } catch (error) {
+      developer.log(
+        'ONNX device memory budget query failed; treating as unknown',
+        name: logName,
+        error: error,
+      );
+      return null;
+    }
+  }
+
   Future<Set<OnnxExecutionProvider>> availableAcceleratedProviders() async {
     final List<OrtProvider> providers = await _runtime.getAvailableProviders();
     return providers

--- a/fushi/test/asr/asr_encoder_buckets_test.dart
+++ b/fushi/test/asr/asr_encoder_buckets_test.dart
@@ -135,9 +135,9 @@ class _FakeFactory implements OnnxSessionFactory {
 }
 
 AsrSpeechSegment _segment(int ms) => AsrSpeechSegment(
-  startSample: 0,
-  samples: Float32List(ms * kAsrSampleRate ~/ 1000),
-);
+      startSample: 0,
+      samples: Float32List(ms * kAsrSampleRate ~/ 1000),
+    );
 
 const List<AsrEncoderBucket> _buckets = <AsrEncoderBucket>[
   AsrEncoderBucket(frames: 500, batch: 4),
@@ -208,6 +208,27 @@ void main() {
       expect(pool.unavailableReasons.keys.single.batch, 4);
       expect(factory.overrides, hasLength(1), reason: '失败的桶不重试');
       expect((await pool.sessionFor(800))!.bucket.batch, 2);
+    });
+
+    test('按显存预算选桶表：≥10 GiB 全桶、6~10 GiB 半桶、<6 GiB 不用、未知按默认', () {
+      const int gib = 1024 * 1024 * 1024;
+      expect(asrEncoderBucketsForBudget(null), kAsrGpuEncoderBuckets);
+      expect(asrEncoderBucketsForBudget(12 * gib), kAsrGpuEncoderBuckets);
+      expect(asrEncoderBucketsForBudget(10 * gib), kAsrGpuEncoderBuckets);
+      expect(asrEncoderBucketsForBudget(8 * gib), kAsrGpuEncoderBucketsSmall);
+      expect(asrEncoderBucketsForBudget(6 * gib), kAsrGpuEncoderBucketsSmall);
+      expect(asrEncoderBucketsForBudget(4 * gib), isEmpty);
+      // 半桶的每档行数正好是全桶的一半，帧数一致。
+      for (int i = 0; i < kAsrGpuEncoderBuckets.length; i++) {
+        expect(
+          kAsrGpuEncoderBucketsSmall[i].frames,
+          kAsrGpuEncoderBuckets[i].frames,
+        );
+        expect(
+          kAsrGpuEncoderBucketsSmall[i].batch * 2,
+          kAsrGpuEncoderBuckets[i].batch,
+        );
+      }
     });
 
     test('桶表必须按 frames 递增', () {

--- a/fushi/test/asr/asr_encoder_buckets_test.dart
+++ b/fushi/test/asr/asr_encoder_buckets_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -134,10 +135,25 @@ class _FakeFactory implements OnnxSessionFactory {
   }
 }
 
+/// createSession 挂起直到 [release] 的 fake 工厂（模拟 3~8 s 的建桶）。
+class _SlowFactory implements OnnxSessionFactory {
+  final Completer<OnnxSession> _gate = Completer<OnnxSession>();
+
+  void release(OnnxSession session) => _gate.complete(session);
+
+  @override
+  Future<OnnxSession> createSession(
+    String modelPath, {
+    required List<OnnxExecutionProvider> providers,
+    int? intraOpNumThreads,
+    Map<String, int>? freeDimensionOverrides,
+  }) => _gate.future;
+}
+
 AsrSpeechSegment _segment(int ms) => AsrSpeechSegment(
-      startSample: 0,
-      samples: Float32List(ms * kAsrSampleRate ~/ 1000),
-    );
+  startSample: 0,
+  samples: Float32List(ms * kAsrSampleRate ~/ 1000),
+);
 
 const List<AsrEncoderBucket> _buckets = <AsrEncoderBucket>[
   AsrEncoderBucket(frames: 500, batch: 4),
@@ -191,6 +207,29 @@ void main() {
       await pool.close();
       expect(factory.created.single.closed, isTrue);
       expect(await pool.sessionFor(300), isNull, reason: '关闭后不再建');
+    });
+
+    test('close() 不等还在建的桶；那个桶建成后自己关掉', () async {
+      final _SlowFactory factory = _SlowFactory();
+      final AsrStaticEncoderPool pool = AsrStaticEncoderPool(
+        factory: factory,
+        modelPath: 'enc.onnx',
+        providers: const <OnnxExecutionProvider>[
+          OnnxExecutionProvider.directml,
+        ],
+        buckets: _buckets,
+      );
+      final Future<AsrStaticEncoderSession?> building = pool.sessionFor(300);
+      bool closed = false;
+      final Future<void> closing = pool.close().then((_) => closed = true);
+      await Future<void>.delayed(Duration.zero);
+      expect(closed, isTrue, reason: 'close() 不能等 3~8 s 的建桶');
+      // 建桶完成：会话被池子立刻关掉，调用方拿到 null。
+      final _RecordingEncoder late = _RecordingEncoder('late');
+      factory.release(late);
+      expect(await building, isNull);
+      expect(late.closed, isTrue);
+      await closing;
     });
 
     test('建失败的桶记原因、返回 null，不影响其它桶', () async {

--- a/fushi/test/asr/asr_engine_test.dart
+++ b/fushi/test/asr/asr_engine_test.dart
@@ -341,6 +341,30 @@ void main() {
       variant: variant,
     );
 
+    test('shouldPrewarmAllStaticBuckets：全桶表 + 预算已知 + 素材 ≥ 15 min 才全预热', () {
+      const int gib = 1024 * 1024 * 1024;
+      bool f({List<AsrEncoderBucket>? b, int? budget, int? ms}) =>
+          shouldPrewarmAllStaticBuckets(
+            buckets: b ?? kAsrGpuEncoderBuckets,
+            budgetBytes: budget,
+            materialMs: ms,
+          );
+      expect(f(budget: 12 * gib, ms: 9 * 3600 * 1000), isTrue);
+      expect(f(budget: 12 * gib, ms: kAsrPrewarmAllMinMaterialMs), isTrue);
+      expect(
+        f(budget: 12 * gib, ms: 5 * 60 * 1000),
+        isFalse,
+        reason: '短素材',
+      );
+      expect(f(budget: null, ms: 9 * 3600 * 1000), isFalse, reason: '预算未知');
+      expect(f(budget: 12 * gib, ms: null), isFalse, reason: '时长未知');
+      expect(
+        f(b: kAsrGpuEncoderBucketsSmall, budget: 8 * gib, ms: 9 * 3600 * 1000),
+        isFalse,
+        reason: '半桶表 = 预算吃紧',
+      );
+    });
+
     test('编码器落到 GPU EP 时建静态桶：只带 GPU provider + N/T 覆盖；CPU 不建', () async {
       final _FakeFactory gpu = _FakeFactory(
         available: const <OnnxExecutionProvider>{

--- a/fushi/test/asr/asr_engine_test.dart
+++ b/fushi/test/asr/asr_engine_test.dart
@@ -353,8 +353,13 @@ void main() {
         preference: AsrAccelerationPreference.auto,
       );
       expect(onGpu.staticEncoders, isNotNull);
-      // 显存预算查不到（fake runtime）→ 默认桶表，装载时已全部预热。
-      expect(gpu.bucketSessions, hasLength(kAsrGpuEncoderBuckets.length));
+      // 显存预算查不到（fake runtime）→ 默认桶表；装载时只预热最小桶（P0-2），
+      // 大桶留给真出现长段时按需建。
+      expect(gpu.bucketSessions, hasLength(1));
+      expect(
+        gpu.bucketSessions.single.overrides['T'],
+        kAsrGpuEncoderBuckets.first.frames,
+      );
       for (final ({_FakeSession session, Map<String, int> overrides}) b
           in gpu.bucketSessions) {
         expect(b.session.providers, <OnnxExecutionProvider>[

--- a/fushi/test/asr/asr_engine_test.dart
+++ b/fushi/test/asr/asr_engine_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:flutter_onnxruntime/flutter_onnxruntime.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/asr/asr_encoder_buckets.dart';
 import 'package:fushi/src/asr/asr_engine.dart';
 import 'package:fushi/src/asr/asr_model_manifest.dart';
 import 'package:fushi/src/asr/asr_model_store.dart';
@@ -50,6 +51,11 @@ class _FakeFactory extends OrtOnnxSessionFactory {
   final bool rejectAccelerated;
   final String? failOnPathSuffix;
   final Map<String, _FakeSession> sessions = <String, _FakeSession>{};
+
+  /// 静态 shape 桶会话（带 freeDimensionOverrides 建的）单独记，不覆盖同文件
+  /// 的动态会话记录。
+  final List<({_FakeSession session, Map<String, int> overrides})>
+  bucketSessions = <({_FakeSession session, Map<String, int> overrides})>[];
   int probeCalls = 0;
 
   @override
@@ -91,7 +97,11 @@ class _FakeFactory extends OrtOnnxSessionFactory {
             );
           },
         );
-    sessions[p.basename(modelPath)] = session;
+    if (freeDimensionOverrides != null) {
+      bucketSessions.add((session: session, overrides: freeDimensionOverrides));
+    } else {
+      sessions[p.basename(modelPath)] = session;
+    }
     return session;
   }
 }
@@ -330,6 +340,41 @@ void main() {
       preference: preference,
       variant: variant,
     );
+
+    test('编码器落到 GPU EP 时建静态桶：只带 GPU provider + N/T 覆盖；CPU 不建', () async {
+      final _FakeFactory gpu = _FakeFactory(
+        available: const <OnnxExecutionProvider>{
+          OnnxExecutionProvider.directml,
+        },
+      );
+      final AsrEngineSessions onGpu = await AsrEngineLoader(factory: gpu).load(
+        store: store,
+        variant: AsrEncoderVariant.fp32,
+        preference: AsrAccelerationPreference.auto,
+      );
+      expect(onGpu.staticEncoders, isNotNull);
+      // 显存预算查不到（fake runtime）→ 默认桶表，装载时已全部预热。
+      expect(gpu.bucketSessions, hasLength(kAsrGpuEncoderBuckets.length));
+      for (final ({_FakeSession session, Map<String, int> overrides}) b
+          in gpu.bucketSessions) {
+        expect(b.session.providers, <OnnxExecutionProvider>[
+          OnnxExecutionProvider.directml,
+        ], reason: '静态桶不带 CPU 兜底');
+        expect(b.overrides.keys, containsAll(<String>['N', 'T']));
+      }
+      await onGpu.close();
+      expect(gpu.bucketSessions.every((b) => b.session.closed), isTrue);
+
+      final _FakeFactory cpu = _FakeFactory();
+      final AsrEngineSessions onCpu = await AsrEngineLoader(factory: cpu).load(
+        store: store,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.cpuOnly,
+      );
+      expect(onCpu.staticEncoders, isNull);
+      expect(cpu.bucketSessions, isEmpty);
+      await onCpu.close();
+    });
 
     test(
       'encoder 用策略选出的 providers，decoder/joiner/vad 恒 CPU，resolution 透传',

--- a/fushi/test/asr/asr_transcribe_job_pipeline_test.dart
+++ b/fushi/test/asr/asr_transcribe_job_pipeline_test.dart
@@ -129,14 +129,13 @@ class _PlainDecoder implements AsrBatchDecoder {
   @override
   Future<List<AsrDecodedSegment>> decodeBatch(
     List<AsrSpeechSegment> segments,
-  ) async =>
-      <AsrDecodedSegment>[
-        for (final AsrSpeechSegment s in segments)
-          AsrDecodedSegment(
-            tokens: <String>['${s.startMs ~/ 1000}'],
-            tokenOffsetsMs: const <int>[0],
-          ),
-      ];
+  ) async => <AsrDecodedSegment>[
+    for (final AsrSpeechSegment s in segments)
+      AsrDecodedSegment(
+        tokens: <String>['${s.startMs ~/ 1000}'],
+        tokenOffsetsMs: const <int>[0],
+      ),
+  ];
 }
 
 void main() {
@@ -166,6 +165,32 @@ void main() {
     expect(events.last, isA<AsrTranscribeFinishedEvent>());
     return AsrTranscribeJob.loadSegments(job.jobDir);
   }
+
+  test('静态桶模式：一批恰好 cap 行（末批除外），batchSize / 音频预算不参与', () async {
+    // batchSize=1 在动态路径下意味着一批 ≤ 20 s 音频（每段 5/7 s ≈ 0.7 s，
+    // 也就是 4 段一批封顶）；有 shaper 时全按 cap=3 走。
+    final _PipeDecoder pipe = _PipeDecoder();
+    final AsrTranscribeJob job = AsrTranscribeJob(
+      jobDir: Directory(p.join(tmp.path, 'cap')),
+      audioPaths: const <String>['a.mp3'],
+      modelId: 'm',
+      pcm: _Pcm(chunks: 2),
+      segmenter: _Segmenter(perChunk: 7),
+      decoder: pipe,
+      batchSize: 1,
+      chunkSeconds: 5,
+      progressInterval: Duration.zero,
+    );
+    await job.run().toList();
+    final List<int> sizes = pipe.events
+        .where((String e) => e.startsWith('enc-start '))
+        .map((String e) => e.substring(10).split(',').length)
+        .toList();
+    // 每块 7 段：3 + 3 + 1；块末 drain(all) 把不足一批的也发掉。
+    expect(sizes, <int>[3, 3, 1, 3, 3, 1]);
+    expect(sizes.every((int n) => n <= _PipeDecoder.cap), isTrue);
+    expect(job.maxBatchSegments, 4, reason: '动态路径的上限在这里没被用到');
+  });
 
   test('流水线与串行解码产出相同的段落集合（按起点排序后逐条一致）', () async {
     final _PipeDecoder pipe = _PipeDecoder();
@@ -240,8 +265,7 @@ void main() {
         if (state.resumeSamples[0] >= 5 * kAsrSampleRate) {
           segmentsAtCheckpoint = (await AsrTranscribeJob.loadSegments(
             job.jobDir,
-          ))
-              .length;
+          )).length;
         }
       }
     }

--- a/fushi/test/asr/asr_transcribe_job_pipeline_test.dart
+++ b/fushi/test/asr/asr_transcribe_job_pipeline_test.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/asr/asr_transcribe_job.dart';
+import 'package:fushi/src/asr/asr_transducer_decoder.dart';
+import 'package:fushi/src/asr/asr_types.dart';
+import 'package:path/path.dart' as p;
+
+/// 一块 PCM 里放 [segmentsPerChunk] 段的 fake 源 + 切段器。
+class _Pcm implements AsrPcmSource {
+  _Pcm({required this.chunks});
+  final int chunks;
+
+  @override
+  Future<int?> probeDurationMs(String audioPath) async => chunks * 5000;
+
+  @override
+  Stream<AsrPcmChunk> decode(
+    String audioPath, {
+    int startSample = 0,
+    int chunkSeconds = 600,
+  }) async* {
+    for (int c = 0; c < chunks; c++) {
+      yield AsrPcmChunk(
+        startSample: c * 5 * kAsrSampleRate,
+        samples: Float32List(5 * kAsrSampleRate),
+      );
+    }
+  }
+}
+
+class _Segmenter implements AsrSegmenter {
+  _Segmenter({required this.perChunk});
+  final int perChunk;
+
+  @override
+  Future<List<AsrSpeechSegment>> feed(AsrPcmChunk chunk) async {
+    final int len = chunk.samples.length ~/ perChunk;
+    return List<AsrSpeechSegment>.generate(
+      perChunk,
+      (int i) => AsrSpeechSegment(
+        startSample: chunk.startSample + i * len,
+        // 长度略有差异，让排序有事可做。
+        samples: Float32List(len - i * 160),
+      ),
+    );
+  }
+
+  @override
+  Future<List<AsrSpeechSegment>> flush() async => <AsrSpeechSegment>[];
+
+  @override
+  void reset() {}
+
+  @override
+  int? get inProgressSpeechStartSample => null;
+}
+
+/// 三段式 fake：encode / search 各自异步完成，记录事件顺序；结果 = 段起点秒数。
+class _PipeDecoder implements AsrPipelinedDecoder, AsrBatchShaper {
+  _PipeDecoder();
+
+  /// 一批最多 3 段（模拟静态桶封顶）。
+  static const int cap = 3;
+  final List<String> events = <String>[];
+  int encodeCalls = 0;
+  int searchCalls = 0;
+  int featureCalls = 0;
+  int reusedFeatures = 0;
+  int decodeBatchCalls = 0;
+
+  static String _label(List<AsrSpeechSegment> segs) =>
+      segs.map((AsrSpeechSegment s) => s.startMs ~/ 1000).join(',');
+
+  @override
+  int? batchCapFor(int longestSamples) => cap;
+
+  @override
+  AsrBatchFeatures computeFeatures(List<AsrSpeechSegment> segments) {
+    featureCalls++;
+    return AsrBatchFeatures.forTest(segments);
+  }
+
+  @override
+  Future<AsrEncodedBatch> encode(
+    List<AsrSpeechSegment> segments, {
+    AsrBatchFeatures? features,
+  }) async {
+    encodeCalls++;
+    if (features != null && identical(features.segments, segments)) {
+      reusedFeatures++;
+    } else {
+      computeFeatures(segments);
+    }
+    events.add('enc-start ${_label(segments)}');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    events.add('enc-done ${_label(segments)}');
+    return AsrEncodedBatch.forTest(segments);
+  }
+
+  @override
+  Future<List<AsrDecodedSegment>> search(AsrEncodedBatch encoded) async {
+    searchCalls++;
+    events.add('search-start ${_label(encoded.segments)}');
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    events.add('search-done ${_label(encoded.segments)}');
+    return <AsrDecodedSegment>[
+      for (final AsrSpeechSegment s in encoded.segments)
+        AsrDecodedSegment(
+          tokens: <String>['${s.startMs ~/ 1000}'],
+          tokenOffsetsMs: const <int>[0],
+        ),
+    ];
+  }
+
+  @override
+  Future<List<AsrDecodedSegment>> decodeBatch(
+    List<AsrSpeechSegment> segments,
+  ) async {
+    decodeBatchCalls++;
+    return search(await encode(segments));
+  }
+}
+
+/// 只实现 decodeBatch 的普通解码器（对照组）。
+class _PlainDecoder implements AsrBatchDecoder {
+  @override
+  Future<List<AsrDecodedSegment>> decodeBatch(
+    List<AsrSpeechSegment> segments,
+  ) async =>
+      <AsrDecodedSegment>[
+        for (final AsrSpeechSegment s in segments)
+          AsrDecodedSegment(
+            tokens: <String>['${s.startMs ~/ 1000}'],
+            tokenOffsetsMs: const <int>[0],
+          ),
+      ];
+}
+
+void main() {
+  late Directory tmp;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('asr_pipeline_');
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  Future<List<AsrTranscribedSegment>> runJob(AsrBatchDecoder decoder) async {
+    final AsrTranscribeJob job = AsrTranscribeJob(
+      jobDir: Directory(p.join(tmp.path, decoder.runtimeType.toString())),
+      audioPaths: const <String>['a.mp3'],
+      modelId: 'm',
+      pcm: _Pcm(chunks: 3),
+      segmenter: _Segmenter(perChunk: 7),
+      decoder: decoder,
+      batchSize: 3,
+      chunkSeconds: 5,
+      progressInterval: Duration.zero,
+    );
+    final List<AsrTranscribeEvent> events = await job.run().toList();
+    expect(events.last, isA<AsrTranscribeFinishedEvent>());
+    return AsrTranscribeJob.loadSegments(job.jobDir);
+  }
+
+  test('流水线与串行解码产出相同的段落集合（按起点排序后逐条一致）', () async {
+    final _PipeDecoder pipe = _PipeDecoder();
+    final List<AsrTranscribedSegment> a = await runJob(pipe);
+    final List<AsrTranscribedSegment> b = await runJob(_PlainDecoder());
+    int byStart(AsrTranscribedSegment x, AsrTranscribedSegment y) =>
+        x.startMs.compareTo(y.startMs);
+    a.sort(byStart);
+    b.sort(byStart);
+    expect(a.length, 21);
+    expect(
+      a.map((AsrTranscribedSegment s) => '${s.startMs}:${s.text}').toList(),
+      b.map((AsrTranscribedSegment s) => '${s.startMs}:${s.text}').toList(),
+    );
+    expect(pipe.decodeBatchCalls, 0, reason: '任务走的是三段式，不再调 decodeBatch');
+    expect(pipe.encodeCalls, pipe.searchCalls);
+  });
+
+  test('编码第 i 批时搜索第 i-1 批：两者真的重叠', () async {
+    final _PipeDecoder pipe = _PipeDecoder();
+    await runJob(pipe);
+    // 至少有一处「search-start X」出现在「enc-done Y」之前（Y 是后一批）。
+    bool overlapped = false;
+    String? pendingEnc;
+    for (final String e in pipe.events) {
+      if (e.startsWith('enc-start ')) pendingEnc = e.substring(10);
+      if (e.startsWith('search-start ') && pendingEnc != null) {
+        final int idxDone = pipe.events.indexOf('enc-done $pendingEnc');
+        if (idxDone > pipe.events.indexOf(e)) {
+          overlapped = true;
+          break;
+        }
+      }
+    }
+    expect(overlapped, isTrue, reason: pipe.events.join('\n'));
+  });
+
+  test('窥视下一批提前算 fbank：encode 拿到的是同一份特征', () async {
+    final _PipeDecoder pipe = _PipeDecoder();
+    await runJob(pipe);
+    expect(pipe.reusedFeatures, greaterThan(0));
+    expect(
+      pipe.featureCalls,
+      pipe.encodeCalls,
+      reason: '每批的 fbank 只算一次（提前算了就不再重算）',
+    );
+  });
+
+  test('块末检查点之前在飞的批已全部落盘', () async {
+    final _PipeDecoder pipe = _PipeDecoder();
+    final AsrTranscribeJob job = AsrTranscribeJob(
+      jobDir: Directory(p.join(tmp.path, 'ckpt')),
+      audioPaths: const <String>['a.mp3'],
+      modelId: 'm',
+      pcm: _Pcm(chunks: 2),
+      segmenter: _Segmenter(perChunk: 5),
+      decoder: pipe,
+      batchSize: 3,
+      chunkSeconds: 5,
+      progressInterval: Duration.zero,
+    );
+    // 第一块结束时有两条 processedMs=5000 的进度：块内节流那条在检查点之前
+    // （在飞的批可以还没落盘），块末那条紧跟检查点之后——看后者。
+    int segmentsAtCheckpoint = -1;
+    await for (final AsrTranscribeEvent e in job.run()) {
+      if (e is AsrTranscribeProgressEvent && e.progress.processedMs == 5000) {
+        final AsrJobState state = await AsrTranscribeJob.loadState(
+          job.jobDir,
+          const <String>['a.mp3'],
+          modelId: 'm',
+        );
+        if (state.resumeSamples[0] >= 5 * kAsrSampleRate) {
+          segmentsAtCheckpoint = (await AsrTranscribeJob.loadSegments(
+            job.jobDir,
+          ))
+              .length;
+        }
+      }
+    }
+    expect(segmentsAtCheckpoint, 5, reason: '第一块 5 段在检查点前全部落盘');
+  });
+}

--- a/fushi/test/onnx/onnxruntime_async_dispatch_guard_test.dart
+++ b/fushi/test/onnx/onnxruntime_async_dispatch_guard_test.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// vendored `flutter_onnxruntime` 的 delta #9（推理 / 建会话 / 关会话下放工作线程，
+/// 回复经消息窗口回到平台线程）必须完整。
+///
+/// 丢掉它是**静默的性能与体验回退**：上游的同步实现照样能跑、结果逐字正确，
+/// 只是每次 encoder `Run` 都卡住 UI 线程几百毫秒、静态桶建会话时卡几秒，且 GPU
+/// 会话与 CPU 会话永远串行——有声书 ASR 的三级流水线（GPU 编码 ‖ CPU 搜索）
+/// 收益归零。没有别的测试会因此变红。
+Directory _findRepositoryRoot() {
+  Directory current = Directory.current.absolute;
+  while (true) {
+    if (File(
+      '${current.path}/third_party/flutter_onnxruntime/PATCHES.md',
+    ).existsSync()) {
+      return current;
+    }
+    final Directory parent = current.parent;
+    if (parent.path == current.path) {
+      throw StateError('找不到 Hibiki 仓库根目录');
+    }
+    current = parent;
+  }
+}
+
+void main() {
+  final Directory root = _findRepositoryRoot();
+  final String vendored = '${root.path}/third_party/flutter_onnxruntime';
+
+  test('工作线程与平台线程分发器的源文件在，且进了 CMake', () {
+    expect(File('$vendored/windows/src/async_dispatch.h').existsSync(), isTrue);
+    expect(
+        File('$vendored/windows/src/async_dispatch.cc').existsSync(), isTrue);
+    final String cmake =
+        File('$vendored/windows/CMakeLists.txt').readAsStringSync();
+    expect(
+      cmake,
+      contains('src/async_dispatch.cc'),
+      reason: '不进 PLUGIN_SOURCES 就是链接错，但重新 vendor 时最容易漏的正是这行',
+    );
+  });
+
+  test('三个重活都经 queueFor 下放工作线程，回复经 dispatcher 回平台线程', () {
+    final String src = maskComments(
+      File('$vendored/windows/flutter_onnxruntime_plugin.cpp')
+          .readAsStringSync(),
+    );
+    for (final String handler in <String>[
+      'HandleRunInference',
+      'HandleCreateSession',
+      'HandleCloseSession',
+    ]) {
+      final int at = src.indexOf('void FlutterOnnxruntimePlugin::$handler(');
+      expect(at, greaterThan(0), reason: '$handler 不在了，守卫需更新');
+      final int end = src.indexOf('\nvoid FlutterOnnxruntimePlugin::', at + 10);
+      final String body = src.substring(at, end < 0 ? src.length : end);
+      expect(
+        body,
+        contains('queueFor('),
+        reason: '$handler 又回到平台线程同步执行：UI 会被推理卡住、GPU/CPU 会话'
+            '无法重叠，且没有别的测试会红',
+      );
+      expect(
+        body,
+        contains('impl->reply('),
+        reason: '$handler 的结果必须经 dispatcher 回平台线程完成',
+      );
+    }
+    expect(src, contains('PlatformThreadDispatcher dispatcher_'));
+    expect(src, contains('WorkQueue gpuQueue_'));
+    expect(src, contains('WorkQueue cpuQueue_'));
+  });
+
+  test('SessionManager 的会话是 shared_ptr，Run 期间不持 map 锁', () {
+    final String header = maskComments(
+      File('$vendored/windows/src/session_manager.h').readAsStringSync(),
+    );
+    expect(
+      header,
+      contains('std::shared_ptr<Ort::Session> session;'),
+      reason: '在飞的 run 要靠 shared_ptr 在 closeSession 之后活到跑完',
+    );
+    final String impl = maskComments(
+      File('$vendored/windows/src/session_manager.cc').readAsStringSync(),
+    );
+    final int at = impl.indexOf('SessionManager::runInference(');
+    expect(at, greaterThan(0));
+    final int runAt = impl.indexOf('session->Run(', at);
+    expect(runAt, greaterThan(at));
+    final String beforeRun = impl.substring(at, runAt);
+    expect(
+      beforeRun,
+      contains('session_ref = it->second.session;'),
+      reason: 'runInference 必须只在查表时持锁，拿到 shared_ptr 后放锁再 Run',
+    );
+    // 锁的作用域必须在 Run 之前结束：lock_guard 所在的块要在 Run 之前闭合。
+    final int lockAt =
+        beforeRun.indexOf('std::lock_guard<std::mutex> lock(mutex_);');
+    expect(lockAt, greaterThan(0));
+    expect(
+      beforeRun.substring(lockAt),
+      contains('\n  }\n'),
+      reason: 'lock_guard 必须在独立块内、Run 之前释放，否则 GPU/CPU 队列会互相串行',
+    );
+  });
+
+  test('PATCHES.md 记了 delta #9', () {
+    final String md = File('$vendored/PATCHES.md').readAsStringSync();
+    expect(md, contains('async_dispatch'));
+    expect(md, contains('PlatformThreadDispatcher'));
+    expect(md, contains('FLUTTER_ONNXRUNTIME_SYNC'));
+  });
+}

--- a/fushi/test/onnx/onnxruntime_async_dispatch_guard_test.dart
+++ b/fushi/test/onnx/onnxruntime_async_dispatch_guard_test.dart
@@ -108,6 +108,72 @@ void main() {
     );
   });
 
+  test('WorkQueue 的 thread_ 必须是最后一个成员（否则线程跑在成员构造之前）', () {
+    // 成员按声明顺序初始化，而构造函数在初始化 thread_ 的同时就启动了线程，
+    // 新线程进 Run() 立刻 lock(mutex_) / cv_.wait / 读 stopping_。thread_ 声明在
+    // 前面时，这三者可能都还没构造完 —— UB，且失败形态是静默的：stopping_ 读到
+    // 非零垃圾就让 Run() 立刻返回，之后每次 Post 都判队列已停机、任务被丢，
+    // 每个 ORT 调用的 Dart Future 永不完成，转录直接挂死且无异常无日志。
+    final String header = maskComments(
+      File('$vendored/windows/src/async_dispatch.h').readAsStringSync(),
+    );
+    final int classAt = header.indexOf('class WorkQueue {');
+    expect(classAt, greaterThan(0), reason: 'WorkQueue 改名了，守卫需更新');
+    final int end = header.indexOf('\n};', classAt);
+    expect(end, greaterThan(classAt));
+    final String body = header.substring(classAt, end);
+    final int threadAt = body.indexOf('std::thread thread_;');
+    expect(threadAt, greaterThan(0), reason: '找不到 thread_ 成员');
+    for (final String member in <String>[
+      'std::mutex mutex_;',
+      'std::condition_variable cv_;',
+      'std::deque<std::function<void()>> tasks_;',
+      'bool stopping_',
+    ]) {
+      final int at = body.indexOf(member);
+      expect(at, greaterThan(0), reason: '找不到成员 `$member`，守卫需更新');
+      expect(
+        at,
+        lessThan(threadAt),
+        reason: '`$member` 必须声明在 thread_ **之前**：构造函数一初始化 thread_ '
+            '线程就跑起来了，它会立刻用到这个成员',
+      );
+    }
+  });
+
+  test('tensor id 分配必须线程安全（两条 worker 并发调它）', () {
+    // generateTensorId 是 TensorManager 里唯一不持锁的方法——**故意**的，因为 13 个
+    // 内部调用点调它时已经持着 mutex_（非递归锁不能再上）。插件线程化之前全进程
+    // 只有平台线程会碰它；现在 GPU / CPU 两条 worker 按设计并发调用。
+    // 用无同步的函数局部 static RNG，两线程读到同一游标就发出**相同**的 id：
+    // storeTensor 互相覆盖，或 releaseTensor 释放掉对方的 backing buffer。
+    final String impl = maskComments(
+      File('$vendored/windows/src/tensor_manager.cc').readAsStringSync(),
+    );
+    final int at = impl.indexOf('TensorManager::generateTensorId()');
+    expect(at, greaterThan(0), reason: 'generateTensorId 改名了，守卫需更新');
+    final int end = impl.indexOf('\n}', at);
+    expect(end, greaterThan(at));
+    final String body = impl.substring(at, end);
+    expect(
+      body.contains('static std::mt19937'),
+      isFalse,
+      reason: '函数局部 static RNG 在两条 worker 并发下会发出重复 id',
+    );
+    expect(
+      body.contains('fetch_add'),
+      isTrue,
+      reason: 'id 分配必须是原子的（与 SessionManager::generateSessionId 同形）',
+    );
+    expect(
+      maskComments(
+        File('$vendored/windows/src/tensor_manager.h').readAsStringSync(),
+      ),
+      contains('std::atomic<uint64_t> next_tensor_id_'),
+      reason: '计数器本身必须是 atomic；普通 uint64_t 的自增在两线程下同样会撞',
+    );
+  });
+
   test('PATCHES.md 记了 delta #9', () {
     final String md = File('$vendored/PATCHES.md').readAsStringSync();
     expect(md, contains('async_dispatch'));

--- a/fushi/test/onnx/onnxruntime_device_memory_guard_test.dart
+++ b/fushi/test/onnx/onnxruntime_device_memory_guard_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// vendored `flutter_onnxruntime` 的 delta #10（`getDeviceMemoryInfo`：DXGI 显存
+/// 预算）必须两半齐全。
+///
+/// 丢 Dart 半会编译错（`OrtOnnxSessionFactory.deviceMemoryBudgetBytes` 调不存在的
+/// 方法），很响；丢 C++ 半是**静默的**：method channel 回 `MissingPluginException`
+/// / `notImplemented`，Dart 侧按「预算未知」走默认桶表——在 8 GB 卡上就是融合图
+/// 溢出到主机内存、RSS 暴涨到被系统杀掉，而没有任何别的测试会红。
+Directory _findRepositoryRoot() {
+  Directory current = Directory.current.absolute;
+  while (true) {
+    if (File(
+      '${current.path}/third_party/flutter_onnxruntime/PATCHES.md',
+    ).existsSync()) {
+      return current;
+    }
+    final Directory parent = current.parent;
+    if (parent.path == current.path) {
+      throw StateError('找不到 Hibiki 仓库根目录');
+    }
+    current = parent;
+  }
+}
+
+void main() {
+  final Directory root = _findRepositoryRoot();
+  final String vendored = '${root.path}/third_party/flutter_onnxruntime';
+
+  test('Windows 插件实现了 getDeviceMemoryInfo 并真去问 DXGI', () {
+    final String plugin = maskComments(
+      File('$vendored/windows/flutter_onnxruntime_plugin.cpp')
+          .readAsStringSync(),
+    );
+    expect(plugin, contains('"getDeviceMemoryInfo"'));
+    expect(plugin, contains('QueryDeviceMemoryInfo('));
+    final String dxgi = maskComments(
+      File('$vendored/windows/src/dxgi_memory.cc').readAsStringSync(),
+    );
+    expect(dxgi, contains('QueryVideoMemoryInfo('));
+    expect(dxgi, contains('DXGI_MEMORY_SEGMENT_GROUP_LOCAL'));
+    final String cmake =
+        File('$vendored/windows/CMakeLists.txt').readAsStringSync();
+    expect(cmake, contains('src/dxgi_memory.cc'));
+    expect(
+      cmake,
+      matches(RegExp(r'target_link_libraries\([^)]*\bdxgi\b')),
+      reason: '不链 dxgi.lib 就是链接错，重新 vendor 时最容易漏',
+    );
+  });
+
+  test('Dart 侧从平台接口到 barrel 都暴露 getDeviceMemoryInfo', () {
+    expect(
+      maskComments(
+        File('$vendored/lib/src/flutter_onnxruntime_platform_interface.dart')
+            .readAsStringSync(),
+      ),
+      contains('getDeviceMemoryInfo('),
+    );
+    expect(
+      maskComments(
+        File('$vendored/lib/src/flutter_onnxruntime_method_channel.dart')
+            .readAsStringSync(),
+      ),
+      contains("'getDeviceMemoryInfo'"),
+    );
+    expect(
+      maskComments(
+          File('$vendored/lib/src/onnxruntime.dart').readAsStringSync()),
+      contains('class OrtDeviceMemoryInfo'),
+    );
+    expect(
+      File('$vendored/lib/flutter_onnxruntime.dart').readAsStringSync(),
+      contains('OrtDeviceMemoryInfo'),
+      reason: 'barrel 不导出 = 应用侧编译错（响），但一起钉住成本为零',
+    );
+  });
+
+  test('应用侧消费者真的用它选桶', () {
+    final String ort = maskComments(
+      File('${root.path}/fushi/lib/src/onnx/onnx_inference_ort.dart')
+          .readAsStringSync(),
+    );
+    expect(ort, contains('getDeviceMemoryInfo('));
+    final String engine = maskComments(
+      File('${root.path}/fushi/lib/src/asr/asr_engine.dart').readAsStringSync(),
+    );
+    expect(engine, contains('deviceMemoryBudgetBytes('));
+    expect(engine, contains('asrEncoderBucketsForBudget('));
+  });
+
+  test('PATCHES.md 记了 delta #10', () {
+    final String md = File('$vendored/PATCHES.md').readAsStringSync();
+    expect(md, contains('getDeviceMemoryInfo'));
+    expect(md, contains('dxgi_memory'));
+  });
+}

--- a/fushi/test/onnx/onnxruntime_free_dimension_override_guard_test.dart
+++ b/fushi/test/onnx/onnxruntime_free_dimension_override_guard_test.dart
@@ -81,11 +81,27 @@ void main() {
       contains('AddFreeDimensionOverrideByName'),
       reason: 'delta 表里必须有这一条，否则重新 vendor 时没人知道要补回来',
     );
-    // 「照 re-vendor 清单做一遍」必须真能把 8 条 delta 都带回来。
+    // 「照 re-vendor 清单做一遍」必须真能把**当前全部** delta 带回来。
+    //
+    // 这条一度被放宽成 `#1[–-]#(8|9|1[0-9])` —— 那样它就重新接受了自己当初被写出来
+    // 要抓的那个陈旧编号 `#1–#8`，delta #11 落地后也会照单全收 `#1–#10`，等于没守。
+    // 改成从文档里解析出真实的最大 delta 号，再要求清单覆盖到它：编号涨了而清单
+    // 没跟，这里当场红。
+    // delta 表是 `## Delta vs upstream` 下的有序列表，条目就是行首的 `N. `。
+    final List<int> declared = RegExp(r'^(\d+)\. ', multiLine: true)
+        .allMatches(md)
+        .map((RegExpMatch m) => int.parse(m.group(1)!))
+        .toList();
+    expect(declared, isNotEmpty, reason: 'PATCHES.md 的 delta 列表解析不出条目？守卫需更新');
+    final int maxDelta = declared.reduce((int a, int b) => a > b ? a : b);
+    final RegExpMatch? revendor =
+        RegExp(r're-apply deltas #1[\u2013-]#(\d+)').firstMatch(md);
+    expect(revendor, isNotNull, reason: '找不到 re-vendor 清单那句话');
     expect(
-      RegExp(r're-apply deltas #1[–-]#(8|9|1[0-9])').hasMatch(md),
-      isTrue,
-      reason: 're-vendor 清单还停在旧编号 = 照它做就会丢掉后面的 delta',
+      int.parse(revendor!.group(1)!),
+      maxDelta,
+      reason: 're-vendor 清单只覆盖到 #${revendor.group(1)}，而 delta 表里已经有 '
+          '$maxDelta 条 —— 照它做会丢掉后面的 delta',
     );
     expect(
       md,

--- a/fushi/test/onnx/onnxruntime_free_dimension_override_guard_test.dart
+++ b/fushi/test/onnx/onnxruntime_free_dimension_override_guard_test.dart
@@ -44,8 +44,7 @@ void main() {
     expect(
       src,
       contains('AddFreeDimensionOverrideByName'),
-      reason:
-          'delta #8 的 C++ 半没了：Dart 仍会传 freeDimensionOverrides，插件不再'
+      reason: 'delta #8 的 C++ 半没了：Dart 仍会传 freeDimensionOverrides，插件不再'
           '读它，会话静默退回动态 shape —— 结果正确但编码器慢 5~7 倍，'
           '没有任何别的测试会红',
     );
@@ -84,7 +83,7 @@ void main() {
     );
     // 「照 re-vendor 清单做一遍」必须真能把 8 条 delta 都带回来。
     expect(
-      RegExp(r're-apply deltas #1[–-]#8').hasMatch(md),
+      RegExp(r're-apply deltas #1[–-]#(8|9|1[0-9])').hasMatch(md),
       isTrue,
       reason: 're-vendor 清单还停在旧编号 = 照它做就会丢掉后面的 delta',
     );

--- a/third_party/flutter_onnxruntime/PATCHES.md
+++ b/third_party/flutter_onnxruntime/PATCHES.md
@@ -94,17 +94,53 @@ and macOS 13.4–14.0 for free, with no change to the ORT binary or the Dart API
    ignores it stays dynamic and accepts the static-shaped tensors anyway — it
    is 5-7x slower with no error anywhere.
 
-**The Dart API under `lib/` carries exactly one delta (#8, the
-`freeDimensionOverrides` option); everything else there is byte-for-byte
-upstream.** The Apple, Android and Linux native trees are untouched; the Windows
-tree carries deltas 6, 7 and 8 above — provider wiring, error-string encoding
-and free-dimension overrides. No ORT wrapper or inference logic changed
+9. `windows/src/async_dispatch.{h,cc}` (new) + `windows/src/session_manager.*` +
+   `windows/flutter_onnxruntime_plugin.cpp`: `runInference`, `createSession`
+   and `closeSession` no longer execute inside the method-call handler on the
+   platform (UI) thread. Argument parsing and input cloning still happen
+   there; the ORT work is posted to one of two `WorkQueue` worker threads —
+   sessions created with a GPU provider (DirectML / CUDA) share one queue,
+   CPU sessions the other — and the `MethodResult` is completed back on the
+   platform thread through `PlatformThreadDispatcher` (a message-only window
+   + `PostMessage`). `SessionInfo::session` became a `shared_ptr` so a run in
+   flight survives `closeSession`, and `SessionManager::runInference` holds
+   the map mutex only for the lookup, not for `Run` itself.
+
+   Two classes of work, one thread each, is deliberate: DirectML crashes when
+   two sessions issue `Run` concurrently from two threads in one process
+   (reproduced with the Python `onnxruntime-directml` build), while a GPU run
+   and a CPU run overlap fine. The audiobook ASR pipeline relies on exactly
+   that overlap (GPU encoder ‖ CPU greedy search): 30 min of English went
+   from 8.0–8.9 s to 6.1–6.6 s, and the UI thread stopped freezing for the
+   duration of every encoder run and every static-shape session build.
+   `FLUTTER_ONNXRUNTIME_SYNC=1` in the process environment restores the
+   upstream inline behaviour for A/B timing and for isolating threading bugs.
+
+10. `windows/src/dxgi_memory.{h,cc}` (new) + `windows/flutter_onnxruntime_plugin.cpp`
+    + `lib/src/onnxruntime.dart` / `flutter_onnxruntime_platform_interface.dart`
+    / `flutter_onnxruntime_method_channel.dart` / `lib/flutter_onnxruntime.dart`:
+    a `getDeviceMemoryInfo` method returning the DXGI local video-memory
+    budget of an adapter (`OrtDeviceMemoryInfo`; `null` on every other platform
+    and when DXGI cannot answer). Static-shape DirectML graphs allocate every
+    intermediate up front and keep the pool resident per session; a card whose
+    budget cannot hold them does not fail — it spills into system memory and
+    throughput collapses. The Dart consumer (`asrEncoderBucketsForBudget`)
+    sizes its encoder buckets from this number before building any session.
+
+**The Dart API under `lib/` carries two deltas (#8, the
+`freeDimensionOverrides` option, and #10, `getDeviceMemoryInfo`); everything
+else there is byte-for-byte upstream.** The Apple, Android and Linux native
+trees are untouched; the Windows tree carries deltas 6–10 above — provider
+wiring, error-string encoding, free-dimension overrides, worker-thread
+dispatch and the DXGI budget query. No ORT wrapper or inference logic changed
 anywhere.
 
 Guards: `fushi/test/ocr/onnxruntime_windows_error_encoding_guard_test.dart`
-keeps delta 7 in place, and
+keeps delta 7 in place,
 `fushi/test/onnx/onnxruntime_free_dimension_override_guard_test.dart` keeps
-delta 8 — a re-vendor that drops either half fails a guard. Delta 8 needs a
+delta 8, `fushi/test/onnx/onnxruntime_async_dispatch_guard_test.dart` keeps
+delta 9 and `fushi/test/onnx/onnxruntime_device_memory_guard_test.dart` keeps
+delta 10 — a re-vendor that drops either half of any of them fails a guard. Delta 8 needs a
 guard more than the others do because losing only its C++ half is **silent**:
 Dart keeps putting the key in the map, the plugin no longer reads it, the
 session falls back to dynamic shapes, and every result stays correct while the
@@ -126,7 +162,7 @@ path or drift the floors apart.
 
 ## Re-vendoring on upgrade
 
-Copy the new upstream version over this folder, then re-apply deltas #1–#8.
+Copy the new upstream version over this folder, then re-apply deltas #1–#10.
 Before bumping the `onnxruntime-objc` pin, check the new version's podspec
 platforms (`pod spec cat onnxruntime-objc --version=X.Y.Z`) — if the floor moved,
 the four project deployment targets and the guard test move with it.

--- a/third_party/flutter_onnxruntime/lib/flutter_onnxruntime.dart
+++ b/third_party/flutter_onnxruntime/lib/flutter_onnxruntime.dart
@@ -6,7 +6,7 @@
 
 library;
 
-export 'src/onnxruntime.dart' show OnnxRuntime;
+export 'src/onnxruntime.dart' show OnnxRuntime, OrtDeviceMemoryInfo;
 export 'src/ort_session.dart' show OrtSession, OrtSessionOptions, OrtRunOptions;
 export 'src/ort_model_metadata.dart' show OrtModelMetadata;
 export 'src/ort_value.dart' show OrtValue, OrtDataType;

--- a/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_method_channel.dart
+++ b/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_method_channel.dart
@@ -40,6 +40,21 @@ class MethodChannelFlutterOnnxruntime extends FlutterOnnxruntimePlatform {
     return _convertMapToStringDynamic(result ?? {});
   }
 
+  @override
+  Future<Map<String, dynamic>?> getDeviceMemoryInfo({int deviceId = 0}) async {
+    try {
+      final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('getDeviceMemoryInfo', {
+        'deviceId': deviceId,
+      });
+      return result == null ? null : _convertMapToStringDynamic(result);
+    } on MissingPluginException {
+      return null;
+    } on PlatformException catch (e) {
+      if (e.code == 'UNAVAILABLE') return null;
+      rethrow;
+    }
+  }
+
   /// Get the available providers
   @override
   Future<List<String>> getAvailableProviders() async {

--- a/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_platform_interface.dart
+++ b/third_party/flutter_onnxruntime/lib/src/flutter_onnxruntime_platform_interface.dart
@@ -44,6 +44,10 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
     throw UnimplementedError('getAvailableProviders() has not been implemented.');
   }
 
+  /// Hibiki fork: DXGI video-memory budget of adapter [deviceId] (Windows only).
+  /// Returns null where the platform has no such query.
+  Future<Map<String, dynamic>?> getDeviceMemoryInfo({int deviceId = 0}) async => null;
+
   /// Run inference on a session
   ///
   /// [sessionId] is the ID of the session to run inference on

--- a/third_party/flutter_onnxruntime/lib/src/onnxruntime.dart
+++ b/third_party/flutter_onnxruntime/lib/src/onnxruntime.dart
@@ -101,6 +101,20 @@ class OnnxRuntime {
   /// Get the available providers
   ///
   /// Returns a list of the available providers
+  /// Hibiki fork: DXGI video-memory budget of the adapter (Windows only; null
+  /// elsewhere or when DXGI cannot answer).
+  Future<OrtDeviceMemoryInfo?> getDeviceMemoryInfo({int deviceId = 0}) async {
+    final map = await FlutterOnnxruntimePlatform.instance.getDeviceMemoryInfo(deviceId: deviceId);
+    if (map == null) return null;
+    int asInt(Object? v) => v is int ? v : (v is num ? v.toInt() : 0);
+    return OrtDeviceMemoryInfo(
+      dedicatedVideoMemory: asInt(map['dedicatedVideoMemory']),
+      budget: asInt(map['budget']),
+      currentUsage: asInt(map['currentUsage']),
+      isSoftware: map['isSoftware'] == true,
+    );
+  }
+
   Future<List<OrtProvider>> getAvailableProviders() async {
     final providers = await FlutterOnnxruntimePlatform.instance.getAvailableProviders();
     return providers.map((p) {
@@ -111,4 +125,21 @@ class OnnxRuntime {
       return provider;
     }).toList();
   }
+}
+
+/// Hibiki fork: see [OnnxRuntime.getDeviceMemoryInfo].
+class OrtDeviceMemoryInfo {
+  const OrtDeviceMemoryInfo({
+    required this.dedicatedVideoMemory,
+    required this.budget,
+    required this.currentUsage,
+    required this.isSoftware,
+  });
+
+  final int dedicatedVideoMemory;
+
+  /// OS-provided budget for local video memory (bytes).
+  final int budget;
+  final int currentUsage;
+  final bool isSoftware;
 }

--- a/third_party/flutter_onnxruntime/windows/CMakeLists.txt
+++ b/third_party/flutter_onnxruntime/windows/CMakeLists.txt
@@ -93,7 +93,7 @@ set(flutter_onnxruntime_bundled_libraries "${ONNXRUNTIME_DLL}" "${ONNXRUNTIME_PR
 add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -DUNICODE -D_UNICODE)
 
 # Any new source files that you add to the plugin should be added here.
-list(APPEND PLUGIN_SOURCES "src/dml_provider.cc"
+list(APPEND PLUGIN_SOURCES "src/async_dispatch.cc" "src/dml_provider.cc" "src/dxgi_memory.cc"
   "src/session_manager.cc" "src/value_conversion.cc" "src/tensor_manager.cc"
      "src/windows_utils.cc")
 
@@ -157,7 +157,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${ONNXRUNTIME_LIBRARIES})
 
 # Link against Windows Shell API library for PathRemoveFileSpecW
-target_link_libraries(${PLUGIN_NAME} PRIVATE Shlwapi)
+target_link_libraries(${PLUGIN_NAME} PRIVATE Shlwapi dxgi)
 
 # Copy the complete DirectML runtime next to the plugin for local runs. Flutter
 # also consumes flutter_onnxruntime_bundled_libraries when assembling the app.

--- a/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.cpp
+++ b/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.cpp
@@ -23,7 +23,9 @@
 
 
 // Include our implementation headers
+#include "src/async_dispatch.h"
 #include "src/dml_provider.h"
+#include "src/dxgi_memory.h"
 #include "src/session_manager.h"
 #include "src/tensor_manager.h"
 #include "src/value_conversion.h"
@@ -51,6 +53,21 @@ void FailWith(const std::unique_ptr<flutter::MethodResult<flutter::EncodableValu
   result->Error(code, WindowsUtils::toUtf8Message(message), nullptr);
 }
 
+void FailWith(flutter::MethodResult<flutter::EncodableValue> &result, const std::string &code,
+              const std::string &message) {
+  result.Error(code, WindowsUtils::toUtf8Message(message), nullptr);
+}
+
+using SharedResult = std::shared_ptr<flutter::MethodResult<flutter::EncodableValue>>;
+
+// Outcome of a worker-thread task, carried back to the platform thread.
+struct TaskOutcome {
+  flutter::EncodableValue reply;
+  std::string error_code;
+  std::string error_message;
+  bool failed() const { return !error_code.empty(); }
+};
+
 } // namespace
 
 // Private implementation class to hold managers
@@ -62,6 +79,26 @@ public:
   // Manager instances
   std::unique_ptr<SessionManager> sessionManager_;
   std::unique_ptr<TensorManager> tensorManager_;
+
+  // Hibiki fork: replies are marshalled back here; heavy ORT work runs on the
+  // two worker queues (declared after the dispatcher so they are joined before
+  // the dispatcher window goes away).
+  PlatformThreadDispatcher dispatcher_;
+  WorkQueue gpuQueue_{"flutter_onnxruntime gpu"};
+  WorkQueue cpuQueue_{"flutter_onnxruntime cpu"};
+
+  WorkQueue &queueFor(bool is_gpu) { return is_gpu ? gpuQueue_ : cpuQueue_; }
+
+  // Complete [result] on the platform thread with [outcome].
+  void reply(const SharedResult &result, std::shared_ptr<TaskOutcome> outcome) {
+    dispatcher_.Post([result, outcome]() {
+      if (outcome->failed()) {
+        FailWith(*result, outcome->error_code, outcome->error_message);
+      } else {
+        result->Success(outcome->reply);
+      }
+    });
+  }
 };
 
 // static
@@ -118,6 +155,9 @@ void FlutterOnnxruntimePlugin::HandleMethodCall(
   // Session-related methods
   if (method_name == "createSession") {
     HandleCreateSession(method_call, std::move(result));
+    return;
+  } else if (method_name == "getDeviceMemoryInfo") {
+    HandleGetDeviceMemoryInfo(method_call, std::move(result));
     return;
   } else if (method_name == "getAvailableProviders") {
     HandleGetAvailableProviders(method_call, std::move(result));
@@ -454,6 +494,7 @@ void FlutterOnnxruntimePlugin::HandleCreateSession(
 
     // Create session options
     Ort::SessionOptions session_options;
+    bool is_gpu = false;
 
     // Configure session options if provided
     auto session_options_it = args->find(flutter::EncodableValue("sessionOptions"));
@@ -569,11 +610,13 @@ void FlutterOnnxruntimePlugin::HandleCreateSession(
 
             // Append CUDA execution provider to session options
             session_options.AppendExecutionProvider_CUDA_V2(*cuda_options_ptr);
+            is_gpu = true;
           } else if (provider == "DIRECT_ML") {
             // DirectML requires sequential execution. Memory patterns are
             // disabled because their allocations cannot be reused safely
             // across DML device resources.
             AppendDirectMLProvider(session_options, device_id);
+            is_gpu = true;
           } else if (provider == "TENSOR_RT") {
             // Use TensorRT if available
             // This is just a placeholder - actual implementation would depend on TensorRT availability
@@ -591,40 +634,50 @@ void FlutterOnnxruntimePlugin::HandleCreateSession(
       }
     }
 
-    // Create the session
-    std::string session_id = impl_->sessionManager_->createSession(model_path.c_str(), session_options);
-
-    if (session_id.empty()) {
-      FailWith(result, "SESSION_CREATION_ERROR", "Failed to create ONNX Runtime session");
-      return;
-    }
-
-    // Get input and output names
-    std::vector<std::string> input_names = impl_->sessionManager_->getInputNames(session_id);
-    std::vector<std::string> output_names = impl_->sessionManager_->getOutputNames(session_id);
-
-    // Prepare response
-    flutter::EncodableMap response;
-    response[flutter::EncodableValue("sessionId")] = flutter::EncodableValue(session_id);
-
-    // Convert input names to Flutter list
-    flutter::EncodableList input_names_list;
-    for (const auto &name : input_names) {
-      input_names_list.push_back(flutter::EncodableValue(name));
-    }
-    response[flutter::EncodableValue("inputNames")] = flutter::EncodableValue(input_names_list);
-
-    // Convert output names to Flutter list
-    flutter::EncodableList output_names_list;
-    for (const auto &name : output_names) {
-      output_names_list.push_back(flutter::EncodableValue(name));
-    }
-    response[flutter::EncodableValue("outputNames")] = flutter::EncodableValue(output_names_list);
-
-    // Add status for compatibility
-    response[flutter::EncodableValue("status")] = flutter::EncodableValue("success");
-
-    result->Success(flutter::EncodableValue(response));
+    // Create the session on the worker queue of its provider class: a
+    // static-shape DirectML graph takes seconds to build and must not freeze
+    // the platform thread. The reply is marshalled back via the dispatcher.
+    SharedResult shared_result(std::move(result));
+    auto options = std::make_shared<Ort::SessionOptions>(std::move(session_options));
+    SessionManager *session_manager = impl_->sessionManager_.get();
+    FlutterOnnxruntimePluginImpl *impl = impl_.get();
+    impl_->queueFor(is_gpu).Post([impl, session_manager, shared_result, options, model_path, is_gpu]() {
+      auto outcome = std::make_shared<TaskOutcome>();
+      try {
+        std::string session_id = session_manager->createSession(model_path.c_str(), *options, is_gpu);
+        if (session_id.empty()) {
+          outcome->error_code = "SESSION_CREATION_ERROR";
+          outcome->error_message = "Failed to create ONNX Runtime session";
+        } else {
+          std::vector<std::string> input_names = session_manager->getInputNames(session_id);
+          std::vector<std::string> output_names = session_manager->getOutputNames(session_id);
+          flutter::EncodableMap response;
+          response[flutter::EncodableValue("sessionId")] = flutter::EncodableValue(session_id);
+          flutter::EncodableList input_names_list;
+          for (const auto &name : input_names) {
+            input_names_list.push_back(flutter::EncodableValue(name));
+          }
+          response[flutter::EncodableValue("inputNames")] = flutter::EncodableValue(input_names_list);
+          flutter::EncodableList output_names_list;
+          for (const auto &name : output_names) {
+            output_names_list.push_back(flutter::EncodableValue(name));
+          }
+          response[flutter::EncodableValue("outputNames")] = flutter::EncodableValue(output_names_list);
+          response[flutter::EncodableValue("status")] = flutter::EncodableValue("success");
+          outcome->reply = flutter::EncodableValue(response);
+        }
+      } catch (const Ort::Exception &e) {
+        outcome->error_code = "ORT_ERROR";
+        outcome->error_message = e.what();
+      } catch (const std::exception &e) {
+        outcome->error_code = "PLUGIN_ERROR";
+        outcome->error_message = e.what();
+      } catch (...) {
+        outcome->error_code = "INTERNAL_ERROR";
+        outcome->error_message = "Unknown error occurred";
+      }
+      impl->reply(shared_result, outcome);
+    });
   } catch (const Ort::Exception &e) {
     FailWith(result, "ORT_ERROR", e.what());
   } catch (const std::exception &e) {
@@ -632,6 +685,32 @@ void FlutterOnnxruntimePlugin::HandleCreateSession(
   } catch (...) {
     FailWith(result, "INTERNAL_ERROR", "Unknown error occurred");
   }
+}
+
+// Hibiki: DXGI budget for adapter `deviceId` (default 0). Errors as
+// UNAVAILABLE so the Dart side can treat "unknown" distinctly from a number.
+void FlutterOnnxruntimePlugin::HandleGetDeviceMemoryInfo(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  int device_id = 0;
+  const auto *args = std::get_if<flutter::EncodableMap>(method_call.arguments());
+  if (args != nullptr) {
+    auto it = args->find(flutter::EncodableValue("deviceId"));
+    if (it != args->end() && std::holds_alternative<int32_t>(it->second)) {
+      device_id = std::get<int32_t>(it->second);
+    }
+  }
+  DeviceMemoryInfo info;
+  if (!QueryDeviceMemoryInfo(device_id, &info)) {
+    FailWith(result, "UNAVAILABLE", "DXGI video memory info unavailable for this adapter");
+    return;
+  }
+  flutter::EncodableMap reply;
+  reply[flutter::EncodableValue("dedicatedVideoMemory")] = flutter::EncodableValue(info.dedicated_video_memory);
+  reply[flutter::EncodableValue("budget")] = flutter::EncodableValue(info.budget);
+  reply[flutter::EncodableValue("currentUsage")] = flutter::EncodableValue(info.current_usage);
+  reply[flutter::EncodableValue("isSoftware")] = flutter::EncodableValue(info.is_software);
+  result->Success(flutter::EncodableValue(reply));
 }
 
 void FlutterOnnxruntimePlugin::HandleGetAvailableProviders(
@@ -790,54 +869,63 @@ void FlutterOnnxruntimePlugin::HandleRunInference(
       }
     }
 
-    // Build a vector of Ort::Value references for Session::Run
-    std::vector<Ort::Value> input_tensors;
-    input_tensors.reserve(cloned_inputs.size());
-    for (auto &ci : cloned_inputs) {
-      input_tensors.push_back(std::move(ci.value));
-    }
-
-    // Run inference using SessionManager with input names
-    // Note: cloned_inputs (with backing buffers) stays alive through this scope
-    std::vector<Ort::Value> output_tensors;
-    if (!input_tensors.empty()) {
-      output_tensors = impl_->sessionManager_->runInference(session_id, input_tensors, input_names, &run_options);
-    }
-
-    // Process outputs
-    flutter::EncodableMap outputs_map;
-
-    // For each output tensor, store it using TensorManager
-    for (size_t i = 0; i < output_tensors.size(); i++) {
-      // Create a tensor ID
-      std::string value_id = impl_->tensorManager_->generateTensorId();
-
-      // Store the tensor - this transfers ownership
-      // TensorManager::storeTensor returns void (not bool)
-      impl_->tensorManager_->storeTensor(value_id, std::move(output_tensors[i]));
-
-      // Get the tensor type and shape
-      std::string tensor_type = impl_->tensorManager_->getTensorType(value_id);
-      std::vector<int64_t> shape = impl_->tensorManager_->getTensorShape(value_id);
-
-      // Add the value ID to the outputs map
-      flutter::EncodableList shape_list;
-      for (const auto &dim : shape) {
-        shape_list.push_back(static_cast<int64_t>(dim));
+    // Everything above (argument parsing, input cloning) ran on the platform
+    // thread; the actual Run and the output bookkeeping go to the worker queue
+    // of the session's provider class so GPU and CPU sessions overlap and the
+    // UI thread never blocks on inference.
+    const bool is_gpu = impl_->sessionManager_->isGpuSession(session_id);
+    SharedResult shared_result(std::move(result));
+    auto inputs = std::make_shared<std::vector<ClonedTensor>>(std::move(cloned_inputs));
+    auto names = std::make_shared<std::vector<std::string>>(std::move(input_names));
+    auto outputs_names = std::make_shared<std::vector<std::string>>(std::move(output_names));
+    auto run_opts = std::make_shared<Ort::RunOptions>(std::move(run_options));
+    SessionManager *session_manager = impl_->sessionManager_.get();
+    TensorManager *tensor_manager = impl_->tensorManager_.get();
+    FlutterOnnxruntimePluginImpl *impl = impl_.get();
+    impl_->queueFor(is_gpu).Post([impl, session_manager, tensor_manager, shared_result, inputs, names, outputs_names,
+                                  run_opts, session_id]() {
+      auto outcome = std::make_shared<TaskOutcome>();
+      try {
+        std::vector<Ort::Value> input_tensors;
+        input_tensors.reserve(inputs->size());
+        for (auto &ci : *inputs) {
+          input_tensors.push_back(std::move(ci.value));
+        }
+        std::vector<Ort::Value> output_tensors;
+        if (!input_tensors.empty()) {
+          output_tensors = session_manager->runInference(session_id, input_tensors, *names, run_opts.get());
+        }
+        flutter::EncodableMap outputs_map;
+        for (size_t i = 0; i < output_tensors.size(); i++) {
+          std::string value_id = tensor_manager->generateTensorId();
+          tensor_manager->storeTensor(value_id, std::move(output_tensors[i]));
+          std::string tensor_type = tensor_manager->getTensorType(value_id);
+          std::vector<int64_t> shape = tensor_manager->getTensorShape(value_id);
+          flutter::EncodableList shape_list;
+          for (const auto &dim : shape) {
+            shape_list.push_back(static_cast<int64_t>(dim));
+          }
+          flutter::EncodableList output_info;
+          output_info.push_back(flutter::EncodableValue(value_id));
+          output_info.push_back(flutter::EncodableValue(tensor_type));
+          output_info.push_back(flutter::EncodableValue(shape_list));
+          if (i < outputs_names->size()) {
+            outputs_map[flutter::EncodableValue((*outputs_names)[i])] = flutter::EncodableValue(output_info);
+          }
+        }
+        outcome->reply = flutter::EncodableValue(outputs_map);
+      } catch (const Ort::Exception &e) {
+        outcome->error_code = "INFERENCE_ERROR";
+        outcome->error_message = e.what();
+      } catch (const std::exception &e) {
+        outcome->error_code = "PLUGIN_ERROR";
+        outcome->error_message = e.what();
+      } catch (...) {
+        outcome->error_code = "INTERNAL_ERROR";
+        outcome->error_message = "Unknown error occurred";
       }
-
-      // Create output info (value_id, type, shape)
-      flutter::EncodableList output_info;
-      output_info.push_back(flutter::EncodableValue(value_id));
-      output_info.push_back(flutter::EncodableValue(tensor_type));
-      output_info.push_back(flutter::EncodableValue(shape_list));
-
-      if (i < output_names.size()) {
-        outputs_map[flutter::EncodableValue(output_names[i])] = flutter::EncodableValue(output_info);
-      }
-    }
-
-    result->Success(flutter::EncodableValue(outputs_map));
+      impl->reply(shared_result, outcome);
+    });
   } catch (const Ort::Exception &e) {
     FailWith(result, "INFERENCE_ERROR", e.what());
   } catch (const std::exception &e) {
@@ -868,11 +956,26 @@ void FlutterOnnxruntimePlugin::HandleCloseSession(
     }
     std::string session_id = std::get<std::string>(session_id_it->second);
 
-    // Close the session
-    impl_->sessionManager_->closeSession(session_id);
-
-    // Return null for success
-    result->Success(nullptr);
+    // Close on the session's own queue so it lands after any run still queued
+    // there (a run in flight also holds its own shared_ptr, see SessionInfo).
+    const bool is_gpu = impl_->sessionManager_->isGpuSession(session_id);
+    SharedResult shared_result(std::move(result));
+    SessionManager *session_manager = impl_->sessionManager_.get();
+    FlutterOnnxruntimePluginImpl *impl = impl_.get();
+    impl_->queueFor(is_gpu).Post([impl, session_manager, shared_result, session_id]() {
+      auto outcome = std::make_shared<TaskOutcome>();
+      try {
+        session_manager->closeSession(session_id);
+        outcome->reply = flutter::EncodableValue();
+      } catch (const Ort::Exception &e) {
+        outcome->error_code = "ORT_ERROR";
+        outcome->error_message = e.what();
+      } catch (const std::exception &e) {
+        outcome->error_code = "PLUGIN_ERROR";
+        outcome->error_message = e.what();
+      }
+      impl->reply(shared_result, outcome);
+    });
   } catch (const Ort::Exception &e) {
     FailWith(result, "ORT_ERROR", e.what());
   } catch (const std::exception &e) {

--- a/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.cpp
+++ b/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.cpp
@@ -520,7 +520,8 @@ void FlutterOnnxruntimePlugin::HandleCreateSession(
         const auto &free_dims = std::get<flutter::EncodableMap>(free_dims_it->second);
         for (const auto &dim_pair : free_dims) {
           if (!std::holds_alternative<std::string>(dim_pair.first)) {
-            continue;
+            FailWith(result, "INVALID_ARG", "freeDimensionOverrides keys must be dimension names (strings)");
+            return;
           }
           int64_t dim_value = -1;
           if (std::holds_alternative<int32_t>(dim_pair.second)) {

--- a/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.h
+++ b/third_party/flutter_onnxruntime/windows/flutter_onnxruntime_plugin.h
@@ -41,6 +41,9 @@ private:
   void HandleGetAvailableProviders(const flutter::MethodCall<flutter::EncodableValue> &method_call,
                                    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
+  void HandleGetDeviceMemoryInfo(const flutter::MethodCall<flutter::EncodableValue> &method_call,
+                                 std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
   void HandleRunInference(const flutter::MethodCall<flutter::EncodableValue> &method_call,
                           std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 

--- a/third_party/flutter_onnxruntime/windows/src/async_dispatch.cc
+++ b/third_party/flutter_onnxruntime/windows/src/async_dispatch.cc
@@ -1,0 +1,126 @@
+// Hibiki fork: see async_dispatch.h.
+
+#include "async_dispatch.h"
+
+#include <string>
+
+namespace flutter_onnxruntime {
+
+namespace {
+
+constexpr UINT kDispatchMessage = WM_USER + 0x4F52; // 'OR'
+constexpr wchar_t kWindowClassName[] = L"FlutterOnnxruntimeDispatchWindow";
+
+} // namespace
+
+// ── WorkQueue ────────────────────────────────────────────────────────────────
+
+WorkQueue::WorkQueue(const char *name) : thread_([this, name = std::string(name)]() {
+  // Best-effort thread naming for debuggers; failure is irrelevant.
+  std::wstring wide(name.begin(), name.end());
+  SetThreadDescription(GetCurrentThread(), wide.c_str());
+  Run();
+}) {}
+
+WorkQueue::~WorkQueue() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    stopping_ = true;
+  }
+  cv_.notify_all();
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+bool WorkQueue::Post(std::function<void()> task) {
+  if (PlatformThreadDispatcher::SyncModeRequested()) {
+    task();
+    return true;
+  }
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (stopping_) {
+      return false;
+    }
+    tasks_.push_back(std::move(task));
+  }
+  cv_.notify_one();
+  return true;
+}
+
+void WorkQueue::Run() {
+  for (;;) {
+    std::function<void()> task;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      cv_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+      if (stopping_ && tasks_.empty()) {
+        return;
+      }
+      task = std::move(tasks_.front());
+      tasks_.pop_front();
+    }
+    task();
+  }
+}
+
+// ── PlatformThreadDispatcher ─────────────────────────────────────────────────
+
+PlatformThreadDispatcher::PlatformThreadDispatcher() {
+  WNDCLASSEXW wc = {};
+  wc.cbSize = sizeof(wc);
+  wc.lpfnWndProc = &PlatformThreadDispatcher::WndProc;
+  wc.hInstance = GetModuleHandleW(nullptr);
+  wc.lpszClassName = kWindowClassName;
+  // Registering twice (plugin re-registered in the same process) is harmless:
+  // ERROR_CLASS_ALREADY_EXISTS just means the earlier registration is reused.
+  RegisterClassExW(&wc);
+  hwnd_ = CreateWindowExW(0, kWindowClassName, L"", 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, wc.hInstance, nullptr);
+}
+
+PlatformThreadDispatcher::~PlatformThreadDispatcher() {
+  if (hwnd_ != nullptr) {
+    DestroyWindow(hwnd_);
+    hwnd_ = nullptr;
+  }
+}
+
+// static
+bool PlatformThreadDispatcher::SyncModeRequested() {
+  static const bool sync = [] {
+    wchar_t buffer[8] = {};
+    DWORD n = GetEnvironmentVariableW(L"FLUTTER_ONNXRUNTIME_SYNC", buffer, 8);
+    return n > 0 && n < 8 && buffer[0] == L'1';
+  }();
+  return sync;
+}
+
+void PlatformThreadDispatcher::Post(std::function<void()> callback) {
+  if (SyncModeRequested() || hwnd_ == nullptr) {
+    // No dispatcher window (creation failed): run inline rather than drop the
+    // reply. This only happens in pathological environments and keeps the
+    // caller from hanging forever on a Future that never completes.
+    callback();
+    return;
+  }
+  auto *boxed = new std::function<void()>(std::move(callback));
+  if (!PostMessageW(hwnd_, kDispatchMessage, 0, reinterpret_cast<LPARAM>(boxed))) {
+    delete boxed;
+  }
+}
+
+// static
+LRESULT CALLBACK PlatformThreadDispatcher::WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+  if (message == kDispatchMessage) {
+    auto *boxed = reinterpret_cast<std::function<void()> *>(lparam);
+    if (boxed != nullptr) {
+      (*boxed)();
+      delete boxed;
+    }
+    return 0;
+  }
+  return DefWindowProcW(hwnd, message, wparam, lparam);
+}
+
+} // namespace flutter_onnxruntime

--- a/third_party/flutter_onnxruntime/windows/src/async_dispatch.h
+++ b/third_party/flutter_onnxruntime/windows/src/async_dispatch.h
@@ -1,0 +1,80 @@
+// Hibiki fork: off-platform-thread execution for ONNX Runtime work.
+//
+// Upstream runs every `runInference` / `createSession` synchronously inside the
+// method-call handler, i.e. on the Flutter platform (UI) thread. A DirectML
+// encoder run or a static-shape session build then freezes the UI for hundreds
+// of milliseconds to several seconds, and — worse for throughput — a GPU run
+// and a CPU run can never overlap because they share that one thread.
+//
+// This file provides:
+//   * WorkQueue: a single worker thread with a FIFO of tasks. The plugin keeps
+//     two of them: one for sessions on a GPU provider (DirectML runs are NOT
+//     safe to issue concurrently from several threads in one process — two
+//     sessions on two threads crash inside the DML provider), one for CPU
+//     sessions. GPU and CPU work therefore overlap while each class stays
+//     serialised.
+//   * PlatformThreadDispatcher: a message-only window created on the platform
+//     thread; `Post` marshals a callback back onto that thread so MethodResult
+//     replies are always completed where Flutter expects them.
+
+#ifndef FLUTTER_ONNXRUNTIME_ASYNC_DISPATCH_H_
+#define FLUTTER_ONNXRUNTIME_ASYNC_DISPATCH_H_
+
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <windows.h>
+
+namespace flutter_onnxruntime {
+
+class WorkQueue {
+public:
+  explicit WorkQueue(const char *name);
+  ~WorkQueue();
+
+  WorkQueue(const WorkQueue &) = delete;
+  WorkQueue &operator=(const WorkQueue &) = delete;
+
+  // Enqueue a task; returns false if the queue is shutting down. In sync mode
+  // (see PlatformThreadDispatcher::SyncModeRequested) the task runs inline.
+  bool Post(std::function<void()> task);
+
+private:
+  void Run();
+
+  std::thread thread_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<std::function<void()>> tasks_;
+  bool stopping_ = false;
+};
+
+class PlatformThreadDispatcher {
+public:
+  // Must be constructed on the platform thread (the plugin registrar's thread).
+  PlatformThreadDispatcher();
+  ~PlatformThreadDispatcher();
+
+  PlatformThreadDispatcher(const PlatformThreadDispatcher &) = delete;
+  PlatformThreadDispatcher &operator=(const PlatformThreadDispatcher &) = delete;
+
+  // Run [callback] on the platform thread. Safe to call from any thread.
+  void Post(std::function<void()> callback);
+
+  // Diagnostics escape hatch: with FLUTTER_ONNXRUNTIME_SYNC=1 in the process
+  // environment every queue runs its task inline on the platform thread and
+  // Post() invokes the callback directly — i.e. upstream's synchronous
+  // behaviour, for A/B timing and for isolating threading bugs.
+  static bool SyncModeRequested();
+
+private:
+  static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+
+  HWND hwnd_ = nullptr;
+};
+
+} // namespace flutter_onnxruntime
+
+#endif // FLUTTER_ONNXRUNTIME_ASYNC_DISPATCH_H_

--- a/third_party/flutter_onnxruntime/windows/src/async_dispatch.h
+++ b/third_party/flutter_onnxruntime/windows/src/async_dispatch.h
@@ -44,11 +44,20 @@ public:
 private:
   void Run();
 
-  std::thread thread_;
+  // Declaration order matters: members are initialised in declaration order,
+  // and the constructor starts the thread as part of initialising thread_.
+  // With thread_ declared first, the worker enters Run() -- which immediately
+  // locks mutex_, waits on cv_ and reads stopping_ -- while those four members
+  // may still be uninitialised. That is UB, and its failure mode is silent:
+  // stopping_ read as garbage-nonzero makes Run() return at once, every later
+  // Post() then reports the queue as shutting down, tasks are dropped, and the
+  // Dart Future behind each ORT call never completes (transcription just hangs,
+  // no exception, no log). Keep thread_ LAST.
   std::mutex mutex_;
   std::condition_variable cv_;
   std::deque<std::function<void()>> tasks_;
   bool stopping_ = false;
+  std::thread thread_;
 };
 
 class PlatformThreadDispatcher {

--- a/third_party/flutter_onnxruntime/windows/src/dxgi_memory.cc
+++ b/third_party/flutter_onnxruntime/windows/src/dxgi_memory.cc
@@ -1,0 +1,41 @@
+// Hibiki fork: DXGI video-memory budget query (see dxgi_memory.h).
+
+#include "src/dxgi_memory.h"
+
+#include <dxgi1_4.h>
+#include <wrl/client.h>
+
+namespace flutter_onnxruntime {
+
+bool QueryDeviceMemoryInfo(int device_id, DeviceMemoryInfo *out) {
+  if (out == nullptr) {
+    return false;
+  }
+  Microsoft::WRL::ComPtr<IDXGIFactory4> factory;
+  if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
+    return false;
+  }
+  Microsoft::WRL::ComPtr<IDXGIAdapter1> adapter;
+  if (FAILED(factory->EnumAdapters1(static_cast<UINT>(device_id), &adapter))) {
+    return false;
+  }
+  DXGI_ADAPTER_DESC1 desc = {};
+  if (FAILED(adapter->GetDesc1(&desc))) {
+    return false;
+  }
+  Microsoft::WRL::ComPtr<IDXGIAdapter3> adapter3;
+  if (FAILED(adapter.As(&adapter3))) {
+    return false;
+  }
+  DXGI_QUERY_VIDEO_MEMORY_INFO info = {};
+  if (FAILED(adapter3->QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info))) {
+    return false;
+  }
+  out->dedicated_video_memory = static_cast<int64_t>(desc.DedicatedVideoMemory);
+  out->budget = static_cast<int64_t>(info.Budget);
+  out->current_usage = static_cast<int64_t>(info.CurrentUsage);
+  out->is_software = (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) != 0;
+  return true;
+}
+
+} // namespace flutter_onnxruntime

--- a/third_party/flutter_onnxruntime/windows/src/dxgi_memory.h
+++ b/third_party/flutter_onnxruntime/windows/src/dxgi_memory.h
@@ -1,0 +1,31 @@
+// Hibiki fork: DXGI video-memory budget query.
+//
+// Static-shape DirectML graphs allocate every intermediate tensor up front and
+// keep the pool resident per session; on a card whose budget cannot hold them
+// the allocations spill into system memory and throughput collapses instead of
+// failing. The Dart side sizes its encoder buckets from this budget before it
+// builds any session. Kept free of flutter headers like dml_provider.cc.
+
+#ifndef FLUTTER_ONNXRUNTIME_DXGI_MEMORY_H_
+#define FLUTTER_ONNXRUNTIME_DXGI_MEMORY_H_
+
+#include <cstdint>
+
+namespace flutter_onnxruntime {
+
+struct DeviceMemoryInfo {
+  int64_t dedicated_video_memory = 0;
+  // OS-provided budget for the local (video) memory segment group; this is
+  // what the process may allocate before DXGI starts evicting.
+  int64_t budget = 0;
+  int64_t current_usage = 0;
+  bool is_software = false;
+};
+
+// Fills [out] for DXGI adapter [device_id]; false if the adapter or the
+// IDXGIAdapter3 query interface is unavailable (older OS / no GPU).
+bool QueryDeviceMemoryInfo(int device_id, DeviceMemoryInfo *out);
+
+} // namespace flutter_onnxruntime
+
+#endif // FLUTTER_ONNXRUNTIME_DXGI_MEMORY_H_

--- a/third_party/flutter_onnxruntime/windows/src/pch.h
+++ b/third_party/flutter_onnxruntime/windows/src/pch.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric> // For std::accumulate
+#include <atomic>  // Lock-free id allocation across the worker threads
 #include <random>  // For random number generation
 #include <sstream> // For std::stringstream
 #include <stdexcept>

--- a/third_party/flutter_onnxruntime/windows/src/session_manager.cc
+++ b/third_party/flutter_onnxruntime/windows/src/session_manager.cc
@@ -20,11 +20,16 @@ SessionManager::~SessionManager() {
   sessions_.clear();
 }
 
-std::string SessionManager::createSession(const char *model_path, const Ort::SessionOptions &session_options) {
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  // Generate a session ID
-  std::string session_id = generateSessionId();
+std::string SessionManager::createSession(const char *model_path, const Ort::SessionOptions &session_options,
+                                          bool is_gpu) {
+  // Only the id allocation and the final insert take the lock: building a
+  // session can take seconds (static-shape DirectML graphs), and holding the
+  // lock that long would stall every run on the other worker queue.
+  std::string session_id;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    session_id = generateSessionId();
+  }
 
   try {
     // On Windows, need to convert the model path from char* to wchar_t*
@@ -39,12 +44,13 @@ std::string SessionManager::createSession(const char *model_path, const Ort::Ses
     }
 
     // Create a new session with the provided options
-    std::unique_ptr<Ort::Session> ort_session =
-        std::make_unique<Ort::Session>(env_, wide_model_path.c_str(), session_options);
+    std::shared_ptr<Ort::Session> ort_session =
+        std::make_shared<Ort::Session>(env_, wide_model_path.c_str(), session_options);
 
     // Create session info
     SessionInfo session_info;
     session_info.session = std::move(ort_session);
+    session_info.is_gpu = is_gpu;
 
     // Get input names
     Ort::AllocatorWithDefaultOptions allocator;
@@ -66,7 +72,10 @@ std::string SessionManager::createSession(const char *model_path, const Ort::Ses
     }
 
     // Store the session info
-    sessions_[session_id] = std::move(session_info);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      sessions_[session_id] = std::move(session_info);
+    }
 
     return session_id;
   } catch (const Ort::Exception &e) {
@@ -88,6 +97,12 @@ bool SessionManager::closeSession(const std::string &session_id) {
   }
 
   return false;
+}
+
+bool SessionManager::isGpuSession(const std::string &session_id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = sessions_.find(session_id);
+  return it != sessions_.end() && it->second.is_gpu;
 }
 
 bool SessionManager::hasSession(const std::string &session_id) {
@@ -302,15 +317,23 @@ std::vector<Ort::Value> SessionManager::runInference(const std::string &session_
                                                      const std::vector<std::string> &input_names,
                                                      Ort::RunOptions *run_options) {
 
-  std::lock_guard<std::mutex> lock(mutex_);
   std::vector<Ort::Value> output_tensors;
 
-  auto it = sessions_.find(session_id);
-  if (it == sessions_.end()) {
-    throw Ort::Exception("Session not found", ORT_INVALID_ARGUMENT);
+  // Hold the lock only to look the session up: Run() itself may take hundreds
+  // of milliseconds and the GPU and CPU queues must be able to run at once.
+  std::shared_ptr<Ort::Session> session_ref;
+  std::vector<std::string> output_names;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = sessions_.find(session_id);
+    if (it == sessions_.end()) {
+      throw Ort::Exception("Session not found", ORT_INVALID_ARGUMENT);
+    }
+    session_ref = it->second.session;
+    output_names = it->second.output_names;
   }
 
-  Ort::Session *session = it->second.session.get();
+  Ort::Session *session = session_ref.get();
   if (!session) {
     throw Ort::Exception("Session is invalid", ORT_INVALID_ARGUMENT);
   }
@@ -331,7 +354,7 @@ std::vector<Ort::Value> SessionManager::runInference(const std::string &session_
 
   // Prepare output names
   std::vector<const char *> output_names_char;
-  for (const auto &name : it->second.output_names) {
+  for (const auto &name : output_names) {
     output_names_char.push_back(name.c_str());
   }
 

--- a/third_party/flutter_onnxruntime/windows/src/session_manager.h
+++ b/third_party/flutter_onnxruntime/windows/src/session_manager.h
@@ -22,9 +22,14 @@ class TensorManager;
 
 // Session information structure
 struct SessionInfo {
-  std::unique_ptr<Ort::Session> session;
+  // shared_ptr (Hibiki fork): a run in flight on a worker thread keeps the
+  // session alive even if closeSession() erases the map entry meanwhile.
+  std::shared_ptr<Ort::Session> session;
   std::vector<std::string> input_names;
   std::vector<std::string> output_names;
+  // Whether the session was created with a GPU provider (DirectML / CUDA);
+  // decides which worker queue its work is serialised on.
+  bool is_gpu = false;
 };
 
 // Model metadata structure
@@ -51,7 +56,10 @@ public:
   ~SessionManager();
 
   // Create a new session from a model file path
-  std::string createSession(const char *model_path, const Ort::SessionOptions &session_options);
+  std::string createSession(const char *model_path, const Ort::SessionOptions &session_options, bool is_gpu = false);
+
+  // Whether the session runs on a GPU provider (false for unknown sessions).
+  bool isGpuSession(const std::string &session_id);
 
   // Close and remove a session
   bool closeSession(const std::string &session_id);

--- a/third_party/flutter_onnxruntime/windows/src/tensor_manager.cc
+++ b/third_party/flutter_onnxruntime/windows/src/tensor_manager.cc
@@ -21,18 +21,12 @@ TensorManager::~TensorManager() {
 }
 
 std::string TensorManager::generateTensorId() {
-  // Create a random tensor ID
-  static std::random_device rd;
-  static std::mt19937 gen(rd());
-  static std::uniform_int_distribution<> dis(0, 15);
-
-  std::stringstream ss;
-  ss << "tensor_";
-  for (int i = 0; i < 16; i++) {
-    ss << std::hex << dis(gen);
-  }
-
-  return ss.str();
+  // See next_tensor_id_ in the header for why this must not use a shared
+  // unsynchronised RNG: this is called concurrently from the GPU and CPU
+  // worker threads, and duplicate ids corrupt the tensor tables.
+  // The id is not a security token -- it never leaves the process and is not
+  // guessable-by-attacker territory -- so a monotonic counter is enough.
+  return "tensor_" + std::to_string(next_tensor_id_.fetch_add(1, std::memory_order_relaxed));
 }
 
 std::string TensorManager::createFloat32Tensor(const std::vector<float> &data, const std::vector<int64_t> &shape) {

--- a/third_party/flutter_onnxruntime/windows/src/tensor_manager.h
+++ b/third_party/flutter_onnxruntime/windows/src/tensor_manager.h
@@ -109,6 +109,20 @@ private:
   // Mutex for thread safety
   std::mutex mutex_;
 
+  // Tensor id allocator.
+  //
+  // MUST be lock-free-safe on its own: generateTensorId() is called both from
+  // internal helpers that already hold mutex_ (so it cannot take mutex_ itself
+  // -- it is not recursive) AND, since the plugin went multi-threaded, from the
+  // GPU and CPU worker threads concurrently. The previous implementation used a
+  // function-local `static std::mt19937` with no synchronisation at all: two
+  // workers reading the same internal cursor hand out the SAME id, and then
+  // storeTensor() silently overwrites the other tensor's data/shape/type (or
+  // releaseTensor() frees the other one's backing buffer). Same shape as
+  // SessionManager::generateSessionId(), just atomic because this one is hot on
+  // two threads.
+  std::atomic<uint64_t> next_tensor_id_{0};
+
   // Memory info for CPU memory
   Ort::MemoryInfo memory_info_{nullptr};
 };

--- a/tool/asr/verify_greedy_graph.py
+++ b/tool/asr/verify_greedy_graph.py
@@ -71,12 +71,13 @@ def _checked_program(name: str) -> str:
     return real
 
 
-def _checked_dir(label: str, path: str, *, create: bool = False) -> str:
+def _checked_dir(label: str, path: str) -> str:
+    """把目录参数解析成一个确实存在的绝对路径。不代为创建：脚本只往调用方给的、
+    已经存在的目录里写（--out-dir 不存在就先 mkdir 再来），避免拿命令行参数去
+    创建任意路径。"""
     real = os.path.realpath(os.path.expanduser(path))
-    if create:
-        os.makedirs(real, exist_ok=True)
     if not os.path.isdir(real):
-        raise SystemExit(f"{label} 不是目录：{path}")
+        raise SystemExit(f"{label} 不是已存在的目录：{path}")
     return real
 
 
@@ -356,7 +357,7 @@ def main() -> None:
     ap.add_argument("--models-dir", help="含 decoder/joiner(.int8).onnx、encoder-epoch-99-avg-1.int8.onnx、tokens.txt 的目录")
     ap.add_argument("--wav", default=os.path.join(FIXTURES, "ja_tts_16k.wav"))
     ap.add_argument("--dart", default=os.environ.get("DART", "dart"), help="dart 可执行文件（默认 $DART 或 PATH 里的 dart）")
-    ap.add_argument("--out-dir", help="生成图落盘目录（默认临时目录，结束后删除）")
+    ap.add_argument("--out-dir", help="生成图落盘目录，必须已存在（默认临时目录，结束后删除）")
     ap.add_argument("--repeat", type=int, default=3)
     ap.add_argument("--bench-shape", default="8,250", help="合成计时用例的 N,T（真实批次量级；空串跳过）")
     ap.add_argument("--strict-dart", action="store_true", help="int8 下也要求与 dart 批方式参考逐元素相等")
@@ -365,7 +366,7 @@ def main() -> None:
     args = ap.parse_args()
 
     dart_exe = _checked_program(args.dart)
-    out_dir = (_checked_dir("--out-dir", args.out_dir, create=True) if args.out_dir
+    out_dir = (_checked_dir("--out-dir", args.out_dir) if args.out_dir
                else tempfile.mkdtemp(prefix="fushi_greedy_"))
     all_ok = True
     try:


### PR DESCRIPTION
接 #1231（已合并到 `b471f4adfd`）。那条 PR 合并时我后推的三个提交没赶上，这里基于最新 `develop` 原样重放，零冲突（只有 i18n 生成文件按 develop 基底重生成）。

## 1. `flutter_onnxruntime` 工作线程化（vendored，Windows；PATCHES.md delta #9）

`runInference` / `createSession` / `closeSession` 从平台线程搬到工作线程：GPU 会话一条队列、CPU 会话一条（DirectML 不能多线程并发 `Run`，两条独立会话也会崩，所以按 provider 类别串行、类别之间并行）；`MethodResult` 经消息窗口 `PostMessage` 回平台线程完成。UI 线程从此不被推理阻塞（之前每批 encoder 卡几百毫秒，静态桶建会话时卡几秒）。`SessionManager` 会话改 `shared_ptr`、`Run` 期间不持锁；`FLUTTER_ONNXRUNTIME_SYNC=1` 退回同步执行给 A/B 与排障用。守卫 `test/onnx/onnxruntime_async_dispatch_guard_test.dart`。

## 2. 三级流水线

`AsrPipelinedDecoder`（fbank / encode / search，与 `decodeBatch` 逐字等价）：GPU 编码第 i 批 ‖ CPU 贪心搜索第 i−1 批 ‖ Dart 算第 i+1 批 fbank；块末 `drain(all)` 先把在飞批冲干净再落检查点。单测钉住：结果与串行逐条一致、真重叠、fbank 只算一次、检查点前落盘、静态桶模式一批恰好 cap 行。

## 3. 显存预算选桶 + 预热策略（delta #10）

插件新增 `getDeviceMemoryInfo`（DXGI 本地显存预算），`asrEncoderBucketsForBudget`：≥10 GiB 全桶（32×560 + 16×1120）、6~10 GiB 半桶、<6 GiB 不建静态桶。预热策略 `shouldPrewarmAllStaticBuckets`（纯函数 + 单测）：全桶表 + 预算已知 + **素材 ≥ 15 分钟**才全预热并 `await`，否则只预热最小桶、大桶按需建——大桶留到中途按需建会在 GPU 队列上停住编码 3~8 s，但 5 分钟片段自己只转 2~3 s，为省几百毫秒 padding 先花 8 s 建桶是净亏。`close()` 不再等在建的桶。守卫 `test/onnx/onnxruntime_device_memory_guard_test.dart`。

## 4. 其它

- 弹层在静态融合图真在跑时显示「运行于 DirectML (GPU) · 静态融合图」。
- 成批规则文档写明静态模式下 `batchSize` / 音频预算不参与；`paddingRatio` 口径写明；插件 `freeDimensionOverrides` 非 string key 与非法值同样 `FailWith`。
- `tool/asr/verify_greedy_graph.py`：`--out-dir` 不再代为 `makedirs`（#1231 Sonar 安全评级 C 的唯一 OPEN 项）。
- 桶表 A/B 留档（`ASR_BUCKETS` 覆盖透传到引擎）：段长分布偏短（英语 71% ≤ 5 s、日语 99% ≤ 5 s），但加 280 帧桶英语 padding 不动（最长优先成批用不到）、日语 padding 3.25→2.53x 却把 12 GB 卡顶到溢出 wall 翻倍。维持两档，证据表进 `asr_encoder_buckets.dart` 文件头。

## 真机（RTX 4070 Ti，独占 GPU）

| 30 分钟英语 | wall |
|---|---|
| 同步插件 + 串行（#1231 合并态） | 8.0~8.9 s |
| 异步插件 + 串行 | 8.2 s |
| 异步插件 + 三级流水线 | **6.1~6.6 s**（RTF 0.0034，约 300×） |

插件往返延迟（silero-vad，300 次）：异步 3.9 ms / 同步 5.3 ms。峰值显存（含 4.5 GB 桌面基线）10.1~11.5 GB。

## 验证

`flutter analyze`（ASR / ONNX / 有声书 / 插件 Dart / 测试）No issues；`test/asr` + `test/onnx` + `test/ocr` + 转录弹层 / 模型设置 widget + i18n 全过。英语 30 分钟 / 10 分钟、日语 10 分钟 E2E（CPU int8 / GPU fp32 / 分阶段基准）全过。
