### PR TITLE
fix(video): 隐藏字幕在暂停/查词时让位（BUG-2198）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2038 条。点号进各自文件。
+> 共 2039 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2198](bugs/BUG-2198-subtitle-hide-pause-reveal.md) | ✅ | ✅ | 隐藏字幕在暂停/查词时不恢复显示 |
 | [BUG-2165](bugs/BUG-2165-pack-download-no-visible-progress.md) | ✅ | ✅ | 推荐包后台下载没有任何看得见的地方，半截包重启后既看不见也续不上 |
 | [BUG-2164](bugs/BUG-2164-asr-pcm-mov-chapter-track-noise.md) | ✅ | ✅ | ASR PCM 抽取 mov 容器混入章节 text 轨，奇数字节标题的整章解成白噪声 |
 | [BUG-2163](bugs/BUG-2163-asr-match-start-anchor-colophon.md) | ✅ | ✅ | ASR 字幕匹配起点被片头出版社名钉到书尾版权页，整本匹配率 0% |

--- a/docs/bugs/BUG-2198-subtitle-hide-pause-reveal.md
+++ b/docs/bugs/BUG-2198-subtitle-hide-pause-reveal.md
@@ -1,0 +1,26 @@
+## BUG-2198 · 隐藏字幕在暂停/查词时不恢复显示
+- **报告**：2026-09-06（用户：「查词的时候隐藏字幕也会隐藏，而且暂停的时候隐藏字幕不会恢复」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/media/video/video_subtitle_overlay.dart:1247`（修前）：
+  遮蔽模式两种视觉走了**不对称的门**。模糊是 `blurEnabled && !revealed && controller.isPlaying`
+  （BUG-199「暂停时清晰」），隐藏却是 `subtitleHidden && !revealed`——刻意绕过 `isPlaying`，
+  当时的理由写在注释里：「隐藏的语义是我不想看见它，暂停时自己冒出来才是惊吓」。
+  这条特例同时造出用户报的两个症状：
+  - **查词时也隐藏**：视频查词第一步就是 `controller.pause()`
+    （`fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart:52`）。暂停不解遮蔽，
+    查词期间字幕就仍然看不见；更糟的是同一个 `hidden` 还门控着 `registerHits`
+    （`video_subtitle_overlay.dart:1687`），未显形时字符不进命中登记表——**看不见，也点不到**，
+    查词浮层里无从对照原句。模糊没这个问题纯粹是因为它吃 `isPlaying`，查词一暂停就自动清晰。
+  - **暂停不恢复**：用户主动暂停想读一眼当前句，隐藏照旧不让位。
+- **[x] ① 已修复** — 删掉不对称：抽出共同门 `obscureActive = !revealed && isPlaying`，模糊与隐藏
+  只在「用哪种视觉」上分叉，判据不再有第二份（`video_subtitle_overlay.dart` 的 `_buildSubtitleLayer`）。
+  暂停（含查词自动暂停）时两种遮蔽一起让位、字符同时恢复可查词；恢复播放下一帧自动遮回去，
+  不需要复位显形态。副字幕（`secondaryHidden`）同一条门。提交见本文件所在分支。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_hide_hover_reveal_test.dart`
+  （① 组翻转旧断言 + 新增「恢复播放重新隐藏」「暂停时模糊也让位」对称基准；⑧ 组新增
+  「暂停让位 → 字符同时恢复可查词」直接钉住用户诉求 ①）与
+  `fushi/test/media/video/video_secondary_subtitle_obscure_test.dart`（副字幕暂停让位 + 播放遮回）。
+  变异实测：把 `hidden` 改回旧的 `!revealed`，这 4 条新守卫全红（不是空壳断言）。
+- **备注**：旧行为有一条测试专门钉着（「暂停时隐藏依然生效（不吃 isPlaying 门，与模糊不同）」），
+  本次按用户诉求翻转。原文件里大量隐藏用例的 controller **未起播**，靠的正是这条特例；
+  改门后它们等于在测暂停态，故 helper 统一 `debugSetIsPlayingForTesting(true)`，
+  ⑨ 组两条自建 controller 的用例单独补起播——否则断言恒假、变成空壳绿。

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -546,6 +546,9 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 共用同一套显形通道（桌面 [MouseRegion] 悬停 / 移动端点击热区），移开即复原。
   /// 未显形时不登记查词命中（看不见的字不可点选），仍不影响查词浮层 / 字幕列表 /
   /// cue 同步等其它文本通道。
+  ///
+  /// BUG-2198：与 [blurEnabled] 一样只在**播放中**遮蔽——暂停（含查词自动暂停）时
+  /// 字幕照常显示、字符也照常可点选查词，恢复播放即自动遮回去。
   final bool subtitleHidden;
 
   /// 副字幕「模糊」（TODO-1382，镜像 [blurEnabled]）：为 true 时**副字幕层**默认高斯模糊，
@@ -555,7 +558,8 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 副字幕「隐藏」（TODO-1382，镜像 [subtitleHidden]）：为 true 时副字幕层布局照常但
   /// 不绘制（[Opacity] 为 0），与 [secondaryBlurEnabled] 正交且优先级更高。默认 false。
   /// 与主字幕同构：悬停 / 点击可临时显形，未显形时不登记查词命中。隐藏只针对副字幕
-  /// overlay，不影响查词 / 字幕列表 / cue 同步等其它通道。
+  /// overlay，不影响查词 / 字幕列表 / cue 同步等其它通道。BUG-2198：同样只在播放中
+  /// 遮蔽（暂停 / 查词时显示），与 [subtitleHidden] 一条门。
   final bool secondaryHidden;
 
   /// 字幕字号（外观设置）。
@@ -1233,20 +1237,27 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     List<AudioCue> cues, {
     required bool isSecondary,
   }) {
-    // 听力沉浸模糊只在播放中生效（暂停 / 查词时清晰，BUG-199）。TODO-1382：主/副字幕
-    // 各按自己的 obscure 开关与独立 reveal 态决定是否模糊（副字幕不再无条件清晰）。
+    // 遮蔽只在播放中生效（暂停 / 查词时清晰，BUG-199 / BUG-2198）：模糊与隐藏共用
+    // **同一条**门——该层开着遮蔽、当前未显形、且正在播放。历史上隐藏单独绕过
+    // isPlaying（「暂停时自己冒出来才是惊吓」），实测这条特例正是用户报的两个症状：
+    // ① 查词必先 `controller.pause()`（`lookup_favorite.part.dart`），暂停不解遮蔽
+    //    就等于「查词时字幕仍然看不见」，而 registerHits 又按 [hidden] 关掉了字符命中
+    //    登记——看不见也点不到，查词页面上无从对照原句；
+    // ② 用户主动暂停想读一眼当前句时字幕也不回来。
+    // 两症状同一根因，故删掉不对称、不再为隐藏留特例：暂停 = 用户已停下来看，遮蔽
+    // （无论哪种视觉）都让位；恢复播放即自动遮回去（下一帧重算，无需复位显形态）。
     final bool obscureBlurEnabled =
         isSecondary ? widget.secondaryBlurEnabled : widget.blurEnabled;
     final bool revealed = _revealedFor(isSecondary: isSecondary);
-    final bool blurred =
-        obscureBlurEnabled && !revealed && widget.controller.isPlaying;
-    // 隐藏态（该层开着「隐藏」且当前未显形）。与 [blurred] 互斥（两者来自互斥的
+    // 该层此刻是否应遮蔽（与具体视觉无关的共同门）：模糊与隐藏只在这一处分叉成两种
+    // 视觉，判据本身不再有第二份。
+    final bool obscureActive = !revealed && widget.controller.isPlaying;
+    final bool blurred = obscureBlurEnabled && obscureActive;
+    // 隐藏态（该层开着「隐藏」且该遮蔽）。与 [blurred] 互斥（两者来自互斥的
     // VideoSubtitleObscureMode），但共用同一个显形态：悬停 / 点击即显形。
-    // **不**吃 isPlaying 门（模糊有 BUG-199 的「暂停时清晰」，隐藏没有）：隐藏的语义是
-    // 「我不想看见它」，暂停时自己冒出来才是惊吓；历史上隐藏态暂停也不显示，保持不变。
     final bool hidden =
         (isSecondary ? widget.secondaryHidden : widget.subtitleHidden) &&
-            !revealed;
+            obscureActive;
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {

--- a/fushi/test/media/video/video_secondary_subtitle_obscure_test.dart
+++ b/fushi/test/media/video/video_secondary_subtitle_obscure_test.dart
@@ -64,6 +64,8 @@ void main() {
       c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
       c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
       c.debugUpdateCueForPosition(1000);
+      // BUG-2198：遮蔽只在播放中生效，不起播就是在测暂停态（断言会恒假）。
+      c.debugSetIsPlayingForTesting(true);
 
       await _pumpOverlay(tester, c, secondaryHidden: true);
 
@@ -91,6 +93,28 @@ void main() {
       expect(find.text('副'), findsWidgets, reason: '默认不隐藏，副字幕照常渲染');
       expect(_opaqueZero(tester, find.text('副')), isFalse,
           reason: '不隐藏时不得有 Opacity(0) 遮蔽层');
+    });
+
+    // BUG-2198：副字幕隐藏与主字幕同一条门——暂停（含查词自动暂停）让位、播放遮回去。
+    testWidgets('暂停时副字幕隐藏让位、恢复播放再遮回去（与主字幕同一条门）',
+        (tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
+      c.debugUpdateCueForPosition(1000);
+      c.debugSetIsPlayingForTesting(false);
+
+      await _pumpOverlay(tester, c, secondaryHidden: true);
+
+      expect(_opaqueZero(tester, find.text('副')), isFalse,
+          reason: '暂停时副字幕也该显示（查词对照原句走同一条路径）');
+
+      c.debugSetIsPlayingForTesting(true);
+      await tester.pump();
+
+      expect(_opaqueZero(tester, find.text('副')), isTrue,
+          reason: '继续播放就该遮回去，否则一暂停等于永久解除隐藏');
     });
   });
 

--- a/fushi/test/media/video/video_subtitle_hide_hover_reveal_test.dart
+++ b/fushi/test/media/video/video_subtitle_hide_hover_reveal_test.dart
@@ -44,6 +44,9 @@ bool _obscured(WidgetTester tester, Finder of) => tester
         find.ancestor(of: of.first, matching: find.byType(Opacity)))
     .any((Opacity o) => o.opacity == 0);
 
+/// BUG-2198：两种遮蔽都只在**播放中**生效（暂停 / 查词时字幕让位），故本文件的
+/// 「该遮蔽」用例一律起播——不起播就等于在测暂停态，遮蔽断言会恒假。暂停语义本身由
+/// ① 组的专门用例覆盖（那条显式设 false）。
 VideoPlayerController _controller(WidgetTester tester,
     {String main = '主', String? secondary}) {
   final VideoPlayerController c = VideoPlayerController();
@@ -53,6 +56,7 @@ VideoPlayerController _controller(WidgetTester tester,
     c.setSecondaryCues(<AudioCue>[_cue(secondary, 0, 6000)]);
   }
   c.debugUpdateCueForPosition(1000);
+  c.debugSetIsPlayingForTesting(true);
   return c;
 }
 
@@ -133,15 +137,41 @@ void main() {
           reason: '不遮蔽时不得平白多出透明层');
     });
 
-    testWidgets('暂停时隐藏依然生效（不吃 isPlaying 门，与模糊不同）', (tester) async {
+    // BUG-2198（用户报「查词的时候隐藏字幕也会隐藏，而且暂停的时候隐藏字幕不会恢复」）：
+    // 隐藏原本单独绕过 isPlaying 门。查词必先 `controller.pause()`，于是「暂停不解遮蔽」
+    // 直接等于「查词时看不见原句」；用户主动暂停想读一眼也回不来。改为与模糊同一条门。
+    testWidgets('暂停时隐藏让位、字幕显示（与模糊对称，查词同此路径）', (tester) async {
       final VideoPlayerController c = _controller(tester);
-      expect(c.isPlaying, isFalse, reason: '前置：本用例未起播');
+      c.debugSetIsPlayingForTesting(false);
 
       await _pump(tester, c, subtitleHidden: true);
 
-      // 模糊有 BUG-199 的「暂停时清晰」，隐藏没有——否则一暂停字幕就自己冒出来。
+      expect(find.text('主'), findsWidgets);
+      expect(_obscured(tester, find.text('主')), isFalse,
+          reason: '暂停 = 用户停下来看，隐藏必须让位（查词自动暂停走的也是这条）');
+    });
+
+    testWidgets('恢复播放 → 重新隐藏（让位只针对暂停，不是把隐藏关掉）', (tester) async {
+      final VideoPlayerController c = _controller(tester);
+      c.debugSetIsPlayingForTesting(false);
+      await _pump(tester, c, subtitleHidden: true);
+      expect(_obscured(tester, find.text('主')), isFalse, reason: '前置：暂停已让位');
+
+      c.debugSetIsPlayingForTesting(true);
+      await tester.pump();
+
       expect(_obscured(tester, find.text('主')), isTrue,
-          reason: '暂停不该让隐藏的字幕自己显形');
+          reason: '继续播放就该遮回去，否则等于一暂停就永久解除隐藏');
+    });
+
+    testWidgets('暂停时模糊也让位（对称基准，防单边改坏）', (tester) async {
+      final VideoPlayerController c = _controller(tester);
+      c.debugSetIsPlayingForTesting(false);
+
+      await _pump(tester, c, blurEnabled: true);
+
+      expect(_blurredVisual(tester, find.text('主')), isFalse,
+          reason: 'BUG-199 既有契约：暂停时模糊清晰');
     });
   });
 
@@ -360,6 +390,23 @@ void main() {
       expect(ht.hitTest(tester.getCenter(find.text('主').first))?.sentence, '主');
       expect(ht.caretAnchorEntry(), greaterThanOrEqualTo(0));
     });
+
+    // BUG-2198 的另一半：查词第一步就是 `controller.pause()`（video_fushi 的
+    // lookup_favorite.part.dart）。暂停若不解遮蔽，registerHits 会一直关着——字幕既
+    // 看不见、字也点不到，用户「查词时对照原句」这条路整个断掉。看得见就必须点得到。
+    testWidgets('暂停时隐藏让位 → 字符同时恢复可查词（看得见就点得到）', (tester) async {
+      final VideoPlayerController c = _controller(tester);
+      final VideoSubtitleHitTester ht = VideoSubtitleHitTester();
+      c.debugSetIsPlayingForTesting(false);
+
+      await _pump(tester, c, subtitleHidden: true, hitTester: ht);
+
+      expect(_obscured(tester, find.text('主')), isFalse, reason: '前置：暂停已让位');
+      expect(ht.hitTest(tester.getCenter(find.text('主').first))?.sentence, '主',
+          reason: '暂停时看得见的字必须能查词，否则查词浮层里对不上原句');
+      expect(ht.caretEntryCount(), greaterThan(0));
+      expect(ht.caretAnchorEntry(), greaterThanOrEqualTo(0));
+    });
   });
 
   group('⑨ 点击显形只豁免当前这句（触摸端的撤销手段）', () {
@@ -373,6 +420,7 @@ void main() {
       // A[0,2000) 紧接 B[2000,4000)：中间没有任何空档。
       c.setCues(<AudioCue>[_cue('甲', 0, 2000), _cue('乙', 2000, 4000)]);
       c.debugUpdateCueForPosition(1000);
+      c.debugSetIsPlayingForTesting(true); // BUG-2198：遮蔽只在播放中生效
       await _pump(tester, c, subtitleHidden: true);
 
       await tester.tap(find.text('甲').first, warnIfMissed: false);
@@ -392,6 +440,7 @@ void main() {
       addTearDown(c.dispose);
       c.setCues(<AudioCue>[_cue('甲', 0, 2000), _cue('乙', 2000, 4000)]);
       c.debugUpdateCueForPosition(1000);
+      c.debugSetIsPlayingForTesting(true); // BUG-2198：遮蔽只在播放中生效
       await _pump(tester, c, subtitleHidden: true);
 
       await _hoverOver(tester, find.text('甲'));


### PR DESCRIPTION
用户报：「查词的时候隐藏字幕也会隐藏，而且暂停的时候隐藏字幕不会恢复」。

## 根因

遮蔽模式（`VideoSubtitleObscureMode`）的两种视觉走了**不对称的门**（`video_subtitle_overlay.dart` `_buildSubtitleLayer`，修前）：

- 模糊：`blurEnabled && !revealed && controller.isPlaying` —— 暂停即清晰（BUG-199）
- 隐藏：`subtitleHidden && !revealed` —— 刻意绕过 `isPlaying`，注释理由是「隐藏的语义是我不想看见它，暂停时自己冒出来才是惊吓」

这条特例同时造出用户报的两个症状：

1. **查词时也隐藏**：视频查词第一步就是 `controller.pause()`（`video_fushi/lookup_favorite.part.dart:52`）。暂停不解遮蔽，查词期间字幕就仍然看不见；更糟的是同一个 `hidden` 还门控着 `registerHits`，未显形时字符不进命中登记表——**看不见，也点不到**，查词浮层里无从对照原句。模糊没这个问题纯粹是因为它吃 `isPlaying`，查词一暂停就自动清晰。
2. **暂停不恢复**：用户主动暂停想读一眼当前句，隐藏照旧不让位。

## 修法

删掉特例，不加开关：抽出共同门 `obscureActive = !revealed && isPlaying`，模糊与隐藏只在「用哪种视觉」上分叉，判据不再有第二份。副字幕（`secondaryHidden`）同一条门。恢复播放下一帧自动遮回去，不需要复位显形态。

## 验证

- 定向测试 7 个文件 **83 条全绿**（遮蔽三态 / 悬停显形 / registerHits / 模糊 gap reset / Shift 悬停查词 / 切换成本）
- **变异实测**：把 `hidden` 改回旧的 `!revealed`，4 条新守卫全红（不是空壳断言）
- `flutter analyze` 改动文件 + 全量：No issues found

## 行为变更说明

旧行为有一条测试专门钉着（「暂停时隐藏依然生效（不吃 isPlaying 门，与模糊不同）」），本次按用户诉求翻转。原文件里大量隐藏用例的 controller **未起播**，靠的正是这条特例——改门后它们等于在测暂停态、断言会恒假变成空壳绿，故 helper 统一 `debugSetIsPlayingForTesting(true)`，⑨ 组两条自建 controller 的用例单独补起播。

BUG-2198

https://claude.ai/code/session_01UfYejj97b6dCFcbPbXDcie
