### PR TITLE
fix(video): BUG-2229 复审补修——修正「唯一退出入口」的错误叙述；init/load 异常给诊断归宿

### DIFF
--- a/docs/bugs/BUG-2229-video-missing-resource-no-back.md
+++ b/docs/bugs/BUG-2229-video-missing-resource-no-back.md
@@ -5,13 +5,13 @@
   而资源缺失态在 `controller.load` 之前就短路了 —— `_controller` 恒为 null ⇒ 视频内顶栏根本没挂载。
   同一 `_buildScaffold` 的另外两个非播放态都记得自带出口：加载态 `_buildLoadingBody` 给了 `VideoLoadingOverlay.onBack`，
   失败态 `_buildFailedBody` 给了「返回」按钮；唯独缺失态只给了「重新导入 / 删除」两个**修复动作**，没有退出动作。
-  桌面端又没有系统返回键（`PopScope` 拦的是系统 back），于是 Windows 上进入即死路。
+  这里要把范围说准（初稿写成「Windows 上进入即死路」，复审时按代码核实后修正）：**退出路径本身一直是通的**——`PopScope` 挂在 `_buildScaffold` **之外**，缺失态照样挂载，Android 系统返回键从来没被吃掉；键盘/手柄主通道里 `globalBack` 又被**刻意**分流在 `controller == null` 那道门之前（源码注释写明了理由），所以桌面端 Esc / Alt+← / 手柄 B 在缺失态一直退得出去。真实缺口是**鼠标用户没有可见出口**（可发现性），而不是可达性。把它写成「唯一退出入口」会让下一个人以为那条分流多余而把它删掉。
   `_promptMissingResource` 的注释里写的「可重连磁盘后**退页重进**」，实际上没有可退的入口。
   截图那一例还更糟：条目 `canDelete == false`（播放列表/远端），连「删除」都不显示，整页只剩一个按钮。
 - **[x] ① 已修复** — `_buildMissingResourceBody` 的按钮组补一颗「返回」`TextButton`，走与失败态/加载态同一条
   `_handleBackOrExit()`（同样 flush 播放位置、先清浮层栈再 pop）。文案复用既有通用 key `t.back`（17 语言齐全，
   不新增 key、不产生翻译欠账）。
-- **[x] ② 已加自动化测试** — `fushi/test/pages/video_missing_resource_test.dart`
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_missing_resource_test.dart`（另补一条源码守卫钉住「globalBack 必须分流在 `controller == null` 之前」——那条不变式之前零守卫，而初稿文档还把它说成不存在；不写成行为用例是因为本文件的最小 harness 没有 app 根部的全局快捷键层，实测发 Esc 没有接收者，硬凑一个壳测的就是那个壳）
   新增 `missing state offers a working back button (BUG-2229)`：把视频页 push 在占位根路由之上（这样 pop 有东西可退），
   驱动真实缺失链落到缺失态，关掉首帧提示对话框，断言正文里有「返回」按钮，**并点击它验证真的退回了占位路由**。
   变异实测：删掉那颗按钮后该用例红在 `backButton` 断言（`FLUTTER TEST VERDICT: FAILED`），恢复后

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -7525,9 +7525,16 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 对话框被取消，用户仍能从这里再次触发。「重新导入」走 [_reimportMissingResource]
   /// 真动作（BUG-805 前是空操作 pop）。
   ///
-  /// 「返回」是**唯一退出入口**，不可省（BUG-2229）：本页有意不挂 AppBar（BUG-102，
-  /// 退出/标题/剧集导航全并进 media_kit controls 的视频内顶栏），而缺失态根本没有
-  /// controller ⇒ 内顶栏不存在；桌面端又没有系统返回键，少了这颗按钮用户进来就出不去。
+  /// 「返回」是缺失态**唯一可见、可点**的出口，不可省（BUG-2229）：本页有意不挂
+  /// AppBar（BUG-102，退出/标题/剧集导航全并进 media_kit controls 的视频内顶栏），
+  /// 而缺失态根本没有 controller ⇒ 内顶栏不存在。于是鼠标用户在屏幕上找不到任何
+  /// 退出入口——这正是用户报上来的那张截图。
+  ///
+  /// **但它不是唯一的退出路径**，别据此以为别的路在缺失态是断的（照那样理解会去
+  /// 删掉真正在起作用的东西）：`PopScope` 挂在 [_buildScaffold] **之外**，所以
+  /// Android 系统返回键一直通；键盘/手柄主通道里 `globalBack` 被**刻意**分流在
+  /// `controller == null` 那道门之前（见本文件里那段注释），所以 Esc / Alt+← /
+  /// 手柄 B 也一直通。这颗按钮补的是**可发现性**，不是可达性。
   /// 与失败态 [_buildFailedBody]、加载态 [_buildLoadingBody] 的退出走同一条
   /// [_handleBackOrExit]（同样会 flush 播放位置、清浮层栈）。
   Widget _buildMissingResourceBody(ColorScheme cs) {

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -166,6 +166,8 @@ class _StandaloneVideoWorkDetailState
     try {
       await _load();
     } catch (e, st) {
+      // 同 web_video：给了用户归宿就不能把诊断扔了（release 版 debugPrint 落空）。
+      ErrorLogService.instance.log('video_work_detail', 'load failed: $e', st);
       debugPrint('VideoWorkDetailPage load failed: $e\n$st');
       if (!mounted) return;
       setState(() => _loading = false);

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -461,6 +461,11 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
     try {
       await _init();
     } catch (e, st) {
+      // release 版 Windows 上 stdout 无人接收，debugPrint 等于丢弃——而 BUG-2230
+      // 的立论就是「异常无归宿」。给了用户归宿（失败终态）就不能把诊断也扔了：
+      // WebViewEnvironment.create 失败 / 资源缺失 / cookie 拷贝 IO 错这三类根因
+      // 只有落进 error_log 才区分得出来。
+      ErrorLogService.instance.log('web_video', 'init failed: $e', st);
       debugPrint('WebVideoFushiPage init failed: $e\n$st');
       if (!mounted) return;
       setState(() => _failReason = t.video_load_failed_generic);

--- a/fushi/test/pages/video_missing_resource_test.dart
+++ b/fushi/test/pages/video_missing_resource_test.dart
@@ -18,6 +18,7 @@ import 'package:fushi/src/platform/platform_services.dart';
 import 'package:fushi_core/fushi_core.dart';
 
 import '../helpers/fake_anki_repository.dart';
+import '../helpers/source_guard.dart';
 import '../helpers/test_platform_services.dart';
 
 /// TODO-897 widget 行为守卫：本地视频文件缺失（被移动/删除/盘未挂载）时，页面进入
@@ -171,9 +172,12 @@ void main() {
   });
 
   // BUG-2229：缺失态是**没有视频内顶栏**的（没有 controller ⇒ media_kit controls
-  // 根本没挂载），本页又有意不挂 AppBar（BUG-102）。所以正文里的「返回」按钮是唯一
-  // 退出入口；桌面端没有系统返回键，少了它用户进来就出不去。这条守卫盯的是「按钮
-  // 存在且真的退得出去」，不是「文案长什么样」。
+  // 根本没挂载），本页又有意不挂 AppBar（BUG-102）。所以正文里的「返回」按钮是缺失态
+  // 唯一**可见可点**的出口——鼠标用户在屏幕上找不到别的地方可按。
+  // 它不是唯一的退出**路径**：PopScope 在 _buildScaffold 之外（系统返回键一直通），
+  // globalBack 也被刻意分流在 controller == null 那道门之前（Esc / 手柄 B 一直通）。
+  // 下面第二条用例把后者钉住，免得有人把那条分流当成多余删掉。
+  // 这条守卫盯的是「按钮存在且真的退得出去」，不是「文案长什么样」。
   testWidgets('missing state offers a working back button (BUG-2229)',
       (WidgetTester tester) async {
     const String missing = r'D:\does\not\exist\gone.mp4';
@@ -198,7 +202,7 @@ void main() {
     await tester.tap(find.text(t.dialog_cancel));
     await drive(tester);
 
-    // 正文里必须有返回入口——缺失态此时没有任何其它出口。
+    // 正文里必须有返回入口——鼠标用户在缺失态看得到的只有这一个。
     final Finder backButton = find.widgetWithText(TextButton, t.back);
     expect(backButton, findsOneWidget);
 
@@ -210,5 +214,34 @@ void main() {
     expect(find.text('shelf-placeholder'), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  // 缺失态下 Esc 也必须退得出去 —— 这里用源码守卫，不是行为用例。
+  //
+  // 不变式本身成立：本页键盘主通道把 globalBack **刻意**分流在 `controller == null`
+  // 那道门之前（加载态 / 缺失态下 controller 恒为 null，跟着整表被挡住就等于 Esc
+  // 不再走本页阶梯）。但在 BUG-2229 之前没有任何测试钉它，而本 PR 的初稿注释还把它
+  // 说成「不存在」——下一个人照注释办事，很可能把那条分流当多余删掉，删完全绿。
+  //
+  // 为什么不写成 widget 行为用例：本文件的 harness 是最小 MaterialApp，没有 app 根部
+  // 的全局快捷键层，页面自身的 Focus 又是 canRequestFocus:false / skipTraversal，
+  // 按键在这里根本没有接收者（实测：发 Esc 后页面仍在）。硬凑一个能收键的壳，测的
+  // 就是那个壳而不是真接线。源码守卫是这条不变式在单测层最强的可落地形式。
+  test('globalBack 必须分流在 controller == null 之前（缺失态/加载态的键盘出口）', () {
+    final File f = File('lib/src/pages/implementations/video_fushi_page.dart');
+    expect(f.existsSync(), isTrue, reason: '守卫目标文件不在了');
+    final String src = maskComments(f.readAsStringSync());
+
+    const String branch = 'if (action == ShortcutAction.globalBack) {';
+    const String gate = 'if (controller == null) return false;';
+    final int branchAt = src.indexOf(branch);
+    final int gateAt = src.indexOf(gate);
+    expect(branchAt, greaterThan(-1),
+        reason: 'globalBack 的分流没了：缺失态/加载态下 Esc 会跟着整表被 controller '
+            '门挡住，键盘和手柄都退不出去');
+    expect(gateAt, greaterThan(-1), reason: 'controller 门改写了，守卫需更新');
+    expect(branchAt, lessThan(gateAt),
+        reason: 'globalBack 必须排在 controller == null 之前——它的执行体是本页的'
+            '逐级退出阶梯，整条不碰播放器，没有理由被播放器就绪与否挡住');
   });
 }


### PR DESCRIPTION
BUG-2229 的复审补修。原 PR #1273 在我把这几条推上去**之前**就被合并了，所以这些改动
留在了已合并的分支上、没有进 develop（已按内容核实：develop 上两条 grep 均为 0）。
这条 PR 把它们送进去，内容与当时推送的一字不差。

审查判的两条阻断：

**1. 「返回按钮是唯一退出入口」这个叙述是错的，而且写进了源码注释、BUG 文档、测试注释三处。**

按代码核实：
- `PopScope` 挂在 `_buildScaffold` **之外**（`video_fushi_page.dart:7433-7444`），缺失态
  照样挂载 ⇒ Android 系统返回键在缺失态一直是通的；
- 键盘/手柄主通道里 `globalBack` 被**刻意**分流在 `controller == null` 那道门**之前**
  （`:5344-5352`，源码注释写明了理由）⇒ 桌面端 Esc / Alt+← / 手柄 B 一直能退。

真实缺口只是**鼠标用户没有可见出口**（可发现性），不是可达性。补按钮这个修法是对的，
但把「唯一出口」写进注释是给下一个人埋雷——他会据此认为那条刻意的分流是多余的而删掉，
删完全绿。三处叙述全部改成实话。

顺带补一条源码守卫钉住那条分流（`globalBack` 分支必须排在 controller 门之前）。它此前
**零守卫**，而文档正把它置于删除风险中。

为什么不写成行为用例：该文件的 harness 是最小 MaterialApp，没有 app 根部的全局快捷键层，
页面自身的 `Focus` 又是 `canRequestFocus:false` / `skipTraversal`——实测发 Esc 后页面仍在。
硬凑一个能收键的壳，测的就是那个壳而不是真接线。源码守卫是这条不变式在单测层最强的
可落地形式。

**2. 两个新 catch 只 `debugPrint`，等于把诊断扔了。**

release 版 Windows 上 stdout 无人接收，而 BUG-2230 的立论就是「异常无归宿」。现在给了
用户归宿（失败终态）却没给诊断归宿：`WebViewEnvironment.create` 失败 / 资源缺失 /
cookie 拷贝 IO 错这三类根因在 `error_log` 里一个字都没有。改用同文件已在用的
`ErrorLogService.instance.log`（`video_work_detail_page` 同理），`debugPrint` 保留。

验证（在当前 develop `db76e70581` 上重跑）：`flutter analyze` 零问题；
`video_missing_resource`（5 条）+ `video_page_exit_affordance` 全绿。
