### PR TITLE
feat(download): 直链下载行补「打开文件位置」与「删除任务」

### DIFF
--- a/fushi/lib/src/media/discovery/discovery_download_queue.dart
+++ b/fushi/lib/src/media/discovery/discovery_download_queue.dart
@@ -86,6 +86,7 @@ class DiscoveryDownloadTask {
     DiscoveryDownloadStatus status = DiscoveryDownloadStatus.queued,
     int receivedBytes = 0,
     int? totalBytes,
+    String? filePath,
   }) {
     return DiscoveryDownloadTask._(
       item: item,
@@ -93,7 +94,8 @@ class DiscoveryDownloadTask {
     )
       ..status = status
       ..receivedBytes = receivedBytes
-      ..totalBytes = totalBytes;
+      ..totalBytes = totalBytes
+      ..filePath = filePath;
   }
 
   final DiscoveryResourceItem item;
@@ -229,6 +231,23 @@ class DiscoveryDownloadQueue extends ChangeNotifier {
       return;
     }
     _tasks.remove(task);
+    notifyListeners();
+  }
+
+  /// 从队列里彻底移除一条任务（下载页行内「删除任务」）。
+  ///
+  /// 与 [cancel] 的差别只在终态：cancel 是「中止这次下载」，对已结束任务 no-op
+  /// （终态行留给「清除已完成」批量清）；remove 是「这行消失」，任何状态都受理。
+  /// 执行中的任务先掐断连接再摘行，`.part` 与已落盘文件都不动（与 cancel 同口径
+  /// ——重新入队即续传，已入库的文件更不该被一个列表操作删掉）；收尾 `_finish`
+  /// 仍以 `_running` 身份认领这次执行并放行下一个任务。
+  void remove(DiscoveryDownloadTask task) {
+    _retryTimers.remove(task)?.cancel();
+    if (identical(task, _running)) {
+      task._cancelRequested = true;
+      task._client?.close(force: true);
+    }
+    if (!_tasks.remove(task)) return;
     notifyListeners();
   }
 

--- a/fushi/lib/src/media/discovery/discovery_download_tasks_section.dart
+++ b/fushi/lib/src/media/discovery/discovery_download_tasks_section.dart
@@ -4,6 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
 import 'package:fushi/src/media/discovery/discovery_labels.dart';
 import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/video_download_jobs_panel.dart'
+    show showDownloadTaskDeleteConfirm;
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
 import 'package:fushi/utils.dart';
 
 /// 「下载」页任务 tab 的发现页直链下载区：渲染 [DiscoveryDownloadQueue] 的任务
@@ -18,10 +21,22 @@ import 'package:fushi/utils.dart';
 /// 行内可取消排队/执行中的任务、重试失败/取消的任务；已结束任务经「清除已完成」
 /// 批量清掉。范式与 `MokuroMoeTasksSection` 相同。
 class DiscoveryDownloadTasksSection extends ConsumerWidget {
-  const DiscoveryDownloadTasksSection({super.key, this.queueOverride});
+  const DiscoveryDownloadTasksSection({
+    super.key,
+    this.queueOverride,
+    this.pathRevealer,
+    this.revealHostProbe,
+  });
 
   /// 测试注入队列（null = 取 [AppModel.discoveryDownloadQueue]）。
   final DiscoveryDownloadQueue? queueOverride;
+
+  /// 测试注入文件管理器调用（null = [revealInFileManager]）。
+  final Future<bool> Function(String path)? pathRevealer;
+
+  /// 测试注入平台探针（null = [currentRevealHost]）。移动端返回 null → 整条
+  /// 「打开文件位置」入口隐藏，不画点了没反应的按钮。
+  final RevealHost? Function()? revealHostProbe;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -153,10 +168,32 @@ class DiscoveryDownloadTasksSection extends ConsumerWidget {
     final bool errorTone =
         task.status == DiscoveryDownloadStatus.failed ||
         task.status == DiscoveryDownloadStatus.waitingRetry;
-    return FushiListItem(
-      key: ValueKey<String>(
-        'discovery-download-${task.item.sourceId}-${task.item.id}',
+    final String rowKey =
+        'discovery-download-${task.item.sourceId}-${task.item.id}';
+    // 状态相关的那一个动作（重试 / 取消）；done 没有。
+    final Widget? statusAction = switch (task.status) {
+      DiscoveryDownloadStatus.failed ||
+      DiscoveryDownloadStatus.cancelled => FushiIconButton(
+        tooltip: t.retry,
+        icon: Icons.refresh,
+        size: 20,
+        onTap: () => queue.retry(task),
       ),
+      DiscoveryDownloadStatus.done => null,
+      DiscoveryDownloadStatus.queued ||
+      DiscoveryDownloadStatus.running ||
+      DiscoveryDownloadStatus.waitingRetry => FushiIconButton(
+        tooltip: t.dialog_cancel,
+        icon: Icons.close,
+        size: 20,
+        onTap: () => queue.cancel(task),
+      ),
+    };
+    final String? path = discoveryDownloadRevealTarget(task);
+    final String? revealTarget =
+        (revealHostProbe ?? currentRevealHost)() == null ? null : path;
+    return FushiListItem(
+      key: ValueKey<String>(rowKey),
       density: FushiListDensity.compact,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
       subtitleMaxLines: 2,
@@ -171,25 +208,61 @@ class DiscoveryDownloadTasksSection extends ConsumerWidget {
           color: errorTone ? scheme.error : null,
         ),
       ),
-      trailing: switch (task.status) {
-        DiscoveryDownloadStatus.failed ||
-        DiscoveryDownloadStatus.cancelled => FushiIconButton(
-          tooltip: t.retry,
-          icon: Icons.refresh,
-          size: 20,
-          onTap: () => queue.retry(task),
-        ),
-        DiscoveryDownloadStatus.done => null,
-        DiscoveryDownloadStatus.queued ||
-        DiscoveryDownloadStatus.running ||
-        DiscoveryDownloadStatus.waitingRetry => FushiIconButton(
-          tooltip: t.dialog_cancel,
-          icon: Icons.close,
-          size: 20,
-          onTap: () => queue.cancel(task),
-        ),
-      },
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (revealTarget != null)
+            FushiIconButton(
+              key: ValueKey<String>('$rowKey-location'),
+              tooltip: t.download_task_open_location,
+              icon: Icons.folder_open_outlined,
+              size: 20,
+              onTap: () => _openLocation(context, revealTarget),
+            ),
+          if (statusAction != null) statusAction,
+          FushiIconButton(
+            key: ValueKey<String>('$rowKey-delete'),
+            tooltip: t.download_task_delete,
+            icon: Icons.delete_outline,
+            size: 20,
+            enabledColor: scheme.error,
+            onTap: () => _confirmDelete(context, queue, task),
+          ),
+        ],
+      ),
     );
+  }
+
+  /// 在系统文件管理器里定位这条任务的落盘物。
+  ///
+  /// 失败（路径已不在 / 启动失败）必须出声——与视频下载任务面板同一口径，
+  /// 不能让按钮点了什么都不发生。
+  Future<void> _openLocation(BuildContext context, String path) async {
+    final bool revealed = await (pathRevealer ?? revealInFileManager)(path);
+    if (revealed || !context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(t.download_task_location_open_failed)),
+    );
+  }
+
+  /// 行内「删除任务」：确认后把这行从队列摘掉（文件不动）。
+  ///
+  /// 复用下载中心的删除确认框以保持两处口径一致，但 `offerDeleteFiles: false`
+  /// ——直链任务完成后文件已经入库，一个列表操作不该连库里的文件一起删；
+  /// 未完成任务删掉的只是任务，`.part` 留着下次续传。
+  Future<void> _confirmDelete(
+    BuildContext context,
+    DiscoveryDownloadQueue queue,
+    DiscoveryDownloadTask task,
+  ) async {
+    final bool? confirmed = await showDownloadTaskDeleteConfirm(
+      context,
+      title: task.item.title,
+      keySuffix: 'discovery-${task.item.sourceId}-${task.item.id}',
+      offerDeleteFiles: false,
+    );
+    if (confirmed == null) return;
+    queue.remove(task);
   }
 
   /// 生产队列。与漫画目录区同一道门：DownloadsPage 会在数据库打开前被轻量
@@ -203,6 +276,17 @@ class DiscoveryDownloadTasksSection extends ConsumerWidget {
   static bool _canRetry(DiscoveryDownloadTask task) =>
       task.status == DiscoveryDownloadStatus.failed ||
       task.status == DiscoveryDownloadStatus.cancelled;
+}
+
+/// 「打开文件位置」的目标路径（纯函数，供测试直接断言）。
+///
+/// 已下完的取落盘文件本身（文件管理器会选中它），否则退回目标目录；两者都没有
+/// （目录未定 / 测试桩）返回 null —— 调用方据此整条隐藏按钮，不画点了没反应的入口。
+String? discoveryDownloadRevealTarget(DiscoveryDownloadTask task) {
+  final String file = task.filePath?.trim() ?? '';
+  if (file.isNotEmpty) return file;
+  final String dir = task.destinationDir.trim();
+  return dir.isEmpty ? null : dir;
 }
 
 /// 任务进度 0..1；总大小未知（服务端没给 Content-Length）返回 null → 不定进度。

--- a/fushi/test/media/discovery/discovery_download_queue_test.dart
+++ b/fushi/test/media/discovery/discovery_download_queue_test.dart
@@ -305,6 +305,71 @@ void main() {
     expect(queue.totalCount, 0);
   });
 
+  test('remove 摘掉任意状态的一行：终态也受理，落盘文件不动', () async {
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async =>
+          okBytes(utf8.encode('x')),
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    await _waitFor(() => queue.tasks.single.isFinished);
+    final DiscoveryDownloadTask done = queue.tasks.single;
+    expect(done.status, DiscoveryDownloadStatus.done);
+
+    // cancel 对终态 no-op（那是「中止下载」）；remove 是「这行消失」。
+    queue.cancel(done);
+    expect(queue.totalCount, 1);
+    queue.remove(done);
+    expect(queue.totalCount, 0);
+    expect(
+      File(done.filePath!).existsSync(),
+      isTrue,
+      reason: '删的是任务不是文件——它已经入库了',
+    );
+    queue.remove(done); // 已不在队列：二次删除 no-op，不抛。
+    expect(queue.totalCount, 0);
+  });
+
+  // 注入的 openOverride 路径不建真 HttpClient，所以这里断言的是「摘行 + 让出
+  // 执行位」这半（强关连接那半与 cancel 共用同一行代码，由取消用例覆盖）。
+  test('remove 执行中的任务：立刻摘行，收尾照常放行下一个', () async {
+    final Completer<void> gate = Completer<void>();
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: _defaultResolver,
+      importer: (DiscoveryDownloadTask _, File __) async =>
+          const DiscoveryImportOutcome(),
+      openOverride: (Uri uri, Map<String, String> headers) async {
+        if (uri.path.endsWith('book.epub')) await gate.future;
+        return okBytes(utf8.encode('x'));
+      },
+    );
+    addTearDown(queue.dispose);
+
+    queue.enqueue(_item('1'), destinationDir: tempDir.path);
+    queue.enqueue(
+      _item('2', url: 'https://example.com/files/two.epub'),
+      destinationDir: tempDir.path,
+    );
+    await _waitFor(
+      () => queue.tasks.first.status == DiscoveryDownloadStatus.running,
+    );
+
+    final DiscoveryDownloadTask running = queue.tasks.first;
+    queue.remove(running);
+    expect(queue.tasks.contains(running), isFalse);
+    expect(queue.totalCount, 1);
+
+    // 收尾仍以 `_running` 身份认领这次执行 → 执行位释放，第二个任务跑完。
+    gate.complete();
+    await _waitFor(() => queue.tasks.single.status ==
+        DiscoveryDownloadStatus.done);
+    expect(queue.runningTask, isNull);
+  });
+
   group('sanitizeDiscoveryFileName', () {
     test('剥路径分隔与 Windows 非法字符', () {
       expect(

--- a/fushi/test/media/discovery/discovery_download_tasks_section_test.dart
+++ b/fushi/test/media/discovery/discovery_download_tasks_section_test.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
 import 'package:fushi/src/media/discovery/discovery_download_tasks_section.dart';
 import 'package:fushi/src/media/discovery/discovery_labels.dart';
 import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
 
 import '../../helpers/source_guard.dart';
 
@@ -43,6 +44,8 @@ Future<void> _pump(
   WidgetTester tester,
   DiscoveryDownloadQueue queue, {
   Size size = const Size(800, 700),
+  Future<bool> Function(String path)? pathRevealer,
+  RevealHost? Function()? revealHostProbe,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1;
@@ -58,7 +61,13 @@ Future<void> _pump(
           home: Scaffold(
             body: Column(
               children: <Widget>[
-                DiscoveryDownloadTasksSection(queueOverride: queue),
+                DiscoveryDownloadTasksSection(
+                  queueOverride: queue,
+                  pathRevealer: pathRevealer,
+                  // 默认按桌面渲染：这套行的动作在三桌面端都在，测试不该跟着
+                  // 跑测试的宿主平台变结论（CI 是 Linux，本机是 Windows）。
+                  revealHostProbe: revealHostProbe ?? () => RevealHost.windows,
+                ),
                 const Expanded(child: SizedBox.shrink()),
               ],
             ),
@@ -206,6 +215,144 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('行内「打开文件位置」调文件管理器；失败出声', (
+    WidgetTester tester,
+  ) async {
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: (DiscoveryResourceItem item) =>
+          throw StateError('boom'),
+      importer: (DiscoveryDownloadTask task, File file) async =>
+          const DiscoveryImportOutcome(),
+    );
+    addTearDown(queue.dispose);
+    final List<String> revealed = <String>[];
+    await _pump(
+      tester,
+      queue,
+      pathRevealer: (String path) async {
+        revealed.add(path);
+        return false; // 路径已不在 / 启动失败
+      },
+    );
+    queue.enqueue(_item('g1', title: 'Game One'), destinationDir: r'C:\dl');
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('discovery-download-src-g1-location')),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(revealed, <String>[r'C:\dl']);
+    expect(
+      find.text(t.download_task_location_open_failed),
+      findsOneWidget,
+      reason: 'reveal 失败必须出声，不能点了什么都不发生',
+    );
+  });
+
+  test('打开文件位置的目标：落盘文件优先于目标目录，都没有则不画按钮', () {
+    DiscoveryDownloadTask task({String dir = '', String? filePath}) =>
+        DiscoveryDownloadTask.forTesting(
+          item: _item('x'),
+          destinationDir: dir,
+          filePath: filePath,
+        );
+    expect(
+      discoveryDownloadRevealTarget(
+        task(dir: r'C:\dl', filePath: r'C:\dl.zip'),
+      ),
+      r'C:\dl.zip',
+      reason: '下完了就选中文件本身，用户要的是那个文件',
+    );
+    expect(
+      discoveryDownloadRevealTarget(task(dir: r'C:\dl')),
+      r'C:\dl',
+      reason: '还没下完只能打开目标目录',
+    );
+    expect(discoveryDownloadRevealTarget(task()), isNull);
+    expect(discoveryDownloadRevealTarget(task(dir: '  ')), isNull);
+  });
+
+  testWidgets('行内「删除任务」：确认后摘行、文件留着；取消则什么都不做', (
+    WidgetTester tester,
+  ) async {
+    // 用「必失败」的 resolver 让两条都停在终态：running 行的进度环是无限动画，
+    // 会让确认框的 pumpAndSettle 永远等不到静止。
+    final DiscoveryDownloadQueue queue = DiscoveryDownloadQueue(
+      resolvePayload: (DiscoveryResourceItem item) =>
+          throw StateError('boom'),
+      importer: (DiscoveryDownloadTask task, File file) async =>
+          const DiscoveryImportOutcome(),
+    );
+    addTearDown(queue.dispose);
+    await _pump(tester, queue);
+    queue.enqueue(_item('g1', title: 'Game One'), destinationDir: r'C:\dl');
+    queue.enqueue(
+      _item('g2', title: 'Game Two'),
+      destinationDir: r'C:\dl',
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+    expect(queue.totalCount, 2);
+    expect(
+      queue.tasks.every((DiscoveryDownloadTask t) => t.isFinished),
+      isTrue,
+    );
+
+    Finder deleteButton(String id) =>
+        find.byKey(ValueKey<String>('discovery-download-src-$id-delete'));
+
+    // 取消确认：任务留着。
+    await tester.tap(deleteButton('g1'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(t.download_task_delete_files),
+      findsNothing,
+      reason: '直链行不提供「同时删除已下载文件」——完成的文件已经入库',
+    );
+    await tester.tap(find.text(t.dialog_cancel));
+    await tester.pumpAndSettle();
+    expect(queue.totalCount, 2);
+    expect(_row('g1'), findsOneWidget);
+
+    // 确认：这行消失。
+    await tester.tap(deleteButton('g1'));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const ValueKey<String>(
+          'video-download-job-delete-confirm-discovery-src-g1',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(queue.totalCount, 1);
+    expect(_row('g1'), findsNothing);
+    expect(_row('g2'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('移动端没有文件管理器契约：隐藏「打开文件位置」，删除仍在', (
+    WidgetTester tester,
+  ) async {
+    final DiscoveryDownloadQueue queue = _hangingQueue();
+    addTearDown(queue.dispose);
+    await _pump(tester, queue, revealHostProbe: () => null);
+    queue.enqueue(_item('g1', title: 'Game One'), destinationDir: '/sdcard/dl');
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey<String>('discovery-download-src-g1-location')),
+      findsNothing,
+      reason: '画一个点了没反应的按钮比没有按钮更糟',
+    );
+    expect(
+      find.byKey(const ValueKey<String>('discovery-download-src-g1-delete')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('360 逻辑像素宽不溢出', (WidgetTester tester) async {
     final DiscoveryDownloadQueue queue = _hangingQueue();
     addTearDown(queue.dispose);
@@ -217,7 +364,8 @@ void main() {
             'A very long game title that keeps going and going '
             'to force wrapping on narrow phones',
       ),
-      destinationDir: '',
+      // 非空目录 = 「打开文件位置」也在 → 量的是三个动作全在的最宽形态。
+      destinationDir: r'C:\dl',
     );
     await tester.pump();
     expect(_row('g1'), findsOneWidget);


### PR DESCRIPTION
## 问题

下载页任务 tab 的「直链下载」区，每行只有一个状态按钮（重试 / 取消）；而同屏下面的 torrent 任务卡有「查看详情 / 打开文件位置 / 删除任务」。同一个下载中心里，直链任务下完了既定位不到文件，也删不掉单条行——只能整批「清除已完成」。

## 改动

- `DiscoveryDownloadQueue.remove(task)`：与 `cancel` 的差别只在终态——cancel 是「中止这次下载」（终态 no-op），remove 是「这行消失」（任何状态都受理）。执行中的先掐断连接再摘行，`.part` 与已落盘文件都不动；收尾 `_finish` 仍以 `_running` 身份认领这次执行并放行下一个任务。
- 行尾改成三槽 `Row`：打开文件位置 / 状态动作（重试 · 取消）/ 删除任务。
- 位置目标由纯函数 `discoveryDownloadRevealTarget` 定：落盘文件优先（文件管理器选中它），否则退回目标目录，都没有就整条隐藏按钮；移动端无文件管理器契约（`currentRevealHost()` 为 null）同样隐藏，不画点了没反应的入口。reveal 失败照视频下载面板口径弹 SnackBar。
- 删除复用下载中心的确认框保持口径一致，但 `offerDeleteFiles: false`：直链任务完成后文件已入库，一个列表操作不该连库里的文件一起删。
- i18n 全部复用既有 key（`download_task_open_location` / `download_task_delete` / `download_task_location_open_failed`），无新增 key。

## 测试

- 队列层：`remove` 终态可删（cancel 不受理）、二次删 no-op、落盘文件保留；remove 执行中的任务后摘行并放行下一个。
- Widget 层：打开位置调 revealer 且失败出声；删除确认后摘行、取消则什么都不做、确认框不提供「同时删除已下载文件」；移动端隐藏位置按钮；360 逻辑像素三按钮不溢出；目标路径优先级纯函数用例。

## 验证

- `flutter analyze` 全量：No issues found（117s）。
- `flutter test test/media/discovery` + 下载页三条守卫：173 条全绿。
- 直链区块自身：25 条全绿。

https://claude.ai/code/session_01GqrwZbA2miH9nB2XVdoHBp
