### PR TITLE
feat(video): 视频首页加「已更新未看」行——订阅番剧有集没看即列出，点开播 Next-Up 那集

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 73032 (4296 per locale)
+/// Strings: 73066 (4298 per locale)
 ///
-/// Built on 2026-09-06 at 04:15 UTC
+/// Built on 2026-09-06 at 13:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5923,6 +5923,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get onboarding_pack_paused_desc =>
       'Progress is kept on disk — resuming picks up where it stopped.';
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  String get video_home_subscription_updates => 'Updated, not watched';
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -15968,6 +15972,12 @@ class _StringsAr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -26240,6 +26250,12 @@ class _StringsDe extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -36565,6 +36581,12 @@ class _StringsEs extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -46924,6 +46946,12 @@ class _StringsFr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -57087,6 +57115,12 @@ class _StringsId extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -67342,6 +67376,12 @@ class _StringsIt extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -76984,6 +77024,12 @@ class _StringsJa extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => '更新済み・未視聴';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      '第${n}話 · 未視聴 ${count} 話';
 }
 
 // Path: <root>
@@ -86636,6 +86682,12 @@ class _StringsKo extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -96846,6 +96898,12 @@ class _StringsNl extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -107110,6 +107168,12 @@ class _StringsPtBr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -117352,6 +117416,12 @@ class _StringsRu extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -127393,6 +127463,12 @@ class _StringsTh extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -137551,6 +137627,12 @@ class _StringsTr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -147680,6 +147762,12 @@ class _StringsVi extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => 'Updated, not watched';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      'Episode ${n} · ${count} unwatched';
 }
 
 // Path: <root>
@@ -156990,6 +157078,12 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_pack_paused_desc => '进度留在磁盘上，继续下载会从中断处接着下。';
   @override
   String get onboarding_pack_mini_bar_hide => '收起';
+  @override
+  String get video_home_subscription_updates => '已更新未看';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      '第 ${n} 集 · ${count} 集未看';
 }
 
 // Path: <root>
@@ -166325,6 +166419,12 @@ class _StringsZhHk extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String get video_home_subscription_updates => '已更新未看';
+  @override
+  String video_home_subscription_unwatched_episode(
+          {required Object n, required Object count}) =>
+      '第 ${n} 集 · ${count} 集未看';
 }
 
 /// Flat map(s) containing all translations.
@@ -175152,6 +175252,11 @@ extension on _StringsEn {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -183974,6 +184079,11 @@ extension on _StringsAr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -192841,6 +192951,11 @@ extension on _StringsDe {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -201699,6 +201814,11 @@ extension on _StringsEs {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -210566,6 +210686,11 @@ extension on _StringsFr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -219404,6 +219529,11 @@ extension on _StringsId {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -228264,6 +228394,11 @@ extension on _StringsIt {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -237051,6 +237186,11 @@ extension on _StringsJa {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return '更新済み・未視聴';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            '第${n}話 · 未視聴 ${count} 話';
       default:
         return null;
     }
@@ -245842,6 +245982,11 @@ extension on _StringsKo {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -254695,6 +254840,11 @@ extension on _StringsNl {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -263543,6 +263693,11 @@ extension on _StringsPtBr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -272398,6 +272553,11 @@ extension on _StringsRu {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -281225,6 +281385,11 @@ extension on _StringsTh {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -290067,6 +290232,11 @@ extension on _StringsTr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -298903,6 +299073,11 @@ extension on _StringsVi {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return 'Updated, not watched';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            'Episode ${n} · ${count} unwatched';
       default:
         return null;
     }
@@ -307663,6 +307838,11 @@ extension on _StringsZhCn {
         return '进度留在磁盘上，继续下载会从中断处接着下。';
       case 'onboarding_pack_mini_bar_hide':
         return '收起';
+      case 'video_home_subscription_updates':
+        return '已更新未看';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            '第 ${n} 集 · ${count} 集未看';
       default:
         return null;
     }
@@ -316428,6 +316608,11 @@ extension on _StringsZhHk {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'video_home_subscription_updates':
+        return '已更新未看';
+      case 'video_home_subscription_unwatched_episode':
+        return ({required Object n, required Object count}) =>
+            '第 ${n} 集 · ${count} 集未看';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "更新済み・未視聴",
+  "video_home_subscription_unwatched_episode": "第$n話 · 未視聴 $count 話"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "Updated, not watched",
+  "video_home_subscription_unwatched_episode": "Episode $n · $count unwatched"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "推荐包下载已暂停",
   "onboarding_pack_download_resume": "继续下载",
   "onboarding_pack_paused_desc": "进度留在磁盘上，继续下载会从中断处接着下。",
-  "onboarding_pack_mini_bar_hide": "收起"
+  "onboarding_pack_mini_bar_hide": "收起",
+  "video_home_subscription_updates": "已更新未看",
+  "video_home_subscription_unwatched_episode": "第 $n 集 · $count 集未看"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4294,5 +4294,7 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "video_home_subscription_updates": "已更新未看",
+  "video_home_subscription_unwatched_episode": "第 $n 集 · $count 集未看"
 }

--- a/fushi/lib/src/media/video/video_subscription_updates.dart
+++ b/fushi/lib/src/media/video/video_subscription_updates.dart
@@ -1,0 +1,146 @@
+import 'package:fushi_core/fushi_core.dart'
+    show
+        MediaCollectionRow,
+        VideoDownloadJobRow,
+        VideoDownloadSubscriptionItemRow,
+        VideoDownloadSubscriptionRow;
+
+import 'package:fushi/src/media/video/video_home_layout.dart';
+
+/// 视频首页「已更新未看」行的纯函数：订阅 → 合集解析 + 合集内未看目标集选取。
+///
+/// 用户视角（2026-09-06）：「订阅的动漫更新了就看，跟收菜一样」——首页要有一行
+/// 列出**订阅过、且有集数还没看**的作品，点开直接播第一集没看的。两套订阅链路
+/// 各自落合集的方式不同，这里统一解析成合集 id 集合，页面按合集折叠成员即可，
+/// 与「下一集」「最近添加」两行同一成员序列口径。
+///
+/// 全部无副作用，单测在 `test/media/video/video_subscription_updates_test.dart`。
+
+/// 新链路（Drift `video_download_subscriptions`）+ 旧链路（AniList JSON 订阅）的
+/// 订阅作品 → 已入库合集 id。
+///
+/// 解析顺序（同一订阅多条路径命中取并集，不互斥）：
+/// * `subscriptions[i].collectionId` 直绑（列存在但 pipeline 目前不回写，留作前向
+///   兼容）；
+/// * 订阅条目 → 任务 → `VideoDownloadJobs.collectionId`（pipeline 入库后回写，是
+///   新链路的主路径）；
+/// * 订阅的元数据身份 `(metadataProvider, externalId)` → 同身份的任务 → 合集
+///   （与订阅服务 `_managedEpisodeKeys` 同口径：条目 `jobId` 因任务删除被
+///   setNull 后仍能靠身份找回）；
+/// * 订阅的元数据身份 → 刮削作品 → 合集（[collectionIdByProviderIdentity] 由
+///   调用方按订阅逐条查好，键 `'$provider|$externalId'`）；
+/// * 旧链路：订阅 `anilistId` → `MediaCollections.anilistId` 直绑。
+///
+/// **不看 `enabled`**：暂停/已完成（oneShot fulfilled）的订阅仍是「订阅过的作品」，
+/// 已下载未看的集数照样该出现在这一行。
+Set<int> subscribedVideoCollectionIds({
+  required List<VideoDownloadSubscriptionRow> subscriptions,
+  required Map<String, List<VideoDownloadSubscriptionItemRow>>
+      itemsBySubscription,
+  required List<VideoDownloadJobRow> jobs,
+  required Map<String, int> collectionIdByProviderIdentity,
+  required Iterable<int> legacyAnilistIds,
+  required Iterable<MediaCollectionRow> collections,
+}) {
+  final Set<int> out = <int>{};
+  final Map<String, int> collectionByJob = <String, int>{
+    for (final VideoDownloadJobRow job in jobs)
+      if (job.collectionId case final int cid) job.jobId: cid,
+  };
+  final Map<String, Set<int>> collectionsByJobIdentity = <String, Set<int>>{};
+  for (final VideoDownloadJobRow job in jobs) {
+    final String? provider = job.metadataProvider;
+    final String? externalId = job.externalId;
+    final int? cid = job.collectionId;
+    if (provider == null || externalId == null || cid == null) continue;
+    collectionsByJobIdentity
+        .putIfAbsent(providerIdentityKey(provider, externalId), () => <int>{})
+        .add(cid);
+  }
+  for (final VideoDownloadSubscriptionRow sub in subscriptions) {
+    if (sub.collectionId case final int cid) out.add(cid);
+    for (final VideoDownloadSubscriptionItemRow item
+        in itemsBySubscription[sub.subscriptionId] ??
+            const <VideoDownloadSubscriptionItemRow>[]) {
+      final String? jobId = item.jobId;
+      if (jobId == null) continue;
+      if (collectionByJob[jobId] case final int cid) out.add(cid);
+    }
+    final String? provider = sub.metadataProvider;
+    final String? externalId = sub.externalId;
+    if (provider != null && externalId != null) {
+      final String key = providerIdentityKey(provider, externalId);
+      out.addAll(collectionsByJobIdentity[key] ?? const <int>{});
+      if (collectionIdByProviderIdentity[key] case final int cid) out.add(cid);
+    }
+  }
+  final Set<int> anilist = legacyAnilistIds.toSet();
+  if (anilist.isNotEmpty) {
+    for (final MediaCollectionRow c in collections) {
+      if (c.anilistId case final int id when anilist.contains(id)) {
+        out.add(c.id);
+      }
+    }
+  }
+  return out;
+}
+
+/// [subscribedVideoCollectionIds] 的 `collectionIdByProviderIdentity` 键。
+String providerIdentityKey(String provider, String externalId) =>
+    '$provider|$externalId';
+
+/// 一个订阅合集在「已更新未看」行里的展示事实。
+class VideoSubscriptionUpdate {
+  const VideoSubscriptionUpdate({
+    required this.targetIndex,
+    required this.unwatchedCount,
+    required this.latestUnwatchedImportedAtMs,
+  });
+
+  /// 点卡片要播的那集（合集稳定集序下标，0 起）。
+  final int targetIndex;
+
+  /// 还没看的集数（`!completed && positionMs <= 0`，与库页「未看」筛选同判据）。
+  final int unwatchedCount;
+
+  /// 未看成员里最新的入库时刻（行内排序键；成员都没有入库时刻 = 0）。
+  final int latestUnwatchedImportedAtMs;
+}
+
+/// 选出合集的「已更新未看」事实；一集未看的都没有 → null（不占行）。
+///
+/// 目标集：最近实际播放的那集**之后**的第一集未看（Next-Up 口径，与
+/// [nextEpisodeAfterLatestPlayed] 同源——用户跳着看时不把已跳过的旧集塞回来）；
+/// 之后没有未看（或从没播过）→ 整个合集里第一集未看。
+///
+/// [members] 与 [importedAtMs] 按合集稳定集序对齐、等长；入库时刻 null（远端旧
+/// host 不带）按 0 计。
+VideoSubscriptionUpdate? selectVideoSubscriptionUpdate(
+  List<VideoSeriesPlaybackState> members,
+  List<int?> importedAtMs,
+) {
+  assert(members.length == importedAtMs.length);
+  int unwatched = 0;
+  int latestImported = 0;
+  int? firstUnwatched;
+  final int? latestPlayed = latestPlayedSeriesIndex(members);
+  int? firstUnwatchedAfterPlayed;
+  for (int index = 0; index < members.length; index++) {
+    final VideoSeriesPlaybackState state = members[index];
+    final bool isUnwatched = !state.completed && state.positionMs <= 0;
+    if (!isUnwatched) continue;
+    unwatched++;
+    firstUnwatched ??= index;
+    if (latestPlayed != null && index > latestPlayed) {
+      firstUnwatchedAfterPlayed ??= index;
+    }
+    final int imported = importedAtMs[index] ?? 0;
+    if (imported > latestImported) latestImported = imported;
+  }
+  if (firstUnwatched == null) return null;
+  return VideoSubscriptionUpdate(
+    targetIndex: firstUnwatchedAfterPlayed ?? firstUnwatched,
+    unwatchedCount: unwatched,
+    latestUnwatchedImportedAtMs: latestImported,
+  );
+}

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -22,7 +22,10 @@ import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:fushi/src/media/video/cover_ui/video_scrape_actions.dart';
 import 'package:fushi/src/media/video/cover_ui/video_specs_badges.dart';
 import 'package:fushi/src/media/video/video_specs_service.dart';
+import 'package:fushi/src/media/torrent/anime_download_subscription.dart'
+    show AnimeDownloadSubscription, AnimeDownloadSubscriptionStore;
 import 'package:fushi/src/media/video/video_home_layout.dart';
+import 'package:fushi/src/media/video/video_subscription_updates.dart';
 import 'package:fushi/src/media/video/scraper/auto_scrape_service.dart';
 import 'package:fushi/src/media/video/scraper/cover_meta_store.dart';
 import 'package:fushi/src/media/video/scraper/cover_scraper_service.dart';
@@ -336,6 +339,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Map<String, int> _runtimeMinutesByBookUid = const <String, int>{};
   Set<String> _localExtraBookUids = const <String>{};
 
+  /// 「已更新未看」行：订阅（新 Drift 订阅 + 旧 AniList JSON 订阅）解析到的
+  /// 合集 id（[subscribedVideoCollectionIds]），与 [_loadLibraryMaps] 同批预取。
+  Set<int> _subscribedCollectionIds = const <int>{};
+
   /// [_loadLibraryMaps] 的 latest-request-wins 代次。全量清理会触发一轮新的空快照；
   /// 清理前已在途的慢查询不得晚到后把旧 AniDB 映射重新写回页面状态。
   int _libraryMapsRequestGeneration = 0;
@@ -386,6 +393,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   final ScrollController _continueRowController = ScrollController();
   final ScrollController _nextRowController = ScrollController();
   final ScrollController _recentRowController = ScrollController();
+  final ScrollController _subscriptionRowController = ScrollController();
+
+  /// 「已更新未看」行的订阅表变更流；旧 JSON 订阅 store 走 [revision] 通知。
+  StreamSubscription<void>? _downloadSubscriptionsSub;
+  AnimeDownloadSubscriptionStore? _legacySubscriptionStore;
 
   @override
   void initState() {
@@ -410,6 +422,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     _scrapePresentationSub = appModelNoUpdate.database
         .watchVideoScrapePresentationChanged()
         .listen(_onScrapePresentationChanged);
+    // 「已更新未看」行：订阅增删（订阅面板）后重解析订阅→合集映射。新订阅表走
+    // Drift 流；旧 AniList JSON 订阅 store 没有表，用它的 revision 通知。入库落
+    // 合集那一步已由上面的合集表流覆盖，这里只补「订阅本身变了」。
+    _downloadSubscriptionsSub = appModelNoUpdate.database
+        .watchVideoDownloadSubscriptions()
+        .listen(_onCollectionTablesChanged);
+    _legacySubscriptionStore = appModelNoUpdate.animeDownloadSubscriptionStore
+      ?..revision.addListener(_onLegacySubscriptionStoreChanged);
     widget.libraryRefreshSignal?.addListener(_onLibraryRefreshRequested);
     // BUG-1182：「显示远端条目」开关落在 prefsRepo（独立 ChangeNotifier），不经
     // AppModel 通知，本页不会因它重建 → 门控翻转后既不重取也不重渲染。显式订阅。
@@ -452,8 +472,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     _continueRowController.dispose();
     _nextRowController.dispose();
     _recentRowController.dispose();
+    _subscriptionRowController.dispose();
     _videoUidsSub?.cancel();
     _collectionTablesSub?.cancel();
+    _downloadSubscriptionsSub?.cancel();
+    _legacySubscriptionStore?.revision
+        .removeListener(_onLegacySubscriptionStoreChanged);
     _collectionsReloadDebounce?.cancel();
     _scrapePresentationSub?.cancel();
     _scrapePresentationReloadDebounce?.cancel();
@@ -497,6 +521,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       if (mounted) _loadLibraryMaps();
     });
   }
+
+  void _onLegacySubscriptionStoreChanged() => _onCollectionTablesChanged(null);
 
   void _onScrapePresentationChanged(void _) {
     _scrapePresentationReloadDebounce?.cancel();
@@ -693,6 +719,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           in await db.getAllVideoMetadataExtras())
         if (extra.bookUid != null) extra.bookUid!,
     };
+    final Set<int> subscribedCollectionIds =
+        await _loadSubscribedCollectionIds(db, appModel, collections);
     // v68 附加图组：一次全表查询按归属分桶（hero 背景/logo、续播行横卡）。
     final Map<int, List<MediaImageRow>> imagesByCollection =
         <int, List<MediaImageRow>>{};
@@ -725,9 +753,59 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       _metadataImagesByWork = metadataImagesByWork;
       _runtimeMinutesByBookUid = runtimeMinutesByBookUid;
       _localExtraBookUids = localExtraBookUids;
+      _subscribedCollectionIds = subscribedCollectionIds;
       _mediaImagesByCollection = imagesByCollection;
       _mediaImagesByBookUid = imagesByBookUid;
     });
+  }
+
+  /// 「已更新未看」行的订阅→合集解析输入（新 Drift 订阅：条目→任务、元数据身份→
+  /// 刮削作品；旧 AniList JSON 订阅：anilistId），纯逻辑在
+  /// [subscribedVideoCollectionIds]。订阅数量是个位数到几十，逐订阅查条目/作品
+  /// 身份的开销可忽略，不值得为它加全表 DAO。
+  Future<Set<int>> _loadSubscribedCollectionIds(
+    FushiDatabase db,
+    AppModel appModel,
+    List<MediaCollectionRow> collections,
+  ) async {
+    final List<VideoDownloadSubscriptionRow> subscriptions =
+        await db.getVideoDownloadSubscriptions();
+    final Map<String, List<VideoDownloadSubscriptionItemRow>>
+        itemsBySubscription = <String, List<VideoDownloadSubscriptionItemRow>>{};
+    final Map<String, int> collectionIdByProviderIdentity = <String, int>{};
+    for (final VideoDownloadSubscriptionRow sub in subscriptions) {
+      itemsBySubscription[sub.subscriptionId] =
+          await db.getVideoDownloadSubscriptionItems(sub.subscriptionId);
+      final String? provider = sub.metadataProvider;
+      final String? externalId = sub.externalId;
+      if (provider == null || externalId == null) continue;
+      final String key = providerIdentityKey(provider, externalId);
+      if (collectionIdByProviderIdentity.containsKey(key)) continue;
+      final VideoMetadataWorkRow? work =
+          await db.getVideoMetadataWorkByProviderIdentity(
+        provider: provider,
+        externalId: externalId,
+      );
+      if (work?.collectionId case final int cid) {
+        collectionIdByProviderIdentity[key] = cid;
+      }
+    }
+    final List<VideoDownloadJobRow> jobs = subscriptions.isEmpty
+        ? const <VideoDownloadJobRow>[]
+        : await db.getVideoDownloadJobs();
+    final List<AnimeDownloadSubscription> legacy =
+        await appModel.animeDownloadSubscriptionStore?.loadAll() ??
+            const <AnimeDownloadSubscription>[];
+    return subscribedVideoCollectionIds(
+      subscriptions: subscriptions,
+      itemsBySubscription: itemsBySubscription,
+      jobs: jobs,
+      collectionIdByProviderIdentity: collectionIdByProviderIdentity,
+      legacyAnilistIds: <int>[
+        for (final AnimeDownloadSubscription s in legacy) s.anilistId,
+      ],
+      collections: collections,
+    );
   }
 
   /// 附加图组里按种类偏好取首张可用图的 provider（文件悬空 = 视作没有）。
@@ -2842,9 +2920,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         _buildContinueRow(filtered, remoteVideos, coverHeight);
     final Widget? nextRow =
         _buildNextEpisodeRow(filtered, remoteVideos, coverHeight);
+    final Widget? subscriptionRow =
+        _buildSubscriptionUpdatesRow(filtered, remoteVideos, coverHeight);
     final Widget? recentRow =
         _buildRecentlyAddedRow(filtered, remoteVideos, coverHeight);
-    if (continueRow == null && nextRow == null && recentRow == null) {
+    if (continueRow == null &&
+        nextRow == null &&
+        subscriptionRow == null &&
+        recentRow == null) {
       return const SizedBox.shrink();
     }
     return Padding(
@@ -2859,6 +2942,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         children: <Widget>[
           if (continueRow != null) continueRow,
           if (nextRow != null) nextRow,
+          if (subscriptionRow != null) subscriptionRow,
           if (recentRow != null) recentRow,
         ],
       ),
@@ -3545,6 +3629,99 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     return _buildHorizontalCardRow(
       title: t.video_next_episode,
       controller: _nextRowController,
+      coverHeight: coverHeight,
+      items: items.take(15).toList(growable: false),
+    );
+  }
+
+  /// 「已更新未看」横滚行：**订阅过的作品**（[_subscribedCollectionIds]）里还有
+  /// 集数没看的合集，按未看成员最新入库时刻倒序取前 15；点卡片直接播第一集
+  /// 没看的（[selectVideoSubscriptionUpdate]，Next-Up 口径）。
+  ///
+  /// 用户视角：订阅的番剧「更新了就看，跟收菜一样」——不用逐个点进合集看哪部
+  /// 更新了。与「下一集」的区别：那一行要求有播放痕迹，新订阅一集没看过的
+  /// 作品进不去；与「最近添加」的区别：那一行 14 天后消失、看没看不管。成员
+  /// 序列与两行同口径（本地行 + 远端占位合成一条稳定集序）。
+  Widget? _buildSubscriptionUpdatesRow(
+    List<VideoBookRow> filtered,
+    List<RemoteVideoInfo> remoteVideos,
+    double coverHeight,
+  ) {
+    if (_subscribedCollectionIds.isEmpty) return null;
+    final Map<int, List<_VideoSlot>> grouped = <int, List<_VideoSlot>>{};
+    for (final VideoBookRow book in filtered) {
+      if (_localExtraBookUids.contains(book.bookUid)) continue;
+      final int? cid =
+          _primaryCollectionByEntry[MediaKind.video.compositeKey(book.bookUid)];
+      if (cid != null &&
+          _subscribedCollectionIds.contains(cid) &&
+          _collectionsById.containsKey(cid)) {
+        grouped
+            .putIfAbsent(cid, () => <_VideoSlot>[])
+            .add(_VideoSlot(local: book));
+      }
+    }
+    for (final RemoteVideoInfo video in remoteVideos) {
+      final int? cid = _remoteCollectionId(video);
+      if (cid == null || !_subscribedCollectionIds.contains(cid)) continue;
+      grouped
+          .putIfAbsent(cid, () => <_VideoSlot>[])
+          .add(_VideoSlot(remote: video));
+    }
+    final DateTime now = DateTime.now();
+    final List<_VideoRowItem> items = <_VideoRowItem>[];
+    grouped.forEach((int cid, List<_VideoSlot> members) {
+      members.sort(
+        (_VideoSlot a, _VideoSlot b) =>
+            _slotSortIndex(a).compareTo(_slotSortIndex(b)),
+      );
+      final VideoSubscriptionUpdate? update = selectVideoSubscriptionUpdate(
+        _slotPlaybackStates(members),
+        <int?>[for (final _VideoSlot m in members) _slotImportedAtMs(m)],
+      );
+      if (update == null) return;
+      final MediaCollectionRow collection = _collectionsById[cid]!;
+      final _VideoSlot target = members[update.targetIndex];
+      final int episodeNumber = update.targetIndex + 1;
+      items.add(
+        _VideoRowItem(
+          recentMs: update.latestUnwatchedImportedAtMs,
+          build: () => _buildRowMediaCard(
+            cardKey:
+                ValueKey<String>('home_video_subscription_collection_$cid'),
+            focusId: FushiFocusId('home-video-subscription-collection-$cid'),
+            cover: _collectionRowCoverProvider(
+                  collection,
+                  _localMembersOf(members),
+                ) ??
+                _slotCoverProvider(target),
+            title: _workTitle(collection),
+            coverHeight: coverHeight,
+            onTap: () => _openSlot(target, playlistCollectionId: cid),
+            onLongPress: () => _showCollectionContextMenu(collection),
+            tags: _collectionTagChips(cid),
+            episodeNumber: episodeNumber,
+            secondaryText: t.video_home_subscription_unwatched_episode(
+              n: episodeNumber,
+              count: update.unwatchedCount,
+            ),
+            // 「新」角标与「最近添加」同一时间窗：最新一集未看是 14 天内入库的。
+            newBadge: isVideoRecentlyAdded(
+              importedAt: update.latestUnwatchedImportedAtMs,
+              now: now,
+            ),
+            cloudBadge: target.local == null,
+          ),
+        ),
+      );
+    });
+    if (items.isEmpty) return null;
+    items.sort(
+      (_VideoRowItem a, _VideoRowItem b) => b.recentMs.compareTo(a.recentMs),
+    );
+    return _buildHorizontalCardRow(
+      title: t.video_home_subscription_updates,
+      controller: _subscriptionRowController,
       coverHeight: coverHeight,
       items: items.take(15).toList(growable: false),
     );

--- a/fushi/test/media/video/video_subscription_updates_test.dart
+++ b/fushi/test/media/video/video_subscription_updates_test.dart
@@ -1,0 +1,225 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_home_layout.dart';
+import 'package:fushi/src/media/video/video_subscription_updates.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 视频首页「已更新未看」行的纯函数门：订阅→合集解析（两套订阅链路四条路径）
+/// 与合集内未看目标集选取（Next-Up 口径）。
+void main() {
+  const int now = 1_800_000_000_000;
+
+  VideoDownloadSubscriptionRow sub(
+    String id, {
+    int? collectionId,
+    String? metadataProvider,
+    String? externalId,
+  }) =>
+      VideoDownloadSubscriptionRow(
+        subscriptionId: id,
+        resourceProvider: 'nyaa',
+        metadataProvider: metadataProvider,
+        externalId: externalId,
+        mediaKind: 'tv',
+        title: 'Show $id',
+        searchQuery: 'Show $id',
+        filterJson: '{}',
+        mode: 'ongoing',
+        backendKind: 'embedded',
+        fingerprint: 'fp-$id',
+        collectionId: collectionId,
+        organizationPolicy: 'library',
+        subtitlePolicy: 'bestEffort',
+        enabled: true,
+        retryCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+  VideoDownloadSubscriptionItemRow item(
+    String subscriptionId,
+    String key, {
+    String? jobId,
+  }) =>
+      VideoDownloadSubscriptionItemRow(
+        id: key.hashCode,
+        subscriptionId: subscriptionId,
+        logicalItemKey: key,
+        resourceProvider: 'nyaa',
+        selectedResourceId: 'r-$key',
+        title: key,
+        jobId: jobId,
+        status: 'processed',
+        discoveredAt: now,
+        updatedAt: now,
+      );
+
+  VideoDownloadJobRow job(
+    String id, {
+    int? collectionId,
+    String? metadataProvider,
+    String? externalId,
+  }) =>
+      VideoDownloadJobRow(
+        jobId: id,
+        resourceProvider: 'nyaa',
+        selectedResourceId: 'r-$id',
+        metadataProvider: metadataProvider,
+        externalId: externalId,
+        mediaKind: 'tv',
+        title: 'Job $id',
+        backendKind: 'embedded',
+        fingerprint: 'fp-$id',
+        collectionId: collectionId,
+        organizationPolicy: 'library',
+        subtitlePolicy: 'bestEffort',
+        lifecycle: 'completed',
+        stage: 'complete',
+        stageProgress: 1,
+        priority: 0,
+        attemptCount: 0,
+        maxAttempts: 3,
+        createdAt: now,
+        updatedAt: now,
+      );
+
+  MediaCollectionRow collection(int id, {int? anilistId}) => MediaCollectionRow(
+        id: id,
+        name: 'C$id',
+        collectionType: 'collection',
+        sortOrder: 0,
+        createdAt: now,
+        orderUpdatedAt: 0,
+        anilistId: anilistId,
+      );
+
+  group('subscribedVideoCollectionIds', () {
+    test('五条路径取并集：直绑 / 条目→任务 / 身份→任务 / 身份→作品 / 旧 anilistId', () {
+      final Set<int> ids = subscribedVideoCollectionIds(
+        subscriptions: <VideoDownloadSubscriptionRow>[
+          sub('direct', collectionId: 1),
+          sub('via-job'),
+          sub('via-work', metadataProvider: 'anidb', externalId: '77'),
+          sub('via-job-identity', metadataProvider: 'anidb', externalId: '88'),
+        ],
+        itemsBySubscription: <String, List<VideoDownloadSubscriptionItemRow>>{
+          'via-job': <VideoDownloadSubscriptionItemRow>[
+            item('via-job', 'e1', jobId: 'j1'),
+            item('via-job', 'e2'),
+          ],
+        },
+        jobs: <VideoDownloadJobRow>[
+          job('j1', collectionId: 2),
+          job('j-none'),
+          // 条目 jobId 已 setNull，但任务与订阅同元数据身份 → 仍能找回合集。
+          job(
+            'j-identity',
+            collectionId: 6,
+            metadataProvider: 'anidb',
+            externalId: '88',
+          ),
+          // 同身份但没入库的任务、与别的身份的任务都不算。
+          job('j-identity-nocol', metadataProvider: 'anidb', externalId: '88'),
+          job(
+            'j-other',
+            collectionId: 7,
+            metadataProvider: 'anidb',
+            externalId: '99',
+          ),
+        ],
+        collectionIdByProviderIdentity: <String, int>{
+          providerIdentityKey('anidb', '77'): 3,
+        },
+        legacyAnilistIds: <int>[500],
+        collections: <MediaCollectionRow>[
+          collection(1),
+          collection(2),
+          collection(3),
+          collection(4, anilistId: 500),
+          collection(5, anilistId: 999),
+          collection(6),
+          collection(7),
+        ],
+      );
+      expect(ids, <int>{1, 2, 3, 4, 6});
+    });
+
+    test('没有订阅 → 空集（首页整行隐藏的前置条件）', () {
+      expect(
+        subscribedVideoCollectionIds(
+          subscriptions: const <VideoDownloadSubscriptionRow>[],
+          itemsBySubscription: const <String,
+              List<VideoDownloadSubscriptionItemRow>>{},
+          jobs: const <VideoDownloadJobRow>[],
+          collectionIdByProviderIdentity: const <String, int>{},
+          legacyAnilistIds: const <int>[],
+          collections: <MediaCollectionRow>[collection(1, anilistId: 500)],
+        ),
+        isEmpty,
+      );
+    });
+  });
+
+  group('selectVideoSubscriptionUpdate', () {
+    VideoSeriesPlaybackState unwatched() => const VideoSeriesPlaybackState(
+          lastWatchedAtMs: 0,
+          positionMs: 0,
+          completed: false,
+        );
+    VideoSeriesPlaybackState completed(int at) => VideoSeriesPlaybackState(
+          lastWatchedAtMs: at,
+          positionMs: 0,
+          completed: true,
+        );
+    VideoSeriesPlaybackState watching(int at) => VideoSeriesPlaybackState(
+          lastWatchedAtMs: at,
+          positionMs: 60_000,
+          completed: false,
+        );
+
+    test('全看完 → null（不占行）', () {
+      expect(
+        selectVideoSubscriptionUpdate(
+          <VideoSeriesPlaybackState>[completed(1), completed(2)],
+          <int?>[now, now],
+        ),
+        isNull,
+      );
+    });
+
+    test('从没播过 → 目标是第 1 集未看，未看数 = 全部', () {
+      final VideoSubscriptionUpdate? u = selectVideoSubscriptionUpdate(
+        <VideoSeriesPlaybackState>[unwatched(), unwatched(), unwatched()],
+        <int?>[now - 3, now - 1, now - 2],
+      );
+      expect(u!.targetIndex, 0);
+      expect(u.unwatchedCount, 3);
+      expect(u.latestUnwatchedImportedAtMs, now - 1);
+    });
+
+    test('Next-Up：目标是最近播放那集之后的第一集未看，跳过的旧集不回塞', () {
+      // 第 1 集没看（跳过），第 2 集看完，第 3 集在看，第 4、5 集未看。
+      final VideoSubscriptionUpdate? u = selectVideoSubscriptionUpdate(
+        <VideoSeriesPlaybackState>[
+          unwatched(),
+          completed(10),
+          watching(20),
+          unwatched(),
+          unwatched(),
+        ],
+        <int?>[1, 2, 3, 4, null],
+      );
+      expect(u!.targetIndex, 3);
+      expect(u.unwatchedCount, 3, reason: '跳过的第 1 集仍计入未看数');
+      expect(u.latestUnwatchedImportedAtMs, 4, reason: 'null 入库时刻按 0 计');
+    });
+
+    test('最近播放之后没有未看 → 回落合集里第一集未看', () {
+      final VideoSubscriptionUpdate? u = selectVideoSubscriptionUpdate(
+        <VideoSeriesPlaybackState>[unwatched(), completed(10), completed(20)],
+        <int?>[1, 2, 3],
+      );
+      expect(u!.targetIndex, 0);
+      expect(u.unwatchedCount, 1);
+    });
+  });
+}

--- a/fushi/test/pages/home_video_subscription_updates_row_test.dart
+++ b/fushi/test/pages/home_video_subscription_updates_row_test.dart
@@ -1,0 +1,240 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/anki/anki_view_model.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/media/video/video_library_section.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/home_video_page.dart';
+import 'package:fushi/src/platform/platform_providers.dart';
+import 'package:fushi/src/platform/platform_services.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 视频首页「已更新未看」行（订阅的番剧「更新了就看，跟收菜一样」）的行为门：
+///
+/// * 订阅（Drift `video_download_subscriptions`）经条目 → 任务 → 合集落到库里的
+///   作品，有集没看 → 出现在本行，副标题写目标集 + 未看数，点开播的是 Next-Up
+///   那一集；
+/// * 同样的合集**没有订阅** → 不进本行（这一行只装订阅过的作品）；
+/// * 订阅作品全看完 → 不进本行。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir = Directory.systemTemp.createTempSync(
+      'fushi_home_subscription_row_pp',
+    );
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync(
+      'fushi_home_subscription_row_store',
+    );
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  Widget buildApp() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: HomeVideoPage(
+                repo: VideoBookRepository(db),
+                section: VideoLibrarySection.home,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> sizeUp(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+
+  /// 三集合集：第 1 集看完、第 2 集看完（最近播放）、第 3 集没看。
+  /// [allWatched] = 第 3 集也看完。
+  Future<int> seedCollection({required bool allWatched}) async {
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    final int cid = await db.createMediaCollection(
+      'MyShow',
+      collectionType: 'collection',
+    );
+    for (int ep = 1; ep <= 3; ep++) {
+      final bool watched = ep < 3 || allWatched;
+      await db.upsertVideoBook(
+        VideoBooksCompanion(
+          bookUid: Value<String>('video/ep$ep'),
+          title: Value<String>('Ep$ep'),
+          videoPath: Value<String>('/abs/ep$ep.mp4'),
+          importedAt: Value<int?>(nowMs - (4 - ep) * 1000),
+          lastPlayedAt: Value<int?>(watched ? nowMs - (4 - ep) * 500 : null),
+          completedAt: Value<DateTime?>(
+            watched ? DateTime.fromMillisecondsSinceEpoch(nowMs) : null,
+          ),
+        ),
+      );
+      await db.addToCollection(cid, MediaKind.video, 'video/ep$ep');
+    }
+    return cid;
+  }
+
+  /// 订阅 → 条目 → 已入库任务（`collectionId` 回写）→ 合集。
+  Future<void> seedSubscription(int cid) async {
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    await db.upsertVideoDownloadSubscription(
+      VideoDownloadSubscriptionsCompanion.insert(
+        subscriptionId: 'sub-myshow',
+        resourceProvider: 'nyaa',
+        mediaKind: 'tv',
+        title: 'MyShow',
+        searchQuery: 'MyShow',
+        backendKind: 'embedded',
+        fingerprint: 'fp',
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      ),
+    );
+    await db.upsertVideoDownloadJob(
+      VideoDownloadJobsCompanion.insert(
+        jobId: 'job-ep3',
+        resourceProvider: 'nyaa',
+        selectedResourceId: 'r-ep3',
+        mediaKind: 'tv',
+        title: 'MyShow',
+        backendKind: 'embedded',
+        fingerprint: 'fp-ep3',
+        collectionId: Value<int?>(cid),
+        lifecycle: const Value<String>(VideoDownloadJobLifecycle.completed),
+        createdAt: nowMs,
+        updatedAt: nowMs,
+      ),
+    );
+    await db.upsertVideoDownloadSubscriptionItem(
+      VideoDownloadSubscriptionItemsCompanion.insert(
+        subscriptionId: 'sub-myshow',
+        logicalItemKey: 's1e3',
+        resourceProvider: 'nyaa',
+        selectedResourceId: 'r-ep3',
+        title: 'MyShow - 03',
+        jobId: const Value<String?>('job-ep3'),
+        status: const Value<String>(
+          VideoDownloadSubscriptionItemStatus.processed,
+        ),
+        discoveredAt: nowMs,
+        updatedAt: nowMs,
+      ),
+    );
+  }
+
+  testWidgets('订阅作品有集没看 → 出现在「已更新未看」行，目标是第 3 集、1 集未看', (
+    WidgetTester tester,
+  ) async {
+    await sizeUp(tester);
+    final int cid = await seedCollection(allWatched: false);
+    await seedSubscription(cid);
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_home_subscription_updates), findsOneWidget);
+    expect(
+      find.byKey(ValueKey<String>('home_video_subscription_collection_$cid')),
+      findsOneWidget,
+      reason: '订阅过、且第 3 集没看 → 合集卡必须在本行',
+    );
+    expect(
+      find.text(t.video_home_subscription_unwatched_episode(n: 3, count: 1)),
+      findsOneWidget,
+      reason: 'Next-Up：最近播放是第 2 集，目标第 3 集；未看数 1',
+    );
+  });
+
+  testWidgets('同样的合集没有订阅 → 不进本行', (WidgetTester tester) async {
+    await sizeUp(tester);
+    final int cid = await seedCollection(allWatched: false);
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_home_subscription_updates), findsNothing);
+    expect(
+      find.byKey(ValueKey<String>('home_video_subscription_collection_$cid')),
+      findsNothing,
+      reason: '本行只装订阅过的作品，普通合集有未看集也不进',
+    );
+  });
+
+  testWidgets('订阅作品全看完 → 不进本行', (WidgetTester tester) async {
+    await sizeUp(tester);
+    final int cid = await seedCollection(allWatched: true);
+    await seedSubscription(cid);
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_home_subscription_updates), findsNothing);
+    expect(
+      find.byKey(ValueKey<String>('home_video_subscription_collection_$cid')),
+      findsNothing,
+      reason: '收完的菜不该再摆在「已更新未看」里',
+    );
+  });
+}


### PR DESCRIPTION
## 改动

视频首页在「下一集」与「最近添加」之间新增一条横滚行 **「已更新未看」**：订阅过的番剧只要还有集数没看就列出来，点卡片直接播下一集该看的，不用逐个点进合集看哪部更新了（用户原话：看动画就跟收菜一样，更新了就看）。

## 判据

- **订阅 → 合集解析**（`video_subscription_updates.dart` 的 `subscribedVideoCollectionIds`，纯函数）：
  - 新 Drift 订阅 `video_download_subscriptions`：`collectionId` 直绑 → 订阅条目 `jobId` → `VideoDownloadJobs.collectionId` → 与订阅同 `(metadataProvider, externalId)` 的任务 → 元数据身份对应的刮削作品 `VideoMetadataWork.collectionId`，四条路径取并集；
  - 旧 AniList JSON 订阅（`AnimeDownloadSubscriptionStore`）：`anilistId` → `MediaCollections.anilistId`。
  - 不看 `enabled`：暂停/oneShot 已完成的订阅仍是订阅过的作品，已下载未看照样出现。
- **目标集**（`selectVideoSubscriptionUpdate`）：最近实际播放那集**之后**的第一集未看（Next-Up 口径，与 `nextEpisodeAfterLatestPlayed` 同源，跳过的旧集不回塞）；之后没有未看或从没播过 → 合集里第一集未看。一集未看都没有 → 不占行。
- 副标题「第 N 集 · M 集未看」；未看成员最新入库在 14 天内带「新」角标（与「最近添加」同一时间窗）；行内按未看成员最新入库时刻倒序取前 15。
- 成员序列与「下一集」「最近添加」同口径（本地行 + 远端占位合成一条稳定集序）。
- 订阅表变更流 / 旧 store `revision` 触发重解析；下载入库落合集由既有合集表流覆盖。

## 与既有两行的区别

- 「下一集」要求有播放痕迹，新订阅一集没看过的作品进不去；
- 「最近添加」14 天后消失、看没看不管。

## 测试

- `test/media/video/video_subscription_updates_test.dart`：解析五条路径并集 / 无订阅空集 / 全看完 null / 从没播过 / Next-Up 跳过旧集 / 回落第一集未看（本地 6 条全绿）。
- `test/pages/home_video_subscription_updates_row_test.dart`：订阅作品有集没看 → 行出现且副标题为「第 3 集 · 1 集未看」；同合集无订阅 → 不进本行；全看完 → 不进本行。（本地首页 widget 测试编译超 10 分钟未跑完，交 CI 兜底。）
- `flutter analyze` 零问题。

https://claude.ai/code/session_01WpSLpa3kEMR8qiTxWWSf2z
