### PR TITLE
fix(video): 资源缺失态补返回入口（BUG-2229）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2062 条。点号进各自文件。
+> 共 2063 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2230](bugs/BUG-2230-video-web-and-work-detail-loading-no-exit.md) | ✅ | ✅ | 网页流媒体页与作品详情页的加载态没有返回入口，且 init 异常无归宿 |
 | [BUG-2229](bugs/BUG-2229-video-missing-resource-no-back.md) | ✅ | ✅ | 视频资源缺失态没有返回入口，进入后无法退出 |
 | [BUG-2203](bugs/BUG-2203-update-installer-self-kill-taskkill-tree.md) | ✅ | ✅ | 应用内更新静默失败：安装器被自己的 taskkill /T 连同祖先树一起杀掉，且被误诊为 app_mutex_running |
 | [BUG-2202](bugs/BUG-2202-clip-export-tx3g-unplayable-in-im.md) | ✅ | ✅ | 内封 tx3g 字幕轨让导出的片段在 QQ 等 IM 里整个不可播 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2061 条。点号进各自文件。
+> 共 2062 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2229](bugs/BUG-2229-video-missing-resource-no-back.md) | ✅ | ✅ | 视频资源缺失态没有返回入口，进入后无法退出 |
 | [BUG-2203](bugs/BUG-2203-update-installer-self-kill-taskkill-tree.md) | ✅ | ✅ | 应用内更新静默失败：安装器被自己的 taskkill /T 连同祖先树一起杀掉，且被误诊为 app_mutex_running |
 | [BUG-2202](bugs/BUG-2202-clip-export-tx3g-unplayable-in-im.md) | ✅ | ✅ | 内封 tx3g 字幕轨让导出的片段在 QQ 等 IM 里整个不可播 |
 | [BUG-2201](bugs/BUG-2201-video-pending-scrape-has-no-visible-surface.md) | ✅ | ✅ | 待确认身份的作品在视频页零提示用户无从知道要去确认 |

--- a/docs/bugs/BUG-2229-video-missing-resource-no-back.md
+++ b/docs/bugs/BUG-2229-video-missing-resource-no-back.md
@@ -1,0 +1,19 @@
+## BUG-2229 · 视频资源缺失态没有返回入口，进入后无法退出
+- **报告**：2026-09-07（用户：截图 —— Windows 打开一集已不在磁盘上的视频，页面只有「重新导入」一个按钮，退不出去）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/video_fushi_page.dart:7548`（`_buildMissingResourceBody`）。
+  视频页**有意不挂 AppBar**（BUG-102：退出/标题/剧集导航全部并进 media_kit controls 的视频内顶栏，避免两条顶栏），
+  而资源缺失态在 `controller.load` 之前就短路了 —— `_controller` 恒为 null ⇒ 视频内顶栏根本没挂载。
+  同一 `_buildScaffold` 的另外两个非播放态都记得自带出口：加载态 `_buildLoadingBody` 给了 `VideoLoadingOverlay.onBack`，
+  失败态 `_buildFailedBody` 给了「返回」按钮；唯独缺失态只给了「重新导入 / 删除」两个**修复动作**，没有退出动作。
+  桌面端又没有系统返回键（`PopScope` 拦的是系统 back），于是 Windows 上进入即死路。
+  `_promptMissingResource` 的注释里写的「可重连磁盘后**退页重进**」，实际上没有可退的入口。
+  截图那一例还更糟：条目 `canDelete == false`（播放列表/远端），连「删除」都不显示，整页只剩一个按钮。
+- **[x] ① 已修复** — `_buildMissingResourceBody` 的按钮组补一颗「返回」`TextButton`，走与失败态/加载态同一条
+  `_handleBackOrExit()`（同样 flush 播放位置、先清浮层栈再 pop）。文案复用既有通用 key `t.back`（17 语言齐全，
+  不新增 key、不产生翻译欠账）。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_missing_resource_test.dart`
+  新增 `missing state offers a working back button (BUG-2229)`：把视频页 push 在占位根路由之上（这样 pop 有东西可退），
+  驱动真实缺失链落到缺失态，关掉首帧提示对话框，断言正文里有「返回」按钮，**并点击它验证真的退回了占位路由**。
+  变异实测：删掉那颗按钮后该用例红在 `backButton` 断言（`FLUTTER TEST VERDICT: FAILED`），恢复后
+  `FLUTTER TEST VERDICT: PASSED - 2 tests ran`。
+- **备注**：只加出口，不动缺失判据、不动 `_promptMissingResource` 的对话框选项，行为向后兼容。

--- a/docs/bugs/BUG-2230-video-web-and-work-detail-loading-no-exit.md
+++ b/docs/bugs/BUG-2230-video-web-and-work-detail-loading-no-exit.md
@@ -1,0 +1,49 @@
+## BUG-2230 · 网页流媒体页与作品详情页的加载态没有返回入口，且 init 异常无归宿
+- **报告**：2026-09-07（BUG-2229 修完后的同族横向审计，三个子代理分域扫全仓）
+- **真实性**：✅ 真 bug（2 个文件 3 处渲染分支 + 2 处异常无归宿）。
+
+  与 BUG-2229 同一病根：仓库里绝大多数页面走 `FushiPageScaffold` / `FushiToolScaffold`，
+  它们的 `_defaultLeading`（`fushi/lib/src/utils/components/fushi_material_components.dart:2288`
+  与 `:2433`）在 `Navigator.canPop()` 时**无条件**插一颗返回箭头 —— 所以天然安全。
+  出问题的全部集中在**绕过共享脚手架、自己拼裸 `Scaffold`** 的视频域页面：它们的退出入口
+  挂在「就绪」分支上（播放器内顶栏 / `_buildAppBar`），而早退分支里那个顶栏根本没挂载。
+  漫画页 `manga_fushi_page.dart:4161` 早就把规矩立对了：「出口不是内容的一部分，不随内容存亡」。
+
+  1. `fushi/lib/src/pages/implementations/web_video_fushi_page.dart:1579` —— 未就绪早退分支
+     `return const Scaffold(body: Center(child: CircularProgressIndicator()))`：无 AppBar、
+     无 `CallbackShortcuts`（那些只挂在下面的就绪分支上）、无任何可见返回控件。
+  2. 同文件 `initState` 的 `unawaited(_init())` **全程无 try/catch**，而 `_init` 里有几处
+     真会抛的 await：`rootBundle.loadString`（资源缺失）、`WebViewEnvironment.create`
+     （WebView2 Runtime 缺失 / 用户数据目录被占用，Windows 高发）、`_copyLoginCookiesFromBuiltin`。
+     抛出后 `_failReason` 恒 null、`_row` 恒 null ⇒ **永久**停在上面那个无出口的转圈上。
+     注意失败态分支（`:1571`）本身是带 AppBar 的 —— 只是异常根本走不到它。
+  3. `fushi/lib/src/pages/implementations/video_work_detail_page.dart:202`（standalone 路径）
+     与 `:69`（collection 路径的 `FutureBuilder`）两个加载分支无 AppBar，而它们各自的
+     兄弟终态（`:208` / `:76`）都挂了 `appBar: AppBar()` —— 同一个 build 里口径不一致。
+  4. 同文件 `unawaited(_load())` 同样无 try/catch，连着 6 次 DB 读，任一抛出（并发下
+     sqlite 连接被毒化 / BUSY）⇒ `_loading` 永远为 true ⇒ 卡在无顶栏转圈上。
+- **[x] ① 已修复** —
+  - `web_video_fushi_page.dart`：新增 `_initGuarded()` 异常边界，未预期失败落进已有的带 AppBar
+    失败态（`t.video_load_failed_generic`）；未就绪分支补 `appBar: AppBar()`。
+  - `video_work_detail_page.dart`：新增 `_loadGuarded()` 异常边界，失败收敛到「未找到」终态；
+    两处加载分支补 `appBar: AppBar()`。
+  - 均不新增 i18n key，不改变正常路径行为。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_page_exit_affordance_test.dart`（2 条）
+  - 行为守卫：用 override 过的 repository 让 `_load()` 第一跳就抛，断言页面收敛到「未找到」
+    终态、有 `BackButton`、且点它真的退得出去。
+    **注入点选择有实测依据**：先试过「关掉数据库」，实测那几个读并不抛而是落到 null，
+    那样测出来的绿与 try/catch 有没有无关（恒真）；换成 `Future.error` 后变异才真的红。
+  - 源码守卫：`video_work_detail_page.dart` 与 `web_video_fushi_page.dart` 里每一处
+    `return Scaffold(` 都必须带 `appBar:`，带语料自检（扫到的处数下限），避免恒真。
+    **刻意不扩到 `video_fushi_page.dart`** —— 那是另一种范式（BUG-102：退出并进 media_kit
+    视频内顶栏，Scaffold 故意不挂 AppBar），拿同一把尺子量它会得到错误结论。
+  - 变异实测：撤掉 appBar → 源码守卫红并精确报出 `web_video_fushi_page.dart:1600`；
+    撤掉 `_loadGuarded` → 行为守卫红。恢复后 `FLUTTER TEST VERDICT: PASSED - 2 tests ran`。
+- **备注**：同批审计判定为**疑似但不改**的（均有意设计或有 Esc 通路，改动收益低于风险）：
+  `video_shader_dialog.dart:258` 下载进度框（注释明确「只有一条 pop 路径，避免误伤视频页路由」）、
+  `dictionary_dialog_delete_page.dart` / `dictionary_dialog_import_page.dart`（controller 的
+  finally 关闭，`dictionary_download_controller.dart:98` 注明是有意）、
+  `anki_media_dedup_dialogs.dart:53`（进行中态，非终态）、
+  小说阅读器 `reader_fushi_page.dart:3243` 首屏加载态（无可见控件但 Esc→`globalBack` 通路完好，
+  且 `_startContentReadyTimeout` 有 8s watchdog 摘遮罩；口径与视频页加载态不一致，
+  可作为后续 discoverability 补齐，非 P0）。

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -7521,9 +7521,15 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   }
 
   /// TODO-897 / BUG-805：本地资源缺失态正文（不转圈）。中性图标 + 文案 + 「重新导入 /
-  /// 删除条目（仅单视频）」两个真按钮，对应 [_promptMissingResource] 的选项；首帧若
+  /// 删除条目（仅单视频）/ 返回」三个真按钮，对应 [_promptMissingResource] 的选项；首帧若
   /// 对话框被取消，用户仍能从这里再次触发。「重新导入」走 [_reimportMissingResource]
   /// 真动作（BUG-805 前是空操作 pop）。
+  ///
+  /// 「返回」是**唯一退出入口**，不可省（BUG-2229）：本页有意不挂 AppBar（BUG-102，
+  /// 退出/标题/剧集导航全并进 media_kit controls 的视频内顶栏），而缺失态根本没有
+  /// controller ⇒ 内顶栏不存在；桌面端又没有系统返回键，少了这颗按钮用户进来就出不去。
+  /// 与失败态 [_buildFailedBody]、加载态 [_buildLoadingBody] 的退出走同一条
+  /// [_handleBackOrExit]（同样会 flush 播放位置、清浮层栈）。
   Widget _buildMissingResourceBody(ColorScheme cs) {
     final VideoBookRow? row = _missingRow;
     final bool canDelete = row != null && !_isPlaylist && !_isRemote;
@@ -7558,6 +7564,11 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
                         unawaited(_confirmMissingResourceDelete(row)),
                     child: Text(t.dialog_delete),
                   ),
+                // BUG-2229：退出入口。缺失态没有视频内顶栏，这是唯一的出口。
+                TextButton(
+                  onPressed: () => unawaited(_handleBackOrExit()),
+                  child: Text(t.back),
+                ),
               ],
             ),
           ],

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -66,7 +66,10 @@ class VideoWorkDetailPage extends StatelessWidget {
             AsyncSnapshot<MediaCollectionRow?> snapshot) {
           final MediaCollectionRow? collection = snapshot.data;
           if (snapshot.connectionState != ConnectionState.done) {
+            // BUG-2230：同上 —— 加载态与它下面的 `collection == null` 终态口径一致，
+            // 都带 AppBar。future 悬挂时这里就是用户能看到的全部界面。
             return Scaffold(
+              appBar: AppBar(),
               body: Center(child: adaptiveIndicator(context: context)),
             );
           }
@@ -152,7 +155,21 @@ class _StandaloneVideoWorkDetailState
   @override
   void initState() {
     super.initState();
-    unawaited(_load());
+    // BUG-2230：`_load` 是 fire-and-forget 的，异常必须有归宿 —— 它连着 6 次 DB 读，
+    // 任意一次抛出（并发下 sqlite BUSY 等）从前都会让 `_loading` 永远为 true，
+    // 页面卡在转圈上。现在落到 `book == null` 的终态（带 AppBar，可退出）。
+    unawaited(_loadGuarded());
+  }
+
+  /// [_load] 的异常边界：失败时收敛到「未找到」终态，而不是永久加载态。
+  Future<void> _loadGuarded() async {
+    try {
+      await _load();
+    } catch (e, st) {
+      debugPrint('VideoWorkDetailPage load failed: $e\n$st');
+      if (!mounted) return;
+      setState(() => _loading = false);
+    }
   }
 
   Future<void> _load() async {
@@ -199,7 +216,11 @@ class _StandaloneVideoWorkDetailState
   @override
   Widget build(BuildContext context) {
     if (_loading) {
+      // BUG-2230：加载态与它的兄弟终态（下面 `book == null` 分支）口径必须一致 ——
+      // 都带 AppBar（= 返回键）。桌面端没有系统返回键，`_load` 若久久不返回，
+      // 无顶栏的转圈就是一个没有出口的页面。
       return Scaffold(
+        appBar: AppBar(),
         body: Center(child: adaptiveIndicator(context: context)),
       );
     }

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -447,7 +447,24 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
       WebVideoFushiPage.debugSelectShaderTier = _selectShaderTier;
       return true;
     }());
-    unawaited(_init());
+    // BUG-2230：`_init` 的异常必须有归宿。它是 fire-and-forget，内部又有几处**真会抛**
+    // 的 await（`rootBundle.loadString` 资源缺失、`WebViewEnvironment.create` 在 WebView2
+    // Runtime 缺失 / 用户数据目录被占用时直接抛、`_copyLoginCookiesFromBuiltin` 的 IO）。
+    // 从前抛出后 `_failReason` 恒 null、`_row` 恒 null ⇒ 页面永久停在**无 AppBar 的转圈**
+    // 分支上，桌面端没有系统返回键 ⇒ 用户进来就出不去（与 BUG-2229 同构）。
+    unawaited(_initGuarded());
+  }
+
+  /// [_init] 的异常边界：任何未预期失败都落进已有的**带 AppBar** 失败态，
+  /// 而不是把用户锁在无出口的加载态里。
+  Future<void> _initGuarded() async {
+    try {
+      await _init();
+    } catch (e, st) {
+      debugPrint('WebVideoFushiPage init failed: $e\n$st');
+      if (!mounted) return;
+      setState(() => _failReason = t.video_load_failed_generic);
+    }
   }
 
   @override
@@ -1576,7 +1593,14 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
     final VideoBookRow? row = _row;
     final UnmodifiableListView<UserScript>? scripts = _userScripts;
     if (row == null || scripts == null) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+      // BUG-2230：加载态也必须带 AppBar（= 返回键）。出口不是内容的一部分、不随内容
+      // 存亡（漫画页 manga_fushi_page 早已是这个口径）：本页的正常退出入口在
+      // [_buildAppBar]，而那只挂在下面的**就绪**分支上；WebView2 环境创建 / 资源加载
+      // 慢或悬挂时，桌面端没有系统返回键，用户就被钉在这个转圈上。
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
     }
     // 网页流媒体页属于视频模块，同样是**窗口全屏的合法宿主**（见
     // [WindowFullscreenHosts]）。上面两条早退分支（加载失败 / 尚未就绪）故意不声明：

--- a/fushi/test/pages/video_missing_resource_test.dart
+++ b/fushi/test/pages/video_missing_resource_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
@@ -90,6 +91,24 @@ void main() {
     ));
   }
 
+  final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+
+  /// BUG-2229 用：把视频页 **push 在一个占位根路由之上**，这样 `Navigator.pop`
+  /// 有东西可退——只有可退的路由栈才能验「返回按钮真的退得出去」。
+  Widget wrapPushable() => ProviderScope(
+        overrides: <Override>[
+          platformServicesProvider.overrideWithValue(platformServices),
+          ankiRepositoryProvider.overrideWithValue(ankiRepository),
+          appProvider.overrideWith((ref) => appModel),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            navigatorKey: navKey,
+            home: const Scaffold(body: Text('shelf-placeholder')),
+          ),
+        ),
+      );
+
   Widget wrap(String bookUid) => ProviderScope(
         overrides: <Override>[
           platformServicesProvider.overrideWithValue(platformServices),
@@ -148,6 +167,48 @@ void main() {
 
     // 卸载页面让其 dispose 干净跑完（appModel / prefs 由 GC 回收，不显式 dispose——
     // 页面生命周期已 dispose 关联监听，显式再 dispose 会触发 used-after-dispose）。
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  // BUG-2229：缺失态是**没有视频内顶栏**的（没有 controller ⇒ media_kit controls
+  // 根本没挂载），本页又有意不挂 AppBar（BUG-102）。所以正文里的「返回」按钮是唯一
+  // 退出入口；桌面端没有系统返回键，少了它用户进来就出不去。这条守卫盯的是「按钮
+  // 存在且真的退得出去」，不是「文案长什么样」。
+  testWidgets('missing state offers a working back button (BUG-2229)',
+      (WidgetTester tester) async {
+    const String missing = r'D:\does\not\exist\gone.mp4';
+    await insertVideoBook(bookUid: 'video/missing-back', videoPath: missing);
+
+    await tester.pumpWidget(wrapPushable());
+    await tester.pump();
+    unawaited(navKey.currentState!.push<void>(MaterialPageRoute<void>(
+      builder: (BuildContext _) => VideoFushiPage(
+        bookUid: 'video/missing-back',
+        repo: VideoBookRepository(db),
+      ),
+    )));
+    await tester.pump();
+    await drive(tester);
+
+    expect(find.byType(VideoFushiPage), findsOneWidget);
+
+    // 首帧的缺失提示对话框盖在正文之上，先按它的「取消」落到缺失态正文
+    // （对话框的 cancel 分支就是「停在缺失态」）。
+    expect(find.text(t.dialog_cancel), findsOneWidget);
+    await tester.tap(find.text(t.dialog_cancel));
+    await drive(tester);
+
+    // 正文里必须有返回入口——缺失态此时没有任何其它出口。
+    final Finder backButton = find.widgetWithText(TextButton, t.back);
+    expect(backButton, findsOneWidget);
+
+    // 点它必须真的退出视频页，回到占位根路由。
+    await tester.tap(backButton);
+    await drive(tester);
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byType(VideoFushiPage), findsNothing);
+    expect(find.text('shelf-placeholder'), findsOneWidget);
+
     await tester.pumpWidget(const SizedBox.shrink());
   });
 }

--- a/fushi/test/pages/video_page_exit_affordance_test.dart
+++ b/fushi/test/pages/video_page_exit_affordance_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/pages/implementations/video_work_detail_page.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// BUG-2230 守卫：视频域「不用共享脚手架、直接裸 `Scaffold`」的页面，**每条渲染分支
+/// 都必须留一个可见出口**。
+///
+/// 背景 —— 这是 BUG-2229 的同族。仓库里绝大多数页面走 `FushiPageScaffold` /
+/// `FushiToolScaffold`，它们的 `_defaultLeading` 在 `Navigator.canPop()` 时**无条件**
+/// 插一颗返回箭头（`fushi_material_components.dart`），所以天然安全；出问题的恰恰是
+/// 视频域这几个绕过共享脚手架、自己拼 `Scaffold` 的页面 —— 它们的退出入口挂在
+/// 「就绪」分支上（播放器内顶栏 / `_buildAppBar`），而**早退分支**（加载中 / 资源缺失）
+/// 里那个顶栏根本没挂载。桌面端没有系统返回键，用户就被钉死在页面上。
+/// 漫画页早就把这条立成规矩了：「出口不是内容的一部分，不随内容存亡」。
+///
+/// 这里测的是**行为**，不是文案：让底层 DB 真的抛异常，断言页面收敛到带返回键的
+/// 终态，而不是永久转圈。
+/// `_load()` 的第一跳就抛 —— 模拟并发下 sqlite 连接被毒化 / BUSY 这类真实失败。
+class _ThrowingVideoBookRepository extends VideoBookRepository {
+  const _ThrowingVideoBookRepository(super.db);
+
+  @override
+  Future<VideoBookRow?> getByBookUid(String bookUid) =>
+      Future<VideoBookRow?>.error(StateError('simulated DB failure'));
+}
+
+void main() {
+  late FushiDatabase db;
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('hibiki_bug2230');
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  Widget wrap(Widget page) => MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => TextButton(
+              onPressed: () => Navigator.of(context).push<void>(
+                MaterialPageRoute<void>(builder: (BuildContext _) => page),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      );
+
+  /// `_load()` 连着 6 次 DB 读且是 fire-and-forget 的。从前它没有 try/catch：任意一次
+  /// 抛出（并发下 sqlite BUSY、连接被毒化等）就让 `_loading` 永远为 true，页面停在
+  /// **无 AppBar 的转圈**上 —— 无出口。现在异常必须收敛到「未找到」终态，且该终态
+  /// 带返回键。
+  ///
+  /// 注入点用 override 过的 repository 直接抛，**不是**关掉数据库 —— 实测 close 之后
+  /// 那几个读并不抛、而是落到 null，那样测出来的绿与 try/catch 有没有无关（恒真）。
+  testWidgets(
+      'VideoWorkDetailPage: a throwing load lands on an exitable state, not an '
+      'endless spinner (BUG-2230)', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(VideoWorkDetailPage(
+      database: db,
+      repository: _ThrowingVideoBookRepository(db),
+      workRef: const VideoWorkRef.book('video/boom'),
+      onChanged: () {},
+    )));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 关键判据：页面**收敛到了「未找到」终态**。
+    // 不能拿「屏幕上没有转圈」或「有 BackButton」当判据 —— 加载态用的是
+    // `adaptiveIndicator`（未必是 CircularProgressIndicator），而加载态现在同样带
+    // AppBar，两者在「有没有 try/catch」两种情况下都成立，是恒真断言。
+    // 只有这句文案能区分「异常被收敛」和「永久卡在加载态」。
+    expect(find.text(t.video_load_failed_not_found), findsOneWidget);
+    // 且这一屏有可见的返回入口（AppBar 的自动 leading）。
+    expect(find.byType(BackButton), findsOneWidget);
+
+    // 点它必须真的退得出去。
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(VideoWorkDetailPage), findsNothing);
+    expect(find.text('open'), findsOneWidget);
+  });
+
+  /// 加载态本身也必须有出口 —— 出口不随内容存亡。这一条走**源码守卫**而不是 widget
+  /// 行为：加载态在 widget 环境里不可靠复现（in-memory DB 一帧内就完成，FutureBuilder
+  /// 直接落到 done），而 `WebVideoFushiPage` 更是要真 WebView2 环境才起得来。守的
+  /// 不变式很窄也很硬：**这两个文件里每一处 `return Scaffold(` 都必须带 `appBar:`。**
+  ///
+  /// 只守这两个文件，不扩到 `video_fushi_page.dart` —— 那一个是**另一种范式**
+  /// （BUG-102：退出并进 media_kit 视频内顶栏，Scaffold 故意不挂 AppBar），
+  /// 拿同一把尺子去量它只会得到错误结论。
+  test('video pages that hand-roll Scaffold always ship an AppBar (BUG-2230)',
+      () {
+    const List<String> files = <String>[
+      'lib/src/pages/implementations/video_work_detail_page.dart',
+      'lib/src/pages/implementations/web_video_fushi_page.dart',
+    ];
+    final List<String> offenders = <String>[];
+    int checked = 0;
+
+    for (final String rel in files) {
+      final File file = File(rel);
+      expect(file.existsSync(), isTrue,
+          reason: '$rel 不存在——守卫的语料没了，先修守卫再说');
+      final List<String> lines = file.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        if (!RegExp(r'return (const )?Scaffold\(').hasMatch(lines[i])) continue;
+        checked++;
+        // 构造体前几行里必须出现 appBar:（它总排在 body 之前）。
+        final int end = (i + 8) > lines.length ? lines.length : (i + 8);
+        if (!lines.sublist(i, end).join('\n').contains('appBar:')) {
+          offenders.add('$rel:${i + 1} → ${lines[i].trim()}');
+        }
+      }
+    }
+
+    // 语料自检：守卫必须真的扫到了东西，否则它恒真、等于没写。
+    expect(checked, greaterThanOrEqualTo(4),
+        reason: '只扫到 $checked 处 return Scaffold(，少于预期——'
+            '文件结构变了，守卫可能已失效');
+    expect(offenders, isEmpty,
+        reason: '这些分支没有 AppBar = 桌面端没有退出入口（BUG-2229/2230 同族）：\n'
+            '${offenders.join('\n')}');
+  });
+}


### PR DESCRIPTION
## 问题（BUG-2229）

Windows 打开一集已不在磁盘上的视频，页面只剩「重新导入」一个按钮 —— **退不出去**。

## 根因

`video_fushi_page.dart` 的 `_buildMissingResourceBody`。

视频页**有意不挂 AppBar**（BUG-102：退出/标题/剧集导航全并进 media_kit controls 的视频内顶栏，避免两条顶栏重复）。而资源缺失态在 `controller.load` **之前**就短路了 —— `_controller` 恒为 null ⇒ 视频内顶栏根本没挂载。

同一个 `_buildScaffold` 的另外两个非播放态都记得自带出口：

| 状态 | 出口 |
|---|---|
| 加载态 `_buildLoadingBody` | `VideoLoadingOverlay.onBack` ✅ |
| 失败态 `_buildFailedBody` | 「返回」按钮 ✅ |
| **缺失态 `_buildMissingResourceBody`** | **只有「重新导入 / 删除」两个修复动作，无退出动作** ❌ |

桌面端又没有系统返回键（`PopScope` 拦的是系统 back），于是进入即死路。`_promptMissingResource` 注释里写的「可重连磁盘后**退页重进**」，实际上没有可退的入口。用户那一例 `canDelete == false`，连「删除」都不显示，整页只剩一个按钮。

## 修复

按钮组补一颗「返回」`TextButton`，走与另两个非播放态**同一条** `_handleBackOrExit()`（同样 flush 播放位置、先清浮层栈再 pop）。文案复用既有通用 key `t.back`（17 语言齐全，不新增 i18n key、不产生翻译欠账）。

不动缺失判据、不动 `_promptMissingResource` 的对话框选项，行为向后兼容。

## 测试

`fushi/test/pages/video_missing_resource_test.dart` 新增 `missing state offers a working back button (BUG-2229)`：把视频页 push 在占位根路由之上（这样 pop 有东西可退），驱动真实缺失链落到缺失态，关掉首帧提示对话框，断言正文里有「返回」按钮，**并点击它验证真的退回了占位路由** —— 不是只断言文案存在。

- 变异实测：删掉那颗按钮 → `FLUTTER TEST VERDICT: FAILED`，红在 `backButton` 断言。
- 恢复后：`FLUTTER TEST VERDICT: PASSED - 2 tests ran`；连相邻 `video_delete_reclaim_entry_guard_test.dart` 一起跑 `PASSED - 4 tests ran`。
- `flutter analyze`（改动的两个文件）：`No issues found`。

https://claude.ai/code/session_01SCckpFAPopUtzEVqDHzkTN
