### PR TITLE
fix(update): 根治应用内更新静默失败 —— 退出期 abort + 安装器自杀 + 误诊 (BUG-2166/2167)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2032 条。点号进各自文件。
+> 共 2034 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2167](bugs/BUG-2167-windows-exit-abort-gamepads-static-thread.md) | ✅ | ✅ | Windows 每次退出 fail-fast 崩溃 0xc0000409：gamepads 全局对象析构 joinable std::thread |
+| [BUG-2166](bugs/BUG-2166-update-installer-self-kill-taskkill-tree.md) | ✅ | ✅ | 应用内更新静默失败：安装器被自己的 taskkill /T 连同祖先树一起杀掉，且被误诊为 app_mutex_running |
 | [BUG-2161](bugs/BUG-2161-mdx-loose-asset-scan-and-size-limits.md) | 🚧 | 🚧 | MDX 松散资源两条上限缺口：img src 只扫前 50 条词条、zip 全取无总量上限 |
 | [BUG-2160](bugs/BUG-2160-mdx-import-oom-ios.md) | ✅ | ✅ | iOS 导入大 MDX 词典闪退：整本词典在内存里物化，jetsam 直接杀进程 |
 | [BUG-2159](bugs/BUG-2159-netflix-ext-mine-audible-playback.md) | ✅ | ✅ | 网飞扩展批量制卡期间扬声器出声 |

--- a/docs/bugs/BUG-2166-update-installer-self-kill-taskkill-tree.md
+++ b/docs/bugs/BUG-2166-update-installer-self-kill-taskkill-tree.md
@@ -95,6 +95,14 @@ marker 有两个写者：Dart 和 C++ `update_launcher.cpp`（`AppendMarkerField
    `test/utils/misc` 三个目录 1051 条绿；三条变异（加回 `/T`、加回 `contains('mutex')`、
    删掉 `~Gamepads()`）全部被守卫抓红。
 
+4. 全量套件：`FLUTTER TEST VERDICT: PASSED - 23074 tests ran, all tests passed`。
+   注意前两次全量是**环境红**，判据三条：失败的是**不同文件**（`galgame_path_match` →
+   `position_pref_keys_guard`）；错误都在传输层而非断言（`Connection closed before test
+   suite loaded` / `Unable to connect to flutter_tester process: WebSocketException:
+   Invalid WebSocket upgrade request`，全程无 `Expected:`）；两文件单跑 17 条全绿且与本
+   改动无交集。**把 `HTTP(S)_PROXY` 整个摘掉后一次就绿** —— 只设 `NO_PROXY` 含 `::1`
+   并不足以挡住劫持。
+
 - **备注**：**端到端的一次真实应用内更新没有跑**——本机运行编译出的安装器会执行
   `taskkill /F /IM fushi.exe`，那会关掉用户当前正开着的生产 Fushi。所以这一层留给下一次
   真实更新验证；上面 1 与 2 已把「/T 会不会连坐」和「脚本能不能编译」两个关键点各自钉死。

--- a/docs/bugs/BUG-2166-update-installer-self-kill-taskkill-tree.md
+++ b/docs/bugs/BUG-2166-update-installer-self-kill-taskkill-tree.md
@@ -1,0 +1,100 @@
+## BUG-2166 · 应用内更新静默失败：安装器被自己的 taskkill /T 连同祖先树一起杀掉，且被误诊为 app_mutex_running
+- **报告**：2026-09-06（用户：应用内更新后仍是旧版，Fushi 报「Inno Setup reported that Fushi was still running」）
+- **真实性**：✅ 真 bug。两处根因：
+  - `fushi/windows/installer/fushi.iss:239` / `:251`（修复前的 `KillGracefully` / `KillImage`）—— `taskkill /IM <exe> /T`
+  - `fushi/lib/src/utils/misc/update_handoff.dart:906`（修复前的 `summarizeWindowsInstallerFailure`）—— `lower.contains('mutex')`
+  - `fushi/lib/src/utils/misc/update_handoff.dart` 的 `fromJson`/`toJson` —— 丢弃 C++ launcher 写入的键
+
+### 现场证据（用户机，2026-09-06）
+
+marker `%APPDATA%\Fushi\Fushi\updates\update-handoff.json`：
+
+| 时刻 (UTC) | 事实 |
+|---|---|
+| 01:32:53.434 | app 写下交接标记，启动 `fushi_update_launcher.exe`（pid 7028，父 = fushi.exe 97348） |
+| 01:34:53.517 | `parentExitObserved:false` —— 恰好 startedAt + 120.001s，即 `WaitForSingleObject` 跑满 `kParentExitTimeoutMs` |
+| 01:35:03.752 | 又过 10.2s（= `kMutexReleaseTimeoutMs`）后仍启动安装器（pid 12024） |
+| 01:35:04.039 | Inno 日志**戛然而止** |
+
+Inno 日志 `fushi-2.2.4-debug.13582-windows-setup.install.log` 全长 25 行，最后一行是
+`Successfully imported the DLL function. Delay loaded? No`。**没有**任何 abort / exception /
+`Deinitializing Setup` —— 这是被外部结束的形状，不是自行中止的形状。
+
+app 在 09:35:59 由 **explorer.exe** 重新拉起（`Win32_Process` 实测 `ParentProcessId=16968`
+= explorer），即用户自己去开始菜单点的：launcher 的 BUG-1708 兜底当时已经不在了。
+
+### 根因 ①：安装器杀掉了自己所在的进程树
+
+应用内静默更新时进程链是
+
+```text
+fushi.exe → fushi_update_launcher.exe → setup.exe（本安装器）
+```
+
+`InitializeSetup()` 检测到互斥量仍被持有后跑 `taskkill /IM fushi.exe /T`。`/T` 是**递归**
+杀整条后代树，本机实测（三层 cmd 副本）：
+
+```text
+taskkill /F /IM fk_parent.exe /T
+成功: 已终止 PID 88128 (属于 PID 47184 子进程)   ← 孙进程也被带走
+```
+
+于是安装器把 launcher 和自己一并杀掉。`/T` 原本是为了带走 WebView2 子进程，但它们的
+image 名就是 `msedgewebview2.exe`，`InitializeSetup` 已经单独扫了一遍 —— `/T` 不提供任何
+额外覆盖，只提供自杀能力。
+
+### 根因 ②：诊断把每一份日志都误判成 app_mutex_running
+
+`summarizeWindowsInstallerFailure` 用 `lower.contains('mutex')` 判「Fushi 仍在运行」。而
+Inno 会把 `[Code]` 段的外部函数导入逐个写进日志，其中就有
+
+```text
+Function and DLL name: OpenMutexW@kernel32.dll
+```
+
+这一行**每一份**日志里都有，无论成败。于是这条判据对任何一次失败都恒真，把真正的原因
+（安装器被杀）盖成了「Fushi 仍在运行」，用户和 agent 都被指向错误方向。
+
+### 根因 ③：launcher 的观测被 Dart 读写一轮抹掉
+
+marker 有两个写者：Dart 和 C++ `update_launcher.cpp`（`AppendMarkerFields`）。app 下次启动
+读回 marker、补诊断再写回，走 `fromJson → copyWith → toJson`，而模型不认识的键在这一步被
+静默丢弃。现场因此只剩一个 `parentExitObserved:false`，`launcherMutexReleased` /
+`parentExitTimedOut` / `appAliveAfterInstaller` 全没了 —— 连「是 OpenProcess 失败还是真的
+等超时」都分不出来。
+
+> 触发这整条链的**上游**是 BUG-2167：app 每次退出都 fail-fast 崩在 `ucrtbase!abort`，
+> 崩溃进程被 WER 冻住不死，于是互斥量一直被持有。两条 bug 各自独立可修：修好 ① 之后，
+> 即使 app 仍崩在退出路径，安装器也能杀掉那个僵住的进程并把这一版装完。
+
+- **[x] ① 已修复** — `fushi.iss` 的 `KillGracefully` / `KillImage` 去掉 `/T`，改为纯按
+  image 名杀（WebView2 由 `KillImage('msedgewebview2.exe')` 单独覆盖）；
+  `update_handoff.dart` 的分类器改为结构判据（`windowsInnoLogStoppedDuringStartup`）+
+  launcher 实测事实（新字段 `launcherMutexReleased`），删掉裸 `mutex` / `is running` 子串；
+  未识别的 marker 键进 `extraFields` 原样写回。
+- **[x] ② 已加自动化测试** —
+  `fushi/test/utils/misc/platform_updater_test.dart`（taskkill 实参不得含 `/T`，断言落在整个
+  实参列表上而非首个字面量）、
+  `fushi/test/utils/misc/update_handoff_test.dart`（用户机那份真实 25 行日志作回归样本 +
+  marker 未知键往返 + 模型自认键闭合）。
+  三条变异实测均被抓到（加回 `/T`、加回 `contains('mutex')`、删掉 `~Gamepads()`）。
+### 本轮验证（2026-09-06，本机）
+
+1. **进程树语义两个方向都实测**（三层 `cmd.exe` 副本夹具，父→子→孙）：
+
+   | 命令 | 结果 |
+   |---|---|
+   | `taskkill /F /IM fk_parent.exe /T` | 父、子、**孙**全部终止（= 安装器自杀） |
+   | `taskkill /F /IM fk_parent.exe` | 只终止父进程，子与孙存活（= launcher 与安装器活下来） |
+
+2. **`.iss` 真编译**：`ISCC.exe /DAppVersion=0.0.0-test /DSourceDir=<Debug 构建> ...` →
+   `Successful compile (70.610 sec)`，退出码 0。（`.iss` 只在 release workflow 里编译，
+   PR CI 抓不到它的语法错，所以本地补了这一步。）
+
+3. Dart 侧 `flutter analyze` 干净；定向测试 99 条绿；`test/platform` + `test/startup` +
+   `test/utils/misc` 三个目录 1051 条绿；三条变异（加回 `/T`、加回 `contains('mutex')`、
+   删掉 `~Gamepads()`）全部被守卫抓红。
+
+- **备注**：**端到端的一次真实应用内更新没有跑**——本机运行编译出的安装器会执行
+  `taskkill /F /IM fushi.exe`，那会关掉用户当前正开着的生产 Fushi。所以这一层留给下一次
+  真实更新验证；上面 1 与 2 已把「/T 会不会连坐」和「脚本能不能编译」两个关键点各自钉死。

--- a/docs/bugs/BUG-2167-windows-exit-abort-gamepads-static-thread.md
+++ b/docs/bugs/BUG-2167-windows-exit-abort-gamepads-static-thread.md
@@ -1,0 +1,80 @@
+## BUG-2167 · Windows 每次退出 fail-fast 崩溃 0xc0000409：gamepads 全局对象析构 joinable std::thread
+- **报告**：2026-09-06（排查 BUG-2166 时从 Windows 事件日志与崩溃转储中发现）
+- **真实性**：✅ 真 bug。根因 `packages/gamepads_windows/windows/gamepad.cpp:14`
+  （`Gamepads gamepads;` 静态存储期全局对象）+ `packages/gamepads_windows/windows/gamepad.h`
+  的 `std::thread reaper_thread;` 成员，且修复前 `Gamepads` **没有析构函数**。
+
+### 证据
+
+Windows 应用程序事件日志（用户机，2026-09-06 09:32:53.762）：
+
+```text
+错误应用程序名称: fushi.exe，版本 2.2.4.13530
+错误模块名称: ucrtbase.dll，版本 10.0.26100.7623
+异常代码: 0xc0000409          ← Subcode 0x7 FAST_FAIL_FATAL_APP_EXIT
+错误偏移: 0x00000000000a4ace  ← ucrtbase!abort+0x4e
+```
+
+崩溃转储 `%LOCALAPPDATA%\CrashDumps\fushi.exe.17436.dmp`（cdb `!analyze -v`）：
+
+```text
+FAILURE_BUCKET_ID: FAIL_FAST_FATAL_APP_EXIT_c0000409_ucrtbase.dll!abort
+
+ucrtbase!abort+0x4e
+gamepads_windows_plugin+0xa2ca
+ucrtbase!execute_onexit_table+0x3d      ← 进程退出时跑 DLL 的静态析构/atexit 表
+gamepads_windows_plugin+0x1006d
+```
+
+`CrashDumps` 目录里 2026-09-05 一天就有 4 份 `fushi.exe.*.dmp`（15:35 那份正对应上一次
+应用内更新的交接时刻），说明这不是偶发。
+
+### 根因
+
+`Gamepads gamepads;` 是静态存储期全局对象，成员含 `std::thread reaper_thread`（在
+`init()` 里启动，前提是机器上有 `GameInput.dll`）。`std::thread` 的析构函数对**仍
+joinable** 的线程直接 `std::terminate()` → `abort()`。
+
+停止线程的 `Gamepads::stop()` 只在 `~GamepadsWindowsPlugin()` 里调用，而 Fushi 的两条退出
+路径最终都是 `exit(0)`：
+
+- 更新交接 `fushi/lib/src/utils/misc/platform_updater.dart`
+- 关窗 `fushi/lib/src/platform/desktop/desktop_lifecycle_service.dart`
+
+`exit(0)` **故意**跳过 Flutter 插件析构（这是它存在的理由：尽快让出文件锁）。于是插件析构
+函数永远不跑，`reaper_thread` 带着 joinable 状态活到 CRT 的 onexit 表 —— 每次退出必崩。
+
+### 下游代价
+
+崩溃进程被 WER 冻住数分钟不死（进程对象还在、句柄还开着），`FushiSingleInstanceMutex`
+随之一直被持有。应用内更新链上 `fushi_update_launcher.exe` 的「等父进程退出」（120s）与
+「等互斥量释放」（10s）因此双双超时（marker 实录 `parentExitObserved:false`，时间戳恰好是
+startedAt + 120.001s），再叠加 BUG-2166 的安装器自杀，整次更新落空。
+
+- **[x] ① 已修复** — 给 `Gamepads` 加析构函数（`gamepad.h` 声明 / `gamepad.cpp` 实现）：
+  置 `reaper_stop` + `notify_all`，用 `WaitForSingleObject(native_handle(), 1000)` 做**有界**
+  等待，等到了 `join()`、等不到 `detach()`。既不 `terminate` 也不卡死。
+  刻意**不**调 `stop()`（它要 `UnregisterCallback(5s)` 并 join 可能停在 GameInput 锁里的轮询
+  线程 —— 那是把崩溃换成卡死），也刻意不动轮询线程（它们的 `GamepadData` 是裸指针、本就不
+  随本对象析构；置停止位反而会让它们在 CRT 已开始拆解时去跑 `neutralize_inputs`/`std::cout`）。
+- **[x] ② 已加自动化测试** —
+  `fushi/test/platform/gamepads_windows_exit_teardown_guard_test.dart`：钉住「全局对象 +
+  `std::thread` 成员」这个成因前提，钉住析构函数存在、真的处置 `reaper_thread`、含
+  `detach()` 兜底、且不调 `stop()`。变异实测（删掉 `~Gamepads();`）当场变红。
+### 真机 A/B 验证（2026-09-06，本机 Windows 11 26200）
+
+同一份 debug 构建、同一套流程（`FUSHI_TEST_HIDDEN=1` + 独立 `FUSHI_TEST_ROOT` +
+独立 `FUSHI_WEBVIEW2_USER_DATA_FOLDER` 起进程 → 等 `FLUTTER_RUNNER_WIN32_WINDOW`
+出现 → 静置 30s → `PostMessage(WM_CLOSE)` → 读**进程退出码**），只改析构函数一处：
+
+| 版本 | 进程退出码 |
+|---|---|
+| 去掉 `~Gamepads()`（= 修复前的现状） | `-1073740791` = `0xC0000409` FAST_FAIL_FATAL_APP_EXIT |
+| 带 `~Gamepads()`（本修复） | `0` |
+
+退出码是比事件日志更直接的判据：fail-fast 会把 `0xC0000409` 原样变成进程退出码。
+两次都跑了两遍，结果稳定。
+
+- **备注**：验证用的是 debug 构建；release 构建的静态析构表布局相同，但未单独复测。
+  另：本 bug 只在装有 `GameInput.dll` 的机器上触发（`init()` 里没有它就直接 return，
+  reaper 从未启动）——没装的机器上退出一直是干净的，这也是它能长期潜伏的原因。

--- a/fushi/lib/src/utils/misc/update_handoff.dart
+++ b/fushi/lib/src/utils/misc/update_handoff.dart
@@ -210,6 +210,7 @@ class WindowsUpdateHandoffRecord {
     this.parentProcessId,
     this.parentExitObserved,
     this.parentExitObservedAt,
+    this.launcherMutexReleased,
     this.installerLaunchSucceeded,
     this.installerLaunchedAt,
     this.installerPid,
@@ -224,6 +225,7 @@ class WindowsUpdateHandoffRecord {
     this.lastPromptedAppVersion,
     this.lastPromptedFailureFingerprint,
     this.lastPromptedAt,
+    this.extraFields = const <String, dynamic>{},
   });
 
   factory WindowsUpdateHandoffRecord.fromJson(Map<String, dynamic> json) {
@@ -269,6 +271,7 @@ class WindowsUpdateHandoffRecord {
       parentProcessId: _int(json['parentProcessId']),
       parentExitObserved: json['parentExitObserved'] as bool?,
       parentExitObservedAt: _dateTime(json['parentExitObservedAt']),
+      launcherMutexReleased: json['launcherMutexReleased'] as bool?,
       installerLaunchSucceeded: json['installerLaunchSucceeded'] as bool?,
       installerLaunchedAt: _dateTime(json['installerLaunchedAt']),
       installerPid: _int(json['installerPid']),
@@ -284,8 +287,64 @@ class WindowsUpdateHandoffRecord {
       lastPromptedFailureFingerprint:
           json['lastPromptedFailureFingerprint'] as String?,
       lastPromptedAt: _dateTime(json['lastPromptedAt']),
+      extraFields: <String, dynamic>{
+        for (final MapEntry<String, dynamic> entry in json.entries)
+          if (!_knownJsonKeys.contains(entry.key)) entry.key: entry.value,
+      },
     );
   }
+
+  /// 本模型自己认识（读得回、写得出）的 marker 键。
+  ///
+  /// BUG-2166：marker 文件有**两个**写者——Dart（本类）和 C++ 的
+  /// `fushi_update_launcher.exe`（`update_launcher.cpp` 的 `AppendMarkerFields`）。
+  /// launcher 在 app 已经退出之后才写下整条交接链上最关键的观测：父进程到底退没退、
+  /// 互斥量到底放没放、安装器结束后 app 有没有回来、是不是 launcher 把它拉回来的。
+  /// 而 app 下次启动读回 marker、补上失败诊断再写回时，走的是
+  /// `fromJson → copyWith → toJson` —— 旧实现里凡是本模型不认识的键**在这一步被静默
+  /// 丢掉**。现场就是这样：`parentExitTimedOut` / `launcherMutexReleased` /
+  /// `appAliveAfterInstaller` 全被抹掉，只剩一个 `parentExitObserved:false`，
+  /// 事后连「是 OpenProcess 失败还是真的等超时」都分不出来。
+  ///
+  /// 所以未识别的键一律进 [extraFields] 原样带回去：marker 是**证据**，
+  /// 不是本类的私有序列化格式，读者无权丢掉另一个写者的观测。
+  static const Set<String> _knownJsonKeys = <String>{
+    'targetVersion',
+    'installerPath',
+    'innoLogPath',
+    'startedAt',
+    'currentExecutablePath',
+    'currentInstallDir',
+    'targetInstallDir',
+    'detectedInstallLocations',
+    'runningFushiProcesses',
+    // 只读不写的旧键（见上面 W2-6 的注释）；同样不该落进 extraFields 再被写回。
+    'runningHibikiProcesses',
+    'libmpvModuleHolders',
+    'galHookModuleHolders',
+    'innoLogDeleteFileFailures',
+    'pathMismatchWarning',
+    'launcherStartedAt',
+    'launcherPid',
+    'parentProcessId',
+    'parentExitObserved',
+    'parentExitObservedAt',
+    'launcherMutexReleased',
+    'installerLaunchSucceeded',
+    'installerLaunchedAt',
+    'installerPid',
+    'innoLogExists',
+    'innoLogSizeBytes',
+    'innoLogModifiedAt',
+    'installerFailureType',
+    'installerFailureSummary',
+    'installerLaunchFailedAt',
+    'launchError',
+    'failureFingerprint',
+    'lastPromptedAppVersion',
+    'lastPromptedFailureFingerprint',
+    'lastPromptedAt',
+  };
 
   final String targetVersion;
   final String installerPath;
@@ -305,6 +364,14 @@ class WindowsUpdateHandoffRecord {
   final int? parentProcessId;
   final bool? parentExitObserved;
   final DateTime? parentExitObservedAt;
+
+  /// `fushi_update_launcher.exe` 在启动 Inno **之前**实测到的事实：
+  /// `FushiSingleInstanceMutex` 是否已经被释放（`WaitForMutexReleased()`）。
+  ///
+  /// 这是「Fushi 是不是还开着」唯一的**观测**来源。日志里出现 mutex 字样不是
+  /// （BUG-2166：Inno 会把 `[Code]` 段的 `OpenMutexW@kernel32.dll` 导入记进每一份
+  /// 日志，无论成败）。
+  final bool? launcherMutexReleased;
   final bool? installerLaunchSucceeded;
   final DateTime? installerLaunchedAt;
   final int? installerPid;
@@ -320,6 +387,10 @@ class WindowsUpdateHandoffRecord {
   final String? lastPromptedFailureFingerprint;
   final DateTime? lastPromptedAt;
 
+  /// marker 里本模型不认识的键（今天全部来自 C++ launcher）。原样带回磁盘，
+  /// 见 [_knownJsonKeys] 的注释。
+  final Map<String, dynamic> extraFields;
+
   WindowsInstallerDiagnostics get diagnostics => WindowsInstallerDiagnostics(
         currentExecutablePath: currentExecutablePath,
         currentInstallDir: currentInstallDir,
@@ -333,6 +404,9 @@ class WindowsUpdateHandoffRecord {
       );
 
   Map<String, dynamic> toJson() => <String, dynamic>{
+        // 先铺未识别键，本模型认识的键随后写入 —— 两边的键集互斥
+        // （[_knownJsonKeys] 过滤过），这里的顺序只决定 JSON 里的字段次序。
+        ...extraFields,
         'targetVersion': targetVersion,
         'installerPath': installerPath,
         'innoLogPath': innoLogPath,
@@ -373,6 +447,8 @@ class WindowsUpdateHandoffRecord {
         if (parentExitObservedAt != null)
           'parentExitObservedAt':
               parentExitObservedAt!.toUtc().toIso8601String(),
+        if (launcherMutexReleased != null)
+          'launcherMutexReleased': launcherMutexReleased,
         if (installerLaunchSucceeded != null)
           'installerLaunchSucceeded': installerLaunchSucceeded,
         if (installerLaunchedAt != null)
@@ -419,6 +495,7 @@ class WindowsUpdateHandoffRecord {
     int? parentProcessId,
     bool? parentExitObserved,
     DateTime? parentExitObservedAt,
+    bool? launcherMutexReleased,
     bool? installerLaunchSucceeded,
     DateTime? installerLaunchedAt,
     int? installerPid,
@@ -433,6 +510,7 @@ class WindowsUpdateHandoffRecord {
     String? lastPromptedAppVersion,
     String? lastPromptedFailureFingerprint,
     DateTime? lastPromptedAt,
+    Map<String, dynamic>? extraFields,
     bool clearLaunchFailure = false,
   }) {
     return WindowsUpdateHandoffRecord(
@@ -458,6 +536,8 @@ class WindowsUpdateHandoffRecord {
       parentProcessId: parentProcessId ?? this.parentProcessId,
       parentExitObserved: parentExitObserved ?? this.parentExitObserved,
       parentExitObservedAt: parentExitObservedAt ?? this.parentExitObservedAt,
+      launcherMutexReleased:
+          launcherMutexReleased ?? this.launcherMutexReleased,
       installerLaunchSucceeded:
           installerLaunchSucceeded ?? this.installerLaunchSucceeded,
       installerLaunchedAt: installerLaunchedAt ?? this.installerLaunchedAt,
@@ -478,6 +558,7 @@ class WindowsUpdateHandoffRecord {
       lastPromptedFailureFingerprint:
           lastPromptedFailureFingerprint ?? this.lastPromptedFailureFingerprint,
       lastPromptedAt: lastPromptedAt ?? this.lastPromptedAt,
+      extraFields: extraFields ?? this.extraFields,
     );
   }
 }
@@ -890,19 +971,52 @@ WindowsInstallerFailureSummary summarizeWindowsInstallerFailure({
   }
 
   final String lower = log.toLowerCase();
+
+  // BUG-2166：安装器根本没走出启动段。这是**日志形状**上的判据，不是措辞猜测：
+  // 从 `Log opened.` 到 `[Code]` 段外部函数导入之间的那几行是 Inno 每次启动都会写的
+  // 固定内容（且始终是英文，与安装器 UI 语言无关），之后一行都没有 —— 既没进复制阶段，
+  // 也没留下任何自行中止的记录。现场就是这个形状：安装器被自己的
+  // `taskkill /IM fushi.exe /T` 连同所在的祖先进程树一起杀掉（见 fushi.iss 的注释），
+  // 日志在启动后 67ms 戛然而止。
+  if (windowsInnoLogStoppedDuringStartup(log)) {
+    final StringBuffer message = StringBuffer(
+      'Inno Setup stopped during startup: the log ends inside the setup '
+      'preamble, with no file-copy phase and no record of Setup stopping on '
+      'its own. That is the shape of an externally terminated installer, not '
+      'of a cancelled one.',
+    );
+    if (record.launcherMutexReleased == false) {
+      message.write(
+        ' The update launcher also observed FushiSingleInstanceMutex still '
+        'held when it started the installer, so a Fushi process was alive at '
+        'that moment.',
+      );
+    }
+    return WindowsInstallerFailureSummary(
+      type: 'installer_stopped_at_startup',
+      message: message.toString(),
+    );
+  }
+
+  // 「Fushi 还开着」只认**观测**：launcher 在启动 Inno 之前实测互斥量仍被持有，
+  // 或者 Inno 自己在日志里写下了它检测到实例在跑。
+  //
+  // 这里**故意不再**匹配裸 `mutex` / `is running` 子串（BUG-2166 的误诊源头）：
+  // Inno 会把 `[Code]` 段的外部函数导入逐个记进日志，其中就有
+  // `Function and DLL name: OpenMutexW@kernel32.dll` —— 这一行**每一份**日志里都有，
+  // 无论安装成功还是失败。于是旧判据对任何一次失败都恒真，把真正的失败原因
+  // （安装器被杀、复制失败、用户取消）全部盖成同一条「Fushi 仍在运行」。
   final bool mentionsRunningApp = lower.contains('currently running') ||
-      lower.contains('is running') ||
       lower.contains('appmutex') ||
-      lower.contains('mutex') ||
       lower.contains('another instance');
   final bool hasEAbort = lower.contains('eabort');
   final bool looksCanceled = lower.contains('cancel') ||
       lower.contains('aborted') ||
       lower.contains('abort');
-  if (mentionsRunningApp) {
+  if (mentionsRunningApp || record.launcherMutexReleased == false) {
     return WindowsInstallerFailureSummary(
       type: 'app_mutex_running',
-      message: 'Inno Setup reported that Fushi was still running. The '
+      message: 'Fushi was still running when the installer started. The '
           'installer is guarded by FushiSingleInstanceMutex, so every active '
           'fushi.exe process must be closed before the silent installer can '
           'continue.',
@@ -922,6 +1036,49 @@ WindowsInstallerFailureSummary summarizeWindowsInstallerFailure({
     message: 'The installer ran, but Fushi restarted with the previous '
         'version. Check the installer log for the full Inno Setup details.',
   );
+}
+
+/// Inno 每次启动都会写、且**与安装器 UI 语言无关**（这段日志恒为英文）的固定行。
+///
+/// 用途见 [windowsInnoLogStoppedDuringStartup]。这里刻意只收「启动段」的行：
+/// 名单之外出现任何一行，就说明安装器已经走出启动段，判据即不成立。
+const List<String> _kInnoStartupLogMarkers = <String>[
+  'Log opened.',
+  'Setup version:',
+  'Original Setup EXE:',
+  'Setup command line:',
+  'Windows version:',
+  'Windows architecture:',
+  'Machine types supported by system:',
+  'User privileges:',
+  'Administrative install mode:',
+  'Install mode root key:',
+  '64-bit install mode:',
+  'RedirectionGuard status',
+  'Created temporary directory:',
+  '-- DLL function import --',
+  'Function and DLL name:',
+  'Importing the DLL function.',
+  'Successfully imported the DLL function.',
+];
+
+/// 日志是否停在 Inno 的启动段——即安装器**从未**走到复制文件的阶段，
+/// 也没有留下任何自行中止的记录（BUG-2166）。
+///
+/// 判据是「除启动段固定行之外一行都没有」，方向刻意保守：名单不全时只会**少报**
+/// （落回 `installer_incomplete`），不会像旧的子串判据那样把每一次失败都误报成
+/// 同一个原因。
+bool windowsInnoLogStoppedDuringStartup(String log) {
+  bool sawLogOpened = false;
+  bool sawAnyLine = false;
+  for (final String raw in const LineSplitter().convert(log)) {
+    final String line = raw.trim();
+    if (line.isEmpty) continue;
+    sawAnyLine = true;
+    if (line.contains('Log opened.')) sawLogOpened = true;
+    if (!_kInnoStartupLogMarkers.any(line.contains)) return false;
+  }
+  return sawAnyLine && sawLogOpened;
 }
 
 String windowsInstallerFailureFingerprint({

--- a/fushi/test/platform/gamepads_windows_exit_teardown_guard_test.dart
+++ b/fushi/test/platform/gamepads_windows_exit_teardown_guard_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2167：Windows 每次退出 fail-fast 崩溃 `0xc0000409`。
+///
+/// 根因不在更新链上，但整条应用内更新链都挂在它下面，所以守卫放在这里：
+///
+/// `packages/gamepads_windows/windows/gamepad.cpp` 里的 `Gamepads gamepads;` 是
+/// **静态存储期**全局对象，成员含 `std::thread reaper_thread`。进程退出时 CRT 的
+/// onexit 表析构它，而 `std::thread` 的析构函数对**仍 joinable** 的线程直接
+/// `std::terminate()` → `abort()`。Fushi 的两条退出路径（更新交接、关窗）最终都调
+/// `exit(0)`，而 `exit(0)` 故意跳过 Flutter 插件析构 —— 于是
+/// `~GamepadsWindowsPlugin()` 里的 `stop()` 永远不跑，`reaper_thread` 带着
+/// joinable 状态活到 onexit 表，**每一次退出都崩**。
+///
+/// 实测转储（`fushi.exe.17436.dmp`，`!analyze -v`）：
+/// ```text
+/// FAILURE_BUCKET_ID: FAIL_FAST_FATAL_APP_EXIT_c0000409_ucrtbase.dll!abort
+/// ucrtbase!abort+0x4e
+/// gamepads_windows_plugin+0xa2ca
+/// ucrtbase!execute_onexit_table+0x3d
+/// gamepads_windows_plugin+0x1006d
+/// ```
+///
+/// 下游代价：崩溃进程被 WER 冻住数分钟不死，`FushiSingleInstanceMutex` 一直被持有，
+/// 于是 `fushi_update_launcher.exe` 的「等父进程退出」（120s）和「等互斥量释放」
+/// （10s）双双超时（现场 marker 实录 `parentExitObserved:false`）。
+///
+/// 本守卫钉住的不变式：**`Gamepads` 必须有析构函数，且它必须真的处置
+/// `reaper_thread`**。删掉析构函数正是回归本身；把它改成一句 `stop()` 则是把崩溃
+/// 换成卡死（`stop()` 要 `UnregisterCallback(5s)` 并 join 可能停在 GameInput 锁里的
+/// 轮询线程），所以这里同样拦。真正的行为验证只能在 Windows 上跑真 app 退出后查
+/// 事件日志有无 `0xc0000409`——这层守卫只保证代码结构不被悄悄改回去。
+void main() {
+  group('BUG-2167 gamepads 全局对象退出期 teardown', () {
+    late final String header;
+    late final String source;
+
+    setUpAll(() {
+      header = File('../packages/gamepads_windows/windows/gamepad.h')
+          .readAsStringSync();
+      source = File('../packages/gamepads_windows/windows/gamepad.cpp')
+          .readAsStringSync();
+    });
+
+    test('前提仍然成立：全局对象 + std::thread 成员', () {
+      // 这两条是本 bug 的**成因前提**。哪天上游把全局改掉、或线程不再是成员，
+      // 守卫的理由就变了，应该有人重新想一遍而不是让它继续恒真地绿着。
+      expect(source, contains('Gamepads gamepads;'),
+          reason: '不再是静态存储期全局对象了？重新评估本守卫。');
+      expect(header, contains('std::thread reaper_thread;'),
+          reason: 'reaper_thread 不再是 std::thread 成员了？重新评估本守卫。');
+    });
+
+    test('Gamepads 声明并实现了析构函数', () {
+      expect(header, contains('~Gamepads();'),
+          reason: '没有析构函数 = joinable 的 reaper_thread 直接走到 '
+              'std::thread 的析构函数 = std::terminate() = 每次退出必崩。');
+      expect(source, contains('Gamepads::~Gamepads()'));
+    });
+
+    test('析构函数处置 reaper_thread，且不阻塞在 stop() 上', () {
+      final int start = source.indexOf('Gamepads::~Gamepads()');
+      expect(start, greaterThan(-1));
+      final int bodyStart = source.indexOf('{', start);
+      final int bodyEnd = source.indexOf('\n}', bodyStart);
+      expect(bodyEnd, greaterThan(bodyStart));
+      final String body = source.substring(bodyStart, bodyEnd);
+
+      expect(body, contains('reaper_thread'),
+          reason: '析构函数没碰 reaper_thread —— 那它没有解决任何问题。');
+      expect(body, contains('reaper_stop'),
+          reason: '不置停止位就等，reaper 永远醒不过来。');
+      expect(body, contains('detach()'),
+          reason: '缺少「等不到就 detach」的兜底：一旦等超时，'
+              'std::thread 的析构函数仍会 terminate。');
+      expect(body, contains('WaitForSingleObject'),
+          reason: 'std::thread 没有带超时的 join，必须用底层句柄做有界等待。');
+      expect(body, isNot(contains('stop()')),
+          reason: '退出路径上调 stop() 会 UnregisterCallback(5s) 并 join 可能'
+              '停在 GameInput 锁里的轮询线程 —— 那是把崩溃换成卡死。');
+    });
+  });
+}

--- a/fushi/test/utils/misc/platform_updater_test.dart
+++ b/fushi/test/utils/misc/platform_updater_test.dart
@@ -328,13 +328,54 @@ void main() {
       expect(script, contains('OpenMutexW'));
       expect(script, contains('@kernel32.dll stdcall'));
       expect(script, contains('FushiSingleInstanceMutex'));
-      // Terminates hibiki.exe and its WebView2 child tree before the check.
+      // Terminates fushi.exe / hibiki.exe / WebView2 **by image name** before
+      // the check (BUG-2166: never by process tree — see the /T guard below).
       expect(script, contains('taskkill'));
       expect(script, contains('hibiki.exe'));
       expect(script, contains('msedgewebview2.exe'));
       // Bounded poll until the mutex is actually released (no infinite wait).
       expect(script, contains('MutexReleasePollAttempts'));
       expect(script, contains('Sleep(MutexReleasePollIntervalMs)'));
+    });
+
+    test(
+        'BUG-2166: taskkill 绝不带 /T —— 安装器自己就在 fushi.exe 的后代进程树里',
+        () {
+      // 应用内静默更新时进程链是
+      //   fushi.exe → fushi_update_launcher.exe → <本 setup.exe>
+      // 而 taskkill 的 /T 递归杀整条后代树（实测：/F /IM <parent> /T 连孙进程
+      // 一起终止）。于是 InitializeSetup 的自我防卫会把 launcher 和安装器自己
+      // 一并杀掉：安装器自杀、日志停在启动段、磁盘留在旧版，且 BUG-1708 的
+      // 「安装失败把 app 拉回来」兜底也随 launcher 一起没了。
+      //
+      // 断言落在**整个实参列表**上，而不是整份文件、也不是第一个字符串字面量：
+      // - 整份文件会假红：注释里就写着 /T（在解释为什么禁用）。
+      // - 只看第一个字面量会假绿：`'/F /IM ' + ExeName + ' /T'` 这种拼接能绕过去
+      //   （这条守卫第一版就是这么写的，变异实测当场放行）。
+      final String script = File(
+        'windows/installer/fushi.iss',
+      ).readAsStringSync();
+
+      final List<RegExpMatch> calls = RegExp(
+        r"Exec\(ExpandConstant\('\{sys\}\\taskkill\.exe'\)([\s\S]*?)\);",
+      ).allMatches(script).toList(growable: false);
+
+      expect(
+        calls,
+        isNotEmpty,
+        reason: '没找到任何 taskkill 调用 —— 要么调用形状变了、要么这条守卫失效了，'
+            '两种都必须有人看一眼，不能静默放行。',
+      );
+      for (final RegExpMatch call in calls) {
+        final String args = call.group(1)!;
+        expect(
+          args.contains('/T'),
+          isFalse,
+          reason: 'taskkill 实参 "${args.trim()}" 里出现了 /T：它会连同安装器'
+              '所在的祖先进程树一起杀掉（BUG-2166）。按 image 名杀就够了 —— '
+              'WebView2 的每个子进程都叫 msedgewebview2.exe，已被单独一行覆盖。',
+        );
+      }
     });
 
     test('update launcher is not the Flutter runner and does not take mutex',

--- a/fushi/test/utils/misc/update_handoff_test.dart
+++ b/fushi/test/utils/misc/update_handoff_test.dart
@@ -1290,4 +1290,204 @@ void main() {
       expect(record.lastPromptedAt, isNull);
     });
   });
+
+  group('BUG-2166 安装器停在启动段 / 诊断只认观测不认子串', () {
+    // 用户机上的**真实**日志（2026-09-06，fushi-2.2.4-debug.13582，逐行照抄，
+    // 只把路径与 /SL5 参数做了脱敏）。现场：09:35:03.752 launcher 启动安装器，
+    // 09:35:04.039 日志戛然而止 —— 安装器在 InitializeSetup 里被自己的
+    // `taskkill /IM fushi.exe /T` 连同所在的祖先进程树（fushi.exe →
+    // fushi_update_launcher.exe → setup.exe）一起杀掉，所以没有任何
+    // abort / exception / Deinitializing 行。
+    const String killedAtStartupLog =
+        r'''2026-09-06 09:35:03.972   Log opened. (Time zone: UTC+08:00)
+2026-09-06 09:35:03.972   Setup version: Inno Setup version 6.7.1
+2026-09-06 09:35:03.972   Original Setup EXE: C:\updates\fushi-setup.exe
+2026-09-06 09:35:03.973   Setup command line: /SL5="x,1,2,C:\setup.exe" /VERYSILENT /SP- /SUPPRESSMSGBOXES /NORESTART /DIR=D:\APP\Hibiki
+2026-09-06 09:35:03.973   Windows version: 10.0.26200
+2026-09-06 09:35:03.973   Windows architecture: x64 (64-bit)
+2026-09-06 09:35:03.973   Machine types supported by system: x86 x64
+2026-09-06 09:35:03.973   User privileges: None
+2026-09-06 09:35:04.037   Administrative install mode: No
+2026-09-06 09:35:04.037   Install mode root key: HKEY_CURRENT_USER
+2026-09-06 09:35:04.037   64-bit install mode: No
+2026-09-06 09:35:04.037   RedirectionGuard status for current process: Enabled in enforcing mode
+2026-09-06 09:35:04.038   Created temporary directory: C:\Temp\is-D5OX8W7L61.tmp
+2026-09-06 09:35:04.039   -- DLL function import --
+2026-09-06 09:35:04.039   Function and DLL name: OpenMutexW@kernel32.dll
+2026-09-06 09:35:04.039   Importing the DLL function. Dest DLL name: kernel32.dll
+2026-09-06 09:35:04.039   Successfully imported the DLL function. Delay loaded? No
+2026-09-06 09:35:04.039   -- DLL function import --
+2026-09-06 09:35:04.039   Function and DLL name: CloseHandle@kernel32.dll
+2026-09-06 09:35:04.039   Importing the DLL function. Dest DLL name: kernel32.dll
+2026-09-06 09:35:04.039   Successfully imported the DLL function. Delay loaded? No
+2026-09-06 09:35:04.039   -- DLL function import --
+2026-09-06 09:35:04.039   Function and DLL name: CreateFileW@kernel32.dll
+2026-09-06 09:35:04.039   Importing the DLL function. Dest DLL name: kernel32.dll
+2026-09-06 09:35:04.039   Successfully imported the DLL function. Delay loaded? No''';
+
+    WindowsUpdateHandoffRecord recordWith({bool? launcherMutexReleased}) {
+      return WindowsUpdateHandoffRecord(
+        targetVersion: '2.2.4-debug.13582',
+        installerPath: r'C:\tmp\setup.exe',
+        innoLogPath: r'C:\tmp\setup.install.log',
+        startedAt: DateTime.utc(2026, 9, 6, 1, 32, 53),
+        innoLogExists: true,
+        launcherMutexReleased: launcherMutexReleased,
+      );
+    }
+
+    test('真实现场日志判成「停在启动段」，不再误报 app_mutex_running', () {
+      final WindowsInstallerFailureSummary summary =
+          summarizeWindowsInstallerFailure(
+        record: recordWith(),
+        innoLogContents: killedAtStartupLog,
+      );
+
+      // 旧实现对这份日志**恒定**给出 app_mutex_running：它把下面这行
+      // `[Code]` 段外部函数导入当成了「Fushi 仍在运行」的证据，而这一行在
+      // 每一份 Inno 日志里都有。这条用例就是那次误诊的回归闸。
+      expect(killedAtStartupLog, contains('OpenMutexW@kernel32.dll'));
+      expect(summary.type, 'installer_stopped_at_startup');
+    });
+
+    test('只剩 OpenMutexW 导入行时，不构成「Fushi 仍在运行」的证据', () {
+      // 把日志拉出启动段（多一行复制阶段），结构判据不再成立；此时与 mutex
+      // 有关的仍只有那行 import —— 不得据此判 app_mutex_running。
+      final WindowsInstallerFailureSummary summary =
+          summarizeWindowsInstallerFailure(
+        record: recordWith(),
+        innoLogContents: '$killedAtStartupLog\n'
+            r'2026-09-06 09:35:05.000   Starting the installation process.',
+      );
+
+      expect(summary.type, 'installer_incomplete');
+    });
+
+    test('launcher 实测互斥量未释放，才判 app_mutex_running', () {
+      final WindowsInstallerFailureSummary summary =
+          summarizeWindowsInstallerFailure(
+        record: recordWith(launcherMutexReleased: false),
+        innoLogContents: '$killedAtStartupLog\n'
+            r'2026-09-06 09:35:05.000   Starting the installation process.',
+      );
+
+      expect(summary.type, 'app_mutex_running');
+    });
+
+    test('停在启动段 + 互斥量未释放：两条事实都要出现在消息里', () {
+      final WindowsInstallerFailureSummary summary =
+          summarizeWindowsInstallerFailure(
+        record: recordWith(launcherMutexReleased: false),
+        innoLogContents: killedAtStartupLog,
+      );
+
+      expect(summary.type, 'installer_stopped_at_startup');
+      expect(summary.message, contains('FushiSingleInstanceMutex'));
+    });
+
+    test('走出启动段的日志不算「停在启动段」，空日志不下结论', () {
+      expect(windowsInnoLogStoppedDuringStartup(killedAtStartupLog), isTrue);
+      expect(
+        windowsInnoLogStoppedDuringStartup(
+          '$killedAtStartupLog\n'
+          r'2026-09-06 09:35:05.000   -- File entry --',
+        ),
+        isFalse,
+      );
+      expect(windowsInnoLogStoppedDuringStartup(''), isFalse);
+    });
+
+    test('launcher 写进 marker 的未知键，经 Dart 读写一轮后仍在', () {
+      // C++ launcher（`update_launcher.cpp` 的 `AppendMarkerFields`）写下的观测。
+      // 旧实现在 fromJson → toJson 这一轮把它们全部静默丢掉，事后连「是
+      // OpenProcess 失败还是真的等超时」都分不出来。
+      final Map<String, dynamic> onDisk = <String, dynamic>{
+        'targetVersion': '2.2.4-debug.13582',
+        'installerPath': r'C:\tmp\setup.exe',
+        'innoLogPath': r'C:\tmp\setup.install.log',
+        'startedAt': '2026-09-06T01:32:53.434671Z',
+        'parentExitObserved': false,
+        'parentExitTimedOut': true,
+        'parentExitTimedOutAt': '2026-09-06T01:34:53.517Z',
+        'launcherMutexReleased': false,
+        'launcherMutexCheckedAt': '2026-09-06T01:35:03.752Z',
+        'appAliveAfterInstaller': false,
+        'appRelaunchedByLauncher': true,
+        'appRelaunchPath': r'D:\APP\Hibiki\fushi.exe',
+      };
+
+      final Map<String, dynamic> roundTripped =
+          WindowsUpdateHandoffRecord.fromJson(onDisk).toJson();
+
+      for (final String key in onDisk.keys) {
+        expect(roundTripped.containsKey(key), isTrue,
+            reason: 'marker 键 $key 在 Dart 读写一轮后丢失了');
+      }
+      expect(roundTripped['parentExitTimedOut'], isTrue);
+      expect(roundTripped['launcherMutexReleased'], isFalse);
+      expect(roundTripped['appRelaunchedByLauncher'], isTrue);
+    });
+
+    test('模型写出的每个键都被自己认识（extraFields 与已知键不重叠）', () {
+      // 新增 model 字段却忘了登记进 `_knownJsonKeys`，会让该键在下一轮读回时落进
+      // extraFields，随后被 toJson 重复写出。这条用例是那个疏漏的闸门。
+      final WindowsUpdateHandoffRecord full = WindowsUpdateHandoffRecord(
+        targetVersion: '1.2.3',
+        installerPath: r'C:\tmp\setup.exe',
+        innoLogPath: r'C:\tmp\setup.log',
+        startedAt: DateTime.utc(2026, 9, 6),
+        currentExecutablePath: r'D:\APP\Hibiki\fushi.exe',
+        currentInstallDir: r'D:\APP\Hibiki',
+        targetInstallDir: r'D:\APP\Hibiki',
+        detectedInstallLocations: const <WindowsDetectedInstallLocation>[
+          WindowsDetectedInstallLocation(
+            source: 'current',
+            path: r'D:\APP\Hibiki',
+          ),
+        ],
+        runningFushiProcesses: const <WindowsProcessInfo>[
+          WindowsProcessInfo(pid: 1, name: 'fushi.exe'),
+        ],
+        libmpvModuleHolders: const <WindowsProcessInfo>[
+          WindowsProcessInfo(pid: 2, name: 'mpv.exe'),
+        ],
+        galHookModuleHolders: const <WindowsProcessInfo>[
+          WindowsProcessInfo(pid: 3, name: 'game.exe'),
+        ],
+        innoLogDeleteFileFailures: const <WindowsInnoDeleteFileFailure>[
+          WindowsInnoDeleteFileFailure(path: r'D:\a.dll', code: 5),
+        ],
+        pathMismatchWarning: 'warn',
+        launcherStartedAt: DateTime.utc(2026, 9, 6, 0, 1),
+        launcherPid: 7028,
+        parentProcessId: 97348,
+        parentExitObserved: false,
+        parentExitObservedAt: DateTime.utc(2026, 9, 6, 0, 2),
+        launcherMutexReleased: false,
+        installerLaunchSucceeded: true,
+        installerLaunchedAt: DateTime.utc(2026, 9, 6, 0, 3),
+        installerPid: 12024,
+        innoLogExists: true,
+        innoLogSizeBytes: 2185,
+        innoLogModifiedAt: DateTime.utc(2026, 9, 6, 0, 4),
+        installerFailureType: 'installer_stopped_at_startup',
+        installerFailureSummary: 'summary',
+        installerLaunchFailedAt: DateTime.utc(2026, 9, 6, 0, 5),
+        launchError: 'err',
+        failureFingerprint: 'fp',
+        lastPromptedAppVersion: '1.2.2',
+        lastPromptedFailureFingerprint: 'fp2',
+        lastPromptedAt: DateTime.utc(2026, 9, 6, 0, 6),
+      );
+
+      final WindowsUpdateHandoffRecord reread =
+          WindowsUpdateHandoffRecord.fromJson(full.toJson());
+      expect(
+        reread.extraFields,
+        isEmpty,
+        reason: '这些键是模型自己写出去的，读回来必须被自己认识：'
+            '${reread.extraFields.keys.join(", ")}',
+      );
+    });
+  });
 }

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -233,27 +233,54 @@ begin
             NamedMutexExists(LegacyAppMutexName);
 end;
 
+{ BUG-2166：这两个过程**绝不能带 /T**。
+
+  应用内静默更新时，本安装器就是被更新的那个 fushi.exe 的**孙进程**：
+      fushi.exe → fushi_update_launcher.exe → <本 setup.exe>
+  （launcher 由 app 用 CreateProcess 拉起、setup 由 launcher 拉起；Windows 无条件
+  把创建者记为父进程，detached 也不例外）。而 taskkill 的 /T 是**递归**杀整条后代树
+  ——不是只杀直接子进程。实测（同机，三层 cmd 副本）：
+      taskkill /F /IM fk_parent.exe /T
+      → 成功: 已终止 PID 88128 (属于 PID 47184 子进程)   ← 孙进程也被带走
+  于是 InitializeSetup 里这一句会把 launcher 和**安装器自己**一起杀掉：安装器在
+  自我防卫时自杀。现场（2026-09-06，用户机）：09:35:03.752 启动安装器，
+  09:35:04.039 Inno 日志戛然而止在启动段的 DLL import 之后，**没有**任何 abort /
+  exception / Deinitializing 行 —— 这正是被外部强杀而非自行中止的形状；磁盘保持旧版。
+  更糟的是 launcher 一并没了，BUG-1708 那条「安装失败时把 app 拉回来」的兜底随之
+  失效，Fushi 从用户桌面上静默消失（用户只能自己去开始菜单重开）。
+
+  /T 原本是为了带走 WebView2 子进程，但它们的 image 名就是 msedgewebview2.exe，
+  InitializeSetup 下面已经按 image 名单独扫了一遍 —— /T 不提供任何额外覆盖，
+  只提供自杀能力。按 image 名杀就够了：fushi.exe / hibiki.exe 的每个实例都会被
+  /IM 命中（包括那个持有互斥量的父进程），而 setup.exe 与 launcher 不叫这个名字
+  （/IM 是整名匹配，fushi.exe 不会命中 fushi_update_launcher.exe），于是安装器
+  活到装完、launcher 活到能兜底。
+
+  本阶段只负责一件事：**让互斥量被释放**，而互斥量只有 fushi.exe 持有。其余
+  helper 子进程（ffmpeg.exe / fushi_voice_injector.exe 之类）不归这里管 —— 它们
+  是「文件锁」问题，由 PrepareToInstall 的 KillProcessesUnderDir 按**镜像路径**
+  在复制前统一清掉（BUG-1459）。所以去掉 /T 没有留下覆盖缺口，只是把两件事各自
+  还给了负责它的那一层。 }
+
 { Gentle close: taskkill WITHOUT /F sends WM_CLOSE so the app can save state
-  and release its mutex on its own. /T also targets child processes (the
-  WebView2 msedgewebview2.exe runs as a child). }
+  and release its mutex on its own. }
 procedure KillGracefully(const ExeName: String);
 var
   ResultCode: Integer;
 begin
   Exec(ExpandConstant('{sys}\taskkill.exe'),
-       '/IM ' + ExeName + ' /T',
+       '/IM ' + ExeName,
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;
 
-{ Force kill: /F forces, /IM by image name, /T takes the whole child-process
-  tree (WebView2 included). ResultCode=128 means no matching process; that is
-  not an error -- the mutex poll is the source of truth. }
+{ Force kill: /F forces, /IM by image name. ResultCode=128 means no matching
+  process; that is not an error -- the mutex poll is the source of truth. }
 procedure KillImage(const ExeName: String);
 var
   ResultCode: Integer;
 begin
   Exec(ExpandConstant('{sys}\taskkill.exe'),
-       '/F /IM ' + ExeName + ' /T',
+       '/F /IM ' + ExeName,
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;
 
@@ -688,8 +715,9 @@ begin
     Sleep(MutexReleasePollIntervalMs);
   end;
 
-  { Still alive: force-kill both exe trees (WebView2 with them), then sweep
-    any orphaned msedgewebview2.exe. }
+  { Still alive: force-kill both exe names, then sweep every msedgewebview2.exe.
+    按 image 名逐个杀，**不用进程树**（BUG-2166：安装器自己就在 fushi.exe 的后代树里）；
+    WebView2 的每一个子进程都叫 msedgewebview2.exe，第三行已经全数覆盖。 }
   KillImage('fushi.exe');
   KillImage('hibiki.exe');
   KillImage('msedgewebview2.exe');

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -13,6 +13,10 @@
 
 Gamepads gamepads;
 
+// ~Gamepads() 在进程退出路径上等 reaper 收尾的上界（BUG-2167）。reaper 被
+// notify 后立刻返回，正常是毫秒级；这个值只是「绝不卡住退出」的兜底。
+static constexpr DWORD kExitReaperJoinTimeoutMs = 1000;
+
 static IGameInput* g_gameInput = nullptr;
 static IGameInputDevice* g_gamepad = nullptr;
 
@@ -280,6 +284,43 @@ void Gamepads::stop() {
 std::list<GamepadData*> Gamepads::get_gamepads() {
   std::lock_guard<std::mutex> lock(gamepads_mutex);
   return this->gamepads;
+}
+
+// BUG-2167：只在进程退出时执行，见 gamepad.h 的声明注释。目标只有一个 ——
+// 让 reaper_thread 在被 std::thread 的析构函数看到之前不再 joinable。
+//
+// 这里**刻意不调用 stop()**。stop() 是给插件析构（正常 teardown）准备的：它要
+// `UnregisterCallback(..., 5000)` 并 join 每一个轮询线程，而轮询线程可能正停在
+// GameInput 自己的锁里（见 read_gamepad 里 BUG-1541 的注释）。在退出路径上阻塞
+// 等它返回，等于把「崩溃」换成「卡死」—— 对上面那条更新交接链没有任何改善，
+// 因为它等的同样是这个进程消失。
+//
+// 也**刻意不动轮询线程**：它们的 GamepadData 是裸指针，本就不随本对象析构；给
+// 它们置停止位反而会让它们在 CRT 已开始拆解的时刻去跑 neutralize_inputs /
+// std::cout。马上就要 ExitProcess，由 OS 统一回收才是最短也最安全的路径。
+//
+// reaper 不同：它只等在 reaper_cv 上，被唤醒后立刻从 reap_loop 返回（毫秒级），
+// 收尾过程不碰 GameInput。所以这里给它一个**有界**的等待：等到了就 join（干净
+// 收尾），等不到就 detach —— 析构函数因此既不会 terminate，也不会卡死。
+Gamepads::~Gamepads() {
+  if (!reaper_thread.joinable()) {
+    return;
+  }
+  {
+    std::lock_guard<std::mutex> lock(reaper_mutex);
+    reaper_stop = true;
+  }
+  reaper_cv.notify_all();
+
+  // std::thread 没有带超时的 join；用底层句柄等，等到了再 join（此时立即返回）。
+  const HANDLE handle = static_cast<HANDLE>(reaper_thread.native_handle());
+  if (handle != nullptr &&
+      ::WaitForSingleObject(handle, kExitReaperJoinTimeoutMs) ==
+          WAIT_OBJECT_0) {
+    reaper_thread.join();
+  } else {
+    reaper_thread.detach();
+  }
 }
 
 void Gamepads::on_gamepad_connected(IGameInputDevice* device) {

--- a/packages/gamepads_windows/windows/gamepad.h
+++ b/packages/gamepads_windows/windows/gamepad.h
@@ -109,6 +109,23 @@ class Gamepads {
   void init();
   void stop();
   std::list<GamepadData*> get_gamepads();
+
+  // BUG-2167: 唯一职责是「进程退出时不留下 joinable 的 std::thread」。
+  //
+  // 全局 `gamepads` 是静态存储期对象，进程退出时由 CRT 的 onexit 表析构。而
+  // `std::thread` 的析构函数对**仍 joinable** 的线程直接 `std::terminate()` →
+  // `abort()`，在 Windows 上表现为 `0xc0000409 FAST_FAIL_FATAL_APP_EXIT`。
+  // 这条路径**每次退出都会走到**：Fushi 的两条退出路径（更新交接
+  // `platform_updater.dart`、关窗 `desktop_lifecycle_service.dart`）最终都调
+  // `exit(0)`，而 `exit(0)` **故意**跳过 Flutter 插件析构，于是
+  // `~GamepadsWindowsPlugin()` 里的 `stop()` 永远不会执行，`reaper_thread`
+  // 带着 joinable 状态活到 onexit 表 —— 只要机器上有 GameInput.dll（即 init()
+  // 起过 reaper）就必然如此。
+  //
+  // 下游代价远不止一条崩溃记录：崩溃进程被 WER 冻住数分钟不死，
+  // `FushiSingleInstanceMutex` 随之一直被持有，应用内更新的整条交接链
+  // （launcher 等父进程退出 → 等互斥量释放 → 启动 Inno）全部超时。
+  ~Gamepads();
 };
 
 extern Gamepads gamepads;


### PR DESCRIPTION
用户报「应用内更新后仍是旧版，Fushi 提示 *Inno Setup reported that Fushi was still running*」。
沿真实路径查下来是**三层独立缺陷串成的一条链**，而那句提示本身还是误诊。

## 现场证据（用户机，2026-09-06）

marker `%APPDATA%\Fushi\Fushi\updates\update-handoff.json`：

| 时刻 (UTC) | 事实 |
|---|---|
| 01:32:53.434 | app 写下交接标记，启动 launcher（pid 7028，父 = fushi.exe 97348） |
| 01:34:53.517 | `parentExitObserved:false` —— 恰好 startedAt + 120.001s，即 `WaitForSingleObject` 跑满超时 |
| 01:35:03.752 | 又 10.2s（= `kMutexReleaseTimeoutMs`）后仍启动安装器（pid 12024） |
| 01:35:04.039 | Inno 日志戛然而止，**没有**任何 abort / exception / Deinitializing 行 |

同一秒的 Windows 事件日志：`fushi.exe` 崩在 `ucrtbase.dll`，异常码 `0xc0000409`。
app 最终由 **explorer.exe** 在 09:35:59 拉起 —— 即用户自己去开始菜单点的。

## 三层根因

### ① BUG-2167 · 每次退出都 fail-fast 崩溃（触发源）

`packages/gamepads_windows` 的 `Gamepads gamepads;` 是静态存储期全局对象，成员含
`std::thread reaper_thread`。停止它的 `stop()` 只在 `~GamepadsWindowsPlugin()` 里调用，
而 Fushi 两条退出路径最终都是 `exit(0)` —— 它**故意**跳过 Flutter 插件析构。于是线程带着
joinable 状态活到 CRT 的 onexit 表，`std::thread` 的析构函数直接 `std::terminate()` →
`abort()`。转储栈坐实：

```text
FAILURE_BUCKET_ID: FAIL_FAST_FATAL_APP_EXIT_c0000409_ucrtbase.dll!abort
ucrtbase!abort+0x4e
gamepads_windows_plugin+0xa2ca
ucrtbase!execute_onexit_table+0x3d
gamepads_windows_plugin+0x1006d
```

崩溃进程被 WER 冻住数分钟不死 ⇒ `FushiSingleInstanceMutex` 一直被持有 ⇒ launcher 的
两道等待双双超时。

**修法**：给 `Gamepads` 加析构函数，置停止位 + `notify_all`，再用
`WaitForSingleObject(native_handle(), 1000)` 做**有界**等待 —— 等到了 `join()`，等不到
`detach()`。既不 `terminate` 也不卡死。刻意**不**调 `stop()`（要 `UnregisterCallback(5s)`
并 join 可能停在 GameInput 锁里的轮询线程 = 把崩溃换成卡死），也刻意不动轮询线程
（`GamepadData` 是裸指针、本就不随本对象析构；置停止位反而会让它们在 CRT 已开始拆解时
去跑 `neutralize_inputs`/`std::cout`）。

### ② BUG-2166 · 安装器杀掉了自己所在的进程树（直接死因）

应用内更新的进程链是 `fushi.exe → fushi_update_launcher.exe → setup.exe`，而
`InitializeSetup` 用 `taskkill /IM fushi.exe /T` 自卫。`/T` 是**递归**杀整条后代树，
本机实测（三层 cmd 副本夹具）：

| 命令 | 结果 |
|---|---|
| `taskkill /F /IM fk_parent.exe /T` | 父、子、**孙**全部终止 = 安装器自杀 |
| `taskkill /F /IM fk_parent.exe` | 只终止父进程，子与孙存活 = launcher 与安装器活下来 |

于是安装器在自我防卫时把 launcher 和自己一并杀掉。更糟的是 launcher 一死，BUG-1708 的
「安装失败时把 app 拉回来」兜底也没了。

**修法**：两处 `taskkill` 去掉 `/T`，纯按 image 名杀。覆盖面没有缺口：互斥量只有
`fushi.exe` 持有；WebView2 的每个子进程都叫 `msedgewebview2.exe`，已被单独一行覆盖；
其余 helper（ffmpeg / injector）是**文件锁**问题，归 `PrepareToInstall` 的
`KillProcessesUnderDir` 按镜像路径管（BUG-1459）。去掉 `/T` 只是把两件事各自还给了负责
它的那一层。

### ③ BUG-2166 · 诊断把每一份日志都误报成 app_mutex_running

判据是 `lower.contains('mutex')`，而 Inno 会把 `[Code]` 段的外部函数导入逐个写进日志：

```text
Function and DLL name: OpenMutexW@kernel32.dll
```

这一行**每一份**日志里都有，无论成败。于是这条判据对任何一次失败恒真，把真正的原因
（安装器被杀、复制失败、用户取消）全部盖成同一条「Fushi 仍在运行」。

**修法**：
- 删掉裸 `mutex` / `is running` 子串判据；
- 新增**结构**判据 `windowsInnoLogStoppedDuringStartup`：日志除启动段固定行（Inno 恒为
  英文、与 UI 语言无关）之外一行都没有 ⇒ 安装器没走出启动段。方向刻意保守，名单不全时
  只会**少报**（落回 `installer_incomplete`）；
- 「Fushi 还开着」改为只认**观测** —— launcher 早就写进 marker 的
  `launcherMutexReleased`（本 PR 提升为一等字段）。

顺带修好 marker 往返丢字段：marker 有 Dart 和 C++ launcher **两个写者**，
`fromJson → copyWith → toJson` 会把模型不认识的键静默丢掉，`launcherMutexReleased` /
`parentExitTimedOut` / `appAliveAfterInstaller` 因此全部丢失 —— 现场连「是 OpenProcess
失败还是真的等超时」都分不出来。未识别的键现在进 `extraFields` 原样写回。

## 验证

- **A/B 真机**（同一 debug 构建、同一流程，只改析构函数一处）：

  | 版本 | 进程退出码 |
  |---|---|
  | 去掉 `~Gamepads()` | `-1073740791` = `0xC0000409` FAST_FAIL_FATAL_APP_EXIT |
  | 带 `~Gamepads()` | `0` |

- **`taskkill` 语义两个方向实测**（见上表）。
- **`.iss` 真编译**：`ISCC` → `Successful compile`，退出码 0。（`.iss` 只在 release
  workflow 里编译，PR CI 抓不到它的语法错，所以本地补了这一步。）
- `flutter analyze` 干净；定向 99 条绿；`test/platform` + `test/startup` +
  `test/utils/misc` 1051 条绿。
- **变异实测**：加回 `/T`、加回 `contains('mutex')`、删掉 `~Gamepads()` —— 三条全部被新
  守卫抓红，不是恒真断言。
- **全量套件**：`FLUTTER TEST VERDICT: PASSED - 23074 tests ran, all tests passed`。

  前两次全量是**环境红**，分型依据三条：失败的是**不同文件**（`galgame_path_match` →
  `position_pref_keys_guard`，真回归会稳定钉在同一条）；错误都在传输层而非断言
  （`Connection closed before test suite loaded` / `Unable to connect to flutter_tester
  process: WebSocketException: Invalid WebSocket upgrade request`，全程无 `Expected:`）；
  两个文件单跑合计 17 条全绿，且与本 PR 改动无交集。把 `HTTP(S)_PROXY` 整个摘掉后一次
  就绿 —— 只设 `NO_PROXY` 含 `::1` 并不足以挡住对 flutter_tester 本地连接的劫持。

## 已知缺口

**没有跑一次真实的端到端应用内更新**：本地编译出的安装器会执行
`taskkill /F /IM fushi.exe`，那会关掉开发机上正开着的生产 Fushi。这一层留给下一次真实
更新验证；上面的 A/B、进程树语义与 `.iss` 编译已把三个关键点各自钉死。
