### PR TITLE
feat(reader): 图片库按阅读进度遮罩「还没读到」的插图，点一下揭开

### DIFF
--- a/fushi/lib/src/epub/epub_book.dart
+++ b/fushi/lib/src/epub/epub_book.dart
@@ -213,7 +213,7 @@ class EpubBook {
       if (ref.isNotEmpty) refs.add(ref);
     }
     for (final html_dom.Element image in doc.querySelectorAll('image')) {
-      final String? ref = _svgImageHref(image);
+      final String? ref = svgImageHref(image);
       if (ref != null && ref.isNotEmpty) refs.add(ref);
     }
     final StringBuffer css = StringBuffer();
@@ -224,7 +224,7 @@ class EpubBook {
       css.writeln(styleEl.text);
     }
     for (final Match match
-        in _backgroundImageUrlPattern.allMatches(css.toString())) {
+        in backgroundImageUrlPattern.allMatches(css.toString())) {
       final String ref = (match.group(1) ?? '').trim();
       if (ref.isNotEmpty) refs.add(ref);
     }
@@ -233,17 +233,20 @@ class EpubBook {
 
   /// Matches a CSS `background-image: url(...)` (or `background:` shorthand),
   /// capturing the reference with surrounding quotes/whitespace stripped.
-  static final RegExp _backgroundImageUrlPattern = RegExp(
+  /// Public because [IllustrationProgressIndex] classifies the same
+  /// references element by element — one pattern, not two drifting copies.
+  static final RegExp backgroundImageUrlPattern = RegExp(
     r'''background(?:-image)?\s*:[^;}]*url\(\s*['"]?([^'")]+?)['"]?\s*\)''',
     caseSensitive: false,
   );
 
-  /// Reads an SVG `<image>` reference. package:html stores a namespaced
+  /// Reads an SVG `<image>` reference (shared with
+  /// [IllustrationProgressIndex]). package:html stores a namespaced
   /// `xlink:href` under an `AttributeName` key (not the plain String
   /// `'xlink:href'`), so match on the attribute's *local* name `href` — this
   /// covers both `xlink:href` (legacy, still the norm in Japanese fixed-layout
   /// EPUB) and the un-prefixed SVG2 `href`.
-  static String? _svgImageHref(html_dom.Element image) {
+  static String? svgImageHref(html_dom.Element image) {
     for (final MapEntry<Object, String> attr in image.attributes.entries) {
       final String name = attr.key.toString();
       if (name == 'href' || name == 'xlink:href' || name.endsWith(':href')) {

--- a/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -2,8 +2,11 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' show ImageFilter;
 
+import 'package:flutter/foundation.dart' show compute;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:fushi_audio/fushi_audio.dart'
+    show ReaderPosition, ReaderPositionRepository;
 import 'package:fushi_core/fushi_core.dart' show FushiDatabase;
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
@@ -15,6 +18,7 @@ import 'package:fushi/src/media/collections/shelf_sort.dart'
 import 'package:fushi/src/media/media_extensions.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart'
     show ReaderFushiSource;
+import 'package:fushi/src/reader/illustration_progress_index.dart';
 import 'package:fushi/src/reader/image_reveal_key.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show GamepadButtonIntent;
@@ -74,9 +78,19 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
   /// live watch（避开 drift keyed watch 的 widget teardown 隐患）。
   final Set<String> _revealed = <String>{};
 
-  /// 防剧透遮罩总开关：与阅读器同一偏好（`ttu_blur_images`）。关闭时图片库始终原图。
+  /// 防剧透遮罩总开关：与阅读器同一偏好（`ttu_blur_images`）。开着时未揭开的图
+  /// 一律遮罩；**关着时仍按阅读进度遮「还没读到」的那些**（见 [_progressIndex]）。
   bool get _blurEnabled =>
       ReaderFushiSource.readerSettings?.blurImages ?? false;
+
+  /// 插图 → 书中位置的索引（后台 isolate 解析已解压目录建成）。`null` = 还没建好
+  /// 或目录不是合法 EPUB（解析失败）→ 不按进度遮罩，退回旧行为。
+  IllustrationProgressIndex? _progressIndex;
+
+  /// 本书当前阅读位置（与 `ReaderPosition` 同坐标）。没有位置行 = 一次没读过，
+  /// 按章首 (0, 0) 处理：除封面/开篇之外的插图都算「还没读到」。
+  int _readChapterIndex = 0;
+  int _readNormCharOffset = 0;
 
   @override
   void initState() {
@@ -85,6 +99,9 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
   }
 
   Future<void> _loadRevealedThenImages() async {
+    // 进度索引与图片抽取并行起跑：前者是后台 isolate 的整本解析，后者是逐张读盘，
+    // 互不依赖，串起来只会白等。
+    final Future<void> progressFuture = _loadReadProgress();
     if (widget.bookUid.isNotEmpty) {
       try {
         final Set<String> keys =
@@ -97,6 +114,32 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
       }
     }
     await _extractImages();
+    await progressFuture;
+  }
+
+  /// 载入「读到哪了」+「每张插图在哪」，两者构成按进度遮罩的判据。
+  ///
+  /// 无 uid（旧行无 uid 的书）没有阅读位置可查 → 不按进度遮罩。索引建好前网格按
+  /// 旧判据渲染，建好后 setState 补遮——不阻塞首屏。
+  Future<void> _loadReadProgress() async {
+    if (widget.bookUid.isEmpty) return;
+    try {
+      final ReaderPosition? position =
+          await ReaderPositionRepository(widget.database)
+              .findByBookUid(widget.bookUid);
+      final IllustrationProgressIndex index =
+          await compute(buildIllustrationProgressIndex, widget.extractDir);
+      if (!mounted) return;
+      setState(() {
+        _progressIndex = index;
+        _readChapterIndex = position?.sectionIndex ?? 0;
+        _readNormCharOffset = position?.normCharOffset ?? 0;
+      });
+    } catch (e, stack) {
+      // 目录不是合法 EPUB（FormatException）等：退回「不按进度遮罩」，不影响看图。
+      ErrorLogService.instance
+          .log('IllustrationsViewer.loadProgress', e, stack);
+    }
   }
 
   /// 某图当前是否应遮罩（共用判据，缩略图 / 全屏一致）。
@@ -104,7 +147,17 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
         blurEnabled: _blurEnabled,
         revealKey: im.revealKey,
         revealed: _revealed,
+        unreadAhead: _isUnread(im),
       );
+
+  /// 这张图是否还没读到（位置在当前阅读位置之后）。索引没建好 / 定位不到 → false。
+  bool _isUnread(_Illustration im) =>
+      _progressIndex?.isUnread(
+        revealKey: im.revealKey,
+        chapterIndex: _readChapterIndex,
+        normCharOffset: _readNormCharOffset,
+      ) ??
+      false;
 
   /// 揭开一张图（幂等）：登记内存集 + 持久化到 Drift（阅读器下次开书据此不遮罩）。
   Future<void> _revealImage(_Illustration im) async {
@@ -300,6 +353,7 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
           initialIndex: initialIndex,
           revealed: _revealed,
           blurEnabled: _blurEnabled,
+          isUnread: _isUnread,
           onReveal: _revealImage,
         ),
       ),
@@ -316,6 +370,7 @@ class _FullScreenGallery extends StatefulWidget {
     required this.initialIndex,
     required this.revealed,
     required this.blurEnabled,
+    required this.isUnread,
     required this.onReveal,
   });
 
@@ -325,6 +380,10 @@ class _FullScreenGallery extends StatefulWidget {
   /// 与网格页共享的已揭开集（同一 Set 引用，揭开双向可见，BUG-898）。
   final Set<String> revealed;
   final bool blurEnabled;
+
+  /// 「还没读到」判据（网格页持有索引与阅读位置，全屏页读同一份，见
+  /// `IllustrationProgressIndex`）。
+  final bool Function(_Illustration) isUnread;
 
   /// 揭开一张图（写共享集 + 持久化）；全屏点击遮罩时调。
   final Future<void> Function(_Illustration) onReveal;
@@ -404,6 +463,7 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
         blurEnabled: widget.blurEnabled,
         revealKey: im.revealKey,
         revealed: widget.revealed,
+        unreadAhead: widget.isUnread(im),
       );
 
   /// 全屏点击遮罩 → 揭开（写共享集 + DB）后本地刷新为原图。

--- a/fushi/lib/src/reader/illustration_progress_index.dart
+++ b/fushi/lib/src/reader/illustration_progress_index.dart
@@ -1,0 +1,216 @@
+import 'package:html/dom.dart' as html_dom;
+
+import 'package:fushi/src/epub/epub_book.dart';
+import 'package:fushi/src/epub/epub_parser.dart';
+import 'package:fushi/src/reader/image_reveal_key.dart';
+import 'package:fushi/src/stats/study_char_count.dart' show countStudyChars;
+
+/// 一张插图在书里的阅读位置：spine 章号 + 章内归一偏移。
+///
+/// 坐标系与 `ReaderPosition`（`sectionIndex` / `normCharOffset`，0~10000 分数基准）
+/// **完全一致**，两者可直接比较——图片库据此判「这张图读到了没有」。
+class IllustrationPosition {
+  const IllustrationPosition({
+    required this.chapterIndex,
+    required this.normCharOffset,
+  });
+
+  /// spine 章号（0-based）。`-1` = 封面（OPF `cover-image`），恒排在正文之前，
+  /// 因此永远算「已读到」——封面不是剧透。
+  final int chapterIndex;
+
+  /// 章内归一偏移（0~10000）：图片之前的实义字符数 ÷ 全章实义字符数。
+  final int normCharOffset;
+
+  /// 本图是否落在阅读位置（[chapterIndex] / [normCharOffset]）**之后** = 还没读到。
+  bool isAfter({required int chapterIndex, required int normCharOffset}) {
+    if (this.chapterIndex != chapterIndex) {
+      return this.chapterIndex > chapterIndex;
+    }
+    return this.normCharOffset > normCharOffset;
+  }
+}
+
+/// 插图 → 阅读位置的索引：图片库「未读到的插图先遮罩」的判据来源。
+///
+/// 键是 [ImageRevealKey] 的稳定 key（extractDir 相对、decode、正斜杠），与阅读器
+/// WebView / Drift `revealed_images` / 图片库磁盘 `File` 三端同一套标识，所以
+/// 「已揭开」与「读到没读到」两个判据能落在同一张图上。
+///
+/// 定位范围：`<img src>`、SVG `<image xlink:href|href>`（日文固定版式插图页常见）
+/// 与**行内** `style="background-image:url(...)"`。`<style>` 块 / 外部 CSS 里的
+/// 背景图不进索引（它们没有 DOM 位置、又常来自共享样式表），这类图定位不到 →
+/// [isUnread] 返回 false → 不遮罩：宁可漏遮，也不凭猜测把已读的图糊住。
+class IllustrationProgressIndex {
+  const IllustrationProgressIndex(this.positions);
+
+  /// 空索引（解析失败 / 无 EPUB 结构时的退化值：一律不按进度遮罩）。
+  static const IllustrationProgressIndex empty = IllustrationProgressIndex(
+    <String, IllustrationPosition>{},
+  );
+
+  /// reveal key → 该图在书中**首次出现**的位置（同一张图被多章引用时取最早那次，
+  /// 早于阅读位置就算读到了）。
+  final Map<String, IllustrationPosition> positions;
+
+  /// [revealKey] 这张图是否还没读到（= 落在阅读位置之后）。
+  ///
+  /// key 为空、或索引里定位不到（正文没引用 / 只在外部 CSS 里出现）一律 false。
+  bool isUnread({
+    required String? revealKey,
+    required int chapterIndex,
+    required int normCharOffset,
+  }) {
+    if (revealKey == null) return false;
+    final IllustrationPosition? position = positions[revealKey];
+    if (position == null) return false;
+    return position.isAfter(
+      chapterIndex: chapterIndex,
+      normCharOffset: normCharOffset,
+    );
+  }
+
+  /// 按 spine 顺序扫全书建索引。纯函数（只读 [book]），可直接在 isolate 内跑。
+  static IllustrationProgressIndex build(EpubBook book) {
+    final Map<String, IllustrationPosition> positions =
+        <String, IllustrationPosition>{};
+
+    void record(String? key, IllustrationPosition position) {
+      if (key == null) return;
+      positions.putIfAbsent(key, () => position);
+    }
+
+    // 封面先登记（章号 -1）：它总在正文之前，任何阅读位置都已「读到」。
+    final String? coverHref = book.coverHref;
+    if (coverHref != null) {
+      record(
+        _revealKeyOf(coverHref),
+        const IllustrationPosition(chapterIndex: -1, normCharOffset: 0),
+      );
+    }
+
+    for (int i = 0; i < book.chapters.length; i++) {
+      final String chapterHref = book.chapters[i].href;
+      final html_dom.Document doc;
+      try {
+        doc = EpubBook.parseChapterHtml(book.chapters[i].html);
+      } catch (_) {
+        // 单章读盘/解析失败（文件缺失、编码坏）不该毁掉整本索引：跳过该章，
+        // 它的图定位不到 → 不遮罩，其余章照常。
+        continue;
+      }
+      final _ChapterScan scan = _scanChapter(doc.body);
+      for (final _ChapterImageHit hit in scan.hits) {
+        record(
+          _revealKeyOf(resolveImageHref(chapterHref, hit.src)),
+          IllustrationPosition(
+            chapterIndex: i,
+            normCharOffset: _normOffset(hit.charsBefore, scan.totalChars),
+          ),
+        );
+      }
+    }
+
+    return IllustrationProgressIndex(
+      Map<String, IllustrationPosition>.unmodifiable(positions),
+    );
+  }
+
+  /// epub-root 相对 href → 稳定 reveal key。href 可能带 percent 转义
+  /// （`foo%20bar.jpg`），磁盘文件名是真空格，故先 decode 再归一（与阅读器 JS
+  /// 侧 `decodeURIComponent` 对称）。
+  static String? _revealKeyOf(String href) {
+    String decoded = href;
+    try {
+      decoded = Uri.decodeComponent(href);
+    } on ArgumentError {
+      // 非法转义序列：按原样归一，至少不丢这张图。
+    }
+    return ImageRevealKey.normalize(decoded);
+  }
+
+  static int _normOffset(int charsBefore, int totalChars) {
+    if (totalChars <= 0) return 0;
+    return ((charsBefore * 10000) / totalChars).round().clamp(0, 10000);
+  }
+
+  /// 按文档顺序走一章的 DOM：累加实义字符数，遇图记下「它前面有多少字」。
+  ///
+  /// 字符口径与 [EpubBook.chapterCharacterCount] 一致（[countStudyChars]，振假名
+  /// `<rt>/<rp>/<rtc>` 跳过），所以算出的分数与阅读器落库的 `normCharOffset`
+  /// 落在同一把尺上。（逐文本节点计数在被标签切断的西文单词处可能与整段计数差
+  /// 一两个字，对「读到没读到」这个判据无影响。）
+  static _ChapterScan _scanChapter(html_dom.Element? body) {
+    final List<_ChapterImageHit> hits = <_ChapterImageHit>[];
+    int chars = 0;
+
+    void visit(html_dom.Node node) {
+      if (node is html_dom.Text) {
+        chars += countStudyChars(node.text);
+        return;
+      }
+      if (node is! html_dom.Element) return;
+      final String tag = (node.localName ?? '').toLowerCase();
+      if (tag == 'rt' || tag == 'rp' || tag == 'rtc') return;
+      for (final String src in _imageRefsOf(node, tag)) {
+        hits.add(_ChapterImageHit(src: src, charsBefore: chars));
+      }
+      for (final html_dom.Node child in node.nodes) {
+        visit(child);
+      }
+    }
+
+    if (body != null) visit(body);
+    return _ChapterScan(hits: hits, totalChars: chars);
+  }
+
+  /// 单个元素自带的图片引用（章节相对 href），复用 [EpubBook] 的既有判据。
+  static List<String> _imageRefsOf(html_dom.Element element, String tag) {
+    final List<String> refs = <String>[];
+    if (tag == 'img') {
+      final String src = (element.attributes['src'] ?? '').trim();
+      if (src.isNotEmpty) refs.add(src);
+    } else if (tag == 'image') {
+      final String? href = EpubBook.svgImageHref(element);
+      if (href != null && href.isNotEmpty) refs.add(href);
+    }
+    final String style = (element.attributes['style'] ?? '').trim();
+    if (style.isNotEmpty) {
+      for (final Match match in EpubBook.backgroundImageUrlPattern.allMatches(
+        style,
+      )) {
+        final String ref = (match.group(1) ?? '').trim();
+        if (ref.isNotEmpty) refs.add(ref);
+      }
+    }
+    return refs;
+  }
+}
+
+class _ChapterImageHit {
+  const _ChapterImageHit({required this.src, required this.charsBefore});
+
+  /// 章节相对的原始引用（未 resolve）。
+  final String src;
+
+  /// 该图之前本章已出现的实义字符数。
+  final int charsBefore;
+}
+
+class _ChapterScan {
+  const _ChapterScan({required this.hits, required this.totalChars});
+
+  final List<_ChapterImageHit> hits;
+  final int totalChars;
+}
+
+/// `compute()` 入口：后台 isolate 里解析已解压目录并建索引。
+///
+/// 图片库开页时整本 html 解析（几十~几百章）不能压在 UI 线程上——与开书路径的
+/// [parseBookOnly] 同款处理。目录不是合法 EPUB（`parseFromExtracted` 抛
+/// [FormatException]）由调用方按「无索引」降级。
+IllustrationProgressIndex buildIllustrationProgressIndex(String extractDir) {
+  return IllustrationProgressIndex.build(
+    EpubParser.parseFromExtracted(extractDir),
+  );
+}

--- a/fushi/lib/src/reader/image_reveal_key.dart
+++ b/fushi/lib/src/reader/image_reveal_key.dart
@@ -49,14 +49,24 @@ class ImageRevealKey {
   static String? fromFile(String filePath, String extractDir) =>
       _sanitizeRel(p.relative(filePath, from: extractDir));
 
-  /// 某图当前是否应显示防剧透遮罩：总开关 [blurEnabled] 开 + 有归一 [revealKey] +
-  /// 未在已揭集 [revealed]。阅读器与图片库共用同一判据（缩略图 / 全屏都调它）。
+  /// 某图当前是否应显示防剧透遮罩：有归一 [revealKey] + 未在已揭集 [revealed]，
+  /// 且满足以下**任一**遮罩理由——
+  /// - 总开关 [blurEnabled] 开：一律遮到用户点开为止（阅读器正文的既有语义）；
+  /// - [unreadAhead]：这张图还没读到（位置在当前阅读位置之后，见
+  ///   `IllustrationProgressIndex`）。图片库据此在开关关着时也挡住后文剧透，
+  ///   阅读器正文不用它（正文本来就只显示读到的地方）。
+  ///
+  /// 「点一下揭开」对两种理由是同一条路径：揭开写进 [revealed]（并落 Drift），
+  /// 此后无论哪个理由都不再遮。
   static bool shouldBlur({
     required bool blurEnabled,
     required String? revealKey,
     required Set<String> revealed,
+    bool unreadAhead = false,
   }) =>
-      blurEnabled && revealKey != null && !revealed.contains(revealKey);
+      (blurEnabled || unreadAhead) &&
+      revealKey != null &&
+      !revealed.contains(revealKey);
 
   /// 正斜杠归一 + 折叠 `.`/`..`/重复斜杠 + 去前导斜杠；越界 / 空返回 `null`。
   static String? _sanitizeRel(String rel) {

--- a/fushi/test/pages/illustrations_viewer_unread_blur_test.dart
+++ b/fushi/test/pages/illustrations_viewer_unread_blur_test.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/pages/implementations/illustrations_viewer_page.dart';
+import 'package:fushi_audio/fushi_audio.dart' show ReaderPositionRepository;
+import 'package:fushi_core/fushi_core.dart' show FushiDatabase;
+
+/// 图片库「还没读到的插图先遮罩」——防的是从书架点进插画页被后文剧透。
+///
+/// 判据是阅读位置（`ReaderPosition`）与插图在书中的位置（`IllustrationProgressIndex`），
+/// **与全局「图片模糊（防剧透）」开关无关**：这里全程不设该开关（`readerSettings`
+/// 为 null ⇒ 关），仍要求未读到的图被遮住。widget 行为测试：真实解压目录 + 真实
+/// Drift 库，断言渲染出的遮罩数量、点击揭开、以及揭开落库。
+void main() {
+  // 1x1 透明 PNG（`Image.memory` 能解码）。
+  final Uint8List onePxPng = Uint8List.fromList(<int>[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, //
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, //
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, //
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, //
+    0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, //
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, //
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, //
+    0x42, 0x60, 0x82,
+  ]);
+
+  const String bookUid = 'test-book';
+
+  late Directory extractDir;
+  late FushiDatabase db;
+  final List<Directory> tempDirs = <Directory>[];
+
+  void writeText(String path, String content) {
+    final File file = File('${extractDir.path}/$path');
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    extractDir = Directory.systemTemp.createTempSync('hibiki_illust_unread');
+    tempDirs.add(extractDir);
+
+    writeText('META-INF/container.xml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+''');
+    writeText('OEBPS/content.opf', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+  </metadata>
+  <manifest>
+    <item id="cover" href="images/a_cover.png" media-type="image/png" properties="cover-image"/>
+    <item id="c1" href="text/ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="c2" href="text/ch2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="c1"/>
+    <itemref idref="c2"/>
+  </spine>
+</package>
+''');
+    // 第 1 章有插图 b_head，第 2 章有插图 c_late；封面 a_cover 恒算已读到。
+    writeText('OEBPS/text/ch1.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <p><img src="../images/b_head.png" alt=""/></p>
+  <p>あいうえおかきくけこ</p>
+</body></html>
+''');
+    writeText('OEBPS/text/ch2.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <p><img src="../images/c_late.png" alt=""/></p>
+  <p>さしすせそたちつてと</p>
+</body></html>
+''');
+    for (final String name in <String>[
+      'a_cover.png',
+      'b_head.png',
+      'c_late.png',
+    ]) {
+      final File file = File('${extractDir.path}/OEBPS/images/$name');
+      file.parent.createSync(recursive: true);
+      file.writeAsBytesSync(onePxPng);
+    }
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  tearDownAll(() {
+    for (final Directory dir in tempDirs) {
+      try {
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      } on FileSystemException {
+        // 临时目录由 OS 回收（Windows 下解码句柄可能仍占用）。
+      }
+    }
+  });
+
+  Widget buildApp() {
+    return TranslationProvider(
+      child: MaterialApp(
+        home: IllustrationsViewerPage(
+          bookTitle: 'Book',
+          extractDir: extractDir.path,
+          bookUid: bookUid,
+          database: db,
+        ),
+      ),
+    );
+  }
+
+  /// 开页并等三张图 + 后台 isolate 建好的进度索引都落定（真实 IO / isolate，
+  /// 必须在 [WidgetTester.runAsync] 内推进）。
+  Future<void> openGrid(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(buildApp());
+      for (int i = 0; i < 60; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+  }
+
+  Finder blurCovers() => find.byIcon(Icons.visibility_off_outlined);
+
+  testWidgets('blurs illustrations past the reading position, cover excluded', (
+    WidgetTester tester,
+  ) async {
+    await ReaderPositionRepository(
+      db,
+    ).save(bookUid: bookUid, sectionIndex: 0, normCharOffset: 0);
+
+    await openGrid(tester);
+
+    // 读到第 1 章章首：封面与章首插图已读到，第 2 章那张还没读到 → 只遮它。
+    expect(blurCovers(), findsOneWidget);
+  });
+
+  testWidgets('reading to the end leaves nothing blurred', (
+    WidgetTester tester,
+  ) async {
+    await ReaderPositionRepository(
+      db,
+    ).save(bookUid: bookUid, sectionIndex: 1, normCharOffset: 10000);
+
+    await openGrid(tester);
+
+    expect(blurCovers(), findsNothing);
+  });
+
+  testWidgets('tapping a blurred illustration reveals it and persists', (
+    WidgetTester tester,
+  ) async {
+    await ReaderPositionRepository(
+      db,
+    ).save(bookUid: bookUid, sectionIndex: 0, normCharOffset: 0);
+
+    await openGrid(tester);
+    expect(blurCovers(), findsOneWidget);
+
+    await tester.runAsync(() async {
+      await tester.tap(blurCovers().first);
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+    });
+    await tester.pump();
+
+    // 揭开：遮罩消失，且写进共享真相源（阅读器下次开书据此不再遮）。
+    expect(blurCovers(), findsNothing);
+    expect(await db.getRevealedImageKeys(bookUid), <String>{
+      'OEBPS/images/c_late.png',
+    });
+  });
+}

--- a/fushi/test/reader/illustration_progress_index_test.dart
+++ b/fushi/test/reader/illustration_progress_index_test.dart
@@ -1,0 +1,223 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/illustration_progress_index.dart';
+
+/// 图片库「还没读到的插图先遮罩」的判据来源：插图 → 书中位置索引。
+///
+/// 这里按真实解压目录（container.xml + OPF + 章节 XHTML + 真图片文件）建索引，
+/// 走的是生产同一条 `EpubParser.parseFromExtracted` → 逐章 DOM 扫描路径，断言：
+/// ① `<img>` / SVG `<image>` / 行内 background-image 三种插图写法都定位得到；
+/// ② 位置坐标（章号 + 章内归一偏移）与 `ReaderPosition` 同尺，章内先后可比；
+/// ③ 封面恒排在正文之前（永远算已读到，不该被当剧透遮住）；
+/// ④ percent 转义的 src 与磁盘真实文件名归一到同一个 reveal key；
+/// ⑤ 正文没引用的孤儿图定位不到 → 不遮罩（宁可漏遮，不凭猜测糊住已读的图）。
+void main() {
+  late Directory extractDir;
+
+  String rel(String path) => '${extractDir.path}/$path';
+
+  void write(String path, String content) {
+    final File file = File(rel(path));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  setUp(() {
+    extractDir = Directory.systemTemp.createTempSync('hibiki_illust_index');
+
+    write('META-INF/container.xml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+''');
+
+    write('OEBPS/content.opf', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:language>ja</dc:language>
+  </metadata>
+  <manifest>
+    <item id="cover" href="images/cover.png" media-type="image/png" properties="cover-image"/>
+    <item id="c1" href="text/ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="c2" href="text/ch2.xhtml" media-type="application/xhtml+xml"/>
+    <item id="c3" href="text/ch3.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="c1"/>
+    <itemref idref="c2"/>
+    <itemref idref="c3"/>
+  </spine>
+</package>
+''');
+
+    // 第 1 章：章首一张 <img>，章中（约一半字数处）再一张。振假名 <rt> 不计字数，
+    // 否则「章中那张」的归一偏移会被读音撑偏。
+    write('OEBPS/text/ch1.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <p><img src="../images/head.png" alt=""/></p>
+  <p>あいうえおかきくけこ<ruby>漢字<rt>かんじ</rt></ruby></p>
+  <p><img src="../images/middle.png" alt=""/></p>
+  <p>さしすせそたちつてとなにぬねの</p>
+</body></html>
+''');
+
+    // 第 2 章：日文固定版式插图页的常见写法——SVG 包一张 JPEG，全章无 <img>。
+    write('OEBPS/text/ch2.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+       viewBox="0 0 800 1200"><image width="800" height="1200" xlink:href="../images/plate.jpg"/></svg>
+</body></html>
+''');
+
+    // 第 3 章：percent 转义的 src + 行内 background-image。
+    write('OEBPS/text/ch3.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body>
+  <p><img src="../images/foo%20bar.png" alt=""/></p>
+  <div style="background-image: url('../images/back.png');">x</div>
+</body></html>
+''');
+
+    for (final String name in <String>[
+      'cover.png',
+      'head.png',
+      'middle.png',
+      'plate.jpg',
+      'foo bar.png',
+      'back.png',
+      'orphan.png',
+    ]) {
+      write('OEBPS/images/$name', 'not-a-real-image');
+    }
+  });
+
+  tearDown(() {
+    try {
+      extractDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      // 临时目录由 OS 回收。
+    }
+  });
+
+  IllustrationProgressIndex build() =>
+      buildIllustrationProgressIndex(extractDir.path);
+
+  test('locates img / svg image / inline background-image across the spine',
+      () {
+    final IllustrationProgressIndex index = build();
+
+    expect(index.positions['OEBPS/images/head.png']?.chapterIndex, 0);
+    expect(index.positions['OEBPS/images/middle.png']?.chapterIndex, 0);
+    expect(index.positions['OEBPS/images/plate.jpg']?.chapterIndex, 1);
+    expect(index.positions['OEBPS/images/foo bar.png']?.chapterIndex, 2);
+    expect(index.positions['OEBPS/images/back.png']?.chapterIndex, 2);
+    // 正文没引用的图定位不到。
+    expect(index.positions.containsKey('OEBPS/images/orphan.png'), isFalse);
+  });
+
+  test('orders images inside a chapter by the study chars before them', () {
+    final IllustrationProgressIndex index = build();
+
+    final IllustrationPosition head = index.positions['OEBPS/images/head.png']!;
+    final IllustrationPosition middle =
+        index.positions['OEBPS/images/middle.png']!;
+    expect(head.normCharOffset, 0);
+    expect(middle.normCharOffset, greaterThan(0));
+    expect(middle.normCharOffset, lessThan(10000));
+
+    // 读到第 1 章章首：章首那张已读到，章中那张还没读到。
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/head.png',
+        chapterIndex: 0,
+        normCharOffset: 0,
+      ),
+      isFalse,
+    );
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/middle.png',
+        chapterIndex: 0,
+        normCharOffset: 0,
+      ),
+      isTrue,
+    );
+    // 读过章中那张之后就不再算未读。
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/middle.png',
+        chapterIndex: 0,
+        normCharOffset: middle.normCharOffset,
+      ),
+      isFalse,
+    );
+  });
+
+  test('later chapters count as unread, earlier ones do not', () {
+    final IllustrationProgressIndex index = build();
+
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/plate.jpg',
+        chapterIndex: 0,
+        normCharOffset: 10000,
+      ),
+      isTrue,
+    );
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/plate.jpg',
+        chapterIndex: 2,
+        normCharOffset: 0,
+      ),
+      isFalse,
+    );
+  });
+
+  test('cover sits before the body and is never treated as unread', () {
+    final IllustrationProgressIndex index = build();
+
+    expect(index.positions['OEBPS/images/cover.png']?.chapterIndex, -1);
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/cover.png',
+        chapterIndex: 0,
+        normCharOffset: 0,
+      ),
+      isFalse,
+    );
+  });
+
+  test('unknown / null keys never blur', () {
+    final IllustrationProgressIndex index = build();
+
+    expect(
+      index.isUnread(revealKey: null, chapterIndex: 0, normCharOffset: 0),
+      isFalse,
+    );
+    expect(
+      index.isUnread(
+        revealKey: 'OEBPS/images/orphan.png',
+        chapterIndex: 0,
+        normCharOffset: 0,
+      ),
+      isFalse,
+    );
+    expect(
+      IllustrationProgressIndex.empty.isUnread(
+        revealKey: 'OEBPS/images/plate.jpg',
+        chapterIndex: 0,
+        normCharOffset: 0,
+      ),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## 问题

从书架进「查看插画」会把整本插图一次铺开，后文的插图直接剧透。

现有防剧透只有一条路径：全局「图片模糊（防剧透）」开关。它默认关，且判据只有「这张图点开过没有」，与读到哪了无关——开关关着时图片库对未读到的插图完全不遮。

## 改动

补一条与开关无关的判据：**插图落在当前阅读位置之后就先遮罩，点一下揭开**（揭开仍写 `revealed_images`，阅读器与图片库两端此后都不再遮）。

- 新增 `IllustrationProgressIndex`（`fushi/lib/src/reader/illustration_progress_index.dart`）：按 spine 顺序扫全书，把每张插图定位到 `(章号, 章内归一偏移)`。偏移与 `ReaderPosition.normCharOffset` 同尺（同一套 `countStudyChars` 口径、跳过振假名 `<rt>/<rp>/<rtc>`），所以章内先后也能比。
  - 定位范围：`<img src>`、SVG `<image xlink:href>`（日文固定版式插图页常见）、行内 `style="background-image:url(...)"`。
  - 封面（OPF `cover-image`）记为章号 `-1`，恒算已读到——封面不是剧透。
  - 定位不到的图（正文没引用 / 只在外部 CSS 里）**不遮罩**：宁可漏遮，也不凭猜测把已读的图糊住。
- `ImageRevealKey.shouldBlur` 增可选 `unreadAhead`：遮罩理由由「总开关」扩成「总开关 **或** 还没读到」。开关开着时行为与之前逐字一致（纯增量）。
- 图片库开页时并行拉阅读位置 + 后台 isolate（`compute`）建索引，整本 html 解析不压 UI 线程（与开书路径 `parseBookOnly` 同款）；目录不是合法 EPUB / 书行无 uid 一律退回旧行为，不影响看图。
- `EpubBook.svgImageHref` / `backgroundImageUrlPattern` 由私有改公开，索引复用同一份判据，不另抄一份。

## 测试

- `fushi/test/reader/illustration_progress_index_test.dart`：真实解压目录（container.xml + OPF + 章节 XHTML + 图片文件）建索引——三种插图写法都定位得到、章内先后可比、封面恒已读、percent 转义 src 与磁盘真实文件名归一到同一个 reveal key、孤儿图不遮。
- `fushi/test/pages/illustrations_viewer_unread_blur_test.dart`：真实 Drift + **全局开关关着**——读到第 1 章时只有后文那张被遮、读完全书一张不遮、点击揭开后遮罩消失且落库 `revealed_images`。

本地 `flutter analyze` 无 issue；上述两个新文件 + 插画页 / `image_reveal_key` / `test/epub` 全部定向测试 279 项通过。

https://claude.ai/code/session_014VBUriRXWLEDY3pv6GAkGb
