### PR TITLE
fix: 用户报的四件事 —— 词典下载失败原因被吞 / 备份漏词典 / AnkiDroid 并行版 / 断句漏词+试听 (BUG-2188/2193/2195/2196)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2039 条。点号进各自文件。
+> 共 2040 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2193](bugs/BUG-2193-backup-export-drops-all-dicts-on-one-ghost-row.md) | ✅ | ✅ | 本地备份导出：一条幽灵词典元数据行让全部词典静默不打包 |
 | [BUG-2188](bugs/BUG-2188-dict-download-failure-reason-swallowed.md) | ✅ | ✅ | 词典下载失败原因被吞：单行标题截断 + 摘要措辞错成导入失败 + 无镜像回退 |
 | [BUG-2165](bugs/BUG-2165-pack-download-no-visible-progress.md) | ✅ | ✅ | 推荐包后台下载没有任何看得见的地方，半截包重启后既看不见也续不上 |
 | [BUG-2164](bugs/BUG-2164-asr-pcm-mov-chapter-track-noise.md) | ✅ | ✅ | ASR PCM 抽取 mov 容器混入章节 text 轨，奇数字节标题的整章解成白噪声 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2041 条。点号进各自文件。
+> 共 2042 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2196](bugs/BUG-2196-reader-newline-splits-sentence.md) | ✅ | ✅ | 阅读器把源码换行当句子分隔符，制卡拿到半截句、音频漏词 |
 | [BUG-2195](bugs/BUG-2195-ankidroid-parallel-build-invisible.md) | ✅ | ✅ | AnkiDroid 并行版（com.ichi2.anki.A）不被识别、权限框从不弹出 |
 | [BUG-2193](bugs/BUG-2193-backup-export-drops-all-dicts-on-one-ghost-row.md) | ✅ | ✅ | 本地备份导出：一条幽灵词典元数据行让全部词典静默不打包 |
 | [BUG-2188](bugs/BUG-2188-dict-download-failure-reason-swallowed.md) | ✅ | ✅ | 词典下载失败原因被吞：单行标题截断 + 摘要措辞错成导入失败 + 无镜像回退 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2040 条。点号进各自文件。
+> 共 2041 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2195](bugs/BUG-2195-ankidroid-parallel-build-invisible.md) | ✅ | ✅ | AnkiDroid 并行版（com.ichi2.anki.A）不被识别、权限框从不弹出 |
 | [BUG-2193](bugs/BUG-2193-backup-export-drops-all-dicts-on-one-ghost-row.md) | ✅ | ✅ | 本地备份导出：一条幽灵词典元数据行让全部词典静默不打包 |
 | [BUG-2188](bugs/BUG-2188-dict-download-failure-reason-swallowed.md) | ✅ | ✅ | 词典下载失败原因被吞：单行标题截断 + 摘要措辞错成导入失败 + 无镜像回退 |
 | [BUG-2165](bugs/BUG-2165-pack-download-no-visible-progress.md) | ✅ | ✅ | 推荐包后台下载没有任何看得见的地方，半截包重启后既看不见也续不上 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2038 条。点号进各自文件。
+> 共 2039 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2188](bugs/BUG-2188-dict-download-failure-reason-swallowed.md) | ✅ | ✅ | 词典下载失败原因被吞：单行标题截断 + 摘要措辞错成导入失败 + 无镜像回退 |
 | [BUG-2165](bugs/BUG-2165-pack-download-no-visible-progress.md) | ✅ | ✅ | 推荐包后台下载没有任何看得见的地方，半截包重启后既看不见也续不上 |
 | [BUG-2164](bugs/BUG-2164-asr-pcm-mov-chapter-track-noise.md) | ✅ | ✅ | ASR PCM 抽取 mov 容器混入章节 text 轨，奇数字节标题的整章解成白噪声 |
 | [BUG-2163](bugs/BUG-2163-asr-match-start-anchor-colophon.md) | ✅ | ✅ | ASR 字幕匹配起点被片头出版社名钉到书尾版权页，整本匹配率 0% |

--- a/docs/bugs/BUG-2188-dict-download-failure-reason-swallowed.md
+++ b/docs/bugs/BUG-2188-dict-download-failure-reason-swallowed.md
@@ -1,0 +1,98 @@
+## BUG-2188 · 词典下载失败原因被吞：单行标题截断 + 摘要措辞错成导入失败 + 无镜像回退
+- **报告**：2026-09-06（用户：Android 词典管理页截图两张——① 进度框标题 `下载失败：Wiktionary JA-ZH (中文): DioError [connection ...`，原因在这里被截断；② 随后一条红色 toast `导入失败: Wiktionary JA-ZH (中文)`，一个字的原因都没有。用户原话：「下载失败，没有说明具体错误原因。并且我们应该用 cf、git 等帮忙传一下」）
+- **真实性**：✅ 真 bug。**四个各自独立的根因**，前三个决定「为什么看不到原因」，第四个决定「为什么会失败」：
+  1. **长错误被塞进单行标题**（用户看到 `DioError [connection ...` 的直接原因）——
+     `dictionary_dialog_page.dart` 的收尾把整串异常写进 `progressNotifier.value`，
+     而进度框把它当**标题**渲染：`DictionaryDownloadProgressDialog` →
+     `FushiModalSheetFrame(title: message)` → `fushi_material_components.dart:1047-1053`
+     的 `Text(title!, maxLines: 1, overflow: TextOverflow.ellipsis)`。
+     **一个 `ValueNotifier<String>` 同时承担「阶段标题」和「诊断全文」两种职责**，
+     而这两者的排版约束正好相反。收起后的状态行同样只给 2 行。
+  2. **异常在收集那一刻就被降维成一个名字**（根因中的根因）——
+     `final List<String> failedNames`，catch 里 `failedNames.add(rec.name)`。
+     原因从此不在数据里，**后面无论怎么改渲染都救不回来**。
+     `DictionaryImportManager.formatImportFailureSummary(List<String>)` 的签名把这个
+     缺陷固化成了跨三条路径（在线下载 / 文件批量 / 目录批量）的共享契约。
+  3. **下载阶段失败被报成「导入失败」**——同一批 `failedNames` 交给
+     `formatImportFailureSummary`，措辞恒为 `t.srt_import_error`（"导入失败"）。
+     于是一次下载失败被呈现两遍、且第二遍说的是另一个阶段，用户合理地以为
+     「先下载失败，然后又导入失败」。**实际上下载失败后根本不会走导入**：
+     `download` 抛出后直接进 catch，`importDictionary` 一次都没被调用，
+     半个 zip 由 `finally` 整棵删。
+  4. **该词典托管在 huggingface.co，且词典链路没有任何镜像回退**——
+     `dictionary_downloader.dart` 的 `_wtyBase =
+     'https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict'`。
+     Android 上 `app_proxy.dart` 的 GUI 系统代理探测**只覆盖桌面三平台**，
+     手机上只剩 env + 用户手填，于是直连 huggingface.co 吃满 30 秒
+     `connectTimeout`。仓库里已有一套 GitHub 公共镜像层
+     （`utils/net/github_mirrors.dart`，更新检查 / Mihon / 着色器三条链路在用），
+     但 `fushi_dictionary` 是它的下游包，反向 import 不了，一直没接。
+- **镜像可行性实测（2026-09-06，经本机代理逐条量过，用于否掉「随便挂个公共镜像」）**：
+
+  | 候选 | 对 `.../wty-ja-zh.zip` 的实测结果 |
+  |---|---|
+  | `huggingface.co` 直连 | 302 → `us.aws.cdn.hf.co` → 200，`content-length: 6840013` |
+  | `hf-mirror.com` | **308 跳回 huggingface.co**，不代理 `/datasets/.../resolve/` |
+  | `ghfast.top` | **403 FORBIDDEN** |
+  | `gh-proxy.com` | **403 Forbidden** |
+
+  即：**没有任何现成公共镜像能救 wty（Wiktionary）系列**。能靠镜像救的是 catalog 里
+  GitHub 托管的条目（jitendex / MarvNC / Kuuuube）。用户提的「用 cf 帮忙传」需要在
+  fushi.moe 侧自建 Worker 反代或把包镜像进 R2，属于**站点仓库的基建改动**，本条不做，
+  见下方「未做」。
+- **[x] ① 已修复** — 四层对应四个根因，分支 `worktree-fix-dict-download-error-anki-parallel`：
+  - **数据结构先改**（根因 2/3）：新增 `DictionaryTaskFailure{name, stage, error, url}`
+    与 `DictionaryTaskStage{download, import}`（`dictionary_import_manager.dart`）。
+    三条路径的 `List<String> failedNames` 全部换成 `List<DictionaryTaskFailure>`，
+    catch 里带上异常本体与阶段（下载点用 `zipDownloaded` 标志区分两个阶段）。
+    `formatImportFailureSummary` 改吃新类型，措辞按 `stage` 选，多条汇总改成
+    **一行一条、每行带自己的原因**（旧实现是名字逗号连成一行、原因一个不给）。
+  - **归因与人话**（根因 1 的另一半）：包内新增
+    `DictionaryDownloadFailureKind`（connectTimeout / stallTimeout / connectionError /
+    badResponse / cancelled / other）+ `classifyDictionaryDownloadFailure` +
+    `DictionaryDownloadException{url, attemptedUrls, cause, kind, host, statusCode}`。
+    app 侧 `describeDictionaryFailure` 把它翻成「连接 huggingface.co 超时，当前网络
+    可能访问不了这个站点」这类点名到主机的一行中文（新增 7 个 i18n key × 17 语言）。
+  - **渲染分道**（根因 1）：controller 新增 `detail` notifier（多行正文），
+    `message` 恢复成「短标题」的单一职责；`DictionaryDownloadProgressDialog` 新增
+    `detailListenable`，在进度条下方以 `SelectableText(maxLines: 6)` 渲染。
+    结束提示改走 `DictionaryDownloadOutcome.details` + `AppModel._presentDictionaryOutcome`
+    → 复用 `showErrorDetails`（可滚动 / 可选中 / 一键复制），不再只发一条被
+    Android 12+ 强制截成两行且不可复制的原生 toast。拿不到全局 context 时退回 toast，
+    提示不会因此静默丢失。
+  - **候选回退**（根因 4）：包内新增进程级钩子 `dictionaryUrlCandidatesResolver` +
+    `dictionaryDownloadCandidates`（与既有 `dictionaryDioFactory` 同一套装配方向），
+    `DictionaryDownloader.download` 改为逐候选尝试；**只有传输层失败才换下一个**
+    （已答复的 404/403 换镜像拿到的是同一份 404），换之前删掉半个文件、进度条归零。
+    app 侧 `installDictionaryUrlCandidatesResolver` 接到 `gitHubMirrorCandidates`。
+    **取消必须原样抛出、绝不包进 `DictionaryDownloadException`**——全仓
+    `DictionaryDownloadController.isCancellation` 按 `DioError.type == cancel` 判
+    「取消不是失败」，包起来就会把用户点取消记成一条下载失败。
+- **[x] ② 已加自动化测试** — 新增 `fushi/test/dictionary/dictionary_download_mirror_fallback_test.dart`
+  （15 条）+ 重写 `fushi/test/models/dictionary_import_failure_summary_test.dart`
+  （新增 5 条「原因必须进得了文案」）+ 升级两条源码守卫。定向批 9 个文件共 **72 条全绿**。
+  - 行为层：直连超时→自动改用镜像→真的落盘且**第一跳必是直连、命中后不再往下试**；
+    全部候选失败→抛 `DictionaryDownloadException` 且 `attemptedUrls` 齐全、
+    **temp 目录不留半个包**；**取消原样抛出**且 `isCancellation` 仍判真。
+  - 归因层：五种 `DioErrorType` 各自归位；`badResponse` / `cancel` 不算传输失败
+    （不触发回退）；dio 把 `SocketException` 塞进 `unknown` 时仍认作连接错误。
+  - 文案层：下载阶段失败不得出现 "import failed"；超时原因里点名 host 且不含
+    `DioError`；全文诊断带原始地址与 cause；多条失败逐条保留不互相覆盖。
+  - 候选层：未接线时只有原址（与接线前逐字等价）；解析器返回空列表仍回落原址；
+    **huggingface 不展开**（把上表的实测结论钉进测试，防止有人日后随手加个假镜像）。
+  - 守卫升级：`dictionary_download_error_surfacing_guard_test.dart` /
+    `dictionary_import_no_delay_guard_test.dart` 原本按变量名 `failedNames` 断言
+    「失败有没有被收集」——**这个判据对根因 2 完全不敏感**（收集了，但收的是名字）。
+    改为断言 `DictionaryTaskFailure(` + `error: e,` + `DictionaryTaskStage.download`。
+  - **变异实测**（非空转）：删掉「取消原样抛出」那三行 → 定向批红在
+    `isCancellation` 那条断言上；还原后源文件 sha256 与变异前逐字节一致。
+- **未做 / 已知缺口**：
+  - **huggingface 系列（wty）在国内仍然连不上**。本条只让它**如实报错**
+    （点名主机 + 可复制全文），没有解决可达性。要解决只有两条路，都在
+    `fushi.moe` 站点仓库、需要部署凭据：① Cloudflare Worker 反代
+    `huggingface.co` 的 resolve 路径；② 把 wty 包镜像进 R2 并在 catalog 里加
+    `mirrors` 字段（推荐包 manifest 已有同名字段可参考）。客户端侧的接入点已经
+    留好——只要给 `dictionaryUrlCandidatesResolver` 多返回一个前缀即可，不需要再改
+    下载器。
+  - **真机复测未做**：本机无 Android 设备接入本次会话，Android 上「点下载 → 看到
+    中文原因 → 点复制」这条路径只由单测与源码守卫覆盖。

--- a/docs/bugs/BUG-2193-backup-export-drops-all-dicts-on-one-ghost-row.md
+++ b/docs/bugs/BUG-2193-backup-export-drops-all-dicts-on-one-ghost-row.md
@@ -1,0 +1,75 @@
+## BUG-2193 · 本地备份导出：一条幽灵词典元数据行让全部词典静默不打包
+- **报告**：2026-09-06（用户：「使用『本地备份-导出』功能时，即便勾选了词典（或勾选其他项），导出的压缩包里也只有 backup_meta.json 和 fushi.db，无法导出词典文件。」）
+- **真实性**：✅ 真 bug，而且**接近静默数据丢失**。根因是一道**无日志的全表 AND 门**：
+  - `backup_service.dart` 的
+    `includeDictionary = wants(dictionary) && await _hasCompleteDictionaryResources(root)`；
+  - `_hasCompleteDictionaryResources` 遍历 `dictionary_metadata` 全表，**任何一行**
+    其 `dictionaryResources/<name>/` 不存在或为空就 `return false`。
+  - 于是「一条坏行 → 一本都不打包」。更糟的是紧接着还会
+    `_stripDictionaryState(tmpDir)`（`clearAllDictionaryMeta` + `clearDictionaryHistory`），
+    把导出副本 DB 里的词典行也整表删掉。**zip 里既没有 `dictionaryResources/`，
+    `fushi.db` 里也没有词典元数据。**
+  - **全程零日志、零 UI 提示**，导出照样弹 `backup_export_success`。
+- **不变式本身是对的，实现方式是错的**：`docs/reviews/2026-06-01-project-review.md`
+  记着当年引入它的理由——「每一行 `dictionary_metadata` 都必须有对应的
+  `dictionaryResources/<name>/` 文件」，目的是不让恢复端造出查不了的幽灵词典。
+  这条不变式没问题，但把它实现成**全表 AND**，代价就从「那一条」放大成了「全部」。
+- **幽灵行怎么来的**（都有代码/档案依据）：
+  1. 运行期引擎**主动容忍**幽灵行——`app_model.dart` 的 `bucketDictPaths` 里
+     `if (!e.exists) continue;`，所以用户平时完全看不出自己有一行坏数据。
+  2. 覆盖式导入把 bak 里的词典行整表灌回、不校验磁盘
+     （`_reapplyDictionaryTablesFromBak`）。
+  3. `docs/bugs/BUG-1994-profile-switch-prunes-dictionary-metadata.md`：
+     profile 切换会误删/误留 `dictionary_metadata` 行。
+  4. 导入中断留下的 `import_temp` / `download_temp`、删除失败的 `.pending_delete`。
+- **第二个根因：显示口径 ≠ 打包口径**。勾选对话框里的「词典 (N)」来自
+  `summarizeLiveContent`，那里 `(await _db.getAllDictionaryMetadata()).length`
+  **只数 DB 行、完全不看磁盘**。于是对话框显示「词典 (12)」，勾上，导出后一本没有——
+  用户没有任何线索。（同一个函数里字体那一格反而是对齐的，注释还写着
+  「这也正是导出会打包的内容，所以预览计数、打包内容、导入回读三者一致」。）
+- **恢复侧会把这个坑埋得更深**（未改，仅记录）：`restoreBackup` 见包里没有
+  `dictionaryResources/` 条目时走 BUG-454 分支，认定「用户当初就没勾词典」，
+  从 `pre-restore.bak` 把本机词典行灌回、**不提示**。恢复到有旧库的机器上问题被完美
+  掩盖；恢复到新机器则词典彻底消失且零告警。
+- **[x] ① 已修复** — `worktree-fix-dict-download-error-anki-parallel`：
+  - **全表 AND → 逐本分区**：新增 `_DictionaryPackPlan{packable, ghosts}` 与
+    `_planDictionaryPack(root)`，逐本查磁盘后分区。不变式依然成立（出包里的每一行
+    都有对应文件），但代价降到「那一条」。
+  - **剥离改成三分支**：没勾词典 → 整表清空（行为不变）；勾了但一本都打不出来 →
+    同上；勾了且有得打 → **只**删缺文件的那几行（新增 `_stripGhostDictionaryRows`，
+    走 `deleteDictionaryMeta(name)` 逐行删，**不动查询历史**——那是「这次不导出词典」
+    才该做的事）。
+  - **打包按词典名枚举**：新增 `_collectDictionaryTrees`，只打 `packable` 里那几个
+    子目录。顺带修掉旧实现的副作用——`_collectTreeFiles` 整棵树无差别打包，会把
+    `import_temp` / `download_temp` / `update_temp` / `.pending_delete` 一起塞进备份包
+    白白撑大。
+  - **不再静默**：`createBackup` 新增 `onDictionariesSkipped` 回调；
+    `runBackupExportFlow` 收到后把成功提示换成
+    `backup_export_dictionaries_skipped`（点名跳过了哪几本，i18n × 17 语言）。
+    用户没勾词典时**不报**——那是他自己的选择，不是缺陷。
+  - **预览计数与打包口径统一**：`summarizeLiveContent` 的词典格改成数
+    `_planDictionaryPack(...).packable.length`。
+- **[x] ② 已加自动化测试** — 新增 `fushi/test/sync/backup_ghost_dictionary_row_test.dart`（6 条）。
+  定向批 8 个文件共 **90 条全绿**（含既有 `backup_categories_test` /
+  `backup_service_test` / `backup_full_export_test`，行为无回归）。
+  - 一条幽灵行不再连累其余词典：两本好的照进包，坏的那本只出现在 `skipped` 里。
+  - 运行期临时目录不进包（按词典名枚举的副产品）。
+  - 全是幽灵行时如实报出全部跳过，且不产出空的 `dictionaryResources/` 前缀。
+  - 没有幽灵行时**一条都不报**（不制造假警报）。
+  - 用户没勾词典时不算「被跳过」。
+  - 预览计数只数打得出来的（3 行 DB / 2 本有文件 → 计数必须是 2）。
+  - **为什么这个形态此前零覆盖**：`backup_categories_test` 的 harness 注释里明写
+    数据是造来「让 `_hasCompleteDictionaryResources` 放行」的；
+    `backup_service_test.dart:460` 那条只覆盖「整个根目录都不存在」，
+    没有覆盖「根在、但某一行的子目录缺失」这个真实形态。
+  - **变异实测**（非空转）：把判据改回 `... && dictionaryPlan.ghosts.isEmpty`
+    （即还原成全表 AND 门）→ 新测试立刻红；还原后源文件 sha256 与变异前逐字节一致。
+- **未做 / 已知缺口**：
+  - **恢复侧的歧义未消**：包里没有词典条目时，`restoreBackup` 仍无法区分
+    「用户没勾」与「导出时被跳过了」。`backup_meta.json` 的 `excludedCategories`
+    已经能表达前者，真正的修法是让恢复端在「没勾 ≠ 空」时给出提示。本条没动它，
+    避免把备份 wire 格式的改动混进来。
+  - **真机复测未做**：本机无 Android 设备接入本次会话，用户那台机器上到底是哪几行
+    幽灵行仍未知。要坐实需要用户的 `dictionary_metadata` 行数与
+    `dictionaryResources/` 实际子目录清单做一次比对——修复后导出时那条
+    「有 N 本词典被跳过（…）」的提示会直接把名字报出来。

--- a/docs/bugs/BUG-2195-ankidroid-parallel-build-invisible.md
+++ b/docs/bugs/BUG-2195-ankidroid-parallel-build-invisible.md
@@ -1,0 +1,85 @@
+## BUG-2195 · AnkiDroid 并行版（com.ichi2.anki.A）不被识别、权限框从不弹出
+- **报告**：2026-09-06（用户：「连接似乎写死的是 ankidroid，我手机某次装的 parallel.a 一直用下来的，就无法识别请求权限连接了，hsa 倒是正常请求权限」）
+- **真实性**：✅ 真 bug。根因是**并行版的三个标识全都带后缀，而我们三处全按主包写死**。
+- **上游事实（实测，不是推断）**：
+  - `ankidroid/Anki-Android` 的 `AnkiDroid/src/main/AndroidManifest.xml`：
+    provider 是 `android:authorities="${applicationId}.flashcards"`，
+    权限是 `<permission android:name="${applicationId}.permission.READ_WRITE_DATABASE">`。
+  - `AnkiDroid/build.gradle`：`applicationIdSuffix project.property("customSuffix")…`
+    —— 并行版就是主包 + 后缀，所以**包名 / authority / 权限名三者同时变**。
+  - 解包我们依赖的 `com.github.ankidroid:Anki-Android:2.17alpha14` 的 AAR，
+    逐个 class 扫常量池：`FlashCardsContract` 里躺着
+    `content://com.ichi2.anki.flashcards`、`com.ichi2.anki.flashcards`、
+    `com.ichi2.anki.permission.READ_WRITE_DATABASE`；`AddContentApi$Companion`
+    里也有 `com.ichi2.anki.flashcards`（就是 `getAnkiDroidPackageName` 用的那个）。
+    **全是编译期常量，没有任何注入点。**
+- **三处写死，对应三个后果**：
+  1. `AndroidManifest.xml` 的 `<queries>` 只声明了 `com.ichi2.anki` →
+     Android 11+ 包可见性把并行版整个挡在外面，`resolveContentProvider` 查不到；
+  2. `AnkiDroidHelper.isApiAvailable` 走 `AddContentApi.getAnkiDroidPackageName`
+     （只认写死的主包 authority）→ 恒 false →
+     `AnkiChannelHandler.requestAnkidroidPermissions` 在 `isApiAvailable` 那一步
+     直接短路成 `unavailable`，**`requestPermissions` 一次都不会被调到**，
+     这就是用户说的「无法识别、不请求权限」；
+  3. `<uses-permission>` 只有主包那一个 → 就算前两条修好，申请的仍是别人的权限名，
+     系统会静默判拒且不弹框（并行版定义的是
+     `com.ichi2.anki.A.permission.READ_WRITE_DATABASE`）。
+  另外 `grantUriPermission("com.ichi2.anki", …)` 与
+  `FlashCardsContract.AnkiMedia.CONTENT_URI` 也是写死的，媒体插入同样落空。
+  BUG-2098 修的是「权限申请不等结果」，与本条无关，它修完之后这条路依然全程不通。
+- **[x] ① 已修复** — `worktree-fix-dict-download-error-anki-parallel`：
+  - **新增 `AnkiDroidTarget`**：按候选包名逐个 `resolveContentProvider(<pkg>.flashcards)`
+    探测，命中即得「包名 / authority / 权限名」三件套，进程内缓存。候选表为
+    主包 + 官方并行版 A–E + `.debug`，**主包永远排第一**（同时装了两份时行为与修复前
+    一致）。上游 `customSuffix` 理论上任意，这张表不可能穷尽；不用
+    `QUERY_ALL_PACKAGES` 去穷举（Play 政策受限权限，为这点功能用它属于滥用）。
+  - **manifest**：`<queries>` 与 `<uses-permission>` 逐个候选各加一条。
+  - **`AnkiDroidHelper`**：`isApiAvailable` 改走 `AnkiDroidTarget.resolve`；
+    权限名收敛到新的 `readWritePermission()`，检查 / 申请 / rationale 三处共用。
+  - **`AnkiChannelHandler`**：`grantUriPermission` 授给解析出的包；
+    `AnkiMedia.CONTENT_URI` 经 `target.rebase(...)` 重挂 authority。
+  - **provider 抽象层**（`AnkiProvider` + `AnkiNote`）：
+    - `AddContentApiProvider` —— 主包用，**逐行委托** AAR 的 `AddContentApi`，
+      唯一的加工是把 `NoteInfo` 换成自己的 `AnkiNote`（并行版造不出 `NoteInfo`：
+      它只有 Kotlin 合成构造和 internal 的 `buildFromCursor$api_release`）。
+      守卫钉死这个类里不许出现 `ContentResolver` / `Cursor`。
+    - `DirectAnkiProvider` —— 并行版用，自己驱动 ContentResolver，authority 来自
+      `AnkiDroidTarget`。**列名 / path 段 / query 参数全部复用
+      `FlashCardsContract` 的常量**（它们不带包名，是 provider 契约的一部分），
+      唯一变的是 authority 一处。查重走 `notes_v2` 的 `mid=? and csum in (?)`
+      —— 与 AAR 的 spec-2 实现同一条路（它的格式串 `"%s=%d and %s in (%s)"`
+      就在常量池里），命中后仍逐条比首字段。
+  - **为什么是双路而不是收成一条**：这是**显式的临时兼容层**，理由是外部依赖不可
+    改（AAR 的 authority 是编译期常量）。**清理条件**：等 `DirectAnkiProvider` 在真机
+    上把「建卡组 / 建笔记类型 / 加笔记 / 查重 / 改字段」全部验证过，就把主包也切到它、
+    删掉 `AddContentApiProvider` 与对 AAR 的依赖，两条合并成一条。在那之前不合并，
+    是因为主包那条路是今天所有 Android 用户在走的，不能让「支持并行版」这件事拿它
+    冒险。
+- **[x] ② 已加自动化测试** — 新增
+  `fushi/test/android/ankidroid_parallel_build_guard_test.dart`（9 条源码守卫）。
+  定向批 5 个文件共 **33 条全绿**。Android 侧没有 JVM 单测基建，同类不变式历来用
+  源码扫描钉（见 `anki_native_createmodel_guard_test.dart`）。
+  - **候选表 ↔ manifest 逐条对应**：从 `CANDIDATE_PACKAGES` 解析出包名，
+    逐个断言 `<package>` 与 `<uses-permission>` 都在。这是最容易出的错——
+    「加了候选却忘了改 manifest」，那一项在 Android 11+ 上会恒不可见。
+  - 主包必须排第一、候选不得重复。
+  - `isApiAvailable` 不得回到 `AddContentApi.getAnkiDroidPackageName`。
+  - 权限名三处都走 `readWritePermission()`。
+  - `grantUriPermission` 不得写死主包；我们自己发的 URI 必须 `rebase`。
+  - 主包实现必须是纯委托（不得出现 `ContentResolver` / `Cursor`）。
+  - 并行版实现的代码里不得残留 `com.ichi2.anki.flashcards`。
+  - **变异实测**（非空转）：删掉 manifest 里 `.D` 那条 `<uses-permission>`
+    → 守卫立刻红在第 78 行；还原后文件 sha256 与变异前逐字节一致。
+  - **编译验证**：`flutter build apk --debug` 通过（`√ Built app-debug.apk`）。
+    过程中真抓到一个错——`FlashCardsContract.Deck` 的常量不叫 `CONTENT_URI`
+    而是 `CONTENT_ALL_URI`（另有 `CONTENT_SELECTED_URI`）。
+- **未做 / 已知缺口（重要）**：
+  - **真机行为未验证**。本机无 Android 设备接入本次会话，`DirectAnkiProvider`
+    的每一条写路径都只过了编译与源码守卫，**没有在真的并行版上跑过一次**。
+    按仓库纪律这条只能算 `implemented_unverified`：修好的是「识别 + 弹权限框」
+    这一段（那部分逻辑简单且有守卫），「并行版上真的能写卡」尚待用户在
+    `com.ichi2.anki.A` 上实测。
+  - 需要用户复测的顺序：① 打开 Anki 设置页看是否弹出权限框；② 授权后看卡组 /
+    笔记类型列表能否列出；③ 制一张卡；④ 带图片/音频的卡（走 media 插入那条）；
+    ⑤ 重复词条是否能正确识别为重复。任何一步失败请把错误码发回来。
+  - 用户当前的可用绕行：设置里打开「在手机上使用 AnkiConnect」。

--- a/docs/bugs/BUG-2196-reader-newline-splits-sentence.md
+++ b/docs/bugs/BUG-2196-reader-newline-splits-sentence.md
@@ -1,0 +1,87 @@
+## BUG-2196 · 阅读器把源码换行当句子分隔符，制卡拿到半截句、音频漏词
+- **报告**：2026-09-06（用户：制卡「选择句子上下文」对话框截图，「当前句」是
+  `shepherds abiding in the field,` —— 以逗号结尾；原话「这里加个试听？有时候断句在
+  很奇怪的地方，可能会漏词，制卡压没念」）
+- **真实性**：✅ 真 bug，且**已用真实 JS 逐字复现用户那一句**。
+  - 根因：`fushi/lib/src/reader/reader_selection_scripts.dart` 的
+    `sentenceDelimiters: '。！？.!?\n\r'` 把 `\n` / `\r` 算作句子分隔符。
+  - 而 `getSentenceContext` 读的是**文本节点的 `textContent`**（`:706` / `:731`），
+    它逐字保留 XHTML 源码里的换行；全文件没有一处 `innerText`，阅读器 CSS 里也没有
+    `white-space: pre`。EPUB 正文普遍在源码里硬换行，于是
+    `...in the field,\n keeping watch...` 被切在**逗号后的那个换行**处。
+  - 唯一的减震器是 `createWalker` 的 `/^[\s　]*$/` 过滤（`:497`），它只挡**纯空白
+    文本节点**（`</p>\n<p>` 之间那种），挡不住「既有可见文字又有换行」的节点——
+    正是 bug 现场。
+  - **复现（实测）**：用仓库既有的 node fake-DOM harness 执行真实抽取的 JS，注入
+    单个 `<p>` 文本节点 `"...shepherds abiding in the field,\n keeping watch over
+    their flock by night."`，在 `abiding` 上取句 →
+    `"And there were in the same country shepherds abiding in the field,"`，
+    **与用户截图逐字一致**。
+- **为什么会「制卡压没念」**：`getSurroundingSentences` 的 `describe()`
+  （`:862-866`）把句边界 `sStartOffset/sEndOffset` 转成 `normOffset/normLength`，
+  这对偏移正是喂给 `miningSentenceAudioRange` 的输入。句子被切成半句 ⇒ 区间是半句 ⇒
+  `CollectionAudioMatcher.findPlaybackRange` 只与更少的 cue 相交 ⇒ 裁出来的音频只有
+  半句。cue 本身一直是对的（`asr_cue_builder` / `audiobook_bridge` 都只按标点切，
+  不含 `\n`），错的自始至终只有 reader 这一侧。
+- **仓库内部的两个反证**（说明「换行不是句边界」才是本仓库的既定语义）：
+  - `reader_visual_novel_scripts.dart` 的同名表**本来就不含** `\n\r`；
+  - `reader_pdf_page.dart` 早就在分句前把 `\n`/`\r` **等长**换成空格，注释原文写着
+    「换行是分句符——直接分句会把每个视觉行切成一句，制卡拿到半截话」。
+    也就是说同一个 bug 在 PDF 那条路上被局部绕开过，EPUB 这条没有。
+- **谁依赖「换行是句边界」**：全仓逐条查过，**阅读器这条链上一个都没有**
+  （歌词模式每条 cue 是独立 `.cue` 块；`text_to_epub` 把行内换行变成 `<br/>`、
+  段落变成 `<p>`，DOM 文本节点里根本没有 `\n`；有声书 cue 对齐与 ASR 造 cue 都只按
+  标点）。**唯一真实依赖是 Windows UIA 全局查词**（`lookup/sentence_extraction.dart`）
+  —— 它拿到的是没有块级结构的裸串，galgame / 聊天窗里一行就是一句、行间常常没有
+  句末标点。两侧输入模型不同，本来就不该同表。
+- **[x] ① 已修复** — `worktree-fix-dict-download-error-anki-parallel`：
+  - `reader_selection_scripts.dart`：`sentenceDelimiters` 去掉 `\n\r`。
+  - 同一函数收尾把句子文本里的换行做**等长**替换成空格
+    （`.replace(/[\n\r]/g, ' ')`）。**必须等长**：`beforeText.length` /
+    `sentenceOffset` / `sStartOffset` / `sEndOffset` / `getNormalizedOffset` 的下标
+    全都建立在这个字符串上，用 `\s+` 折叠会整体打乱偏移，进而毁掉喂给
+    `miningSentenceAudioRange` 的 `normOffset/normLength`——那会把这个 bug 换成一个
+    更难查的。手法照抄 `reader_pdf_page.dart` 的先例。
+  - 三份 `selection.js` 镜像（`assets/popup/`、`assets/browser_extension/vendor/`、
+    `tools/browser-extension/vendor/`）同步去掉 `\n\r`：浏览器 DOM 与 EPUB 同语义。
+  - **`lookup/sentence_extraction.dart` 刻意不动**（扁平 buffer 那条路必须保留换行）。
+  - 漂移守卫 `sentence_extraction_test.dart` 原本要求两张表**逐字节相等**，是过约束
+    （它对本 bug 完全不敏感：两边一起错也算过）。改成「差集恰好是 `\n\r`、且方向
+    固定」：reader 侧不得含 `\n`、扁平侧必须含 `\n`、除此之外任何字符不一致立刻红。
+- **[x] ② 已加自动化测试**（定向批 13 文件 **105 条全绿**）：
+  - `reader_get_sentence_context_boundary_test.js` 新增 **CASE 11**：用用户那句原文，
+    在换行**前**（`abiding`）和**后**（`watch`）各取一次句，断言两次结果相同、都
+    包含 `keeping watch`、句中不含裸 `\n`，且 `field,` 与 `keeping` 之间是**两个**
+    空格——这两个空格就是「等长替换」的证据（折叠式替换只会留一个，并把后面每一个
+    偏移都挪位）。Dart 驱动侧同步断言整句原文。
+  - 原有 10 个特征化用例**逐字节不变**（实测：ORIGINAL 与修复后输出完全相同）。
+    那些用例里的 `makeText('\n  ', …)` 看似依赖换行，其实都是纯空白节点、被
+    `createWalker` 先 REJECT 掉，走不到分隔符判断。
+  - **变异实测**：把 `\n\r` 加回 `sentenceDelimiters` → CASE 11 与漂移守卫当场红；
+    还原后 sha256 与变异前逐字节一致。
+- **[x] ② 之二：加了用户要的「试听」**（BUG-2196 ②，定向批 10 文件 **119 条全绿**）
+  - `SentenceContextDialog` 底部新增试听/停止按钮（i18n × 17 语言）。
+  - **播的是「这次制卡真正会写进卡片的那段音频」**：区间取
+    `_miningDraft.composeAudioRange(_currentSentenceAudioRange())`，
+    **与 `_prepareMiningContext` 里喂给 ffmpeg 的是同一个表达式**，所以听到什么就
+    压出什么。刻意不播「当前句的 cue」——那只能证明这句有音频，证明不了裁出来的
+    那段念全了，而用户报的正是后者。
+  - 每次点都**重新求一次**区间：用户在这个对话框里加减上下文句的目的就是改变它，
+    缓存会让试听放上一次的范围。
+  - 宿主不支持（视频页等没有句级音频区间的表面）时整颗按钮不渲染；
+    宿主说「这句没音频」时按钮弹回并提示，不留一个「像在放但没声音」的状态；
+    取消 / 确认制卡都停播（对话框关了之后用户没有任何入口能停）。
+  - 新增 `fushi/test/pages/sentence_context_dialog_preview_test.dart`（8 条）。
+    **变异实测**：删掉确认路径上的 `unawaited(_stopPreview())` → 当场红；
+    还原后 sha256 逐字节一致。
+- **未做 / 已知缺口**：
+  - **cue 内没有插值**，需要单独立案。`findPlaybackRange` 与 `_expandAroundCue`
+    全程只做**整 cue 命中**（直接抄 `cue.startMs` / `cue.endMs`）。句边界修正后，
+    「压到隔壁句 / 压掉一半」这类会大面积消失，但两种形态仍在：① 粗对齐（后挂音频）
+    下一条 cue 可能覆盖一整段，此时无论句边界多准，拿到的都是那一整条的时间窗；
+    ② cue 比句短时，`normOffset` 与 `SubtitleRematchFragment.normCharStart` 在换行
+    字符上的**计数口径**是否一致尚未验证，不一致会让区间整体漂移。这两条要动的是
+    `packages/fushi_audio` 的匹配层，与本条不同域，另案。
+  - **真机复测未做**：本机无 Android 设备/有声书素材接入本次会话。断句这一段由
+    真实 JS 执行 + 用户原句钉住，试听那一段由 widget 行为测试钉住，但「在真书上点
+    试听真的出声、且与压出来的卡片音频一致」尚待用户实测。

--- a/fushi/android/app/src/main/AndroidManifest.xml
+++ b/fushi/android/app/src/main/AndroidManifest.xml
@@ -263,10 +263,31 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
-    <!-- Used for AnkiDroid API -->
+    <!-- Used for AnkiDroid API.
+         BUG-2195：AnkiDroid 的并行版（parallel builds）由上游 gradle 的 customSuffix
+         经 applicationIdSuffix 生成，包名 / provider authority / 读写权限名**三者都带
+         后缀**（上游 AndroidManifest 里 provider 是 ${applicationId}.flashcards、
+         permission 是 ${applicationId}.permission.READ_WRITE_DATABASE）。
+         权限名不同 = 必须逐个声明：只声明主包那一个时，即便包可见，
+         requestPermissions 对并行版也会静默判拒且不弹框。
+         这份清单必须与 AnkiDroidTarget.CANDIDATE_PACKAGES 逐条对应（有守卫钉）。 -->
     <uses-permission android:name="com.ichi2.anki.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.A.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.B.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.C.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.D.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.E.permission.READ_WRITE_DATABASE"/>
+    <uses-permission android:name="com.ichi2.anki.debug.permission.READ_WRITE_DATABASE"/>
     <queries>
+        <!-- Android 11+ 包可见性。没有这些声明时 resolveContentProvider 查不到并行版，
+             isApiAvailable 恒 false，权限框一次都不会弹（BUG-2195 的直接根因）。 -->
         <package android:name="com.ichi2.anki" />
+        <package android:name="com.ichi2.anki.A" />
+        <package android:name="com.ichi2.anki.B" />
+        <package android:name="com.ichi2.anki.C" />
+        <package android:name="com.ichi2.anki.D" />
+        <package android:name="com.ichi2.anki.E" />
+        <package android:name="com.ichi2.anki.debug" />
         <!-- Hibiki→Fushi 迁移：Android 11+ 包可见性，不声明则 getPackageInfo 查不到新包 -->
         <package android:name="app.hibiki.reader" />
     </queries>

--- a/fushi/android/app/src/main/java/app/fushi/reader/AddContentApiProvider.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AddContentApiProvider.java
@@ -1,0 +1,99 @@
+package app.fushi.reader;
+
+import android.content.Context;
+
+import com.ichi2.anki.api.AddContentApi;
+import com.ichi2.anki.api.NoteInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 主包 {@code com.ichi2.anki} 用的 {@link AnkiProvider}：逐行委托给上游 AAR 的
+ * {@code AddContentApi}（BUG-2195）。
+ *
+ * <p><b>这里不许有任何逻辑</b>。它存在的唯一目的，是让「支持并行版」这件事**一行
+ * 都不碰**今天所有 Android 用户在走的那条路——每个方法都必须是一次直白的转发，
+ * 唯一的加工是把 AAR 的 {@code NoteInfo} 换成我们自己的 {@link AnkiNote}（并行版
+ * 造不出 {@code NoteInfo}，见那个类的说明）。
+ */
+final class AddContentApiProvider implements AnkiProvider {
+
+    private final AddContentApi api;
+
+    AddContentApiProvider(Context context) {
+        this.api = new AddContentApi(context);
+    }
+
+    private static AnkiNote wrap(NoteInfo note) {
+        return note == null
+            ? null
+            : new AnkiNote(note.getId(), note.getFields(), note.getTags());
+    }
+
+    @Override
+    public Map<Long, String> getDeckList() {
+        return api.getDeckList();
+    }
+
+    @Override
+    public Map<Long, String> getModelList(int minNumFields) {
+        return minNumFields <= 0 ? api.getModelList() : api.getModelList(minNumFields);
+    }
+
+    @Override
+    public String getModelName(long modelId) {
+        return api.getModelName(modelId);
+    }
+
+    @Override
+    public String[] getFieldList(long modelId) {
+        return api.getFieldList(modelId);
+    }
+
+    @Override
+    public String getDeckName(long deckId) {
+        return api.getDeckName(deckId);
+    }
+
+    @Override
+    public Long addNewDeck(String deckName) {
+        return api.addNewDeck(deckName);
+    }
+
+    @Override
+    public Long addNote(long modelId, long deckId, String[] fields, Set<String> tags) {
+        return api.addNote(modelId, deckId, fields, tags);
+    }
+
+    @Override
+    public AnkiNote getNote(long noteId) {
+        return wrap(api.getNote(noteId));
+    }
+
+    @Override
+    public boolean updateNoteFields(long noteId, String[] fields) {
+        return api.updateNoteFields(noteId, fields);
+    }
+
+    @Override
+    public List<AnkiNote> findDuplicateNotes(long modelId, String key) {
+        final List<NoteInfo> found = api.findDuplicateNotes(modelId, key);
+        if (found == null) return null;
+        final List<AnkiNote> notes = new ArrayList<>(found.size());
+        for (final NoteInfo note : found) {
+            notes.add(wrap(note));
+        }
+        return notes;
+    }
+
+    @Override
+    public Long addNewCustomModel(String name, String[] fields, String[] cards,
+                                  String[] qfmt, String[] afmt, String css,
+                                  Long deckId, Integer sortFieldIndex) {
+        return api.addNewCustomModel(name, fields, cards, qfmt, afmt, css,
+            deckId, sortFieldIndex);
+    }
+}

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
@@ -17,8 +17,6 @@ import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
 
 import com.ichi2.anki.FlashCardsContract;
-import com.ichi2.anki.api.AddContentApi;
-import com.ichi2.anki.api.NoteInfo;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -103,7 +101,7 @@ public class AnkiChannelHandler {
                 final String filename = call.argument("filename");
                 final String preferredName = call.argument("preferredName");
                 final String mimeType = call.argument("mimeType");
-                final AddContentApi api = new AddContentApi(context);
+                final AnkiProvider api = AnkiProviders.forContext(context);
                 final ArrayList<String> noteTypeFields = call.argument("noteTypeFields");
                 final String noteTypeName = call.argument("noteTypeName");
                 final String cardName = call.argument("cardName");
@@ -194,7 +192,7 @@ public class AnkiChannelHandler {
                         // TODO-1007/1008：按内容（第一字段 = key，可选 reading 过滤）反查
                         // 所有同词卡的 note id + 一行预览，使 AnkiDroid 与桌面 AnkiConnect
                         // 一样能发现「别处/上次会话建的卡」。经 ContentProvider
-                        // findDuplicateNotes(mid, key) -> NoteInfo.getId()，不依赖 bool-only
+                        // findDuplicateNotes(mid, key) -> AnkiNote.getId()，不依赖 bool-only
                         // 的 checkForDuplicates。
                         if (models == null || key == null) {
                             result.error("MISSING_ARG",
@@ -261,7 +259,7 @@ public class AnkiChannelHandler {
                     case "getModelList":
                         if (requirePermission(result)) {
                             try {
-                                result.success(api.getModelList());
+                                result.success(api.getModelList(0));
                             } catch (Exception e) {
                                 result.error(providerErrorCode(e),
                                     e.getMessage(), null);
@@ -398,7 +396,16 @@ public class AnkiChannelHandler {
                         // 制卡断裂。
                         Uri fileUri = FileProvider.getUriForFile(
                             context, BuildConfig.APPLICATION_ID + ".provider", file);
-                        context.grantUriPermission("com.ichi2.anki", fileUri,
+                        // BUG-2195：授给实际安装的那个包。写死主包时，并行版拿不到
+                        // 这个 URI 的读权限，媒体插入必失败。
+                        final AnkiDroidTarget mediaTarget =
+                            AnkiDroidTarget.resolve(context);
+                        if (mediaTarget == null) {
+                            result.error("ANKI_NOT_INSTALLED",
+                                "AnkiDroid is not installed", null);
+                            return;
+                        }
+                        context.grantUriPermission(mediaTarget.packageName, fileUri,
                             Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         ContentValues contentValues = new ContentValues();
                         contentValues.put(FlashCardsContract.AnkiMedia.FILE_URI,
@@ -407,7 +414,9 @@ public class AnkiChannelHandler {
                             preferredName);
                         ContentResolver contentResolver = context.getContentResolver();
                         Uri returnUri = contentResolver.insert(
-                            FlashCardsContract.AnkiMedia.CONTENT_URI, contentValues);
+                            mediaTarget.rebase(
+                                FlashCardsContract.AnkiMedia.CONTENT_URI),
+                            contentValues);
                         if (returnUri == null || returnUri.getPath() == null) {
                             result.error("MEDIA_INSERT_FAILED",
                                 "AnkiDroid media insert returned null", null);
@@ -423,7 +432,7 @@ public class AnkiChannelHandler {
     }
 
     /**
-     * TODO-292: classify an exception thrown by AnkiDroid's {@link AddContentApi}
+     * TODO-292: classify an exception thrown by AnkiDroid's {@link AnkiProvider}
      * ContentProvider client. When the collection database cannot be opened
      * (collection in use / mid-sync / corrupt, AnkiDroid never opened once, API
      * disabled, background process killed) AnkiDroid throws with the literal
@@ -544,7 +553,7 @@ public class AnkiChannelHandler {
     }
 
     /**
-     * Adds a note via {@link AddContentApi#addNote} and returns the new note id.
+     * Adds a note via {@link AnkiProvider#addNote} and returns the new note id.
      *
      * <p>TODO-270 B: AnkiDroid addNote returns the {@code Long} id of the newly
      * created note (or {@code null} if it refused to create one - e.g. a
@@ -556,7 +565,7 @@ public class AnkiChannelHandler {
      */
     private Long addNote(String model, String deck,
                          ArrayList<String> fields, ArrayList<String> tags) {
-        final AddContentApi api = new AddContentApi(context);
+        final AnkiProvider api = AnkiProviders.forContext(context);
 
         long deckId;
         Long existingDeck = ankiDroid.findDeckIdByName(deck);
@@ -588,17 +597,17 @@ public class AnkiChannelHandler {
      * TODO-270 C2: reads an existing note's fields as a {@code name -> value}
      * map (symmetric with the AnkiConnect notesInfo contract).
      *
-     * <p>AnkiDroid is positional: {@link NoteInfo#getFields()} is an array in the
+     * <p>AnkiDroid is positional: {@link AnkiNote#getFields()} is an array in the
      * note's model field order, with no field names attached. We resolve the
      * note's model id (via the {@code Note.MID} column) and zip its field-name
-     * list ({@link AddContentApi#getFieldList}) with the positional values.
+     * list ({@link AnkiProvider#getFieldList}) with the positional values.
      *
      * @return {@code name -> value} (insertion-ordered by field order), or
      *         {@code null} if the note no longer exists / its model is gone.
      */
     private Map<String, String> notesInfo(long noteId) {
-        final AddContentApi api = new AddContentApi(context);
-        NoteInfo note = api.getNote(noteId);
+        final AnkiProvider api = AnkiProviders.forContext(context);
+        AnkiNote note = api.getNote(noteId);
         if (note == null) {
             return null;
         }
@@ -619,7 +628,7 @@ public class AnkiChannelHandler {
      * preserving every field the caller did not name (symmetric with the
      * AnkiConnect updateNoteFields contract).
      *
-     * <p>{@link AddContentApi#updateNoteFields} takes a positional
+     * <p>{@link AnkiProvider#updateNoteFields} takes a positional
      * {@code String[]} keyed by the model's field order. We start from the note's
      * current values and overwrite only the named ones, so unspecified fields are
      * not cleared.
@@ -628,8 +637,8 @@ public class AnkiChannelHandler {
      *         note / its model cannot be found or AnkiDroid refused the update.
      */
     private String updateNoteFields(long noteId, Map<String, String> fieldValues) {
-        final AddContentApi api = new AddContentApi(context);
-        NoteInfo note = api.getNote(noteId);
+        final AnkiProvider api = AnkiProviders.forContext(context);
+        AnkiNote note = api.getNote(noteId);
         if (note == null) {
             return "Note not found: " + noteId;
         }
@@ -657,14 +666,14 @@ public class AnkiChannelHandler {
 
     /**
      * Resolves the field-name list (in field order) for the model that owns
-     * noteId. {@link NoteInfo} carries no model id, so we read the note's
+     * noteId. {@link AnkiNote} carries no model id, so we read the note's
      * {@code Note.MID} column from the ContentProvider, then ask
-     * {@link AddContentApi#getFieldList} for that model's field names.
+     * {@link AnkiProvider#getFieldList} for that model's field names.
      *
      * @return the field names in order, or {@code null} if the note / model is
      *         not resolvable.
      */
-    private String[] fieldNamesForNote(AddContentApi api, long noteId) {
+    private String[] fieldNamesForNote(AnkiProvider api, long noteId) {
         Long modelId = modelIdForNote(noteId);
         if (modelId == null) {
             return null;
@@ -699,18 +708,18 @@ public class AnkiChannelHandler {
     private boolean checkForDuplicates(ArrayList<String> models, String key,
                                        String reading,
                                        ArrayList<Integer> readingFieldIndices) {
-        final AddContentApi api = new AddContentApi(context);
+        final AnkiProvider api = AnkiProviders.forContext(context);
         for (int i = 0; i < models.size(); i++) {
             String model = models.get(i);
             Long mid = ankiDroid.findModelIdByName(model, 1);
             if (mid == null) continue;
-            List<NoteInfo> notes = api.findDuplicateNotes(mid, key);
+            List<AnkiNote> notes = api.findDuplicateNotes(mid, key);
             if (notes.isEmpty()) continue;
             if (reading == null || reading.isEmpty()) return true;
             int readingIdx = (readingFieldIndices != null && i < readingFieldIndices.size())
                     ? readingFieldIndices.get(i) : -1;
             if (readingIdx < 0) return true;
-            for (NoteInfo note : notes) {
+            for (AnkiNote note : notes) {
                 String[] noteFields = note.getFields();
                 if (readingIdx < noteFields.length && reading.equals(noteFields[readingIdx])) {
                     return true;
@@ -728,9 +737,9 @@ public class AnkiChannelHandler {
      *
      * <p>This is the AnkiDroid analogue of the AnkiConnect findNotes + notesInfo
      * path: it discovers cards created anywhere (other apps, previous sessions),
-     * not just the current popup session. {@link AddContentApi#findDuplicateNotes}
-     * gives the matching {@link NoteInfo}s; {@link NoteInfo#getId()} is the note
-     * id and {@link NoteInfo#getFields()}[0] (HTML-stripped on the Dart side) is
+     * not just the current popup session. {@link AnkiProvider#findDuplicateNotes}
+     * gives the matching {@link AnkiNote}s; {@link AnkiNote#getId()} is the note
+     * id and {@link AnkiNote#getFields()}[0] (HTML-stripped on the Dart side) is
      * the preview.
      *
      * @return a list of {@code LinkedHashMap{noteId:Long, preview:String}},
@@ -739,7 +748,7 @@ public class AnkiChannelHandler {
     private List<Map<String, Object>> findNotesByContent(
             ArrayList<String> models, String key, String reading,
             ArrayList<Integer> readingFieldIndices) {
-        final AddContentApi api = new AddContentApi(context);
+        final AnkiProvider api = AnkiProviders.forContext(context);
         // De-dup by note id across models (a card matches at most one model, but
         // guard anyway), then sort newest-first.
         final LinkedHashMap<Long, String> byId = new LinkedHashMap<>();
@@ -747,11 +756,11 @@ public class AnkiChannelHandler {
             String model = models.get(i);
             Long mid = ankiDroid.findModelIdByName(model, 1);
             if (mid == null) continue;
-            List<NoteInfo> notes = api.findDuplicateNotes(mid, key);
+            List<AnkiNote> notes = api.findDuplicateNotes(mid, key);
             if (notes == null || notes.isEmpty()) continue;
             int readingIdx = (readingFieldIndices != null && i < readingFieldIndices.size())
                     ? readingFieldIndices.get(i) : -1;
-            for (NoteInfo note : notes) {
+            for (AnkiNote note : notes) {
                 String[] noteFields = note.getFields();
                 // When a reading is supplied and the model has a reading field,
                 // keep only notes whose reading also matches (mirrors the dupe
@@ -813,7 +822,7 @@ public class AnkiChannelHandler {
     private void createNoteType(String name, ArrayList<String> fields,
                                 String cardName, String front, String back,
                                 String css) {
-        final AddContentApi api = new AddContentApi(context);
+        final AnkiProvider api = AnkiProviders.forContext(context);
         // Idempotent: a model with this name + field count already exists.
         if (ankiDroid.findModelIdByName(name, fields.size()) != null) return;
         api.addNewCustomModel(

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
@@ -11,8 +11,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import android.util.SparseArray;
 
-import com.ichi2.anki.api.AddContentApi;
-import com.ichi2.anki.api.NoteInfo;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -27,25 +25,52 @@ public class AnkiDroidHelper {
     private static final String DECK_REF_DB = "com.ichi2.anki.api.decks";
     private static final String MODEL_REF_DB = "com.ichi2.anki.api.models";
 
-    private AddContentApi mApi;
+    private AnkiProvider mApi;
     private Context mContext;
 
     public AnkiDroidHelper(Context context) {
         mContext = context.getApplicationContext();
-        mApi = new AddContentApi(mContext);
+        // BUG-2195：主包仍是 AddContentApi（逐行委托、行为不变），并行版走自建的
+        // ContentResolver 实现。一个都没装时为 null——调用点在此之前都被
+        // isApiAvailable 挡住了。
+        mApi = AnkiProviders.forContext(mContext);
     }
 
-    public AddContentApi getApi() {
+    public AnkiProvider getApi() {
         return mApi;
     }
 
     /**
      * Whether or not the API is available to use.
      * The API could be unavailable if AnkiDroid is not installed or the user explicitly disabled the API
+     *
+     * <p>BUG-2195：判据从 {@code AddContentApi.getAnkiDroidPackageName}（只认写死的
+     * 主包 authority {@code com.ichi2.anki.flashcards}）换成 {@link AnkiDroidTarget}
+     * 的逐候选探测，否则装了并行版（{@code com.ichi2.anki.A} 等）的机器上这里恒
+     * false，权限框一次都不会弹。
+     *
      * @return true if the API is available to use
      */
     public static boolean isApiAvailable(Context context) {
-        return AddContentApi.getAnkiDroidPackageName(context) != null;
+        return AnkiDroidTarget.resolve(context) != null;
+    }
+
+    /**
+     * 本设备上实际装的那份 AnkiDroid；一个都没有则 null。
+     */
+    public static AnkiDroidTarget target(Context context) {
+        return AnkiDroidTarget.resolve(context);
+    }
+
+    /**
+     * 要申请的读写权限名。BUG-2195：并行版定义的是**它自己**那个带后缀的权限
+     * （{@code com.ichi2.anki.A.permission.READ_WRITE_DATABASE}），申请主包那个只会
+     * 静默判拒。没解析到安装时回退主包常量——此时 shouldRequestPermission 的结果无人
+     * 使用（isApiAvailable 已经先短路了）。
+     */
+    private String readWritePermission() {
+        final AnkiDroidTarget resolved = AnkiDroidTarget.resolve(mContext);
+        return resolved == null ? READ_WRITE_PERMISSION : resolved.permission;
     }
 
     /**
@@ -55,7 +80,7 @@ public class AnkiDroidHelper {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return false;
         }
-        return ContextCompat.checkSelfPermission(mContext, READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED;
+        return ContextCompat.checkSelfPermission(mContext, readWritePermission()) != PackageManager.PERMISSION_GRANTED;
     }
 
     /**
@@ -64,7 +89,7 @@ public class AnkiDroidHelper {
      * @param callbackCode The callback code to be used in onRequestPermissionsResult()
      */
     public void requestPermission(Activity callbackActivity, int callbackCode) {
-        ActivityCompat.requestPermissions(callbackActivity, new String[]{READ_WRITE_PERMISSION}, callbackCode);
+        ActivityCompat.requestPermissions(callbackActivity, new String[]{readWritePermission()}, callbackCode);
     }
 
     /**
@@ -76,7 +101,7 @@ public class AnkiDroidHelper {
      */
     public boolean canAskPermissionAgain(Activity callbackActivity) {
         return ActivityCompat.shouldShowRequestPermissionRationale(
-                callbackActivity, READ_WRITE_PERMISSION);
+                callbackActivity, readWritePermission());
     }
 
 
@@ -102,13 +127,28 @@ public class AnkiDroidHelper {
      * @param tags List of tags to remove duplicates from
      * @param modelId ID of model to search for duplicates on
      */
+    private SparseArray<List<AnkiNote>> findDuplicateNotesByKeys(
+            long modelId, List<String> keys) {
+        // BUG-2195：AnkiProvider 只暴露单 key 查重（两个实现都能可靠支持），多 key
+        // 版在这里按 key 逐个查。本方法只服务下面那个从上游 sample 抄来的
+        // removeDuplicates —— 它全仓无调用，保留只为不删上游对照代码。
+        final SparseArray<List<AnkiNote>> result = new SparseArray<>();
+        for (int i = 0; i < keys.size(); i++) {
+            final List<AnkiNote> found = mApi.findDuplicateNotes(modelId, keys.get(i));
+            if (found != null && !found.isEmpty()) {
+                result.put(i, found);
+            }
+        }
+        return result;
+    }
+
     public void removeDuplicates(LinkedList<String []> fields, LinkedList<Set<String>> tags, long modelId) {
         // Build a list of the duplicate keys (first fields) and find all notes that have a match with each key
         List<String> keys = new ArrayList<>(fields.size());
         for (String[] f: fields) {
             keys.add(f[0]);
         }
-        SparseArray<List<NoteInfo>> duplicateNotes = getApi().findDuplicateNotes(modelId, keys);
+        SparseArray<List<AnkiNote>> duplicateNotes = findDuplicateNotesByKeys(modelId, keys);
         // Do some sanity checks
         if (tags.size() != fields.size()) {
             throw new IllegalStateException("List of tags must be the same length as the list of fields");

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidTarget.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidTarget.java
@@ -1,0 +1,139 @@
+package app.fushi.reader;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
+import android.net.Uri;
+
+/**
+ * 这台设备上**实际安装**的那个 AnkiDroid（BUG-2195）。
+ *
+ * <p>为什么需要它：AnkiDroid 官方除了主包 {@code com.ichi2.anki} 还发布「并行版」
+ * （parallel builds），供用户同时装多份。并行版是由 gradle 的 {@code customSuffix}
+ * 属性经 {@code applicationIdSuffix} 生成的，因此
+ * <ul>
+ *   <li>包名 = {@code com.ichi2.anki.<后缀>}</li>
+ *   <li>ContentProvider authority = {@code ${applicationId}.flashcards}
+ *       （上游 {@code AnkiDroid/src/main/AndroidManifest.xml} 的 provider 段）</li>
+ *   <li>读写权限 = {@code ${applicationId}.permission.READ_WRITE_DATABASE}
+ *       （同文件的 {@code <permission>} 声明）</li>
+ * </ul>
+ * 三者**都带后缀**。而我们依赖的 {@code com.github.ankidroid:Anki-Android} AAR 里，
+ * {@code FlashCardsContract} 把 {@code content://com.ichi2.anki.flashcards} 和
+ * {@code com.ichi2.anki.permission.READ_WRITE_DATABASE} 编译成了常量（已解包该 AAR
+ * 的常量池逐一核对过），{@code AddContentApi.getAnkiDroidPackageName} 也只按那个写死
+ * 的 authority 去 {@code resolveContentProvider}。
+ *
+ * <p>后果就是用户报的现象：装了并行版 A 的机器上
+ * {@code AnkiDroidHelper.isApiAvailable} 恒 false → 权限请求在
+ * {@code AnkiChannelHandler} 里直接短路成 {@code unavailable}，
+ * <b>系统权限对话框一次都不会弹</b>。
+ *
+ * <p>本类把「装的是哪一个」变成一次显式解析：逐个候选 authority 去
+ * {@link PackageManager#resolveContentProvider}，命中即得包名 / authority / 权限名
+ * 三件套。解析结果进程内缓存（安装/卸载会重启进程，缓存不会过期成谎话）。
+ */
+public final class AnkiDroidTarget {
+
+    /** AnkiDroid 主包。并行版都是它加一个后缀。 */
+    public static final String MAIN_PACKAGE = "com.ichi2.anki";
+
+    /**
+     * 候选包名，**按优先级**排列：主包永远第一（同时装了主包和并行版时行为与修复前
+     * 一致），随后是官方并行版 A–E，最后是开发者自编的 debug 版。
+     *
+     * <p>上游的 {@code customSuffix} 理论上可以是任意字符串，所以这张表不可能穷尽；
+     * 它覆盖的是官方实际发布的那几个。用 {@code QUERY_ALL_PACKAGES} 去穷举是不可接受
+     * 的替代方案（Play 政策受限权限，且为这点功能要它属于滥用）。清单必须与
+     * {@code AndroidManifest.xml} 里的 {@code <queries>} / {@code <uses-permission>}
+     * 逐条对应——**只在这里加一项而忘了改 manifest，新项在 Android 11+ 上恒不可见**，
+     * 有源码守卫钉这条一致性。
+     */
+    public static final String[] CANDIDATE_PACKAGES = {
+        MAIN_PACKAGE,
+        MAIN_PACKAGE + ".A",
+        MAIN_PACKAGE + ".B",
+        MAIN_PACKAGE + ".C",
+        MAIN_PACKAGE + ".D",
+        MAIN_PACKAGE + ".E",
+        MAIN_PACKAGE + ".debug",
+    };
+
+    private static volatile AnkiDroidTarget sCached;
+    private static volatile boolean sResolved;
+
+    /** 安装包名，例如 {@code com.ichi2.anki.A}。 */
+    public final String packageName;
+
+    /** 该安装的 flashcards provider authority。 */
+    public final String authority;
+
+    /** 该安装定义的读写权限名。 */
+    public final String permission;
+
+    private AnkiDroidTarget(String packageName) {
+        this.packageName = packageName;
+        this.authority = authorityFor(packageName);
+        this.permission = permissionFor(packageName);
+    }
+
+    public static String authorityFor(String packageName) {
+        return packageName + ".flashcards";
+    }
+
+    public static String permissionFor(String packageName) {
+        return packageName + ".permission.READ_WRITE_DATABASE";
+    }
+
+    /** 是不是主包。并行版无法走 AAR 的 {@code AddContentApi}（authority 写死）。 */
+    public boolean isMainBuild() {
+        return MAIN_PACKAGE.equals(packageName);
+    }
+
+    /**
+     * 把 {@code FlashCardsContract} 里那些写死主包 authority 的 URI 换成本目标的。
+     *
+     * <p>只换 authority，path / query 原样保留——列名、path 段、query 参数都不带包名，
+     * 是 provider 契约的一部分，与装的是哪一份无关。
+     */
+    public Uri rebase(Uri contractUri) {
+        if (contractUri == null) return null;
+        if (authority.equals(contractUri.getAuthority())) return contractUri;
+        return contractUri.buildUpon().authority(authority).build();
+    }
+
+    /**
+     * 解析这台设备上装的 AnkiDroid；一个都没有则返回 {@code null}。
+     *
+     * <p>判据是 {@link PackageManager#resolveContentProvider}——「provider 在不在」比
+     * 「包在不在」更准：用户可能装了 AnkiDroid 但在它的设置里关掉了 API provider，
+     * 那种情况下包查得到、provider 查不到，而我们真正需要的是后者。
+     */
+    public static AnkiDroidTarget resolve(Context context) {
+        if (sResolved) return sCached;
+        synchronized (AnkiDroidTarget.class) {
+            if (sResolved) return sCached;
+            AnkiDroidTarget found = null;
+            final PackageManager pm = context.getPackageManager();
+            for (final String candidate : CANDIDATE_PACKAGES) {
+                final ProviderInfo info =
+                    pm.resolveContentProvider(authorityFor(candidate), 0);
+                if (info != null) {
+                    found = new AnkiDroidTarget(candidate);
+                    break;
+                }
+            }
+            sCached = found;
+            sResolved = true;
+            return found;
+        }
+    }
+
+    /** 仅供测试/诊断：丢弃缓存，下次 {@link #resolve} 重新探测。 */
+    public static void invalidateCache() {
+        synchronized (AnkiDroidTarget.class) {
+            sCached = null;
+            sResolved = false;
+        }
+    }
+}

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiNote.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiNote.java
@@ -1,0 +1,38 @@
+package app.fushi.reader;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * 一条 Anki 笔记的最小快照（BUG-2195）。
+ *
+ * <p>为什么不直接用 AAR 的 {@code com.ichi2.anki.api.NoteInfo}：它没有公开构造函数
+ * （只有 Kotlin 生成的合成构造和 {@code buildFromCursor$api_release} 这个 internal
+ * 方法），并行版走的 {@link DirectAnkiProvider} 自己读 cursor，造不出它。用自己的
+ * DTO 让两个 {@link AnkiProvider} 实现返回同一种类型，调用方因此完全不需要知道
+ * 底下是哪一条路。
+ */
+public final class AnkiNote {
+
+    private final long id;
+    private final String[] fields;
+    private final Set<String> tags;
+
+    public AnkiNote(long id, String[] fields, Set<String> tags) {
+        this.id = id;
+        this.fields = fields == null ? new String[0] : fields;
+        this.tags = tags == null ? Collections.<String>emptySet() : tags;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String[] getFields() {
+        return fields;
+    }
+
+    public Set<String> getTags() {
+        return tags;
+    }
+}

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiProvider.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiProvider.java
@@ -1,0 +1,72 @@
+package app.fushi.reader;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 对 AnkiDroid flashcards ContentProvider 的调用面（BUG-2195）。
+ *
+ * <p>只有两个实现，差别**仅仅**是 provider authority 从哪来：
+ * <ul>
+ *   <li>{@link AddContentApiProvider}：主包 {@code com.ichi2.anki}，直接委托给
+ *       上游 AAR 的 {@code AddContentApi}。逐行委托、零行为改动——这条是今天所有
+ *       Android 用户在走的路，不能因为支持并行版而让它承担任何风险。</li>
+ *   <li>{@link DirectAnkiProvider}：并行版（{@code com.ichi2.anki.A} 等）。AAR 把
+ *       {@code content://com.ichi2.anki.flashcards} 和权限名都编译成了常量（解包
+ *       该 AAR 的常量池核对过），没有任何注入点，所以并行版只能自己驱动
+ *       ContentResolver。</li>
+ * </ul>
+ *
+ * <p><b>这是显式的临时兼容层</b>，理由是外部依赖不可改：上游 AAR 的 authority 是
+ * 编译期常量。清理条件很明确——等 {@link DirectAnkiProvider} 在真机上把「建卡组 /
+ * 建笔记类型 / 加笔记 / 查重 / 改字段」全部验证过之后，把主包也切到它、删掉
+ * {@link AddContentApiProvider} 与对 AAR 的依赖，两条路合并成一条。
+ */
+public interface AnkiProvider {
+
+    /** {@code deckId -> deckName}。 */
+    Map<Long, String> getDeckList();
+
+    /** {@code modelId -> modelName}，字段数不少于 {@code minNumFields}（0 = 不限）。 */
+    Map<Long, String> getModelList(int minNumFields);
+
+    /** 笔记类型名；不存在返回 null。 */
+    String getModelName(long modelId);
+
+    /** 笔记类型的字段名，按字段顺序；不存在返回 null。 */
+    String[] getFieldList(long modelId);
+
+    /** 卡组名；不存在返回 null。 */
+    String getDeckName(long deckId);
+
+    /** 新建卡组，返回 deckId；失败返回 null。 */
+    Long addNewDeck(String deckName);
+
+    /** 加一条笔记，返回 noteId；失败返回 null。 */
+    Long addNote(long modelId, long deckId, String[] fields, Set<String> tags);
+
+    /** 读一条笔记；不存在返回 null。 */
+    AnkiNote getNote(long noteId);
+
+    /** 整体覆盖一条笔记的字段（按笔记类型的字段顺序）。 */
+    boolean updateNoteFields(long noteId, String[] fields);
+
+    /**
+     * 找出 {@code modelId} 下首字段等于 {@code key} 的笔记。
+     *
+     * <p>返回空列表 = 确实没有；返回 {@code null} = **查不了**（调用方必须把它与
+     * 「没有重复」区分开，否则会静默造出重复卡）。
+     */
+    List<AnkiNote> findDuplicateNotes(long modelId, String key);
+
+    /**
+     * 新建自定义笔记类型，返回 modelId；失败返回 null。
+     *
+     * <p>{@code cards} / {@code qfmt} / {@code afmt} 三个数组必须等长（每张卡片模板
+     * 一组）。
+     */
+    Long addNewCustomModel(String name, String[] fields, String[] cards,
+                           String[] qfmt, String[] afmt, String css,
+                           Long deckId, Integer sortFieldIndex);
+}

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiProviders.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiProviders.java
@@ -1,0 +1,24 @@
+package app.fushi.reader;
+
+import android.content.Context;
+
+/**
+ * 按这台设备上装的是哪一份 AnkiDroid，选出对应的 {@link AnkiProvider}（BUG-2195）。
+ *
+ * <p>主包走 {@link AddContentApiProvider}（委托上游 AAR，与修复前逐行等价）；
+ * 并行版走 {@link DirectAnkiProvider}（自己驱动 ContentResolver）。
+ * 一个都没装时返回 {@code null}——调用方在此之前应该已经被
+ * {@code AnkiDroidHelper.isApiAvailable} 挡住了。
+ */
+final class AnkiProviders {
+
+    private AnkiProviders() {}
+
+    static AnkiProvider forContext(Context context) {
+        final AnkiDroidTarget target = AnkiDroidTarget.resolve(context);
+        if (target == null) return null;
+        return target.isMainBuild()
+            ? new AddContentApiProvider(context)
+            : new DirectAnkiProvider(context, target);
+    }
+}

--- a/fushi/android/app/src/main/java/app/fushi/reader/DirectAnkiProvider.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/DirectAnkiProvider.java
@@ -1,0 +1,345 @@
+package app.fushi.reader;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.text.TextUtils;
+
+import com.ichi2.anki.FlashCardsContract;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 并行版 AnkiDroid（{@code com.ichi2.anki.A} 等）用的 {@link AnkiProvider}：自己驱动
+ * ContentResolver，authority 来自 {@link AnkiDroidTarget}（BUG-2195）。
+ *
+ * <p>为什么必须自己写：上游 AAR 把 {@code content://com.ichi2.anki.flashcards} 编译
+ * 成了 {@code FlashCardsContract} 的常量，{@code AddContentApi} 的每一个 URI 都由它
+ * 派生，没有任何注入点（解包 {@code Anki-Android-2.17alpha14.aar} 的常量池逐一核对
+ * 过）。而并行版的 authority 是 {@code ${applicationId}.flashcards}，对不上。
+ *
+ * <p><b>列名、path 段、query 参数全部复用 {@code FlashCardsContract} 的常量</b>——
+ * 它们不带包名，是 provider 契约的一部分，与装的是哪一份无关。这里改的只有
+ * authority 一处，所以「契约漂移」的风险和主包路径是同一个量级。
+ */
+final class DirectAnkiProvider implements AnkiProvider {
+
+    /** Anki 用来分隔一条笔记各字段的字符（0x1f，Unit Separator）。 */
+    private static final String FIELD_SEPARATOR = "\u001f";
+
+    private final ContentResolver resolver;
+    private final AnkiDroidTarget target;
+
+    DirectAnkiProvider(Context context, AnkiDroidTarget target) {
+        this.resolver = context.getContentResolver();
+        this.target = target;
+    }
+
+    // ── URI ────────────────────────────────────────────────────────────
+
+    private Uri notes() {
+        return target.rebase(FlashCardsContract.Note.CONTENT_URI);
+    }
+
+    private Uri notesV2() {
+        return target.rebase(FlashCardsContract.Note.CONTENT_URI_V2);
+    }
+
+    private Uri note(long noteId) {
+        return Uri.withAppendedPath(notes(), Long.toString(noteId));
+    }
+
+    private Uri models() {
+        return target.rebase(FlashCardsContract.Model.CONTENT_URI);
+    }
+
+    private Uri model(long modelId) {
+        return Uri.withAppendedPath(models(), Long.toString(modelId));
+    }
+
+    private Uri decks() {
+        // Deck 的常量名与 Note/Model 不同步：它叫 CONTENT_ALL_URI
+        // （另有 CONTENT_SELECTED_URI 指“当前选中的卡组”）。
+        return target.rebase(FlashCardsContract.Deck.CONTENT_ALL_URI);
+    }
+
+    private Uri deck(long deckId) {
+        return Uri.withAppendedPath(decks(), Long.toString(deckId));
+    }
+
+    // ── 卡组 ───────────────────────────────────────────────────────────
+
+    @Override
+    public Map<Long, String> getDeckList() {
+        final Map<Long, String> result = new LinkedHashMap<>();
+        final Cursor cursor = resolver.query(decks(), null, null, null, null);
+        if (cursor == null) return result;
+        try {
+            final int idIdx = cursor.getColumnIndex(FlashCardsContract.Deck.DECK_ID);
+            final int nameIdx = cursor.getColumnIndex(FlashCardsContract.Deck.DECK_NAME);
+            if (idIdx < 0 || nameIdx < 0) return result;
+            while (cursor.moveToNext()) {
+                result.put(cursor.getLong(idIdx), cursor.getString(nameIdx));
+            }
+        } finally {
+            cursor.close();
+        }
+        return result;
+    }
+
+    @Override
+    public String getDeckName(long deckId) {
+        final Cursor cursor = resolver.query(deck(deckId), null, null, null, null);
+        if (cursor == null) return null;
+        try {
+            final int nameIdx = cursor.getColumnIndex(FlashCardsContract.Deck.DECK_NAME);
+            if (nameIdx < 0 || !cursor.moveToFirst()) return null;
+            return cursor.getString(nameIdx);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public Long addNewDeck(String deckName) {
+        final ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Deck.DECK_NAME, deckName);
+        final Uri inserted = resolver.insert(decks(), values);
+        return lastPathAsLong(inserted);
+    }
+
+    // ── 笔记类型 ───────────────────────────────────────────────────────
+
+    @Override
+    public Map<Long, String> getModelList(int minNumFields) {
+        final Map<Long, String> result = new LinkedHashMap<>();
+        final Cursor cursor = resolver.query(models(), null, null, null, null);
+        if (cursor == null) return result;
+        try {
+            final int idIdx = cursor.getColumnIndex(FlashCardsContract.Model._ID);
+            final int nameIdx = cursor.getColumnIndex(FlashCardsContract.Model.NAME);
+            final int fieldsIdx =
+                cursor.getColumnIndex(FlashCardsContract.Model.FIELD_NAMES);
+            if (idIdx < 0 || nameIdx < 0) return result;
+            while (cursor.moveToNext()) {
+                if (minNumFields > 0 && fieldsIdx >= 0) {
+                    final String[] names = splitFields(cursor.getString(fieldsIdx));
+                    if (names.length < minNumFields) continue;
+                }
+                result.put(cursor.getLong(idIdx), cursor.getString(nameIdx));
+            }
+        } finally {
+            cursor.close();
+        }
+        return result;
+    }
+
+    @Override
+    public String getModelName(long modelId) {
+        final Cursor cursor = resolver.query(model(modelId), null, null, null, null);
+        if (cursor == null) return null;
+        try {
+            final int nameIdx = cursor.getColumnIndex(FlashCardsContract.Model.NAME);
+            if (nameIdx < 0 || !cursor.moveToFirst()) return null;
+            return cursor.getString(nameIdx);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public String[] getFieldList(long modelId) {
+        final Cursor cursor = resolver.query(model(modelId), null, null, null, null);
+        if (cursor == null) return null;
+        try {
+            final int fieldsIdx =
+                cursor.getColumnIndex(FlashCardsContract.Model.FIELD_NAMES);
+            if (fieldsIdx < 0 || !cursor.moveToFirst()) return null;
+            return splitFields(cursor.getString(fieldsIdx));
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public Long addNewCustomModel(String name, String[] fields, String[] cards,
+                                  String[] qfmt, String[] afmt, String css,
+                                  Long deckId, Integer sortFieldIndex) {
+        if (cards == null || qfmt == null || afmt == null
+            || cards.length != qfmt.length || cards.length != afmt.length) {
+            throw new IllegalArgumentException(
+                "cards, qfmt, and afmt arrays must all be same length");
+        }
+        final ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Model.NAME, name);
+        values.put(FlashCardsContract.Model.FIELD_NAMES, joinFields(fields));
+        values.put(FlashCardsContract.Model.NUM_CARDS, cards.length);
+        if (css != null) values.put(FlashCardsContract.Model.CSS, css);
+        if (deckId != null) values.put(FlashCardsContract.Model.DECK_ID, deckId);
+        if (sortFieldIndex != null) {
+            values.put(FlashCardsContract.Model.SORT_FIELD_INDEX, sortFieldIndex);
+        }
+        final Long modelId = lastPathAsLong(resolver.insert(models(), values));
+        if (modelId == null) return null;
+
+        // 模板逐张写：`models/<mid>/templates/<ord>`。笔记类型建出来时模板是占位的，
+        // 不写这一步卡片正反面就是空的。
+        final Uri templates = Uri.withAppendedPath(model(modelId), "templates");
+        for (int ord = 0; ord < cards.length; ord++) {
+            final ContentValues template = new ContentValues();
+            template.put(FlashCardsContract.CardTemplate.NAME, cards[ord]);
+            template.put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, qfmt[ord]);
+            template.put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, afmt[ord]);
+            resolver.update(
+                Uri.withAppendedPath(templates, Integer.toString(ord)),
+                template, null, null);
+        }
+        return modelId;
+    }
+
+    // ── 笔记 ───────────────────────────────────────────────────────────
+
+    @Override
+    public Long addNote(long modelId, long deckId, String[] fields, Set<String> tags) {
+        final ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Note.MID, modelId);
+        values.put(FlashCardsContract.Note.FLDS, joinFields(fields));
+        if (tags != null && !tags.isEmpty()) {
+            values.put(FlashCardsContract.Note.TAGS, TextUtils.join(" ", tags));
+        }
+        // 卡组不是笔记的列，是插入时的 query 参数（契约常量 DECK_ID_QUERY_PARAM）。
+        final Uri target = notes().buildUpon()
+            .appendQueryParameter(
+                FlashCardsContract.Note.DECK_ID_QUERY_PARAM, Long.toString(deckId))
+            .build();
+        return lastPathAsLong(resolver.insert(target, values));
+    }
+
+    @Override
+    public AnkiNote getNote(long noteId) {
+        final Cursor cursor = resolver.query(note(noteId), null, null, null, null);
+        if (cursor == null) return null;
+        try {
+            if (!cursor.moveToFirst()) return null;
+            return readNote(cursor, noteId);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    public boolean updateNoteFields(long noteId, String[] fields) {
+        final ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Note.FLDS, joinFields(fields));
+        return resolver.update(note(noteId), values, null, null) > 0;
+    }
+
+    /**
+     * 查重走 {@code notes_v2} 的 {@code mid=? and csum in (?)}——与上游 AAR 的
+     * spec-2 实现同一条路（它的格式串 {@code "%s=%d and %s in (%s)"} 就在 AAR 的
+     * 常量池里）。csum 只是个哈希桶，命中后仍必须逐条比首字段，这一点也与上游一致。
+     *
+     * <p>算不出 csum（理论上不会发生，SHA-1 是 JDK 必备算法）时返回 {@code null}
+     * 而不是空列表：调用方据此把「查不了」与「没有重复」分开，否则会静默造重复卡。
+     */
+    @Override
+    public List<AnkiNote> findDuplicateNotes(long modelId, String key) {
+        final Long checksum = fieldChecksum(key);
+        if (checksum == null) return null;
+        final String selection = String.format(
+            Locale.US, "%s=%d and %s in (%d)",
+            FlashCardsContract.Note.MID, modelId,
+            FlashCardsContract.Note.CSUM, checksum);
+        final Cursor cursor = resolver.query(notesV2(), null, selection, null, null);
+        if (cursor == null) return null;
+        final List<AnkiNote> matches = new ArrayList<>();
+        try {
+            while (cursor.moveToNext()) {
+                final AnkiNote candidate = readNote(cursor, -1L);
+                if (candidate == null) continue;
+                final String[] noteFields = candidate.getFields();
+                if (noteFields.length > 0 && key.equals(noteFields[0])) {
+                    matches.add(candidate);
+                }
+            }
+        } finally {
+            cursor.close();
+        }
+        return matches;
+    }
+
+    // ── 工具 ───────────────────────────────────────────────────────────
+
+    private static AnkiNote readNote(Cursor cursor, long fallbackId) {
+        final int idIdx = cursor.getColumnIndex(FlashCardsContract.Note._ID);
+        final int fldsIdx = cursor.getColumnIndex(FlashCardsContract.Note.FLDS);
+        final int tagsIdx = cursor.getColumnIndex(FlashCardsContract.Note.TAGS);
+        final long id = idIdx >= 0 ? cursor.getLong(idIdx) : fallbackId;
+        if (id < 0) return null;
+        final String[] fields =
+            fldsIdx >= 0 ? splitFields(cursor.getString(fldsIdx)) : new String[0];
+        Set<String> tags = Collections.emptySet();
+        if (tagsIdx >= 0) {
+            final String raw = cursor.getString(tagsIdx);
+            if (raw != null && !raw.trim().isEmpty()) {
+                tags = new HashSet<>(Arrays.asList(raw.trim().split("\\s+")));
+            }
+        }
+        return new AnkiNote(id, fields, tags);
+    }
+
+    private static String[] splitFields(String flds) {
+        if (flds == null) return new String[0];
+        return flds.split(FIELD_SEPARATOR, -1);
+    }
+
+    private static String joinFields(String[] fields) {
+        if (fields == null) return "";
+        return TextUtils.join(FIELD_SEPARATOR, fields);
+    }
+
+    private static Long lastPathAsLong(Uri uri) {
+        if (uri == null) return null;
+        final String last = uri.getLastPathSegment();
+        if (last == null) return null;
+        try {
+            return Long.parseLong(last);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Anki 的字段校验和：首字段 SHA-1 的**前 8 个 hex 字符**当作无符号整数。
+     *
+     * <p>上游在算之前会先剥掉 HTML 与媒体标签；本 app 传进来的查重 key 是查词得到的
+     * 词条原文（纯文本），剥不剥结果相同。真有 HTML 时最坏结果是**算不中**（查不到
+     * 重复），绝不会误报成重复——这个方向的错误是安全的。
+     */
+    private static Long fieldChecksum(String field) {
+        if (field == null) return null;
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            final byte[] hash = digest.digest(field.getBytes("UTF-8"));
+            final StringBuilder hex = new StringBuilder();
+            for (int i = 0; i < 4 && i < hash.length; i++) {
+                hex.append(String.format(Locale.US, "%02x", hash[i]));
+            }
+            return Long.parseLong(hex.toString(), 16);
+        } catch (NoSuchAlgorithmException | java.io.UnsupportedEncodingException e) {
+            return null;
+        }
+    }
+}

--- a/fushi/assets/browser_extension/vendor/selection.js
+++ b/fushi/assets/browser_extension/vendor/selection.js
@@ -18,7 +18,9 @@ window.fushiSelection = {
     selection: null,
     highlightWrappers: [],
     scanDelimiters: '。、！？…‥「」『』（）()【】〈〉《》〔〕｛｝{}［］[]・：；:;，,.─\n\r"\'“”‘’«»‹›',
-    sentenceDelimiters: '。！？.!?\n\r',
+    // BUG-2196：换行不是句子边界（HTML 里它只是空白）。与
+    // reader_selection_scripts.dart 的同名表保持一致。
+    sentenceDelimiters: '。！？.!?',
     trailingSentenceChars: '。、！？…‥」』）)】〉》〕｝}］]',
     brackets: {'「':'」', '『': '』', '（':'）', '(':')', '【':'】', '〈':'〉', '《':'》', '〔':'〕', '｛':'｝', '{':'}', '［':'］', '[':']'},
 

--- a/fushi/assets/popup/selection.js
+++ b/fushi/assets/popup/selection.js
@@ -18,7 +18,9 @@ window.fushiSelection = {
     selection: null,
     highlightWrappers: [],
     scanDelimiters: '。、！？…‥「」『』（）()【】〈〉《》〔〕｛｝{}［］[]・：；:;，,.─\n\r"\'“”‘’«»‹›',
-    sentenceDelimiters: '。！？.!?\n\r',
+    // BUG-2196：换行不是句子边界（HTML 里它只是空白）。与
+    // reader_selection_scripts.dart 的同名表保持一致。
+    sentenceDelimiters: '。！？.!?',
     trailingSentenceChars: '。、！？…‥」』）)】〉》〕｝}］]',
     brackets: {'「':'」', '『': '』', '（':'）', '(':')', '【':'】', '〈':'〉', '《':'》', '〔':'〕', '｛':'｝', '{':'}', '［':'］', '[':']'},
 

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 73032 (4296 per locale)
+/// Strings: 73151 (4303 per locale)
 ///
-/// Built on 2026-09-06 at 04:15 UTC
+/// Built on 2026-09-06 at 13:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5923,6 +5923,23 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get onboarding_pack_paused_desc =>
       'Progress is kept on disk — resuming picks up where it stopped.';
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -15968,6 +15985,30 @@ class _StringsAr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -26240,6 +26281,30 @@ class _StringsDe extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -36565,6 +36630,30 @@ class _StringsEs extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -46924,6 +47013,30 @@ class _StringsFr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -57087,6 +57200,30 @@ class _StringsId extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -67342,6 +67479,30 @@ class _StringsIt extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -76984,6 +77145,30 @@ class _StringsJa extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -86636,6 +86821,30 @@ class _StringsKo extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -96846,6 +97055,30 @@ class _StringsNl extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -107110,6 +107343,30 @@ class _StringsPtBr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -117352,6 +117609,30 @@ class _StringsRu extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -127393,6 +127674,30 @@ class _StringsTh extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -137551,6 +137856,30 @@ class _StringsTr extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -147680,6 +148009,30 @@ class _StringsVi extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 // Path: <root>
@@ -156990,6 +157343,28 @@ class _StringsZhCn extends _StringsEn {
   String get onboarding_pack_paused_desc => '进度留在磁盘上，继续下载会从中断处接着下。';
   @override
   String get onboarding_pack_mini_bar_hide => '收起';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      '连接 ${host} 超时，当前网络可能访问不了这个站点';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} 传输中断，长时间没有收到数据';
+  @override
+  String dict_error_connection({required Object host}) => '无法连接 ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} 返回 HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      '下载失败：${name}（${reason}）';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      '导入失败：${name}（${reason}）';
+  @override
+  String dict_task_failed_summary({required Object n}) => '${n} 本词典处理失败';
 }
 
 // Path: <root>
@@ -166325,6 +166700,30 @@ class _StringsZhHk extends _StringsEn {
       'Progress is kept on disk — resuming picks up where it stopped.';
   @override
   String get onboarding_pack_mini_bar_hide => 'Hide';
+  @override
+  String dict_error_connect_timeout({required Object host}) =>
+      'Could not reach ${host} (connection timed out)';
+  @override
+  String dict_error_stall_timeout({required Object host}) =>
+      '${host} stopped sending data';
+  @override
+  String dict_error_connection({required Object host}) =>
+      'Could not connect to ${host}';
+  @override
+  String dict_error_http_status(
+          {required Object host, required Object status}) =>
+      '${host} returned HTTP ${status}';
+  @override
+  String dict_task_failed_download(
+          {required Object name, required Object reason}) =>
+      'Download failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_import(
+          {required Object name, required Object reason}) =>
+      'Import failed: ${name} (${reason})';
+  @override
+  String dict_task_failed_summary({required Object n}) =>
+      '${n} dictionary(s) failed';
 }
 
 /// Flat map(s) containing all translations.
@@ -175152,6 +175551,24 @@ extension on _StringsEn {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -183974,6 +184391,24 @@ extension on _StringsAr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -192841,6 +193276,24 @@ extension on _StringsDe {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -201699,6 +202152,24 @@ extension on _StringsEs {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -210566,6 +211037,24 @@ extension on _StringsFr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -219404,6 +219893,24 @@ extension on _StringsId {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -228264,6 +228771,24 @@ extension on _StringsIt {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -237051,6 +237576,24 @@ extension on _StringsJa {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -245842,6 +246385,24 @@ extension on _StringsKo {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -254695,6 +255256,24 @@ extension on _StringsNl {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -263543,6 +264122,24 @@ extension on _StringsPtBr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -272398,6 +272995,24 @@ extension on _StringsRu {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -281225,6 +281840,24 @@ extension on _StringsTh {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -290067,6 +290700,24 @@ extension on _StringsTr {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -298903,6 +299554,24 @@ extension on _StringsVi {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }
@@ -307663,6 +308332,23 @@ extension on _StringsZhCn {
         return '进度留在磁盘上，继续下载会从中断处接着下。';
       case 'onboarding_pack_mini_bar_hide':
         return '收起';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) => '连接 ${host} 超时，当前网络可能访问不了这个站点';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} 传输中断，长时间没有收到数据';
+      case 'dict_error_connection':
+        return ({required Object host}) => '无法连接 ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} 返回 HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            '下载失败：${name}（${reason}）';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            '导入失败：${name}（${reason}）';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} 本词典处理失败';
       default:
         return null;
     }
@@ -316428,6 +317114,24 @@ extension on _StringsZhHk {
         return 'Progress is kept on disk — resuming picks up where it stopped.';
       case 'onboarding_pack_mini_bar_hide':
         return 'Hide';
+      case 'dict_error_connect_timeout':
+        return ({required Object host}) =>
+            'Could not reach ${host} (connection timed out)';
+      case 'dict_error_stall_timeout':
+        return ({required Object host}) => '${host} stopped sending data';
+      case 'dict_error_connection':
+        return ({required Object host}) => 'Could not connect to ${host}';
+      case 'dict_error_http_status':
+        return ({required Object host, required Object status}) =>
+            '${host} returned HTTP ${status}';
+      case 'dict_task_failed_download':
+        return ({required Object name, required Object reason}) =>
+            'Download failed: ${name} (${reason})';
+      case 'dict_task_failed_import':
+        return ({required Object name, required Object reason}) =>
+            'Import failed: ${name} (${reason})';
+      case 'dict_task_failed_summary':
+        return ({required Object n}) => '${n} dictionary(s) failed';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 73168 (4304 per locale)
+/// Strings: 73219 (4307 per locale)
 ///
-/// Built on 2026-09-06 at 14:43 UTC
+/// Built on 2026-09-06 at 15:59 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5943,6 +5943,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  String get popup_ctx_preview_audio => 'Preview audio';
+  String get popup_ctx_preview_stop => 'Stop';
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -16016,6 +16019,12 @@ class _StringsAr extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -26316,6 +26325,12 @@ class _StringsDe extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -36669,6 +36684,12 @@ class _StringsEs extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -47056,6 +47077,12 @@ class _StringsFr extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -57247,6 +57274,12 @@ class _StringsId extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -67530,6 +67563,12 @@ class _StringsIt extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -77200,6 +77239,12 @@ class _StringsJa extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -86880,6 +86925,12 @@ class _StringsKo extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -97118,6 +97169,12 @@ class _StringsNl extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -107410,6 +107467,12 @@ class _StringsPtBr extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -117680,6 +117743,12 @@ class _StringsRu extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -127749,6 +127818,12 @@ class _StringsTh extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -137935,6 +138010,12 @@ class _StringsTr extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -148092,6 +148173,12 @@ class _StringsVi extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 // Path: <root>
@@ -157428,6 +157515,12 @@ class _StringsZhCn extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       '导出完成，但有 ${n} 本词典被跳过：这台设备上找不到它们的文件（${names}）';
+  @override
+  String get popup_ctx_preview_audio => '试听';
+  @override
+  String get popup_ctx_preview_stop => '停止';
+  @override
+  String get popup_ctx_preview_unavailable => '这句没有可试听的音频';
 }
 
 // Path: <root>
@@ -166791,6 +166884,12 @@ class _StringsZhHk extends _StringsEn {
   String backup_export_dictionaries_skipped(
           {required Object n, required Object names}) =>
       'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+  @override
+  String get popup_ctx_preview_audio => 'Preview audio';
+  @override
+  String get popup_ctx_preview_stop => 'Stop';
+  @override
+  String get popup_ctx_preview_unavailable => 'No audio for this sentence';
 }
 
 /// Flat map(s) containing all translations.
@@ -175639,6 +175738,12 @@ extension on _StringsEn {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -184482,6 +184587,12 @@ extension on _StringsAr {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -193370,6 +193481,12 @@ extension on _StringsDe {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -202249,6 +202366,12 @@ extension on _StringsEs {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -211137,6 +211260,12 @@ extension on _StringsFr {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -219996,6 +220125,12 @@ extension on _StringsId {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -228877,6 +229012,12 @@ extension on _StringsIt {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -237685,6 +237826,12 @@ extension on _StringsJa {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -246497,6 +246644,12 @@ extension on _StringsKo {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -255371,6 +255524,12 @@ extension on _StringsNl {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -264240,6 +264399,12 @@ extension on _StringsPtBr {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -273116,6 +273281,12 @@ extension on _StringsRu {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -281964,6 +282135,12 @@ extension on _StringsTh {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -290827,6 +291004,12 @@ extension on _StringsTr {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -299684,6 +299867,12 @@ extension on _StringsVi {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }
@@ -308464,6 +308653,12 @@ extension on _StringsZhCn {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             '导出完成，但有 ${n} 本词典被跳过：这台设备上找不到它们的文件（${names}）';
+      case 'popup_ctx_preview_audio':
+        return '试听';
+      case 'popup_ctx_preview_stop':
+        return '停止';
+      case 'popup_ctx_preview_unavailable':
+        return '这句没有可试听的音频';
       default:
         return null;
     }
@@ -317250,6 +317445,12 @@ extension on _StringsZhHk {
       case 'backup_export_dictionaries_skipped':
         return ({required Object n, required Object names}) =>
             'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
+      case 'popup_ctx_preview_audio':
+        return 'Preview audio';
+      case 'popup_ctx_preview_stop':
+        return 'Stop';
+      case 'popup_ctx_preview_unavailable':
+        return 'No audio for this sentence';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 73151 (4303 per locale)
+/// Strings: 73168 (4304 per locale)
 ///
-/// Built on 2026-09-06 at 13:36 UTC
+/// Built on 2026-09-06 at 14:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5940,6 +5940,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Import failed: ${name} (${reason})';
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -16009,6 +16012,10 @@ class _StringsAr extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -26305,6 +26312,10 @@ class _StringsDe extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -36654,6 +36665,10 @@ class _StringsEs extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -47037,6 +47052,10 @@ class _StringsFr extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -57224,6 +57243,10 @@ class _StringsId extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -67503,6 +67526,10 @@ class _StringsIt extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -77169,6 +77196,10 @@ class _StringsJa extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -86845,6 +86876,10 @@ class _StringsKo extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -97079,6 +97114,10 @@ class _StringsNl extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -107367,6 +107406,10 @@ class _StringsPtBr extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -117633,6 +117676,10 @@ class _StringsRu extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -127698,6 +127745,10 @@ class _StringsTh extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -137880,6 +137931,10 @@ class _StringsTr extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -148033,6 +148088,10 @@ class _StringsVi extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 // Path: <root>
@@ -157365,6 +157424,10 @@ class _StringsZhCn extends _StringsEn {
       '导入失败：${name}（${reason}）';
   @override
   String dict_task_failed_summary({required Object n}) => '${n} 本词典处理失败';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      '导出完成，但有 ${n} 本词典被跳过：这台设备上找不到它们的文件（${names}）';
 }
 
 // Path: <root>
@@ -166724,6 +166787,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String dict_task_failed_summary({required Object n}) =>
       '${n} dictionary(s) failed';
+  @override
+  String backup_export_dictionaries_skipped(
+          {required Object n, required Object names}) =>
+      'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
 }
 
 /// Flat map(s) containing all translations.
@@ -175569,6 +175636,9 @@ extension on _StringsEn {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -184409,6 +184479,9 @@ extension on _StringsAr {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -193294,6 +193367,9 @@ extension on _StringsDe {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -202170,6 +202246,9 @@ extension on _StringsEs {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -211055,6 +211134,9 @@ extension on _StringsFr {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -219911,6 +219993,9 @@ extension on _StringsId {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -228789,6 +228874,9 @@ extension on _StringsIt {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -237594,6 +237682,9 @@ extension on _StringsJa {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -246403,6 +246494,9 @@ extension on _StringsKo {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -255274,6 +255368,9 @@ extension on _StringsNl {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -264140,6 +264237,9 @@ extension on _StringsPtBr {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -273013,6 +273113,9 @@ extension on _StringsRu {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -281858,6 +281961,9 @@ extension on _StringsTh {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -290718,6 +290824,9 @@ extension on _StringsTr {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -299572,6 +299681,9 @@ extension on _StringsVi {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }
@@ -308349,6 +308461,9 @@ extension on _StringsZhCn {
             '导入失败：${name}（${reason}）';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} 本词典处理失败';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            '导出完成，但有 ${n} 本词典被跳过：这台设备上找不到它们的文件（${names}）';
       default:
         return null;
     }
@@ -317132,6 +317247,9 @@ extension on _StringsZhHk {
             'Import failed: ${name} (${reason})';
       case 'dict_task_failed_summary':
         return ({required Object n}) => '${n} dictionary(s) failed';
+      case 'backup_export_dictionaries_skipped':
+        return ({required Object n, required Object names}) =>
+            'Exported, but ${n} dictionary(s) were skipped: their files are missing on this device (${names})';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "推荐包下载已暂停",
   "onboarding_pack_download_resume": "继续下载",
   "onboarding_pack_paused_desc": "进度留在磁盘上，继续下载会从中断处接着下。",
-  "onboarding_pack_mini_bar_hide": "收起"
+  "onboarding_pack_mini_bar_hide": "收起",
+  "dict_error_connect_timeout": "连接 $host 超时，当前网络可能访问不了这个站点",
+  "dict_error_stall_timeout": "$host 传输中断，长时间没有收到数据",
+  "dict_error_connection": "无法连接 $host",
+  "dict_error_http_status": "$host 返回 HTTP $status",
+  "dict_task_failed_download": "下载失败：$name（$reason）",
+  "dict_task_failed_import": "导入失败：$name（$reason）",
+  "dict_task_failed_summary": "$n 本词典处理失败"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "下载失败：$name（$reason）",
   "dict_task_failed_import": "导入失败：$name（$reason）",
   "dict_task_failed_summary": "$n 本词典处理失败",
-  "backup_export_dictionaries_skipped": "导出完成，但有 $n 本词典被跳过：这台设备上找不到它们的文件（$names）"
+  "backup_export_dictionaries_skipped": "导出完成，但有 $n 本词典被跳过：这台设备上找不到它们的文件（$names）",
+  "popup_ctx_preview_audio": "试听",
+  "popup_ctx_preview_stop": "停止",
+  "popup_ctx_preview_unavailable": "这句没有可试听的音频"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host 返回 HTTP $status",
   "dict_task_failed_download": "下载失败：$name（$reason）",
   "dict_task_failed_import": "导入失败：$name（$reason）",
-  "dict_task_failed_summary": "$n 本词典处理失败"
+  "dict_task_failed_summary": "$n 本词典处理失败",
+  "backup_export_dictionaries_skipped": "导出完成，但有 $n 本词典被跳过：这台设备上找不到它们的文件（$names）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4294,5 +4294,12 @@
   "onboarding_pack_status_paused": "Recommended pack download paused",
   "onboarding_pack_download_resume": "Resume download",
   "onboarding_pack_paused_desc": "Progress is kept on disk — resuming picks up where it stopped.",
-  "onboarding_pack_mini_bar_hide": "Hide"
+  "onboarding_pack_mini_bar_hide": "Hide",
+  "dict_error_connect_timeout": "Could not reach $host (connection timed out)",
+  "dict_error_stall_timeout": "$host stopped sending data",
+  "dict_error_connection": "Could not connect to $host",
+  "dict_error_http_status": "$host returned HTTP $status",
+  "dict_task_failed_download": "Download failed: $name ($reason)",
+  "dict_task_failed_import": "Import failed: $name ($reason)",
+  "dict_task_failed_summary": "$n dictionary(s) failed"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4301,5 +4301,6 @@
   "dict_error_http_status": "$host returned HTTP $status",
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
-  "dict_task_failed_summary": "$n dictionary(s) failed"
+  "dict_task_failed_summary": "$n dictionary(s) failed",
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4302,5 +4302,8 @@
   "dict_task_failed_download": "Download failed: $name ($reason)",
   "dict_task_failed_import": "Import failed: $name ($reason)",
   "dict_task_failed_summary": "$n dictionary(s) failed",
-  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)"
+  "backup_export_dictionaries_skipped": "Exported, but $n dictionary(s) were skipped: their files are missing on this device ($names)",
+  "popup_ctx_preview_audio": "Preview audio",
+  "popup_ctx_preview_stop": "Stop",
+  "popup_ctx_preview_unavailable": "No audio for this sentence"
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -34,6 +34,7 @@ import 'package:fushi/src/storage/export_directory.dart';
 import 'package:fushi/src/storage/installer_data_root_bootstrap.dart';
 import 'package:fushi/src/storage/sandbox_relocation.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
+import 'package:fushi/src/utils/misc/error_details_dialog.dart';
 import 'package:fushi/src/utils/misc/lookup_input_limits.dart';
 import 'package:fushi/src/media/drag_drop/desktop_drop_reinitializer.dart';
 import 'package:fushi_audio/fushi_audio.dart';
@@ -977,8 +978,30 @@ class AppModel with ChangeNotifier {
   /// 词典页的 State 上，任务因此不随进度对话框的开关而生死——用户可以把进度框收起来
   /// 回去用 app，下载照跑；也因此它能成为「手动下载」与「启动静默自动更新」两条流程
   /// 的**唯一互斥点**（两条流程的导入共用同一个 `import_temp` 暂存目录，并发会互删）。
-  final DictionaryDownloadController dictionaryDownloadController =
-      DictionaryDownloadController();
+  ///
+  /// BUG-2188：结果展示注入成 [_presentDictionaryOutcome]——带全文诊断的失败改走
+  /// 「错误详情」框（可滚动、可选中、一键复制），不再只发一条被系统截成两行且不可
+  /// 复制的原生 toast。
+  late final DictionaryDownloadController dictionaryDownloadController =
+      DictionaryDownloadController(showOutcome: _presentDictionaryOutcome);
+
+  /// 词典任务结果的展示。有 `details` 且拿得到全局上下文时弹「错误详情」框，
+  /// 否则退回 toast（启动早期 / 无 Navigator 时仍必须送达，不能静默丢弃）。
+  void _presentDictionaryOutcome(DictionaryDownloadOutcome outcome) {
+    final String? details = outcome.details;
+    final BuildContext? context = _ctx;
+    if (details != null && context != null) {
+      unawaited(
+        showErrorDetails(context, title: outcome.message, error: details),
+      );
+      return;
+    }
+    FushiToast.show(
+      msg: outcome.message,
+      severity: outcome.severity,
+      toastLength: outcome.toastLength,
+    );
+  }
 
   /// BUG-2097：新手引导推荐包（9.5 GB 整包）下载任务的所有权持有者。同样挂在
   /// [AppModel] 上：此前它活在向导页的 State 里，向导 `dispose()` 直接 cancel，
@@ -2543,6 +2566,10 @@ class AppModel with ChangeNotifier {
       // 死」。fushi_dictionary 是下游包，反向 import 不了 applyAppProxy，故在这里把它
       // 接进包内的进程级钩子。未接线时钩子是 no-op，行为与接线前逐字等价。
       installDictionaryDioFactory();
+      // BUG-2188：同一个装配方向，把「一个地址 → 原址 + GitHub 公共镜像」的候选展开
+      // 也接进包内钩子。镜像清单的唯一真相源在 utils/net/github_mirrors.dart，
+      // fushi_dictionary 反向 import 不了它。
+      installDictionaryUrlCandidatesResolver();
       // BUG-1498：把「平台 GUI 系统代理探测」这一步异步工作提前做掉并缓存，之后
       // `createAppHttpIoClient()` / `createAppDio()` 就能在构造函数初始化列表里**同步**
       // 装配出口——那正是全仓 40+ 条裸出站接不上代理层的结构性原因（初始化列表不能

--- a/fushi/lib/src/models/dictionary_download_controller.dart
+++ b/fushi/lib/src/models/dictionary_download_controller.dart
@@ -39,11 +39,17 @@ class DictionaryDownloadOutcome {
     required this.message,
     this.severity = ToastSeverity.info,
     this.toastLength = Toast.LENGTH_SHORT,
+    this.details,
   });
 
   final String message;
   final ToastSeverity severity;
   final Toast toastLength;
+
+  /// 可复制的全文诊断（BUG-2188）。非 null 时 [message] 只是标题，真正的原因由
+  /// 「错误详情」框全文展示——移动端原生 toast 会把长文案截成两行且不可复制，
+  /// 诊断信息恰好全在被截掉的那一半。
+  final String? details;
 }
 
 /// 交给任务体（`body`）用的句柄：写进度、读取消、切阶段。
@@ -55,8 +61,14 @@ class DictionaryDownloadJob {
 
   final DictionaryDownloadController _controller;
 
-  /// 进度文案（对话框标题 / 页面状态行都读它）。
+  /// 进度文案（对话框标题 / 页面状态行都读它）。**必须短**——它渲染在单行标题里。
   ValueNotifier<String> get message => _controller.message;
+
+  /// 附加说明（BUG-2188）：失败原因这类**必须完整读到**的文案走这里，渲染在进度框
+  /// 正文里、可多行。以前它和阶段文案挤在同一个 [message] 上，于是被
+  /// `FushiModalSheetFrame` 的 `maxLines: 1 + ellipsis` 截成
+  /// `DioError [connection ...`。
+  ValueNotifier<String> get detail => _controller.detail;
 
   /// 0..1 的下载比例；0 表示「无法估算」（进度条退化为不定态）。
   ValueNotifier<double> get progress => _controller.progress;
@@ -119,8 +131,11 @@ class DictionaryDownloadController {
   final ValueNotifier<DictionaryDownloadPhase> phase =
       ValueNotifier<DictionaryDownloadPhase>(DictionaryDownloadPhase.idle);
 
-  /// 当前进度文案。
+  /// 当前进度文案（单行标题，必须短）。
   final ValueNotifier<String> message = ValueNotifier<String>('');
+
+  /// 当前附加说明（多行正文，可为空）。见 [DictionaryDownloadJob.detail]。
+  final ValueNotifier<String> detail = ValueNotifier<String>('');
 
   /// 当前下载比例（0..1）；0 = 不定态。
   final ValueNotifier<double> progress = ValueNotifier<double>(0);
@@ -177,6 +192,7 @@ class DictionaryDownloadController {
     _cancelToken = CancelToken();
     progress.value = 0;
     message.value = initialMessage;
+    detail.value = '';
     _setPhase(DictionaryDownloadPhase.downloading);
 
     DictionaryDownloadOutcome? outcome;
@@ -186,6 +202,7 @@ class DictionaryDownloadController {
       _setPhase(DictionaryDownloadPhase.idle);
       progress.value = 0;
       message.value = '';
+      detail.value = '';
     }
     if (outcome != null) _showOutcome(outcome);
     return true;
@@ -206,6 +223,7 @@ class DictionaryDownloadController {
   void dispose() {
     phase.dispose();
     message.dispose();
+    detail.dispose();
     progress.dispose();
     cancellable.dispose();
   }

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -160,7 +160,8 @@ class DictionaryImportManager {
       }
 
       totalNotifier.value = zipFiles.length;
-      final List<String> failedNames = [];
+      final List<DictionaryTaskFailure> failedNames =
+          <DictionaryTaskFailure>[];
       for (int i = 0; i < zipFiles.length; i++) {
         countNotifier.value = i + 1;
         try {
@@ -175,7 +176,13 @@ class DictionaryImportManager {
           );
         } catch (e, stack) {
           ErrorLogService.instance.log('DictImport.importZip', e, stack);
-          failedNames.add(path.basenameWithoutExtension(zipFiles[i].path));
+          failedNames.add(
+            DictionaryTaskFailure(
+              name: path.basenameWithoutExtension(zipFiles[i].path),
+              stage: DictionaryTaskStage.import,
+              error: e,
+            ),
+          );
         }
       }
       if (failedNames.isNotEmpty) {
@@ -367,7 +374,8 @@ class DictionaryImportManager {
       }).toList()
             ..sort((File a, File b) => a.path.compareTo(b.path));
 
-      final List<String> failedNames = <String>[];
+      final List<DictionaryTaskFailure> failedNames =
+          <DictionaryTaskFailure>[];
       for (int i = 0; i < dictionaries.length; i++) {
         final File dictionary = dictionaries[i];
         final List<File> cssFiles = Directory(path.dirname(dictionary.path))
@@ -386,7 +394,13 @@ class DictionaryImportManager {
           );
         } catch (e, stack) {
           ErrorLogService.instance.log('DictImport.multiArchive', e, stack);
-          failedNames.add(path.basenameWithoutExtension(dictionary.path));
+          failedNames.add(
+            DictionaryTaskFailure(
+              name: path.basenameWithoutExtension(dictionary.path),
+              stage: DictionaryTaskStage.import,
+              error: e,
+            ),
+          );
         }
       }
 
@@ -935,15 +949,105 @@ class DictionaryImportManager {
     return e is OutOfMemoryError || msg.contains('out of memory');
   }
 
-  /// 批量导入结束后，把失败的词典名汇总成一条提示文案（单条/多条不同措辞）。
-  /// 供文件批量与目录批量两条路径复用，统一在循环结束后一次性展示（BUG-082）。
-  static String formatImportFailureSummary(List<String> failedNames) {
-    if (failedNames.length == 1) {
-      return '${t.srt_import_error}: ${failedNames.first}';
-    }
-    return '${t.dict_import_failed_summary(n: failedNames.length)}\n'
-        '${failedNames.join(', ')}';
+  /// 批量任务结束后，把失败项汇总成一条提示文案（单条/多条不同措辞）。
+  /// 供在线下载、文件批量与目录批量三条路径复用，统一在循环结束后一次性展示
+  /// （BUG-082）。
+  ///
+  /// BUG-2188：入参从 `List<String>`（只有名字）换成 [DictionaryTaskFailure]
+  /// （名字 + 阶段 + 异常）。旧签名把异常在收集那一刻就降维成了一个名字，于是
+  /// **无论怎么改渲染，原因都已经不在数据里了**；而且措辞恒为「导入失败」，下载阶段
+  /// 失败也照报导入，制造了「下载失败之后又导入失败」的假象。
+  static String formatImportFailureSummary(
+    List<DictionaryTaskFailure> failures,
+  ) {
+    if (failures.length == 1) return failures.first.headline;
+    return '${t.dict_task_failed_summary(n: failures.length)}\n'
+        '${failures.map((DictionaryTaskFailure f) => f.line).join('\n')}';
   }
+
+  /// 把一批失败拼成可复制的全文诊断（BUG-2188），供「错误详情」框展示。
+  static String formatFailureDetails(List<DictionaryTaskFailure> failures) =>
+      failures.map((DictionaryTaskFailure f) => f.details).join('\n\n');
+}
+
+/// 词典批量任务里一项失败发生在哪个阶段（BUG-2188）。措辞按它选，不再一律叫
+/// 「导入失败」。
+enum DictionaryTaskStage { download, import }
+
+/// 词典批量任务里的一条失败：名字 + 阶段 + **原始异常**（BUG-2188）。
+///
+/// 存在的理由：以前失败只以名字进汇总，异常在 `catch` 里就被丢掉，用户拿到的提示
+/// 天生带不出原因。这个结构把异常一路带到渲染层，[reason] 给一行人话、[details]
+/// 给可复制的全文诊断。
+class DictionaryTaskFailure {
+  const DictionaryTaskFailure({
+    required this.name,
+    required this.stage,
+    required this.error,
+    this.url,
+  });
+
+  /// 词典显示名。
+  final String name;
+
+  final DictionaryTaskStage stage;
+
+  /// 原始异常，不做任何降维。
+  final Object error;
+
+  /// 下载阶段的原始地址（catalog 条目）；文件导入路径为 null。
+  final String? url;
+
+  /// 一行人话原因，进 toast / 汇总。
+  String get reason => describeDictionaryFailure(error);
+
+  /// 「下载失败：名字（原因）」——单条失败时的完整提示。
+  String get headline => switch (stage) {
+        DictionaryTaskStage.download =>
+          t.dict_task_failed_download(name: name, reason: reason),
+        DictionaryTaskStage.import =>
+          t.dict_task_failed_import(name: name, reason: reason),
+      };
+
+  /// 多条汇总里的一行。
+  String get line => '$name: $reason';
+
+  /// 可复制的全文诊断，进「错误详情」框。**不本地化**：它是给开发者/日志看的。
+  String get details {
+    final StringBuffer buffer = StringBuffer()..writeln(headline);
+    final String? source = url;
+    if (source != null) buffer.writeln('url: $source');
+    buffer.write(error.toString());
+    return buffer.toString();
+  }
+}
+
+/// 把词典链路的异常翻成一行人话（BUG-2188）。
+///
+/// 传输层失败按 [DictionaryDownloadFailureKind] 给出「连不上谁」——用户截图里那句被
+/// 截断的 `DioError [connection ...` 就是这一类。其余异常回退到 `toString()`：它可能
+/// 很长，但汇总里只占一行，全文另有「错误详情」可看，不会再被静默截掉。
+String describeDictionaryFailure(Object error) {
+  if (error is DictionaryDownloadException) {
+    final String host = error.host;
+    switch (error.kind) {
+      case DictionaryDownloadFailureKind.connectTimeout:
+        return t.dict_error_connect_timeout(host: host);
+      case DictionaryDownloadFailureKind.stallTimeout:
+        return t.dict_error_stall_timeout(host: host);
+      case DictionaryDownloadFailureKind.connectionError:
+        return t.dict_error_connection(host: host);
+      case DictionaryDownloadFailureKind.badResponse:
+        return t.dict_error_http_status(
+          host: host,
+          status: '${error.statusCode ?? '?'}',
+        );
+      case DictionaryDownloadFailureKind.cancelled:
+      case DictionaryDownloadFailureKind.other:
+        return error.cause.toString();
+    }
+  }
+  return error.toString();
 }
 
 /// TODO-609：导入时对「同名/同 base 名词典已存在」的决策。

--- a/fushi/lib/src/pages/base_source_page.dart
+++ b/fushi/lib/src/pages/base_source_page.dart
@@ -976,6 +976,10 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
           matched: matched,
           fetchPreview: onSentenceContextPreviewFromDraft,
           setContext: onSetSentenceContextToDraft,
+          // BUG-2196 ②：只有真的能出声的表面才给试听按钮。
+          previewAudio: supportsSentenceAudioPreview ? onPreviewSentenceAudio : null,
+          stopAudioPreview:
+              supportsSentenceAudioPreview ? onStopSentenceAudioPreview : null,
           onConfirm: () =>
               webViewKey.currentState?.mineEntryByIndex(entryIndex),
         ),
@@ -1030,6 +1034,11 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   @protected
   bool get supportsSentenceDraft => false;
 
+  /// 这个表面能不能试听「将写进卡片的那段句子音频」（BUG-2196 ②）。
+  /// 默认 false；阅读器/有声书覆写为 true。
+  @protected
+  bool get supportsSentenceAudioPreview => false;
+
   /// TODO-270 F/G：弹窗「+句」追加当前正查句到本表面会话级制卡草稿，返回累积句数
   /// （含本句）。默认 no-op 返回 0（[supportsSentenceDraft] 为 false 时不会被调用）。
   /// reader 覆写：把当前句 + 句子音频区间推进草稿。
@@ -1057,6 +1066,23 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   @protected
   Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async =>
       const <String, Object?>{};
+
+  /// BUG-2196 ②：试听**这次制卡真正会写进卡片的那段音频**。
+  ///
+  /// 为什么值得单独一个钩子而不是「播当前句的 cue」：写进卡的区间是
+  /// `MiningSentenceDraft.composeAudioRange(当前句区间)` 的结果——它把用户在这个
+  /// 对话框里加减出来的上下文句一起合并了，并且带上首尾留白与 A/V 偏移。播 cue
+  /// 只能证明「这句有音频」，证明不了「裁出来的那段念全了」，而用户报的恰恰是
+  /// 后者（断句歪了 → 区间歪了 → 压出来的音频没念到目标词）。
+  ///
+  /// 返回 false = 这句没有可试听的音频（没挂有声书、跨音频文件、区间解不出来）。
+  /// 默认 false：不支持的表面（视频页等）对话框里就不显示试听按钮。
+  @protected
+  Future<bool> onPreviewSentenceAudio() async => false;
+
+  /// 停止 [onPreviewSentenceAudio] 起的试听，并让主播放恢复原状。
+  @protected
+  Future<void> onStopSentenceAudioPreview() async {}
 
   /// Called when a non-last popup layer is dismissed (the stack shrinks but a
   /// parent popup remains). Override (reader) to keep the char cursor following

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -16,6 +16,7 @@ import 'package:fushi/src/models/dictionary_import_manager.dart';
 import 'package:fushi/src/models/dictionary_repository.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/utils/misc/error_details_dialog.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 
 // ── BUG-1493：下载/导入两阶段的可归因进度 ──────────────────────────────
@@ -523,7 +524,7 @@ class _DictionaryDialogPageState extends BasePageState {
     );
 
     bool hadMemoryError = false;
-    final List<String> failedNames = [];
+    final List<DictionaryTaskFailure> failures = <DictionaryTaskFailure>[];
 
     totalNotifier.value = dictFiles.length;
     for (int i = 0; i < dictFiles.length; i++) {
@@ -549,7 +550,13 @@ class _DictionaryDialogPageState extends BasePageState {
         );
       } catch (e, stack) {
         ErrorLogService.instance.log('DictionaryDialog.fileImport', e, stack);
-        failedNames.add(path.basenameWithoutExtension(file.path));
+        failures.add(
+          DictionaryTaskFailure(
+            name: path.basenameWithoutExtension(file.path),
+            stage: DictionaryTaskStage.import,
+            error: e,
+          ),
+        );
       }
     }
 
@@ -557,17 +564,31 @@ class _DictionaryDialogPageState extends BasePageState {
       Navigator.pop(context);
     }
 
-    if (failedNames.isNotEmpty) {
-      FushiToast.show(
-        msg: DictionaryImportManager.formatImportFailureSummary(failedNames),
-        toastLength: Toast.LENGTH_LONG,
-        severity: ToastSeverity.error,
-      );
+    if (failures.isNotEmpty) {
+      // BUG-2188：文件导入失败同样带全文诊断——原生 toast 会把它截成两行且不可复制。
+      // 页面已经销毁（用户导入期间离开）时退回 toast，失败提示不能因此静默丢失。
+      final String summary =
+          DictionaryImportManager.formatImportFailureSummary(failures);
+      if (mounted) {
+        unawaited(
+          showErrorDetails(
+            context,
+            title: summary,
+            error: DictionaryImportManager.formatFailureDetails(failures),
+          ),
+        );
+      } else {
+        FushiToast.show(
+          msg: summary,
+          toastLength: Toast.LENGTH_LONG,
+          severity: ToastSeverity.error,
+        );
+      }
     }
 
     // TODO-082：成功导入的词典数 = 总数 - 失败数；> 0 就给一条明确的成功提示
     // （失败的另由上面的失败汇总文案告知，两者可同时出现：部分成功部分失败）。
-    final int successCount = dictFiles.length - failedNames.length;
+    final int successCount = dictFiles.length - failures.length;
     if (successCount > 0) {
       FushiToast.show(
         msg: t.dict_import_success_summary(n: successCount),
@@ -932,7 +953,7 @@ class _DictionaryDialogPageState extends BasePageState {
     // 与原因，循环后弹一条持久可见（LENGTH_LONG）的失败汇总，并把完整诊断（异常 +
     // 栈 + URL）写进 ErrorLogService（错误日志页可查、可回传），与「导入词典」按钮的
     // 文件导入路径（_importDictionaryPaths）同一套「记日志 + 汇总 toast」反馈。
-    final List<String> failedNames = <String>[];
+    final List<DictionaryTaskFailure> failures = <DictionaryTaskFailure>[];
 
     await _runWithDownloadProgressDialog(
       initialMessage: t.import_start,
@@ -940,7 +961,6 @@ class _DictionaryDialogPageState extends BasePageState {
         final ValueNotifier<String> progressNotifier = job.message;
         final ValueNotifier<double> downloadProgress = job.progress;
         int successCount = 0;
-        String? lastError;
         bool cancelled = false;
 
         try {
@@ -955,6 +975,9 @@ class _DictionaryDialogPageState extends BasePageState {
             progressNotifier.value = t.dict_downloading(name: rec.name);
             downloadProgress.value = 0;
 
+            // BUG-2188：区分「下载阶段失败」与「导入阶段失败」。以前两者共用一句
+            // 「导入失败」，用户于是先看到下载失败、再看到导入失败，误以为是两次错误。
+            bool zipDownloaded = false;
             try {
               final File zipFile = await DictionaryDownloader.download(
                 url: rec.url,
@@ -968,6 +991,7 @@ class _DictionaryDialogPageState extends BasePageState {
                   total: total,
                 ),
               );
+              zipDownloaded = true;
 
               // BUG-1493：与单本更新同一套阶段切换（归零进度条 → 不定态），否则导入
               // 期间进度条定格满格，看起来就是卡死。BUG-1499：同时把取消按钮禁掉。
@@ -1013,11 +1037,26 @@ class _DictionaryDialogPageState extends BasePageState {
                 '${e.runtimeType} 下载/导入「${rec.name}」失败（${rec.url}）：$e',
                 st,
               );
-              lastError = '${rec.name}: $e';
-              failedNames.add(rec.name);
+              // BUG-2188：异常本体一路带到渲染层。以前这里只留下名字，原因在这
+              // 一行就永久丢失了——后面无论怎么改 UI 都救不回来。
+              failures.add(
+                DictionaryTaskFailure(
+                  name: rec.name,
+                  stage: zipDownloaded
+                      ? DictionaryTaskStage.import
+                      : DictionaryTaskStage.download,
+                  error: e,
+                  url: rec.url,
+                ),
+              );
             }
           }
 
+          // BUG-2188：**标题保持短**（它渲染在 `maxLines: 1` 的单行标题里），失败
+          // 原因走 `job.detail`，在正文里多行显示。以前把整串 `DioError [connection ...`
+          // 塞进标题，用户能看到的恰好是它被截断的前半段。
+          final String lastReason =
+              failures.isEmpty ? '' : failures.last.reason;
           if (cancelled) {
             progressNotifier.value = t.dict_download_cancelled;
           } else if (successCount == toDownload.length) {
@@ -1026,11 +1065,12 @@ class _DictionaryDialogPageState extends BasePageState {
             progressNotifier.value = t.dict_download_partial(
               success: successCount,
               total: toDownload.length,
-              error: lastError ?? '',
+              error: '',
             );
+            job.detail.value = lastReason;
           } else {
-            progressNotifier.value =
-                t.dict_download_failed(error: lastError ?? '');
+            progressNotifier.value = t.dict_download_failed(error: '');
+            job.detail.value = lastReason;
           }
           await Future<void>.delayed(const Duration(seconds: 2));
         } finally {
@@ -1049,12 +1089,15 @@ class _DictionaryDialogPageState extends BasePageState {
             severity: ToastSeverity.info,
           );
         }
-        if (failedNames.isNotEmpty) {
+        if (failures.isNotEmpty) {
           return DictionaryDownloadOutcome(
             message:
-                DictionaryImportManager.formatImportFailureSummary(failedNames),
+                DictionaryImportManager.formatImportFailureSummary(failures),
             toastLength: Toast.LENGTH_LONG,
             severity: ToastSeverity.error,
+            // BUG-2188：全文诊断（含试过哪些地址、原始异常）交给「错误详情」框，
+            // 用户可以整段复制去反馈，而不是抄一段被截断的英文。
+            details: DictionaryImportManager.formatFailureDetails(failures),
           );
         }
         return null;
@@ -1107,6 +1150,7 @@ class _DictionaryDialogPageState extends BasePageState {
             builder: (_, bool cancellable, __) =>
                 DictionaryDownloadProgressDialog(
               message: msg,
+              detailListenable: controller.detail,
               progressListenable: controller.progress,
               // 导入阶段 cancellable 为 false → 按钮置灰 + 说明为什么停不下来，
               // 而不是给一个按了没反应的按钮（BUG-1499）。
@@ -2178,6 +2222,7 @@ class DictionaryDownloadProgressDialog extends StatelessWidget {
   const DictionaryDownloadProgressDialog({
     required this.message,
     required this.progressListenable,
+    this.detailListenable,
     this.onCancel,
     this.onHide,
     this.cancelDisabledHint,
@@ -2186,6 +2231,11 @@ class DictionaryDownloadProgressDialog extends StatelessWidget {
 
   final String message;
   final ValueNotifier<double> progressListenable;
+
+  /// 附加说明（BUG-2188）。失败原因这类**必须完整读到**的文案走这里，渲染在正文里、
+  /// 可多行、可选中；标题 [message] 是 `maxLines: 1 + ellipsis` 的单行，塞长文案进去
+  /// 只会看到被截断的前半段（`DioError [connection ...`）。
+  final ValueListenable<String>? detailListenable;
 
   /// 取消回调。**null = 当前阶段停不下来**（导入中），按钮置灰并显示
   /// [cancelDisabledHint]。给一个按了没反应的按钮比没有按钮更坏（BUG-1499）。
@@ -2231,6 +2281,20 @@ class DictionaryDownloadProgressDialog extends StatelessWidget {
                 value: progress > 0 ? progress : null,
               ),
             ),
+            if (detailListenable != null)
+              ValueListenableBuilder<String>(
+                valueListenable: detailListenable!,
+                builder: (_, String detail, __) => detail.isEmpty
+                    ? const SizedBox.shrink()
+                    : Padding(
+                        padding: EdgeInsets.only(top: tokens.spacing.gap),
+                        child: SelectableText(
+                          detail,
+                          style: tokens.type.listSubtitle,
+                          maxLines: 6,
+                        ),
+                      ),
+              ),
             if (onCancel == null && cancelDisabledHint != null) ...<Widget>[
               SizedBox(height: tokens.spacing.gap),
               Text(

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -3511,6 +3511,34 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     );
   }
 
+  /// BUG-2196 ②：试听「这次制卡真正会写进卡片的那段音频」。
+  ///
+  /// 区间取的是 `_miningDraft.composeAudioRange(_currentSentenceAudioRange())`
+  /// —— **和 `_prepareMiningContext` 里喂给 ffmpeg 的那一个是同一个表达式**，所以
+  /// 听到什么就会压出什么。刻意不播「当前句的 cue」：那只能证明这句有音频，
+  /// 证明不了裁出来的那段念全了，而用户报的正是后者。
+  ///
+  /// 每次调用都重新求一次区间：用户在对话框里加减上下文句的目的就是改变它。
+  @override
+  bool get supportsSentenceAudioPreview => true;
+
+  @override
+  Future<bool> onPreviewSentenceAudio() async {
+    final AudiobookPlayerController? controller = _audiobookController;
+    if (controller == null) return false;
+    final AudioPlaybackRange? clip =
+        _miningDraft.composeAudioRange(_currentSentenceAudioRange());
+    if (clip == null || clip.endMs <= clip.startMs) return false;
+    await controller.playRange(clip);
+    return true;
+  }
+
+  @override
+  Future<void> onStopSentenceAudioPreview() async {
+    // resumeMain: false —— 用户是在制卡对话框里点的试听，不该顺手把正文朗读接着放。
+    await _audiobookController?.stopClip(resumeMain: false);
+  }
+
   @override
   Future<MinePopupResult> onMineFromPopup(Map<String, String> fields) {
     // TODO-644 / BUG-357：经制卡串行队列执行，杜绝快速连制两张卡时两次 prepare→mine

--- a/fushi/lib/src/pages/implementations/sentence_context_dialog.dart
+++ b/fushi/lib/src/pages/implementations/sentence_context_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/utils.dart';
@@ -24,6 +26,8 @@ class SentenceContextDialog extends StatefulWidget {
     required this.fetchPreview,
     required this.setContext,
     required this.onConfirm,
+    this.previewAudio,
+    this.stopAudioPreview,
   });
 
   /// 查到的词表现形，用于在「当前句」里高亮（失配回退 indexOf，再失配无高亮）。
@@ -38,12 +42,23 @@ class SentenceContextDialog extends StatefulWidget {
   /// 确认制卡（回该词条 WebView 制卡按钮）。
   final VoidCallback onConfirm;
 
+  /// BUG-2196 ②：试听**这次制卡真正会写进卡片的那段音频**（不是「当前句的 cue」——
+  /// 写进卡的区间还合并了在这个对话框里加减出来的上下文句，并带首尾留白与 A/V
+  /// 偏移）。返回 false = 这句没有可试听的音频。null = 该表面不支持，不渲染按钮。
+  final Future<bool> Function()? previewAudio;
+
+  /// 停止试听。与 [previewAudio] 同时为 null 或同时非 null。
+  final Future<void> Function()? stopAudioPreview;
+
   @override
   State<SentenceContextDialog> createState() => _SentenceContextDialogState();
 }
 
 class _SentenceContextDialogState extends State<SentenceContextDialog>
     with FushiPagePlaceholders<SentenceContextDialog> {
+  /// 试听是否正在播。只驱动按钮外观；真正的播放状态在宿主控制器里。
+  bool _previewing = false;
+
   List<String> _prev = const <String>[];
   List<String> _next = const <String>[];
   String _current = '';
@@ -121,6 +136,8 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
   }
 
   Future<void> _cancel() async {
+    // 关窗前先停试听：对话框没了但音频还在放，用户没有任何入口能停下来。
+    await _stopPreview();
     // 还原到打开时的上下文。setContext 失败尽力而为，仍关窗。
     try {
       await widget.setContext(_snapPrev, _snapNext);
@@ -129,8 +146,50 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
   }
 
   void _confirm() {
+    // 同上：制卡走了，试听不该继续响。不 await——制卡不等它。
+    unawaited(_stopPreview());
     Navigator.of(context).pop();
     widget.onConfirm();
+  }
+
+  /// BUG-2196 ②：试听/停止的开关。
+  ///
+  /// 每次都重新问宿主要一次区间（而不是打开对话框时缓存一份）：用户在这里加减
+  /// 上下文句的**目的**就是改变那段区间，缓存会让试听放的是上一次的范围。
+  Future<void> _togglePreview() async {
+    final Future<bool> Function()? play = widget.previewAudio;
+    if (play == null) return;
+    if (_previewing) {
+      await _stopPreview();
+      return;
+    }
+    setState(() => _previewing = true);
+    bool ok = false;
+    try {
+      ok = await play();
+    } catch (_) {
+      ok = false;
+    }
+    if (!mounted) return;
+    if (!ok) {
+      // 没有可试听的音频：如实说一声，不要留一个「像在放但没声音」的按钮。
+      setState(() => _previewing = false);
+      FushiToast.show(
+        msg: t.popup_ctx_preview_unavailable,
+        severity: ToastSeverity.info,
+      );
+    }
+  }
+
+  Future<void> _stopPreview() async {
+    if (!_previewing) return;
+    final Future<void> Function()? stop = widget.stopAudioPreview;
+    if (stop != null) {
+      try {
+        await stop();
+      } catch (_) {}
+    }
+    if (mounted) setState(() => _previewing = false);
   }
 
   /// 当前句里把查到的词高亮：offset 命中优先（offset 处正好是 matched），失配回退
@@ -402,6 +461,18 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
       ),
       // 底部动作对齐 Niratan footer：右下角 Cancel + Confirm Mining（主按钮）。
       actions: <Widget>[
+        // BUG-2196 ②：试听放最左，与「取消 / 确认制卡」同一行。只有宿主真的能出声
+        // 的表面才有这个按钮（previewAudio == null 时整颗不渲染）。
+        if (widget.previewAudio != null)
+          TextButton.icon(
+            onPressed: _busy ? null : _togglePreview,
+            icon: Icon(
+              _previewing ? Icons.stop_rounded : Icons.play_arrow_rounded,
+            ),
+            label: Text(
+              _previewing ? t.popup_ctx_preview_stop : t.popup_ctx_preview_audio,
+            ),
+          ),
         TextButton(
           onPressed: _busy ? null : _cancel,
           child: Text(t.popup_ctx_cancel),

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -386,7 +386,15 @@ window.fushiSelection = {
   highlightWrappers: [],
   selectionRubyElements: [],
   scanDelimiters: '。、！？…‥「」『』（）()【】〈〉《》〔〕｛｝{}［］[]・：；:;，,.─\n\r"\'“”‘’«»‹›',
-  sentenceDelimiters: '。！？.!?\n\r',
+  // BUG-2196：**换行不是句子边界**。在 HTML 语义里 \n / \r 只是空白，
+  // 而 EPUB 的 XHTML 正文普遍在源码里硬换行；把它们算作分隔符，
+  // `shepherds abiding in the field,\n keeping watch...` 就会被切在逗号后的换行处，
+  // 制卡拿到半截句、按句区间裁出的音频也跟着漏词（用户报的「制卡压没念」）。
+  // 同仓库先例：视觉小说模式（reader_visual_novel_scripts.dart）本来就不含 \n\r；
+  // PDF 路径（reader_pdf_page.dart）则是先把 \n/\r 等长换成空格再分句。
+  // **扁平文本那条路（lookup/sentence_extraction.dart）刻意保留换行**：Windows UIA
+  // 抓到的是没有块级结构的裸串，galgame / 聊天窗里一行就是一句。
+  sentenceDelimiters: '。！？.!?',
   trailingSentenceChars: '。、！？…‥」』）)】〉》〕｝}］]',
   brackets: {'「':'」', '『': '』', '（':'）', '(':')', '【':'】', '〈':'〉', '《':'》', '〔':'〕', '｛':'｝', '{':'}', '［':'］', '[':']'},
   isCodePointJapanese: function(codePoint) {
@@ -749,7 +757,12 @@ window.fushiSelection = {
       start = 0;
     }
     var beforeText = partsBefore.reverse().join('');
-    var rawSentence = beforeText + partsAfter.join('');
+    // BUG-2196：换行在 HTML 里等价于空格。**等长**替换（1 字符换 1 字符），
+    // 因此 beforeText.length / sentenceOffset / sStartOffset / sEndOffset 与
+    // getNormalizedOffset 的下标全部保持不变——用 \s+ 折叠会把偏移打乱，
+    // 进而毁掉喂给 miningSentenceAudioRange 的 normOffset/normLength。
+    var rawSentence = (beforeText + partsAfter.join(''))
+        .replace(/[\n\r]/g, ' ');
     var trimmedSentence = rawSentence.trim();
     var leadingTrim = rawSentence.length - rawSentence.trimStart().length;
     var sentenceOffset = Math.max(0, beforeText.length - leadingTrim);

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -431,6 +431,33 @@ class BackupContentSummary {
   bool has(BackupCategory c) => present.contains(c);
 }
 
+/// 一次导出里词典的**逐本**打包计划（BUG-2193）。
+///
+/// 存在的理由：以前判据是一个 bool（`_hasCompleteDictionaryResources`），语义是
+/// 「**每一行** dictionary_metadata 都在磁盘上有文件才打包」。这条不变式本身是对的
+/// （不能让恢复端造出查不了的幽灵词典），但把它实现成**全表 AND 门**意味着：
+/// 库里只要有一条幽灵行（profile 切换误删过目录、导入中断、`.pending_delete` 残留
+/// 都会造出来），**全部**词典就一本都不打包，还顺手把 DB 副本里的词典行整表清空，
+/// 而导出照样报成功。用户勾了「词典」，拿到手的 zip 里只有 backup_meta.json 和
+/// fushi.db。
+///
+/// 改法是把「全表 AND」换成「逐本分区」：有文件的照打，幽灵行只删它自己那一行。
+/// 不变式依然成立——出包里的每一行都有对应文件——但代价从「全部」降到「那一条」。
+class _DictionaryPackPlan {
+  const _DictionaryPackPlan({required this.packable, required this.ghosts});
+
+  const _DictionaryPackPlan.empty()
+      : packable = const <String>[],
+        ghosts = const <String>[];
+
+  /// 磁盘上确有文件、这次会被打进 zip 的词典名。
+  final List<String> packable;
+
+  /// 元数据在、磁盘资源缺失的词典名。它们的 DB 行会从导出副本里删掉，
+  /// **只删这些行**，其余词典不受牵连。
+  final List<String> ghosts;
+}
+
 class BackupService {
   BackupService({
     required FushiDatabase db,
@@ -923,7 +950,15 @@ class BackupService {
     final int books = (await _db.getAllEpubBooks()).length;
     final int audiobooks = (await _db.getAllAudiobooks()).length;
     final int videos = (await _db.allVideoBooks()).length;
-    final int dictionaries = (await _db.getAllDictionaryMetadata()).length;
+    // BUG-2193：**只数打得出来的那些**。旧实现数的是 dictionary_metadata 行数，
+    // 与打包判据不同源，于是勾选框显示「词典 (12)」、导出后一本都没有，用户完全
+    // 无从察觉。与下面字体那一条同一条纪律：预览计数 = 实际打包内容。
+    final int dictionaries =
+        (await _planDictionaryPack(_dictionaryResourceDirectory == null
+                ? null
+                : Directory(_dictionaryResourceDirectory)))
+            .packable
+            .length;
     // Count the fonts the USER manages (catalog entries whose file lives under
     // custom_fonts/), not every file in the tree: failed `_tmp_*` downloads and
     // replaced-but-unreferenced old files inflated the count (a user with 2
@@ -1066,6 +1101,7 @@ class BackupService {
     Set<String>? bookKeys,
     Set<String>? videoKeys,
     void Function(double progress)? onProgress,
+    void Function(List<String> names)? onDictionariesSkipped,
   }) async {
     bool wants(BackupCategory c) =>
         categories == null || categories.contains(c);
@@ -1111,8 +1147,14 @@ class BackupService {
       // Honor the category selection: when the user unticked Dictionaries,
       // exclude them entirely (and strip their DB rows below) even if the
       // resource files are present on disk.
-      final bool includeDictionary = wants(BackupCategory.dictionary) &&
-          await _hasCompleteDictionaryResources(dictionaryResourceRoot);
+      // BUG-2193：判据从「全表 AND 门」换成「逐本分区」。以前一条幽灵行就让全部
+      // 词典不打包（且静默），用户勾了词典却拿到一个只有 db 的 zip。
+      final bool wantsDictionary = wants(BackupCategory.dictionary);
+      final _DictionaryPackPlan dictionaryPlan = wantsDictionary
+          ? await _planDictionaryPack(dictionaryResourceRoot)
+          : const _DictionaryPackPlan.empty();
+      final bool includeDictionary =
+          wantsDictionary && dictionaryPlan.packable.isNotEmpty;
       // Whether the "book content" category is packed. When it is NOT, the
       // hoshi_books/ tree is skipped below AND the epub_books rows must be
       // stripped from the DB copy — otherwise a restore/merge would insert book
@@ -1121,8 +1163,22 @@ class BackupService {
       // packed never appears after import.
       final bool includeBooks = wants(BackupCategory.books);
       await _stripCredentials(tmpDir.path);
-      if (!includeDictionary) {
+      if (!wantsDictionary) {
+        // 用户没勾词典 → 整表清空（行为不变）。
         await _stripDictionaryState(tmpDir.path);
+      } else if (dictionaryPlan.packable.isEmpty) {
+        // 勾了，但一本都打不出来 → 与上同（避免恢复端造出全是幽灵的词典库）。
+        await _stripDictionaryState(tmpDir.path);
+      } else {
+        // 勾了且有得打 → **只**删缺文件的那几行，其余词典照常出包。
+        await _stripGhostDictionaryRows(tmpDir.path, dictionaryPlan.ghosts);
+      }
+      // 无论哪条分支，跳过的词典都必须让调用方知道——这正是本 bug 里
+      // 「导出报成功、包里没词典」的那半个真相。
+      if (wantsDictionary && dictionaryPlan.ghosts.isNotEmpty) {
+        onDictionariesSkipped?.call(
+          List<String>.unmodifiable(dictionaryPlan.ghosts),
+        );
       }
       // Which books' records survive in the exported DB copy:
       //  - book content unticked      → keep NONE (strip every epub_books row).
@@ -1303,8 +1359,8 @@ class BackupService {
       );
 
       if (includeDictionary) {
-        await _collectTreeFiles(
-            dictionaryResourceRoot!, _dictionaryResourcesPrefix, files);
+        await _collectDictionaryTrees(
+            dictionaryResourceRoot!, dictionaryPlan.packable, files);
       }
       if (_booksRootDirectory != null && includeBooks) {
         if (bookKeys == null) {
@@ -3601,18 +3657,75 @@ class BackupService {
     });
   }
 
-  Future<bool> _hasCompleteDictionaryResources(Directory? root) async {
-    if (root == null || !await root.exists()) return false;
+
+  /// 逐本盘点词典资源，产出 [_DictionaryPackPlan]（BUG-2193）。
+  ///
+  /// 资源根不存在 = 这台设备一本词典的文件都没有，所有行都是幽灵。
+  Future<_DictionaryPackPlan> _planDictionaryPack(Directory? root) async {
     final List<DictionaryMetaRow> dictionaries =
         await _db.getAllDictionaryMetadata();
-    if (dictionaries.isEmpty) return false;
+    if (root == null || !await root.exists()) {
+      return _DictionaryPackPlan(
+        packable: const <String>[],
+        ghosts: <String>[
+          for (final DictionaryMetaRow d in dictionaries) d.name,
+        ],
+      );
+    }
+    final List<String> packable = <String>[];
+    final List<String> ghosts = <String>[];
     for (final DictionaryMetaRow dictionary in dictionaries) {
       final Directory dictionaryDir = Directory(
         p.join(root.path, dictionary.name),
       );
-      if (!await _directoryHasFiles(dictionaryDir)) return false;
+      if (await _directoryHasFiles(dictionaryDir)) {
+        packable.add(dictionary.name);
+      } else {
+        ghosts.add(dictionary.name);
+      }
     }
-    return true;
+    return _DictionaryPackPlan(packable: packable, ghosts: ghosts);
+  }
+
+  /// 只把 [names] 这几本词典的目录打进 zip（BUG-2193）。
+  ///
+  /// 顺带修掉旧实现的一个副作用：`_collectTreeFiles` 会把整棵
+  /// `dictionaryResources/` 无差别打包，连 `download_temp` / `import_temp` /
+  /// `update_temp` / `.pending_delete` 这些运行期临时目录一起塞进备份包白白撑大。
+  /// 按词典名枚举天然把它们排除在外。
+  static Future<void> _collectDictionaryTrees(
+    Directory root,
+    List<String> names,
+    Map<String, String> into,
+  ) async {
+    for (final String name in names) {
+      await _collectTreeFiles(
+        Directory(p.join(root.path, name)),
+        p.posix.join(_dictionaryResourcesPrefix, name),
+        into,
+      );
+    }
+  }
+
+  /// 从导出副本里删掉 [names] 这几本词典的元数据行（BUG-2193）。
+  ///
+  /// 与 [_stripDictionaryState] 的区别是**不动词典查询历史、也不清空整表**：
+  /// 这里处理的是「个别行没有对应文件」，不是「这次不导出词典」。
+  static Future<void> _stripGhostDictionaryRows(
+    String dbDirectory,
+    List<String> names,
+  ) async {
+    if (names.isEmpty) return;
+    final db = FushiDatabase(dbDirectory);
+    try {
+      for (final String name in names) {
+        await db.deleteDictionaryMeta(name);
+      }
+      await db.customStatement('VACUUM');
+      await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      await db.close();
+    }
   }
 
   static Future<bool> _directoryHasFiles(Directory directory) async {

--- a/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -717,6 +717,9 @@ Future<void> runBackupExportFlow({
   appModel.beginBackupExport();
   String? failure;
   bool cancelled = false;
+  // BUG-2193：打包时被跳过的词典（元数据在、磁盘资源缺失）。以前这种情况让**全部**
+  // 词典都不进包，而导出照样报「成功」——用户下次在新设备恢复才会发现词典全没了。
+  List<String> skippedDictionaries = const <String>[];
   try {
     final Directory tmpDir = await getTemporaryDirectory();
     await _sweepStaleBackupArchives(tmpDir);
@@ -729,6 +732,8 @@ Future<void> runBackupExportFlow({
       bookKeys: bookKeys,
       videoKeys: videoKeys,
       onProgress: appModel.reportBackupExportProgress,
+      onDictionariesSkipped: (List<String> names) =>
+          skippedDictionaries = names,
     );
     if (Platform.isAndroid || Platform.isIOS) {
       await FushiShare.shareFiles(
@@ -766,7 +771,12 @@ Future<void> runBackupExportFlow({
   _showSnackBar(
     rootCtx,
     failure == null
-        ? t.backup_export_success
+        ? (skippedDictionaries.isEmpty
+            ? t.backup_export_success
+            : t.backup_export_dictionaries_skipped(
+                n: skippedDictionaries.length,
+                names: skippedDictionaries.join('、'),
+              ))
         : t.backup_export_failed(message: failure),
   );
 }

--- a/fushi/lib/src/utils/net/dictionary_dio.dart
+++ b/fushi/lib/src/utils/net/dictionary_dio.dart
@@ -25,10 +25,31 @@ import 'package:dio/io.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
 import 'package:fushi/src/utils/net/app_proxy.dart';
+import 'package:fushi/src/utils/net/github_mirrors.dart';
 
 /// 把词典链路的 Dio 工厂接到全应用的代理解析层。幂等，可重复调用。
 void installDictionaryDioFactory() {
   dictionaryDioFactory = createProxiedDictionaryDio;
+}
+
+/// BUG-2188：把词典下载的候选地址解析接到全仓唯一的 GitHub 镜像清单
+/// （[gitHubMirrorCandidates]）。幂等，可重复调用。
+///
+/// 覆盖面**只有 GitHub 托管的 catalog 条目**（jitendex / MarvNC / Kuuuube）。
+/// wty（Wiktionary）系列托管在 `huggingface.co`，实测公共 GitHub 镜像对它一律 403、
+/// `hf-mirror.com` 对 `/datasets/.../resolve/...` 是 308 跳回原站——没有任何现成公共
+/// 镜像能代理它，故这里对它只返回原址，由 UI 如实报「连不上 huggingface.co」。
+void installDictionaryUrlCandidatesResolver() {
+  dictionaryUrlCandidatesResolver = dictionaryDownloadUrlCandidates;
+}
+
+/// **纯函数**：词典下载地址 → 候选序列（首位恒为原址）。
+List<String> dictionaryDownloadUrlCandidates(String url) {
+  final Uri? parsed = Uri.tryParse(url);
+  if (parsed == null) return <String>[url];
+  return gitHubMirrorCandidates(parsed)
+      .map((Uri candidate) => candidate.toString())
+      .toList(growable: false);
 }
 
 /// 建一个走应用代理的 [Dio]。超时由 `createDictionaryDio` 统一兜底钉死，这里只管代理。

--- a/fushi/test/android/ankidroid_parallel_build_guard_test.dart
+++ b/fushi/test/android/ankidroid_parallel_build_guard_test.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-2195：AnkiDroid 并行版（`com.ichi2.anki.A` 等）支持的源码守卫。
+///
+/// 为什么需要守卫而不是只靠单测：这条链路的关键事实全在 **Java 源码和
+/// AndroidManifest** 里，而本仓库的 Android 侧没有 JVM 单测基建（历史上同类不变式
+/// 也都是用源码扫描钉的，见 `anki_native_createmodel_guard_test.dart`）。
+///
+/// 三条不变式：
+///  1. 候选包清单与 manifest 的 `<queries>` / `<uses-permission>` **逐条对应**。
+///     漏一条 = 那个并行版在 Android 11+ 上恒不可见，权限框永远不弹——正是本 bug。
+///  2. 可用性判断不得回到 `AddContentApi.getAnkiDroidPackageName`（它按写死的主包
+///     authority 解析）。
+///  3. 我们自己发出去的 provider URI 与 `grantUriPermission` 不得写死主包。
+void main() {
+  final Directory javaDir = Directory(
+    'android/app/src/main/java/app/fushi/reader',
+  );
+  String java(String name) =>
+      maskComments(File('${javaDir.path}/$name').readAsStringSync());
+  String javaRaw(String name) =>
+      File('${javaDir.path}/$name').readAsStringSync();
+
+  final String manifest =
+      File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+
+  /// 从 `AnkiDroidTarget.CANDIDATE_PACKAGES` 里把候选包名读出来。
+  List<String> candidatePackages() {
+    final String source = java('AnkiDroidTarget.java');
+    final int start = source.indexOf('CANDIDATE_PACKAGES');
+    expect(start, greaterThan(-1),
+        reason: 'AnkiDroidTarget 必须有 CANDIDATE_PACKAGES 清单');
+    final int open = source.indexOf('{', start);
+    final int close = source.indexOf('}', open);
+    final String body = source.substring(open + 1, close);
+    final List<String> packages = <String>[];
+    for (final String raw in body.split(',')) {
+      final String entry = raw.trim();
+      if (entry.isEmpty) continue;
+      if (entry == 'MAIN_PACKAGE') {
+        packages.add('com.ichi2.anki');
+        continue;
+      }
+      final RegExpMatch? m =
+          RegExp(r'MAIN_PACKAGE\s*\+\s*"([^"]+)"').firstMatch(entry);
+      expect(m, isNotNull, reason: '看不懂的候选项：$entry');
+      packages.add('com.ichi2.anki${m!.group(1)}');
+    }
+    return packages;
+  }
+
+  test('候选包清单非空，且主包排第一', () {
+    final List<String> packages = candidatePackages();
+    expect(packages.length, greaterThanOrEqualTo(6),
+        reason: '至少要覆盖主包 + 官方并行版 A–E');
+    expect(packages.first, 'com.ichi2.anki',
+        reason: '同时装了主包和并行版时，主包必须先命中（与修复前行为一致）');
+    expect(packages.toSet().length, packages.length, reason: '候选不得重复');
+  });
+
+  test('每个候选包都在 manifest 的 <queries> 里声明了包可见性', () {
+    for (final String pkg in candidatePackages()) {
+      expect(
+        manifest.contains('<package android:name="$pkg" />'),
+        isTrue,
+        reason: '$pkg 没有 <queries> 声明：Android 11+ 上 resolveContentProvider '
+            '查不到它，isApiAvailable 恒 false，权限框一次都不会弹',
+      );
+    }
+  });
+
+  test('每个候选包的读写权限都单独声明了', () {
+    for (final String pkg in candidatePackages()) {
+      expect(
+        manifest.contains(
+          '<uses-permission android:name="$pkg.permission.READ_WRITE_DATABASE"/>',
+        ),
+        isTrue,
+        reason: '$pkg 定义的是它自己那个带后缀的权限；只声明主包那一个时，'
+            '即便包可见，requestPermissions 也会静默判拒',
+      );
+    }
+  });
+
+  test('可用性判断不得回到写死主包 authority 的 getAnkiDroidPackageName', () {
+    final String helper = java('AnkiDroidHelper.java');
+    expect(helper.contains('AnkiDroidTarget.resolve('), isTrue,
+        reason: 'isApiAvailable 必须走逐候选探测');
+    expect(helper.contains('AddContentApi.getAnkiDroidPackageName'), isFalse,
+        reason: '它只认写死的 com.ichi2.anki.flashcards，并行版恒 null');
+  });
+
+  test('权限名按解析出的目标拼，不用 AAR 的写死常量', () {
+    final String helper = java('AnkiDroidHelper.java');
+    expect(helper.contains('readWritePermission()'), isTrue);
+    // 三个用到权限名的地方（检查 / 申请 / rationale）都必须走那个方法。
+    expect(
+      RegExp(r'readWritePermission\(\)').allMatches(helper).length,
+      greaterThanOrEqualTo(4),
+      reason: 'checkSelfPermission / requestPermissions / '
+          'shouldShowRequestPermissionRationale 三处 + 定义本身',
+    );
+  });
+
+  test('grantUriPermission 授给解析出的包，不写死主包', () {
+    final String handler = java('AnkiChannelHandler.java');
+    expect(handler.contains('context.grantUriPermission("com.ichi2.anki"'),
+        isFalse,
+        reason: '写死主包时并行版拿不到媒体 URI 的读权限，插入必失败');
+    expect(
+        handler.contains('grantUriPermission(mediaTarget.packageName'), isTrue);
+  });
+
+  test('我们自己发的 provider URI 都重挂过 authority', () {
+    final String handler = java('AnkiChannelHandler.java');
+    // 契约常量里的 CONTENT_URI 带的是写死的主包 authority；凡是直接交给
+    // ContentResolver 的，都必须先过 rebase。
+    final Iterable<RegExpMatch> inserts =
+        RegExp(r'resolver\.insert\(|contentResolver\.insert\(')
+            .allMatches(handler);
+    expect(inserts.isNotEmpty, isTrue);
+    expect(handler.contains('.rebase('), isTrue,
+        reason: 'AnkiMedia.CONTENT_URI 必须重挂 authority');
+  });
+
+  test('两个 provider 实现都存在，主包那条仍是纯委托', () {
+    expect(File('${javaDir.path}/AddContentApiProvider.java').existsSync(),
+        isTrue);
+    expect(
+        File('${javaDir.path}/DirectAnkiProvider.java').existsSync(), isTrue);
+    final String delegating = java('AddContentApiProvider.java');
+    // 纯委托的判据：没有 ContentResolver、没有 Cursor —— 一旦有人在这里写逻辑，
+    // 「支持并行版不碰主包路径」这条保证就没了。
+    expect(delegating.contains('ContentResolver'), isFalse,
+        reason: '主包实现必须是对 AddContentApi 的直白转发，不许有自己的查询逻辑');
+    expect(delegating.contains('Cursor'), isFalse);
+  });
+
+  test('并行版实现不得残留写死的主包 authority', () {
+    final String direct = javaRaw('DirectAnkiProvider.java');
+    // 注释里允许出现（说明为什么要有这个类），代码里不许。
+    final String code = java('DirectAnkiProvider.java');
+    expect(code.contains('com.ichi2.anki.flashcards'), isFalse);
+    expect(code.contains('target.rebase('), isTrue);
+    expect(direct.contains('FIELD_SEPARATOR'), isTrue,
+        reason: 'Anki 的字段分隔符是 0x1f，必须有单一常量而不是散落的字面量');
+  });
+}

--- a/fushi/test/dictionary/dictionary_download_mirror_fallback_test.dart
+++ b/fushi/test/dictionary/dictionary_download_mirror_fallback_test.dart
@@ -1,0 +1,284 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/dictionary_download_controller.dart';
+import 'package:fushi/src/utils/net/dictionary_dio.dart';
+import 'package:fushi/src/utils/net/github_mirrors.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+/// 按 URL 决定成功/失败的假适配器：记录每一次实际发出的请求。
+class _ScriptedAdapter implements HttpClientAdapter {
+  _ScriptedAdapter(this.respond);
+
+  /// 返回 null = 该请求抛连接超时；返回字节 = 该请求成功。
+  final Uint8List? Function(String url) respond;
+  final List<String> requested = <String>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final String url = options.uri.toString();
+    requested.add(url);
+    final Uint8List? body = respond(url);
+    if (body == null) {
+      throw DioError(
+        requestOptions: options,
+        type: DioErrorType.connectionTimeout,
+      );
+    }
+    return ResponseBody.fromBytes(body, 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// BUG-2188：词典下载的候选回退与失败归因。
+///
+/// 为什么这些用例值得存在：用户点「下载 Wiktionary JA-ZH」，界面只给出
+/// `下载失败：Wiktionary JA-ZH (中文): DioError [connection ...`——原因被截断、
+/// 措辞还错成「导入失败」。修复分两层：**候选回退**（GitHub 托管的条目多试几个镜像）
+/// 与**结构化归因**（失败带得出「连不上谁」）。下面逐层钉死。
+void main() {
+  setUp(() {
+    dictionaryUrlCandidatesResolver = null;
+    dictionaryDioFactory = null;
+  });
+  tearDown(() {
+    dictionaryUrlCandidatesResolver = null;
+    dictionaryDioFactory = null;
+  });
+
+  group('候选地址展开', () {
+    test('未接线时只有原址——与接线前逐字等价', () {
+      const String url = 'https://example.com/a.zip';
+      expect(dictionaryDownloadCandidates(url), <String>[url]);
+    });
+
+    test('GitHub 托管的词典展开出镜像候选，原址恒在首位', () {
+      installDictionaryUrlCandidatesResolver();
+      const String url =
+          'https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/x.zip';
+      final List<String> candidates = dictionaryDownloadCandidates(url);
+      expect(candidates.first, url, reason: '直连必须先试：有代理时它最快也最权威');
+      expect(candidates.length, kGitHubMirrorPrefixes.length + 1);
+      expect(candidates.toSet().length, candidates.length, reason: '候选不得重复');
+    });
+
+    test('raw.githubusercontent 同样展开', () {
+      installDictionaryUrlCandidatesResolver();
+      const String url =
+          'https://raw.githubusercontent.com/MarvNC/yomitan-dictionaries/master/dl/x.zip';
+      expect(
+        dictionaryDownloadCandidates(url).length,
+        kGitHubMirrorPrefixes.length + 1,
+      );
+    });
+
+    test(
+        'huggingface 不展开——公共 GitHub 镜像对它实测一律 403，'
+        'hf-mirror 对 /datasets/.../resolve/ 是 308 跳回原站', () {
+      installDictionaryUrlCandidatesResolver();
+      const String url =
+          'https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/ja/zh/wty-ja-zh.zip';
+      expect(dictionaryDownloadCandidates(url), <String>[url]);
+    });
+
+    test('解析器返回空列表时仍回落到原址，绝不产出空候选', () {
+      dictionaryUrlCandidatesResolver = (String _) => const <String>[];
+      const String url = 'https://example.com/a.zip';
+      expect(dictionaryDownloadCandidates(url), <String>[url]);
+    });
+  });
+
+  group('失败归因', () {
+    DioError dioError(DioErrorType type, {int? status}) => DioError(
+          requestOptions: RequestOptions(path: '/x'),
+          type: type,
+          response: status == null
+              ? null
+              : Response<void>(
+                  requestOptions: RequestOptions(path: '/x'),
+                  statusCode: status,
+                ),
+        );
+
+    test('连接超时 / 停顿超时 / 连接错误各自归位', () {
+      expect(
+        classifyDictionaryDownloadFailure(
+          dioError(DioErrorType.connectionTimeout),
+        ),
+        DictionaryDownloadFailureKind.connectTimeout,
+      );
+      expect(
+        classifyDictionaryDownloadFailure(
+          dioError(DioErrorType.receiveTimeout),
+        ),
+        DictionaryDownloadFailureKind.stallTimeout,
+      );
+      expect(
+        classifyDictionaryDownloadFailure(
+          dioError(DioErrorType.connectionError),
+        ),
+        DictionaryDownloadFailureKind.connectionError,
+      );
+    });
+
+    test('服务器已答复的状态错误不算传输失败——换镜像拿到的是同一份 404', () {
+      final DioError e = dioError(DioErrorType.badResponse, status: 404);
+      expect(
+        classifyDictionaryDownloadFailure(e),
+        DictionaryDownloadFailureKind.badResponse,
+      );
+      expect(isDictionaryTransportFailure(e), isFalse);
+    });
+
+    test('取消不算传输失败，也不该触发回退', () {
+      final DioError e = dioError(DioErrorType.cancel);
+      expect(
+        classifyDictionaryDownloadFailure(e),
+        DictionaryDownloadFailureKind.cancelled,
+      );
+      expect(isDictionaryTransportFailure(e), isFalse);
+    });
+
+    test('dio 把 SocketException 塞进 unknown 时仍认作连接错误', () {
+      final DioError e = DioError(
+        requestOptions: RequestOptions(path: '/x'),
+        type: DioErrorType.unknown,
+        error: const SocketException('no route'),
+      );
+      expect(
+        classifyDictionaryDownloadFailure(e),
+        DictionaryDownloadFailureKind.connectionError,
+      );
+      expect(isDictionaryTransportFailure(e), isTrue);
+    });
+
+    test('异常全文带上试过的地址与原始 cause', () {
+      final DictionaryDownloadException e = DictionaryDownloadException(
+        url: 'https://github.com/o/r/releases/download/v1/a.zip',
+        attemptedUrls: <String>[
+          'https://github.com/o/r/releases/download/v1/a.zip',
+          'https://ghfast.top/https://github.com/o/r/releases/download/v1/a.zip',
+        ],
+        cause: dioError(DioErrorType.connectionTimeout),
+      );
+      expect(e.host, 'github.com');
+      expect(e.kind, DictionaryDownloadFailureKind.connectTimeout);
+      final String text = e.toString();
+      expect(text, contains('ghfast.top'));
+      expect(text, contains('connectTimeout'));
+    });
+
+    test('badResponse 带出状态码，供 UI 说清「返回了什么」', () {
+      final DictionaryDownloadException e = DictionaryDownloadException(
+        url: 'https://example.com/a.zip',
+        attemptedUrls: <String>['https://example.com/a.zip'],
+        cause: dioError(DioErrorType.badResponse, status: 403),
+      );
+      expect(e.statusCode, 403);
+      expect(e.toString(), contains('403'));
+    });
+  });
+
+  group('download() 的真实回退行为', () {
+    late Directory tempDir;
+    const String url =
+        'https://github.com/yomidevs/jmdict-yomitan/releases/latest/download/x.zip';
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('dict_dl_test');
+      installDictionaryUrlCandidatesResolver();
+    });
+    tearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    /// 装一个只对 [okUrlPart] 命中的假适配器，返回它记录到的请求序列。
+    _ScriptedAdapter installAdapter(String? okUrlPart) {
+      final _ScriptedAdapter adapter = _ScriptedAdapter(
+        (String u) => okUrlPart != null && u.contains(okUrlPart)
+            ? Uint8List.fromList(<int>[1, 2, 3, 4])
+            : null,
+      );
+      dictionaryDioFactory = () async => Dio()..httpClientAdapter = adapter;
+      return adapter;
+    }
+
+    test('直连超时后自动改用镜像，并真的落盘', () async {
+      final _ScriptedAdapter adapter = installAdapter('ghfast.top');
+      final File file = await DictionaryDownloader.download(
+        url: url,
+        tempDir: tempDir,
+        progressNotifier: ValueNotifier<double>(0),
+      );
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsBytesSync(), <int>[1, 2, 3, 4]);
+      expect(adapter.requested.first, url, reason: '第一跳必须是直连');
+      expect(adapter.requested.length, 2, reason: '第二跳命中镜像后就不再往下试');
+      expect(adapter.requested.last, contains('ghfast.top'));
+    });
+
+    test('全部候选都连不上时抛 DictionaryDownloadException，带齐试过的地址', () async {
+      final _ScriptedAdapter adapter = installAdapter(null);
+      await expectLater(
+        DictionaryDownloader.download(
+          url: url,
+          tempDir: tempDir,
+          progressNotifier: ValueNotifier<double>(0),
+        ),
+        throwsA(
+          isA<DictionaryDownloadException>()
+              .having(
+                (DictionaryDownloadException e) => e.kind,
+                'kind',
+                DictionaryDownloadFailureKind.connectTimeout,
+              )
+              .having(
+                (DictionaryDownloadException e) => e.host,
+                'host',
+                'github.com',
+              )
+              .having(
+                (DictionaryDownloadException e) => e.attemptedUrls.length,
+                'attempted',
+                kGitHubMirrorPrefixes.length + 1,
+              ),
+        ),
+      );
+      expect(adapter.requested.length, kGitHubMirrorPrefixes.length + 1);
+      expect(tempDir.listSync(), isEmpty, reason: '失败后不得留下半个包');
+    });
+
+    test('用户取消原样抛 DioError，不得被包成下载失败', () async {
+      final _ScriptedAdapter adapter = _ScriptedAdapter((String _) => null);
+      dictionaryDioFactory = () async => Dio()..httpClientAdapter = adapter;
+      final CancelToken token = CancelToken()..cancel();
+      Object? caught;
+      try {
+        await DictionaryDownloader.download(
+          url: url,
+          tempDir: tempDir,
+          progressNotifier: ValueNotifier<double>(0),
+          cancelToken: token,
+        );
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught, isNot(isA<DictionaryDownloadException>()));
+      expect(
+        DictionaryDownloadController.isCancellation(caught!),
+        isTrue,
+        reason: '取消被包起来的话，用户点取消会被记成一条下载失败',
+      );
+    });
+  });
+}

--- a/fushi/test/lookup/sentence_extraction_test.dart
+++ b/fushi/test/lookup/sentence_extraction_test.dart
@@ -129,10 +129,41 @@ void main() {
           reason: 'could not locate sentenceDelimiters in reader scripts');
       expect(readerTrailing, isNotNull,
           reason: 'could not locate trailingSentenceChars in reader scripts');
-      expect(readerSentence, kSentenceDelimiters,
-          reason: 'sentence_extraction.dart kSentenceDelimiters drifted from '
-              'the reader; re-sync so app-external capture matches in-app '
-              'sentence boundaries');
+      // BUG-2196：两侧**刻意**只差换行这一处，逐字节相等的老判据是过约束。
+      //
+      // 输入模型不同才是根据：reader 走的是 DOM 文本节点（有块级边界，源码里的
+      // 硬换行只是排版空白），扁平那条走的是 Windows UIA 抓来的裸串（galgame /
+      // 聊天窗里一行就是一句，行间常常没有句末标点）。所以换行在 reader 侧必须
+      // 不是分隔符、在扁平侧必须是。
+      //
+      // 判据写成「差集恰好是 \n\r，且方向固定」——既挡住真漂移（任何别的字符
+      // 不一致立刻红），又不会因为这处有意的差异而假红。
+      const String newlineOnly = '\n\r';
+      expect(
+        readerSentence,
+        isNot(contains('\n')),
+        reason: 'BUG-2196：换行在 HTML 里只是空白，reader 侧不得把它当句子边界',
+      );
+      expect(
+        kSentenceDelimiters,
+        contains('\n'),
+        reason: 'Windows UIA 抓到的是没有块级结构的裸串，换行在那条路上是唯一的'
+            '句子边界，不能跟着 reader 一起删',
+      );
+      expect(
+        kSentenceDelimiters.split('').toSet().difference(
+              readerSentence!.split('').toSet(),
+            ),
+        newlineOnly.split('').toSet(),
+        reason: '两侧只允许差换行；出现别的差异说明有人改了一边忘了另一边',
+      );
+      expect(
+        readerSentence.split('').toSet().difference(
+              kSentenceDelimiters.split('').toSet(),
+            ),
+        isEmpty,
+        reason: 'reader 侧不得有扁平侧没有的分隔符',
+      );
       expect(readerTrailing, kTrailingSentenceChars,
           reason: 'sentence_extraction.dart kTrailingSentenceChars drifted '
               'from the reader; re-sync the trailing-closer table');

--- a/fushi/test/models/dictionary_download_error_surfacing_guard_test.dart
+++ b/fushi/test/models/dictionary_download_error_surfacing_guard_test.dart
@@ -57,8 +57,17 @@ void main() {
 
     test('failures are collected and surfaced via a persistent summary toast',
         () {
-      expect(body.contains('failedNames'), isTrue,
-          reason: 'per-dictionary failures must be collected, not dropped');
+      // BUG-2188：判据从「有没有收集」升级成「收集的时候有没有把异常一起带上」。
+      // 旧实现收的是 `List<String>`——原因在收集那一刻就永久丢了，后面无论怎么改
+      // 渲染都救不回来，而按变量名 `failedNames` 断言恰好对这个缺陷完全不敏感。
+      expect(body.contains('DictionaryTaskFailure('), isTrue,
+          reason: 'per-dictionary failures must be collected with their error, '
+              'not reduced to a bare name');
+      expect(body.contains('error: e,'), isTrue,
+          reason: 'the caught exception itself must reach the failure record');
+      expect(body.contains('DictionaryTaskStage.download'), isTrue,
+          reason: 'a download-stage failure must not be reported as an import '
+              'failure (the two used to share one wording)');
       expect(
           body.contains('DictionaryImportManager.formatImportFailureSummary'),
           isTrue,

--- a/fushi/test/models/dictionary_import_failure_summary_test.dart
+++ b/fushi/test/models/dictionary_import_failure_summary_test.dart
@@ -1,24 +1,116 @@
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/models/dictionary_import_manager.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+DictionaryTaskFailure _importFailure(String name, [Object? error]) =>
+    DictionaryTaskFailure(
+      name: name,
+      stage: DictionaryTaskStage.import,
+      error: error ?? Exception('boom'),
+    );
+
+/// 造一个「连接超时」的下载失败，形状与真实链路一致（dio 5.1 的类名是 `DioError`）。
+DictionaryTaskFailure _downloadTimeout(String name, String url) =>
+    DictionaryTaskFailure(
+      name: name,
+      stage: DictionaryTaskStage.download,
+      url: url,
+      error: DictionaryDownloadException(
+        url: url,
+        attemptedUrls: <String>[url],
+        cause: DioError(
+          requestOptions: RequestOptions(path: url),
+          type: DioErrorType.connectionTimeout,
+        ),
+      ),
+    );
 
 void main() {
   group('DictionaryImportManager.formatImportFailureSummary (BUG-082)', () {
     test('single failure names the one dictionary', () {
-      final String msg =
-          DictionaryImportManager.formatImportFailureSummary(['辞書A']);
+      final String msg = DictionaryImportManager.formatImportFailureSummary(
+        <DictionaryTaskFailure>[_importFailure('辞書A')],
+      );
       expect(msg, contains('辞書A'));
-      expect(msg, isNot(contains(',')),
-          reason: 'single failure should not look like a list');
+      expect(
+        msg,
+        isNot(contains(',')),
+        reason: 'single failure should not look like a list',
+      );
     });
 
     test('multiple failures list every failed dictionary in one message', () {
       final String msg = DictionaryImportManager.formatImportFailureSummary(
-          ['辞書A', '辞書B', '辞書C']);
+        <DictionaryTaskFailure>[
+          _importFailure('辞書A'),
+          _importFailure('辞書B'),
+          _importFailure('辞書C'),
+        ],
+      );
       expect(msg, contains('辞書A'));
       expect(msg, contains('辞書B'));
       expect(msg, contains('辞書C'));
-      // names are joined into a single summary string, not shown one-by-one
-      expect(msg, contains('辞書A, 辞書B, 辞書C'));
+      // BUG-2188：多条汇总一行一条，每行都带自己的原因——旧实现把名字逗号连成一行、
+      // 原因一个都不给。
+      expect(
+        msg.split('\n').length,
+        4,
+        reason: 'one header line plus one line per failure',
+      );
+    });
+  });
+
+  group('失败原因必须进得了文案（BUG-2188）', () {
+    test('下载阶段失败说「下载失败」，不再谎报导入失败', () {
+      final String msg = DictionaryImportManager.formatImportFailureSummary(
+        <DictionaryTaskFailure>[
+          _downloadTimeout(
+            'Wiktionary JA-ZH',
+            'https://huggingface.co/a/b.zip',
+          ),
+        ],
+      );
+      expect(msg.toLowerCase(), contains('download'));
+      expect(msg.toLowerCase(), isNot(contains('import failed')));
+    });
+
+    test('导入阶段失败才说「导入失败」', () {
+      final String msg = DictionaryImportManager.formatImportFailureSummary(
+        <DictionaryTaskFailure>[_importFailure('辞書A')],
+      );
+      expect(msg.toLowerCase(), contains('import'));
+    });
+
+    test('连接超时的原因里点名了连不上的主机，而不是甩一串 DioError', () {
+      final DictionaryTaskFailure failure = _downloadTimeout(
+        'Wiktionary JA-ZH',
+        'https://huggingface.co/a/b.zip',
+      );
+      expect(failure.reason, contains('huggingface.co'));
+      expect(failure.reason, isNot(contains('DioError')));
+    });
+
+    test('全文诊断带上原始地址与原始异常，可整段复制去反馈', () {
+      final DictionaryTaskFailure failure = _downloadTimeout(
+        'Wiktionary JA-ZH',
+        'https://huggingface.co/a/b.zip',
+      );
+      final String details = DictionaryImportManager.formatFailureDetails(
+        <DictionaryTaskFailure>[failure],
+      );
+      expect(details, contains('https://huggingface.co/a/b.zip'));
+      expect(details, contains('connectTimeout'));
+    });
+
+    test('多条失败的全文诊断逐条保留，不互相覆盖', () {
+      final String details =
+          DictionaryImportManager.formatFailureDetails(<DictionaryTaskFailure>[
+        _downloadTimeout('A', 'https://huggingface.co/a.zip'),
+        _importFailure('B', StateError('bad zip')),
+      ]);
+      expect(details, contains('https://huggingface.co/a.zip'));
+      expect(details, contains('bad zip'));
     });
   });
 

--- a/fushi/test/models/dictionary_import_no_delay_guard_test.dart
+++ b/fushi/test/models/dictionary_import_no_delay_guard_test.dart
@@ -35,8 +35,10 @@ void main() {
 
   group('dictionary_dialog_page.dart batch loop', () {
     test('collects failed names and shows one summary', () {
-      expect(dialog.contains('failedNames'), isTrue,
-          reason: 'the multi-file import loop must collect failures');
+      // BUG-2188：同上，收集必须带着异常本体。
+      expect(dialog.contains('DictionaryTaskFailure('), isTrue,
+          reason: 'the multi-file import loop must collect failures with their '
+              'error attached');
       expect(dialog.contains('formatImportFailureSummary'), isTrue,
           reason: 'and present them via the shared summary formatter');
     });

--- a/fushi/test/pages/sentence_context_dialog_preview_test.dart
+++ b/fushi/test/pages/sentence_context_dialog_preview_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/pages/implementations/sentence_context_dialog.dart';
+
+/// BUG-2196 ②：「制卡前调整 · 选择句子上下文」里的试听按钮。
+///
+/// 用户诉求原文：「这里加个试听？有时候断句在很奇怪的地方，可能会漏词，制卡压没念」。
+/// 也就是说这颗按钮要能回答的问题是「**这次制卡压出来的那段音频，念全了吗**」，
+/// 而不是「这句话有没有音频」。所以下面的用例钉的是：
+///   * 宿主不支持时整颗按钮不渲染（视频页等没有句级音频区间的表面）；
+///   * 每次点都**重新问宿主要一次**区间（用户在这个对话框里加减上下文句的目的
+///     就是改变那段区间，缓存会让试听放的是上一次的范围）；
+///   * 宿主说「这句没音频」时如实提示，不留一个「像在放但没声音」的按钮；
+///   * 关窗（取消 / 确认制卡）都必须停播——对话框没了之后用户没有任何入口能停。
+void main() {
+  late int previewCalls;
+  late int stopCalls;
+  late bool previewSucceeds;
+  late int confirmCalls;
+
+  Map<String, Object?> preview() => <String, Object?>{
+        'prev': <String>[],
+        'current': 'shepherds abiding in the field, keeping watch.',
+        'currentOffset': 10,
+        'next': <String>[],
+        'total': 0,
+      };
+
+  Widget harness({required bool withPreview}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext ctx) => Center(
+            child: ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: ctx,
+                builder: (_) => SentenceContextDialog(
+                  matched: 'abiding',
+                  fetchPreview: () async => preview(),
+                  setContext: (int p, int n) async => p + n,
+                  onConfirm: () => confirmCalls++,
+                  previewAudio: withPreview
+                      ? () async {
+                          previewCalls++;
+                          return previewSucceeds;
+                        }
+                      : null,
+                  stopAudioPreview: withPreview
+                      ? () async {
+                          stopCalls++;
+                        }
+                      : null,
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  setUp(() {
+    previewCalls = 0;
+    stopCalls = 0;
+    previewSucceeds = true;
+    confirmCalls = 0;
+  });
+
+  Future<void> open(WidgetTester tester, {bool withPreview = true}) async {
+    tester.view.physicalSize = const Size(1200, 2000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(harness(withPreview: withPreview));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('宿主不支持试听时整颗按钮不渲染', (WidgetTester tester) async {
+    await open(tester, withPreview: false);
+    expect(find.text(t.popup_ctx_preview_audio), findsNothing);
+    expect(find.text(t.popup_ctx_preview_stop), findsNothing);
+  });
+
+  testWidgets('宿主支持时显示试听按钮，点一下开始播并变成停止', (WidgetTester tester) async {
+    await open(tester);
+    expect(find.text(t.popup_ctx_preview_audio), findsOneWidget);
+    await tester.tap(find.text(t.popup_ctx_preview_audio));
+    await tester.pumpAndSettle();
+    expect(previewCalls, 1);
+    expect(find.text(t.popup_ctx_preview_stop), findsOneWidget,
+        reason: '正在播时按钮必须变成「停止」，否则用户再点会以为是重放');
+  });
+
+  testWidgets('再点一下停止，并真的调到宿主的停播', (WidgetTester tester) async {
+    await open(tester);
+    await tester.tap(find.text(t.popup_ctx_preview_audio));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.popup_ctx_preview_stop));
+    await tester.pumpAndSettle();
+    expect(stopCalls, 1);
+    expect(find.text(t.popup_ctx_preview_audio), findsOneWidget);
+  });
+
+  testWidgets('每次试听都重新问宿主要区间，不缓存', (WidgetTester tester) async {
+    await open(tester);
+    for (int i = 0; i < 3; i++) {
+      await tester.tap(find.text(t.popup_ctx_preview_audio));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.popup_ctx_preview_stop));
+      await tester.pumpAndSettle();
+    }
+    expect(previewCalls, 3, reason: '加减上下文句就是为了改变那段区间；缓存会让试听放上一次的范围');
+  });
+
+  testWidgets('这句没有可试听音频时按钮弹回，不停在「停止」态', (WidgetTester tester) async {
+    previewSucceeds = false;
+    await open(tester);
+    await tester.tap(find.text(t.popup_ctx_preview_audio));
+    await tester.pumpAndSettle();
+    expect(previewCalls, 1);
+    expect(find.text(t.popup_ctx_preview_audio), findsOneWidget,
+        reason: '没声音却停在「停止」态，用户会以为在播、只是听不见');
+    expect(find.text(t.popup_ctx_preview_stop), findsNothing);
+  });
+
+  testWidgets('取消关窗时停播', (WidgetTester tester) async {
+    await open(tester);
+    await tester.tap(find.text(t.popup_ctx_preview_audio));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.popup_ctx_cancel));
+    await tester.pumpAndSettle();
+    expect(stopCalls, 1, reason: '对话框关了之后用户没有任何入口能停下这段音频');
+  });
+
+  testWidgets('确认制卡时也停播，且制卡照常发生', (WidgetTester tester) async {
+    await open(tester);
+    await tester.tap(find.text(t.popup_ctx_preview_audio));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.popup_ctx_confirm));
+    await tester.pumpAndSettle();
+    expect(stopCalls, 1);
+    expect(confirmCalls, 1, reason: '停播不得挡住制卡');
+  });
+
+  testWidgets('没点过试听就关窗，不该去打扰宿主的播放器', (WidgetTester tester) async {
+    await open(tester);
+    await tester.tap(find.text(t.popup_ctx_cancel));
+    await tester.pumpAndSettle();
+    expect(stopCalls, 0);
+  });
+}

--- a/fushi/test/reader/reader_get_sentence_context_boundary_test.dart
+++ b/fushi/test/reader/reader_get_sentence_context_boundary_test.dart
@@ -59,6 +59,16 @@ void main() {
     // `card_mined_no_sentence_captured` keys off exactly this).
     expect(stdout, contains('case4_whitespace_only :: {"sentence":""'),
         reason: 'only the whitespace-only container yields an empty sentence');
+    // BUG-2196：源码硬换行不再切句。这一条钉的是用户报的原句——修复前它会停在
+    // 逗号后的换行处，制卡拿到半截话、按句裁的音频也跟着漏词。
+    expect(
+      stdout,
+      contains('case11_before_wrap :: {"sentence":"And there were in the same '
+          'country shepherds abiding in the field,  keeping watch over their '
+          'flock by night."}'),
+      reason: 'a hard wrap inside one <p> must not end the sentence, and the '
+          'newline must be normalised to a space',
+    );
   });
 }
 

--- a/fushi/test/reader/reader_get_sentence_context_boundary_test.js
+++ b/fushi/test/reader/reader_get_sentence_context_boundary_test.js
@@ -423,5 +423,54 @@ let passed = 0;
   passed++;
 })();
 
+// CASE 11 (BUG-2196): a source-code hard wrap inside one <p>. This is the
+// user's actual report: the EPUB text node is
+//   "...shepherds abiding in the field,\n keeping watch over their flock..."
+// BEFORE the fix '\n' was a sentenceDelimiter, so looking up any word in the
+// first half returned the half sentence "shepherds abiding in the field,"
+// (comma-terminated -- exactly what the user's screenshot shows), and the
+// per-sentence audio range cut from it missed the rest of the line.
+// AFTER: the whole line up to the real '.' is one sentence, and the newline
+// itself is normalised to a space (EQUAL LENGTH, so offsets never shift).
+(function case11_hard_wrap_is_not_a_sentence_boundary() {
+  const p = makeElement('p');
+  const text = makeText(
+    'And there were in the same country shepherds abiding in the field,'
+      + '\n keeping watch over their flock by night.',
+    p,
+  );
+  const document = buildDocument(p);
+  const sel = loadFushiSelection(document);
+  // Caret on 'abiding' (before the wrap) and on 'watch' (after it) must
+  // both yield the SAME full sentence.
+  const onAbiding = sel.getSentenceContext(text, 55);
+  const onWatch = sel.getSentenceContext(text, 76);
+  record('case11_before_wrap', { sentence: onAbiding.sentence });
+  record('case11_after_wrap', { sentence: onWatch.sentence });
+  assert.ok(
+    onAbiding.sentence.indexOf('keeping watch') >= 0,
+    'CASE11: a hard wrap must not end the sentence (the audio range cut '
+      + 'from a half sentence is what dropped the spoken words)',
+  );
+  assert.strictEqual(
+    onAbiding.sentence,
+    onWatch.sentence,
+    'CASE11: both halves of a wrapped line belong to one sentence',
+  );
+  assert.ok(
+    onAbiding.sentence.indexOf('\n') < 0,
+    'CASE11: the newline must be normalised away, not shipped into {sentence}',
+  );
+  assert.ok(
+    onAbiding.sentence.indexOf('field,  keeping') >= 0,
+    'CASE11: normalisation is an EQUAL-LENGTH swap to a space, so offsets '
+      + 'stay valid. TWO spaces here is the proof: the newline became one '
+      + 'space and the original space is still there. A collapsing replace '
+      + 'would leave one space and shift every later offset, breaking the '
+      + 'normOffset/normLength fed to miningSentenceAudioRange.',
+  );
+  passed++;
+})();
+
 console.log('passed ' + passed + ' cases');
 console.log('all assertions passed');

--- a/fushi/test/sync/backup_ghost_dictionary_row_test.dart
+++ b/fushi/test/sync/backup_ghost_dictionary_row_test.dart
@@ -1,0 +1,204 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/backup_service.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'temp_dir_cleanup.dart';
+
+/// BUG-2193：`dictionary_metadata` 里的一条**幽灵行**（元数据在、磁盘目录不在）
+/// 曾经让**整批**词典都不进备份包，并且顺手把 DB 副本里的词典行整表清空——导出还
+/// 照样报成功。用户勾了「词典」，拿到的 zip 里只有 `backup_meta.json` 和 `fushi.db`。
+///
+/// 既有的 `backup_categories_test` / `backup_service_test` 全部把测试数据造成
+/// 「元数据与磁盘完全一致」的理想世界（前者的 harness 注释里就明说是为了让
+/// `_hasCompleteDictionaryResources` 放行），所以这个形态一条覆盖都没有。
+void main() {
+  late Directory src;
+
+  setUp(() async {
+    src = await Directory.systemTemp.createTemp('bk_ghost_src_');
+  });
+  tearDown(() async {
+    try {
+      if (src.existsSync()) await cleanupTempDir(src);
+    } on PathNotFoundException {
+      // Windows 上递归清理会和已被移除的临时路径抢。
+    }
+  });
+
+  Future<void> writeFile(String path, String content) async {
+    final File f = File(path);
+    f.parent.createSync(recursive: true);
+    await f.writeAsString(content);
+  }
+
+  /// 造一台「装了三本词典，其中一本的目录不见了」的设备。
+  Future<({BackupService service, FushiDatabase db})> buildDevice({
+    required List<String> onDisk,
+    required List<String> inDb,
+  }) async {
+    final String dbDir = p.join(src.path, 'db');
+    final String dict = p.join(src.path, 'dictionaryResources');
+    Directory(dbDir).createSync(recursive: true);
+    for (final String name in onDisk) {
+      await writeFile(p.join(dict, name, 'index.bin'), 'IDX-$name');
+    }
+    // 运行期临时目录：它们**不该**进备份包。
+    await writeFile(p.join(dict, 'import_temp', 'half.zip'), 'JUNK');
+    await writeFile(p.join(dict, '.pending_delete', 'old.bin'), 'JUNK');
+
+    final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
+    for (int i = 0; i < inDb.length; i++) {
+      await db.upsertDictionaryMeta(
+        DictionaryMetadataCompanion.insert(
+          name: inDb[i],
+          formatKey: 'yomitan',
+          order: i,
+        ),
+      );
+    }
+    return (
+      service: BackupService(
+        db: db,
+        dbDirectory: dbDir,
+        appVersion: '1.0.0',
+        dictionaryResourceDirectory: dict,
+      ),
+      db: db,
+    );
+  }
+
+  Future<Archive> readZip(String zipPath) async {
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      return ZipDecoder().decodeBuffer(input);
+    } finally {
+      await input.close();
+    }
+  }
+
+  test('一条幽灵行不再连累其余词典：好的照打，坏的只删自己那一行', () async {
+    final built = await buildDevice(
+      onDisk: <String>['JMdict', 'Daijirin'],
+      inDb: <String>['JMdict', 'Daijirin', 'GoneDict'],
+    );
+    final String zip = p.join(src.path, 'out.zip');
+    List<String> skipped = const <String>[];
+    await built.service.createBackup(
+      zip,
+      onDictionariesSkipped: (List<String> names) => skipped = names,
+    );
+    await built.db.close();
+
+    final Archive archive = await readZip(zip);
+    expect(archive.findFile('dictionaryResources/JMdict/index.bin'), isNotNull,
+        reason: '有文件的词典必须照常进包');
+    expect(
+      archive.findFile('dictionaryResources/Daijirin/index.bin'),
+      isNotNull,
+      reason: '第二本同样不该被那条幽灵行连累',
+    );
+    expect(skipped, <String>['GoneDict'], reason: '跳过了谁必须报出来，不能静默');
+  });
+
+  test('运行期临时目录不进包（按词典名枚举的副产品）', () async {
+    final built = await buildDevice(
+      onDisk: <String>['JMdict'],
+      inDb: <String>['JMdict'],
+    );
+    final String zip = p.join(src.path, 'out.zip');
+    await built.service.createBackup(zip);
+    await built.db.close();
+
+    final Archive archive = await readZip(zip);
+    expect(archive.findFile('dictionaryResources/JMdict/index.bin'), isNotNull);
+    expect(
+      archive.files.any((ArchiveFile f) =>
+          f.name.contains('import_temp') || f.name.contains('.pending_delete')),
+      isFalse,
+      reason: '整棵树无差别打包会把半个下载包和待删目录一起塞进备份',
+    );
+  });
+
+  test('全都是幽灵行时如实报出全部跳过，且不产出空的词典前缀', () async {
+    final built = await buildDevice(
+      onDisk: <String>[],
+      inDb: <String>['GoneA', 'GoneB'],
+    );
+    final String zip = p.join(src.path, 'out.zip');
+    List<String> skipped = const <String>[];
+    await built.service.createBackup(
+      zip,
+      onDictionariesSkipped: (List<String> names) => skipped = names,
+    );
+    await built.db.close();
+
+    expect(skipped, <String>['GoneA', 'GoneB']);
+    final Archive archive = await readZip(zip);
+    expect(
+      archive.files.any(
+        (ArchiveFile f) => f.name.startsWith('dictionaryResources/'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('没有幽灵行时一条都不报——不制造假警报', () async {
+    final built = await buildDevice(
+      onDisk: <String>['JMdict'],
+      inDb: <String>['JMdict'],
+    );
+    final String zip = p.join(src.path, 'out.zip');
+    bool called = false;
+    await built.service.createBackup(
+      zip,
+      onDictionariesSkipped: (List<String> _) => called = true,
+    );
+    await built.db.close();
+    expect(called, isFalse);
+  });
+
+  test('用户没勾词典时不算「被跳过」——那是他自己的选择', () async {
+    final built = await buildDevice(
+      onDisk: <String>['JMdict'],
+      inDb: <String>['JMdict', 'GoneDict'],
+    );
+    final String zip = p.join(src.path, 'out.zip');
+    bool called = false;
+    await built.service.createBackup(
+      zip,
+      categories: BackupCategory.values.toSet()
+        ..remove(BackupCategory.dictionary),
+      onDictionariesSkipped: (List<String> _) => called = true,
+    );
+    await built.db.close();
+    expect(called, isFalse);
+    final Archive archive = await readZip(zip);
+    expect(
+      archive.files.any(
+        (ArchiveFile f) => f.name.startsWith('dictionaryResources/'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('预览计数只数打得出来的，与实际打包内容一致', () async {
+    final built = await buildDevice(
+      onDisk: <String>['JMdict', 'Daijirin'],
+      inDb: <String>['JMdict', 'Daijirin', 'GoneDict'],
+    );
+    final BackupContentSummary summary =
+        await built.service.summarizeLiveContent();
+    await built.db.close();
+    expect(
+      summary.counts[BackupCategory.dictionary],
+      2,
+      reason: '旧实现数 dictionary_metadata 行数（3），与打包判据不同源，'
+          '于是勾选框写着 3、导出后 0 本，用户完全无从察觉',
+    );
+  });
+}

--- a/packages/fushi_dictionary/lib/src/formats/dictionary_downloader.dart
+++ b/packages/fushi_dictionary/lib/src/formats/dictionary_downloader.dart
@@ -44,6 +44,140 @@ Future<Dio> createDictionaryDio() async {
   return dio;
 }
 
+/// 候选地址解析钩子（BUG-2188）：把 catalog 里的**一个**下载地址展开成按优先级排序的
+/// 候选序列（首位必须是原址）。app 在启动时接线成 GitHub 公共镜像展开
+/// （`installDictionaryUrlCandidatesResolver`）；未接线时（单测 / popup 等精简入口）
+/// 回退成「只有原址」，行为与接线前逐字等价。
+///
+/// **为什么是钩子而不是包内常量**：镜像清单的唯一真相源是 app 侧
+/// `utils/net/github_mirrors.dart`（更新检查 / Mihon / 着色器三条链路共用），而
+/// `fushi_dictionary` 是它的**下游**包，反向 import 不了。与 [dictionaryDioFactory]
+/// 同一套装配方向。
+List<String> Function(String url)? dictionaryUrlCandidatesResolver;
+
+/// [url] 的候选地址序列。恒非空、首位恒为 [url]、无重复。
+List<String> dictionaryDownloadCandidates(String url) {
+  final List<String> resolved =
+      dictionaryUrlCandidatesResolver?.call(url) ?? const <String>[];
+  return <String>{url, ...resolved}.toList(growable: false);
+}
+
+/// 下载失败的传输层归因。UI 据此选人话文案，**不再把 `DioError.toString()` 直接甩给
+/// 用户**（BUG-2188：那串英文被单行标题截成 `DioError [connection ...`）。
+enum DictionaryDownloadFailureKind {
+  /// 连不上：DNS / TCP / TLS 在 [kDictionaryConnectTimeout] 内没建起来。
+  /// 国内直连 huggingface.co / github.com 的典型形态。
+  connectTimeout,
+
+  /// 连上了但服务器把连接晾着：两个数据块间隔超过 [kDictionaryStallTimeout]。
+  stallTimeout,
+
+  /// 连接被拒 / 中断 / 证书失败。
+  connectionError,
+
+  /// 服务器**已经答复**了一个错误状态（404 / 403 / 5xx）。换镜像没用。
+  badResponse,
+
+  /// 用户取消。
+  cancelled,
+
+  /// 其它（含解压/落盘等非传输失败）。
+  other,
+}
+
+/// 把任意异常归因成 [DictionaryDownloadFailureKind]。
+DictionaryDownloadFailureKind classifyDictionaryDownloadFailure(Object error) {
+  if (error is DictionaryDownloadException) return error.kind;
+  if (error is! DioError) return DictionaryDownloadFailureKind.other;
+  switch (error.type) {
+    case DioErrorType.connectionTimeout:
+      return DictionaryDownloadFailureKind.connectTimeout;
+    case DioErrorType.receiveTimeout:
+    case DioErrorType.sendTimeout:
+      return DictionaryDownloadFailureKind.stallTimeout;
+    case DioErrorType.connectionError:
+    case DioErrorType.badCertificate:
+      return DictionaryDownloadFailureKind.connectionError;
+    case DioErrorType.badResponse:
+      return DictionaryDownloadFailureKind.badResponse;
+    case DioErrorType.cancel:
+      return DictionaryDownloadFailureKind.cancelled;
+    case DioErrorType.unknown:
+      // dio 5.1 把 SocketException / TlsException 一律塞进 unknown 的 `error` 里。
+      final Object? inner = error.error;
+      if (inner is SocketException || inner is TlsException) {
+        return DictionaryDownloadFailureKind.connectionError;
+      }
+      return DictionaryDownloadFailureKind.other;
+  }
+}
+
+/// [error] 是否「这一跳根本没送到 / 没拿到响应」——只有这种失败才值得换下一个候选
+/// 重来。服务器已答复的状态错误（404 / 403）换镜像拿到的是同一份 404，回退只会
+/// 掩盖真正原因；取消更不该重试。与 app 侧 `isTransportFailure` 同一条判据。
+bool isDictionaryTransportFailure(Object error) {
+  switch (classifyDictionaryDownloadFailure(error)) {
+    case DictionaryDownloadFailureKind.connectTimeout:
+    case DictionaryDownloadFailureKind.stallTimeout:
+    case DictionaryDownloadFailureKind.connectionError:
+      return true;
+    case DictionaryDownloadFailureKind.badResponse:
+    case DictionaryDownloadFailureKind.cancelled:
+    case DictionaryDownloadFailureKind.other:
+      return false;
+  }
+}
+
+/// 词典下载失败（BUG-2188）。
+///
+/// 存在的理由：调用方以前只能拿到最后一个 `DioError`，既不知道**试过哪些地址**，也
+/// 没有稳定的归因可用来选文案。这个异常把三件事一起带出来：归因 [kind]、原始地址
+/// [url]、实际试过的 [attemptedUrls]，[toString] 则给出可直接进错误日志/详情框的全文。
+class DictionaryDownloadException implements Exception {
+  DictionaryDownloadException({
+    required this.url,
+    required this.attemptedUrls,
+    required this.cause,
+  }) : kind = classifyDictionaryDownloadFailure(cause);
+
+  /// catalog 里的原始地址。
+  final String url;
+
+  /// 本次实际试过的地址（含原址与镜像），按尝试顺序。
+  final List<String> attemptedUrls;
+
+  /// 最后一个候选抛出的异常。
+  final Object cause;
+
+  final DictionaryDownloadFailureKind kind;
+
+  /// 原始地址的主机名，UI 用来说清「连不上的是谁」。
+  String get host => Uri.tryParse(url)?.host ?? '';
+
+  /// 服务器答复的 HTTP 状态码（仅 [DictionaryDownloadFailureKind.badResponse] 有值）。
+  int? get statusCode {
+    final Object c = cause;
+    return c is DioError ? c.response?.statusCode : null;
+  }
+
+  @override
+  String toString() {
+    final StringBuffer buffer = StringBuffer()
+      ..writeln('DictionaryDownloadException: ${kind.name}')
+      ..writeln('url: $url');
+    if (attemptedUrls.length > 1) {
+      buffer.writeln('attempted (${attemptedUrls.length}):');
+      for (final String attempt in attemptedUrls) {
+        buffer.writeln('  - $attempt');
+      }
+    }
+    final int? status = statusCode;
+    if (status != null) buffer.writeln('status: $status');
+    buffer.write('cause: $cause');
+    return buffer.toString();
+  }
+}
+
 enum DictionaryCategory {
   jaEn,
   jaJa,
@@ -811,6 +945,12 @@ class DictionaryDownloader {
   /// 下载 [url] 到 [tempDir]。[progressNotifier] 收 0..1 的比例（供进度条），
   /// [onBytes] 收原始字节数（供「x / y MB」这类可归因文案，BUG-1493）——服务器不给
   /// `Content-Length` 时 `total` 为 -1，调用方据此退化成只显示已收字节。
+  ///
+  /// BUG-2188：按 [dictionaryDownloadCandidates] 逐个候选尝试。只有**传输层**失败
+  /// （连不上 / 超时 / 连接被拒，见 [isDictionaryTransportFailure]）才换下一个候选；
+  /// 服务器已答复的 404/403 与用户取消都立即停。全部候选失败时抛
+  /// [DictionaryDownloadException]，它带着归因、原址与试过的地址——调用方因此能给出
+  /// 人话原因，而不是把 `DioError [connection ...` 甩给用户。
   static Future<File> download({
     required String url,
     required Directory tempDir,
@@ -822,29 +962,65 @@ class DictionaryDownloader {
       tempDir.createSync(recursive: true);
     }
 
+    // 落盘文件名恒取自**原址**：镜像候选是「前缀 + 原址」，路径尾段虽然相同，但让
+    // 产物名字随候选变化只会让后续导入路径难以复现。
     final String fileName = Uri.parse(url).pathSegments.last;
     final String destPath = path.join(tempDir.path, fileName);
-    final Dio dio = await createDictionaryDio();
+    final List<String> candidates = dictionaryDownloadCandidates(url);
+    final List<String> attempted = <String>[];
 
-    try {
-      await dio.download(
-        url,
-        destPath,
-        cancelToken: cancelToken,
-        options: Options(
-          followRedirects: true,
-          maxRedirects: 5,
-        ),
-        onReceiveProgress: (int received, int total) {
-          if (total > 0) {
-            progressNotifier.value = received / total;
+    Object? lastError;
+    for (final String candidate in candidates) {
+      attempted.add(candidate);
+      final Dio dio = await createDictionaryDio();
+      try {
+        await dio.download(
+          candidate,
+          destPath,
+          cancelToken: cancelToken,
+          options: Options(
+            followRedirects: true,
+            maxRedirects: 5,
+          ),
+          onReceiveProgress: (int received, int total) {
+            if (total > 0) {
+              progressNotifier.value = received / total;
+            }
+            onBytes?.call(received, total);
+          },
+        );
+        return File(destPath);
+      } catch (e) {
+        lastError = e;
+        // 上一跳可能已经写了半个文件；不删掉的话下一个候选的 `dio.download` 会在
+        // 同一路径上继续写，产出一个前半段来自 A、后半段来自 B 的坏包。
+        final File partial = File(destPath);
+        if (partial.existsSync()) {
+          try {
+            partial.deleteSync();
+          } catch (_) {
+            // 删不掉不该盖住真正的下载失败；下一跳的 download 会覆盖写。
           }
-          onBytes?.call(received, total);
-        },
-      );
-      return File(destPath);
-    } finally {
-      dio.close();
+        }
+        // 取消**原样抛出**，绝不包进 [DictionaryDownloadException]：全仓的
+        // `DictionaryDownloadController.isCancellation` 按 `DioError.type == cancel`
+        // 判「取消不是失败」，一旦包起来，用户点取消会被记成一条下载失败。
+        if (classifyDictionaryDownloadFailure(e) ==
+            DictionaryDownloadFailureKind.cancelled) {
+          rethrow;
+        }
+        if (!isDictionaryTransportFailure(e)) break;
+        // 进度条归零，否则下一个候选从上一跳的比例开始往回跳。
+        progressNotifier.value = 0;
+      } finally {
+        dio.close();
+      }
     }
+
+    throw DictionaryDownloadException(
+      url: url,
+      attemptedUrls: attempted,
+      cause: lastError ?? StateError('no download candidate for $url'),
+    );
   }
 }

--- a/tools/browser-extension/vendor/selection.js
+++ b/tools/browser-extension/vendor/selection.js
@@ -18,7 +18,9 @@ window.fushiSelection = {
     selection: null,
     highlightWrappers: [],
     scanDelimiters: '。、！？…‥「」『』（）()【】〈〉《》〔〕｛｝{}［］[]・：；:;，,.─\n\r"\'“”‘’«»‹›',
-    sentenceDelimiters: '。！？.!?\n\r',
+    // BUG-2196：换行不是句子边界（HTML 里它只是空白）。与
+    // reader_selection_scripts.dart 的同名表保持一致。
+    sentenceDelimiters: '。！？.!?',
     trailingSentenceChars: '。、！？…‥」』）)】〉》〕｝}］]',
     brackets: {'「':'」', '『': '』', '（':'）', '(':')', '【':'】', '〈':'〉', '《':'》', '〔':'〕', '｛':'｝', '{':'}', '［':'］', '[':']'},
 


### PR DESCRIPTION
用户一次报的四件事，四个独立 BUG，一个提交一件。

| BUG | 症状 | 根因一句话 |
|---|---|---|
| 2188 | 词典下载失败只给 `DioError [connection ...`，随后又弹「导入失败」 | 长错误被塞进 `maxLines:1` 的**标题**；异常在收集那一刻就降维成一个名字；下载阶段失败却报「导入失败」；wty 词典托管在 huggingface 且词典链路无镜像回退 |
| 2193 | 勾了词典导出，zip 里只有 `backup_meta.json` + `fushi.db` | `_hasCompleteDictionaryResources` 是**全表 AND 门**：一条幽灵元数据行让全部词典不打包，还顺手清空 DB 副本里的词典行，导出照报成功 |
| 2195 | AnkiDroid 并行版（`com.ichi2.anki.A`）识别不到、权限框从不弹 | 并行版的包名 / provider authority / 权限名**三者都带后缀**，我们三处全按主包写死 |
| 2196 | 制卡断句在奇怪的地方，「制卡压没念」 | reader 把源码 `\n` 当句子分隔符；半句 → 半句音频区间 → 裁出来的音频漏词 |

顺带做了用户要的**试听**：制卡「选择句子上下文」对话框底部加试听按钮，播的是
`_miningDraft.composeAudioRange(...)`，**与喂给 ffmpeg 的是同一个表达式**，所以
听到什么就压出什么。

---

## 各条要点

### BUG-2188 词典下载失败原因被吞

四层对应四个根因：把 `List<String> failedNames` 换成
`DictionaryTaskFailure{name, stage, error, url}`（异常本体一路带到渲染层）；
包内新增 `DictionaryDownloadFailureKind` 归因 + `DictionaryDownloadException`；
controller 拆出 `detail` notifier 让标题恢复单一职责，失败原因走可复制的
「错误详情」框；下载器改为按 `dictionaryUrlCandidatesResolver` 逐候选回退，
app 侧接到既有的 `gitHubMirrorCandidates`。

**镜像可行性逐条实测过**（经代理量的）：

| 候选 | 对 `wty-ja-zh.zip` 的结果 |
|---|---|
| huggingface.co 直连 | 302 → CDN → 200，6,840,013 字节 |
| hf-mirror.com | **308 跳回原站**，不代理该路径 |
| ghfast.top / gh-proxy.com | **403** |

即：没有现成公共镜像能救 wty 系列。本 PR 只让它**如实报错**；要真正解决需要在
fushi.moe 侧自建 CF 反代或镜像进 R2，客户端接入点已留好（多返回一个候选前缀即可）。

**取消必须原样抛出**，绝不包进 `DictionaryDownloadException`——否则
`isCancellation` 会把用户点取消记成一条下载失败。有测试钉这条。

### BUG-2193 备份导出静默丢词典

全表 AND → 逐本分区（`_DictionaryPackPlan{packable, ghosts}`）。不变式（出包里
每一行都有对应文件）依然成立，代价从「全部」降到「那一条」。剥离改三分支；打包
改按词典名枚举，顺带修掉旧实现把 `import_temp` / `.pending_delete` 一起塞进备份包
的副作用；新增 `onDictionariesSkipped` 让导出不再静默报成功；预览计数改用同一判据。

这个形态此前**零覆盖**——`backup_categories_test` 的 harness 注释明写数据是造来
让那道门放行的，`backup_service_test` 只覆盖「整个根目录都不存在」。

### BUG-2195 AnkiDroid 并行版

上游事实实测：provider 是 `${applicationId}.flashcards`、权限是
`${applicationId}.permission.READ_WRITE_DATABASE`，并行版由 `applicationIdSuffix`
生成。解包我们依赖的 AAR 扫常量池确认：那两个字符串都是**编译期常量**，
`AddContentApi` 无注入点。

新增 `AnkiDroidTarget` 逐候选 `resolveContentProvider` 探测；manifest 的
`<queries>` / `<uses-permission>` 逐候选各加一条；新增 provider 抽象层——
主包走 `AddContentApiProvider`（**逐行委托 AAR，零行为改动**，守卫钉死它里面不许有
`ContentResolver`/`Cursor`），并行版走 `DirectAnkiProvider`（自驱 ContentResolver，
只换 authority 一处）。

双路是**显式的临时兼容层**，理由是外部依赖不可改；清理条件写在 bug 档案里：
等真机验证过就把主包也切过去、删掉 AAR 依赖，合成一条。

> ⚠️ **真机未验证**：本机无 Android 设备。识别与弹权限框那段逻辑简单且有守卫，
> 「并行版上真能写卡」需要用户在 `com.ichi2.anki.A` 上实测，复测顺序写在档案里。

### BUG-2196 换行不是句子边界

已用仓库既有的 node fake-DOM harness 执行真实 JS，**逐字复现用户截图那一句**。

仓库内部两个反证：视觉小说模式的同名表本来就不含 `\n\r`；PDF 路径早就在分句前把
`\n`/`\r` **等长**换成空格，注释写的正是「换行是分句符，直接分句会拿到半截话」。
同一个 bug 在那条路上被局部绕开过，EPUB 这条没有。

`lookup/sentence_extraction.dart`（Windows UIA 扁平 buffer）**刻意不动**——两侧输入
模型不同。原来要求两表逐字节相等的漂移守卫是过约束（对本 bug 完全不敏感，两边一起
错也算过），改成「差集恰好是 `\n\r` 且方向固定」。

换行做**等长**替换成空格：`sentenceOffset` / `sStartOffset` / `sEndOffset` /
`getNormalizedOffset` 的下标全建立在这个串上，`\s+` 折叠会整体打乱偏移，把这个 bug
换成一个更难查的。

---

## 验证

- `flutter analyze`（含 test 目录）**No issues found**。
- 定向测试：72 / 90 / 33 / 105 / 119 条，全绿。
- **合并后必跑的 51 条目录枚举型守卫：362 条全绿**（= 文档记录的当前基线）。
- `flutter build apk --debug` 通过（Java 侧改动的编译验证；过程中真抓到一个错：
  `FlashCardsContract.Deck` 的常量叫 `CONTENT_ALL_URI` 不是 `CONTENT_URI`）。
- **每条都做了变异实测**，且还原后源文件 sha256 逐字节一致：
  - 删掉「取消原样抛出」→ 红；
  - 把备份判据改回 `&& ghosts.isEmpty` → 红；
  - 删掉 manifest 里 `.D` 那条 `uses-permission` → 红；
  - 把 `\n\r` 加回 `sentenceDelimiters` / 删掉确认路径的 `stopPreview` → 红。
- `dart run tool/bug.dart check` 跨 1294 个 ref + 578 个工作区复核：4 个新号无冲突。

## 已知缺口（都写进了各自的 bug 档案）

1. **huggingface 系列在国内仍连不上**——本 PR 只让它如实报错，可达性要靠 fushi.moe
   侧自建反代或 R2 镜像（站点仓库 + 部署凭据）。
2. **AnkiDroid 并行版的写路径真机未验证**（本机无设备）。
3. **备份恢复侧**仍无法区分「用户没勾词典」与「导出时被跳过」——要动 backup wire
   格式，没混进本 PR。
4. **cue 内没有插值**（`findPlaybackRange` / `_expandAroundCue` 只做整 cue 命中），
   句边界修好后仍有两种残余形态，属 `packages/fushi_audio` 匹配层，另案。
