### PR TITLE
feat(home): 首页卡片悬停放大 + fix(cover): 去背封面不再是一圈死灰

### DIFF
--- a/fushi/lib/src/media/video/cover_ui/cover_aspect_probe.dart
+++ b/fushi/lib/src/media/video/cover_ui/cover_aspect_probe.dart
@@ -1,4 +1,8 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
+
+import 'package:fushi/src/media/video/cover_ui/cover_backdrop_color.dart';
 
 /// 槽向自适应封面组件的**共享内核**（TODO-2426）。
 ///
@@ -17,10 +21,23 @@ mixin CoverAspectProbe<T extends StatefulWidget> on State<T> {
   /// 同一 [ImageStream]，宽高比探测因此是零额外解码成本。
   ImageProvider probedImageOf(T widget);
 
+  /// 宽高比为 [aspect] 的图会走「模糊垫底」吗？
+  ///
+  /// **只有走垫底的图才需要主色底**，所以这也是采样的开关：取主色要 `toByteData`
+  /// 把整图 RGBA 拉出来（一张 400×600 就是近 1MB），视频库墙格几十上百张卡全采
+  /// 一遍纯属白烧。合槽直接 `cover` 铺满的图压根看不到底色。
+  ///
+  /// 判据就是子类 build 里那条 mismatch 分支，两处必须同源——各写一份迟早漂移。
+  bool needsBackdropSeed(double aspect);
+
   ImageStream? _stream;
   ImageStreamListener? _listener;
   double? _aspect;
   bool _failed = false;
+  Color? _backdropSeed;
+
+  /// 每次换图自增：异步主色采样回来时对不上号就丢弃（图片已经换了）。
+  int _sampleGeneration = 0;
 
   /// 图片固有宽高比（宽 / 高）；null = 首帧解码前尺寸未知。
   ///
@@ -30,6 +47,10 @@ mixin CoverAspectProbe<T extends StatefulWidget> on State<T> {
 
   /// 加载 / 解码是否已失败（调用方据此走 errorBuilder）。
   bool get coverFailed => _failed;
+
+  /// 垫底底色种子（图片非透明像素的加权平均色），null = 尚未采样完成，或整图
+  /// 几乎不透明、压根不需要底色。语义与调制手法见 [sampleCoverBackdropSeed]。
+  Color? get coverBackdropSeed => _backdropSeed;
 
   @override
   void didChangeDependencies() {
@@ -43,6 +64,8 @@ mixin CoverAspectProbe<T extends StatefulWidget> on State<T> {
     if (probedImageOf(widget) != probedImageOf(oldWidget)) {
       _aspect = null;
       _failed = false;
+      _backdropSeed = null;
+      _sampleGeneration++;
       _resolveProbedImage();
     }
   }
@@ -74,12 +97,33 @@ mixin CoverAspectProbe<T extends StatefulWidget> on State<T> {
 
   void _onImage(ImageInfo info, bool syncCall) {
     final double aspect = info.image.width / info.image.height;
+    // 主色采样要读像素（异步），而 info.dispose() 之后底层 image 就不能再用了。
+    // clone 拿一份自己的句柄，采样完在 [_sampleBackdrop] 里各自释放。
+    final ui.Image sample = info.image.clone();
     info.dispose();
+    if (needsBackdropSeed(aspect)) {
+      _sampleBackdrop(sample, _sampleGeneration);
+    } else {
+      sample.dispose();
+    }
     if (!mounted || _aspect == aspect) return;
     setState(() {
       _aspect = aspect;
       _failed = false;
     });
+  }
+
+  /// 异步取垫底底色。[generation] 用来丢弃过期结果：采样期间 widget 可能已经换图。
+  Future<void> _sampleBackdrop(ui.Image image, int generation) async {
+    try {
+      final CoverBackdropSeed? seed = await sampleCoverBackdropSeed(image);
+      if (!mounted || generation != _sampleGeneration) return;
+      final Color? color = seed?.color;
+      if (_backdropSeed == color) return;
+      setState(() => _backdropSeed = color);
+    } finally {
+      image.dispose();
+    }
   }
 
   void _onError(Object exception, StackTrace? stackTrace) {

--- a/fushi/lib/src/media/video/cover_ui/cover_backdrop_color.dart
+++ b/fushi/lib/src/media/video/cover_ui/cover_backdrop_color.dart
@@ -100,17 +100,26 @@ int _sampleStep(int pixelCount) {
 /// 在一排卡片里互相打架。所以只留**色相**，饱和度收进上限、亮度按主题钉死：
 /// 卡片背景该是安静的有色底，不是色块。
 Color harmonizeBackdrop(Color seed, Brightness brightness) {
+  final bool dark = brightness == Brightness.dark;
   final HSLColor hsl = HSLColor.fromColor(seed);
   return hsl
-      .withSaturation(hsl.saturation.clamp(0.0, kBackdropMaxSaturation))
-      .withLightness(brightness == Brightness.dark
-          ? kBackdropDarkLightness
-          : kBackdropLightLightness)
+      .withSaturation(hsl.saturation.clamp(0.0, backdropMaxSaturation(brightness)))
+      .withLightness(dark ? kBackdropDarkLightness : kBackdropLightLightness)
       .toColor();
 }
 
-/// 饱和度上限（只留色相倾向，不铺色块）。
-const double kBackdropMaxSaturation = 0.42;
+/// 饱和度上限：暗色主题收得更紧。低亮度下的暖色（尤其黄）人眼会读成脏的橄榄褐，
+/// 实测柚子社那张全黄 logo 在 0.42 下就是这个毛病；亮色主题没有这个问题。
+double backdropMaxSaturation(Brightness brightness) =>
+    brightness == Brightness.dark
+        ? kBackdropMaxSaturationDark
+        : kBackdropMaxSaturationLight;
+
+/// 亮色主题的饱和度上限（只留色相倾向，不铺色块）。
+const double kBackdropMaxSaturationLight = 0.42;
+
+/// 暗色主题的饱和度上限。
+const double kBackdropMaxSaturationDark = 0.26;
 
 /// 暗色主题下的背景亮度。
 const double kBackdropDarkLightness = 0.22;

--- a/fushi/lib/src/media/video/cover_ui/cover_backdrop_color.dart
+++ b/fushi/lib/src/media/video/cover_ui/cover_backdrop_color.dart
@@ -1,0 +1,141 @@
+/// 「模糊垫底」在封面自带透明区时缺的那一层底色。
+///
+/// 为什么需要它：垫底手法是「同图放大 + 高斯模糊」，这条路默认图片是**不透明**的
+/// 照片 / 海报。galgame 封面链末端却是 exe 内嵌图标（`extractLargestIconPng` 从 PE
+/// 资源解出的 PNG）——角色立绘四周整片透明。透明的图模糊之后还是透明，垫底层等于
+/// 什么都没画，卡片只剩死灰一片。
+///
+/// 修法不是给透明图另开一条分支，而是把垫底补全：**先铺一层由图片自身算出的底色**。
+/// 图片不透明时这层被模糊图完全盖住（零观感变化），透明时它就是背景——色相取自
+/// 立绘本身，因此天然与前景协调。
+///
+/// 采样时机挂在宽高比探测的同一个 [ui.Image] 上（`CoverAspectProbe`），不额外解码。
+library;
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// 参与主色统计的最低 alpha：低于此值算「背景空白」，不计入色相，也不计入
+/// [CoverBackdropSeed.opaqueRatio]。取 32/255≈12.5%，抗 PNG 边缘羽化。
+const int kBackdropSampleMinAlpha = 32;
+
+/// 采样点数量目标。按总像素开方定步长，图再大也只取这么多点——主色是统计量，
+/// 多采不会更准，只会更慢。
+const int kBackdropSampleTargetPoints = 2048;
+
+/// 「几乎不透明」阈值：不透明像素占比高于此值就不需要底色了（模糊垫底本来就能
+/// 铺满），返回 null 省掉一层 widget。
+const double kBackdropOpaqueSkipRatio = 0.995;
+
+/// 一次主色采样的结果。
+class CoverBackdropSeed {
+  const CoverBackdropSeed({required this.color, required this.opaqueRatio});
+
+  /// 非透明像素按 alpha 加权的平均色（未经明暗调制，见 [harmonizeBackdrop]）。
+  final Color color;
+
+  /// 非透明像素占采样点的比例，1.0 = 整图不透明。
+  final double opaqueRatio;
+}
+
+/// 从已解码的 [image] 取主色种子；整图几乎不透明（或全透明 / 读像素失败）时返回
+/// null，表示「不需要底色」。
+///
+/// 调用方负责 [image] 的生命周期——本函数只读，不 dispose。
+Future<CoverBackdropSeed?> sampleCoverBackdropSeed(ui.Image image) async {
+  final ByteData? data =
+      await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  if (data == null) return null;
+  final Uint8List bytes = data.buffer.asUint8List();
+  final int pixelCount = image.width * image.height;
+  if (pixelCount <= 0) return null;
+  // 按总像素开方定步长：面积越大跳得越远，采样点数恒在目标量级。
+  final int step = _sampleStep(pixelCount);
+
+  int sampled = 0;
+  int opaque = 0;
+  // alpha 加权累加：半透明的羽化边缘不该和实心区域等权拉偏主色。
+  double weight = 0;
+  double r = 0;
+  double g = 0;
+  double b = 0;
+  for (int i = 0; i < pixelCount; i += step) {
+    final int o = i * 4;
+    if (o + 3 >= bytes.length) break;
+    sampled++;
+    final int a = bytes[o + 3];
+    if (a < kBackdropSampleMinAlpha) continue;
+    opaque++;
+    final double w = a / 255.0;
+    weight += w;
+    r += bytes[o] * w;
+    g += bytes[o + 1] * w;
+    b += bytes[o + 2] * w;
+  }
+  if (sampled == 0 || weight <= 0) return null;
+  final double opaqueRatio = opaque / sampled;
+  if (opaqueRatio >= kBackdropOpaqueSkipRatio) return null;
+  return CoverBackdropSeed(
+    color: Color.fromARGB(
+      0xFF,
+      (r / weight).round().clamp(0, 255),
+      (g / weight).round().clamp(0, 255),
+      (b / weight).round().clamp(0, 255),
+    ),
+    opaqueRatio: opaqueRatio,
+  );
+}
+
+int _sampleStep(int pixelCount) {
+  if (pixelCount <= kBackdropSampleTargetPoints) return 1;
+  final int step = (pixelCount / kBackdropSampleTargetPoints).floor();
+  return step < 1 ? 1 : step;
+}
+
+/// 主色种子 → 真正铺上去的背景色。
+///
+/// 立绘主色常常很艳（发色 / 服装的高饱和粉紫），原样铺满整张卡会喧宾夺主，还会
+/// 在一排卡片里互相打架。所以只留**色相**，饱和度收进上限、亮度按主题钉死：
+/// 卡片背景该是安静的有色底，不是色块。
+Color harmonizeBackdrop(Color seed, Brightness brightness) {
+  final HSLColor hsl = HSLColor.fromColor(seed);
+  return hsl
+      .withSaturation(hsl.saturation.clamp(0.0, kBackdropMaxSaturation))
+      .withLightness(brightness == Brightness.dark
+          ? kBackdropDarkLightness
+          : kBackdropLightLightness)
+      .toColor();
+}
+
+/// 饱和度上限（只留色相倾向，不铺色块）。
+const double kBackdropMaxSaturation = 0.42;
+
+/// 暗色主题下的背景亮度。
+const double kBackdropDarkLightness = 0.22;
+
+/// 亮色主题下的背景亮度。
+const double kBackdropLightLightness = 0.87;
+
+/// 背景渐变的上下亮度偏移：纯平色显得像色块，给一点点纵向明暗就有了体积感。
+const double kBackdropGradientLightnessDelta = 0.06;
+
+/// 把背景色摊成纵向渐变（上略亮、下略暗）。
+Gradient coverBackdropGradient(Color base) {
+  final HSLColor hsl = HSLColor.fromColor(base);
+  return LinearGradient(
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+    colors: <Color>[
+      hsl
+          .withLightness((hsl.lightness + kBackdropGradientLightnessDelta)
+              .clamp(0.0, 1.0))
+          .toColor(),
+      hsl
+          .withLightness((hsl.lightness - kBackdropGradientLightnessDelta)
+              .clamp(0.0, 1.0))
+          .toColor(),
+    ],
+  );
+}

--- a/fushi/lib/src/media/video/cover_ui/cover_orientation_builder.dart
+++ b/fushi/lib/src/media/video/cover_ui/cover_orientation_builder.dart
@@ -52,6 +52,11 @@ class _CoverOrientationProbeState extends State<_CoverOrientationProbe>
   @override
   ImageProvider probedImageOf(_CoverOrientationProbe widget) => widget.image;
 
+  /// 本组件只回答「这张图是横是竖」，一个像素都不画——垫底和主色底是下游封面组件
+  /// 的事，这里采样纯属白烧。
+  @override
+  bool needsBackdropSeed(double aspect) => false;
+
   @override
   Widget build(BuildContext context) {
     // 解码失败按竖卡渲染（卡内封面组件自会走占位 errorBuilder）。

--- a/fushi/lib/src/media/video/cover_ui/landscape_cover_image.dart
+++ b/fushi/lib/src/media/video/cover_ui/landscape_cover_image.dart
@@ -2,6 +2,8 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/video/cover_ui/cover_aspect_probe.dart';
+import 'package:fushi/src/media/video/cover_ui/cover_backdrop_color.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 
 /// 宽幅（约 2.7:1）封面槽的填充组件 —— [PortraitCoverImage] 的镜像。
 ///
@@ -13,8 +15,8 @@ import 'package:fushi/src/media/video/cover_ui/cover_aspect_probe.dart';
 ///
 /// * 横图（宽高比 ≥ [landscapeAspectThreshold]，抽帧 16:9≈1.78）→ 直接
 ///   `BoxFit.cover` 铺满，[overlays] 压在其上。**与本组件引入前逐像素相同。**
-/// * 竖图（刮削海报 2:3≈0.71）→ 同图两层：底层 `cover` 放大 + 高斯模糊 + 半透明
-///   压暗垫底，前景 `contain` 完整显示、按 [foregroundAlignment] 靠边避让 hero
+/// * 竖图（刮削海报 2:3≈0.71）→ 同图分层：主色底 + `cover` 放大高斯模糊（自身
+///   压暗），前景 `contain` 完整显示、按 [foregroundAlignment] 靠边避让 hero
 ///   文字。直接 `cover` 一张 2:3 海报进 2.7:1 槽要放大 4.5 倍、只剩中间 26% 的
 ///   高度带（人脸糊满屏、头顶被切），正是 BUG-1298 的现象。
 /// * 尺寸未知（首帧解码前）先按 `cover` 渲染，[ImageStream] 拿到尺寸后再切换，
@@ -80,6 +82,11 @@ class _LandscapeCoverImageState extends State<LandscapeCoverImage>
   @override
   ImageProvider probedImageOf(LandscapeCoverImage widget) => widget.image;
 
+  /// 竖图落进宽幅槽 —— build 的渲染分支与主色采样开关共用的唯一判据。
+  @override
+  bool needsBackdropSeed(double aspect) =>
+      aspect < LandscapeCoverImage.landscapeAspectThreshold;
+
   @override
   Widget build(BuildContext context) {
     if (coverFailed) {
@@ -87,8 +94,7 @@ class _LandscapeCoverImageState extends State<LandscapeCoverImage>
     }
     final double? aspect = coverAspect;
     // 首帧前 aspect 未知 → 按横图走（= 引入本组件前的行为），拿到尺寸再切。
-    final bool portrait =
-        aspect != null && aspect < LandscapeCoverImage.landscapeAspectThreshold;
+    final bool portrait = aspect != null && needsBackdropSeed(aspect);
 
     if (!portrait) {
       return ClipRect(
@@ -114,20 +120,7 @@ class _LandscapeCoverImageState extends State<LandscapeCoverImage>
       child: Stack(
         fit: StackFit.expand,
         children: <Widget>[
-          // 垫底：同图放大模糊（blur 溢出由外层 ClipRect 收口）。
-          ImageFiltered(
-            imageFilter: ImageFilter.blur(
-              sigmaX: LandscapeCoverImage.backdropBlurSigma,
-              sigmaY: LandscapeCoverImage.backdropBlurSigma,
-            ),
-            child: Image(
-              image: widget.image,
-              fit: BoxFit.cover,
-              // 垫底解码失败不接管整块（前景/流监听兜底），静默留空。
-              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-            ),
-          ),
-          const ColoredBox(color: LandscapeCoverImage.backdropDimColor),
+          ..._backdropLayers(context),
           // 遮罩压在模糊垫底上（保证文字可读），但压不到下面的清晰海报。
           ...widget.overlays,
           Padding(
@@ -144,6 +137,53 @@ class _LandscapeCoverImageState extends State<LandscapeCoverImage>
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  /// 前景之下的垫底层序（底 → 上）：主色底 → 模糊图（自身压暗）。
+  ///
+  /// 与 [PortraitCoverImage] 同一处修正：**压暗只作用于模糊图自身**
+  /// （[BlendMode.srcATop] 保留源 alpha）。旧实现把压暗铺成一整层 `ColoredBox`，
+  /// 图源带透明区时那层直接涂在空白上，卡片只剩一圈死灰；不透明图两种写法等价。
+  List<Widget> _backdropLayers(BuildContext context) {
+    return <Widget>[
+      if (_backdropDecoration(context) case final BoxDecoration decoration)
+        DecoratedBox(decoration: decoration),
+      // 压暗在内、模糊在外：压暗作用于**原图的 alpha**，透明区因此原样透出下面
+      // 的主色底；随后整体模糊，边缘羽化也跟着自然衰减。反过来嵌套（先模糊再压暗）
+      // 视觉几乎等价，但会把 ImageFiltered 从 Stack 的直接子节点上挪走，hero 的
+      // 层序守卫按类型认这一层（collection_hero_cover_orientation_test）。
+      ImageFiltered(
+        imageFilter: ImageFilter.blur(
+          sigmaX: LandscapeCoverImage.backdropBlurSigma,
+          sigmaY: LandscapeCoverImage.backdropBlurSigma,
+        ),
+        child: ColorFiltered(
+          colorFilter: const ColorFilter.mode(
+            LandscapeCoverImage.backdropDimColor,
+            BlendMode.srcATop,
+          ),
+          child: Image(
+            image: widget.image,
+            fit: BoxFit.cover,
+            // 垫底解码失败不接管整块（前景/流监听兜底），静默留空。
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ];
+  }
+
+  /// 主色底装饰；采样未完成 / 图源几乎不透明（不需要底色）时返回 null。
+  /// 墨水屏不上色（灰阶屏上有色底只会削对比）。
+  BoxDecoration? _backdropDecoration(BuildContext context) {
+    if (isEinkTheme(context)) return null;
+    final Color? seed = coverBackdropSeed;
+    if (seed == null) return null;
+    return BoxDecoration(
+      gradient: coverBackdropGradient(
+        harmonizeBackdrop(seed, Theme.of(context).brightness),
       ),
     );
   }

--- a/fushi/lib/src/media/video/cover_ui/portrait_cover_image.dart
+++ b/fushi/lib/src/media/video/cover_ui/portrait_cover_image.dart
@@ -2,6 +2,8 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/video/cover_ui/cover_aspect_probe.dart';
+import 'package:fushi/src/media/video/cover_ui/cover_backdrop_color.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 
 /// 槽向自适应封面（Kazumi 式，用户拍板 2026-07-24 统一竖版；BUG-1299 推广为
 /// 横竖槽通用）。
@@ -11,8 +13,8 @@ import 'package:fushi/src/media/video/cover_ui/cover_aspect_probe.dart';
 /// 竖版、无海报横版」的混排特例**：
 ///
 /// * 图片朝向与槽位一致（竖槽竖图 / 横槽横图）→ 直接 `BoxFit.cover` 铺满；
-/// * 朝向不一致（竖槽里的 16:9 截帧 / 横槽里的 2:3 海报）→ 同图两层：底层
-///   `cover` 放大 + 高斯模糊 + 半透明压暗垫底，前景 `contain` 居中完整显示；
+/// * 朝向不一致（竖槽里的 16:9 截帧 / 横槽里的 2:3 海报）→ 同图分层：主色底 +
+///   `cover` 放大高斯模糊（自身压暗）+ 前景 `contain` 居中完整显示；
 /// * 尺寸未知（首帧解码前）先按 `cover` 渲染，[ImageStream] 拿到尺寸后再切换，
 ///   避免先占位后闪换；
 /// * 加载/解码失败 → [errorBuilder]（通常是调用方的占位封面）。
@@ -62,6 +64,14 @@ class _PortraitCoverImageState extends State<PortraitCoverImage>
   @override
   ImageProvider probedImageOf(PortraitCoverImage widget) => widget.image;
 
+  /// 朝向是否不合槽 —— build 的渲染分支与主色采样开关共用的唯一判据。
+  bool _mismatch(double aspect) => widget.landscapeSlot
+      ? aspect < PortraitCoverImage.landscapeAspectThreshold
+      : aspect > PortraitCoverImage.portraitAspectThreshold;
+
+  @override
+  bool needsBackdropSeed(double aspect) => _mismatch(aspect);
+
   @override
   Widget build(BuildContext context) {
     if (coverFailed) {
@@ -69,10 +79,7 @@ class _PortraitCoverImageState extends State<PortraitCoverImage>
     }
     final double? aspect = coverAspect;
     // 朝向不合槽 = 垫底 + contain；首帧前（aspect 未知）按合槽 cover 渲染。
-    final bool mismatch = aspect != null &&
-        (widget.landscapeSlot
-            ? aspect < PortraitCoverImage.landscapeAspectThreshold
-            : aspect > PortraitCoverImage.portraitAspectThreshold);
+    final bool mismatch = aspect != null && _mismatch(aspect);
     final Widget foreground = Image(
       key: widget.imageKey,
       image: widget.image,
@@ -88,23 +95,59 @@ class _PortraitCoverImageState extends State<PortraitCoverImage>
       child: Stack(
         fit: StackFit.expand,
         children: <Widget>[
-          // 垫底：同图放大模糊（blur 溢出由外层 ClipRect 收口）。
-          ImageFiltered(
-            imageFilter: ImageFilter.blur(
-              sigmaX: PortraitCoverImage.backdropBlurSigma,
-              sigmaY: PortraitCoverImage.backdropBlurSigma,
-            ),
-            child: Image(
-              image: widget.image,
-              fit: BoxFit.cover,
-              // 垫底解码失败不接管整卡（前景/流监听兜底），静默留空。
-              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-            ),
-          ),
-          // 半透明压暗垫底，突出前景。
-          const ColoredBox(color: kCoverBackdropDimColor),
+          ..._backdropLayers(context),
           foreground,
         ],
+      ),
+    );
+  }
+
+  /// 前景之下的垫底层序（底 → 上）：主色底 → 模糊图（自身压暗）。
+  ///
+  /// **压暗只作用于模糊图自身**（[BlendMode.srcATop] 保留源 alpha），这是与旧
+  /// 实现的关键差别：旧实现把压暗铺成一整层 `ColoredBox`，图片带透明区时那层就
+  /// 直接涂在空白上——galgame 封面链末端的 exe 内嵌图标正是四周整片透明的立绘，
+  /// 模糊之后仍然透明，于是卡片只剩压暗色涂出来的一圈死灰。图片不透明时两种写法
+  /// 等价，所以这个缺陷一直藏着。
+  List<Widget> _backdropLayers(BuildContext context) {
+    return <Widget>[
+      if (_backdropDecoration(context) case final BoxDecoration decoration)
+        DecoratedBox(decoration: decoration),
+      // 压暗在内、模糊在外：压暗作用于**原图的 alpha**，透明区因此原样透出下面
+      // 的主色底；随后整体模糊，边缘羽化也跟着自然衰减。反过来嵌套（先模糊再压暗）
+      // 视觉几乎等价，但会把 ImageFiltered 从 Stack 的直接子节点上挪走，hero 的
+      // 层序守卫按类型认这一层（collection_hero_cover_orientation_test）。
+      ImageFiltered(
+        imageFilter: ImageFilter.blur(
+          sigmaX: PortraitCoverImage.backdropBlurSigma,
+          sigmaY: PortraitCoverImage.backdropBlurSigma,
+        ),
+        child: ColorFiltered(
+          colorFilter: const ColorFilter.mode(
+            kCoverBackdropDimColor,
+            BlendMode.srcATop,
+          ),
+          child: Image(
+            image: widget.image,
+            fit: BoxFit.cover,
+            // 垫底解码失败不接管整卡（前景/流监听兜底），静默留空。
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ];
+  }
+
+  /// 主色底装饰；采样未完成 / 图片几乎不透明（不需要底色）时返回 null。
+  ///
+  /// 墨水屏不上色：屏幕本就是灰阶，有色底只会把立绘背景压成中灰、削掉对比。
+  BoxDecoration? _backdropDecoration(BuildContext context) {
+    if (isEinkTheme(context)) return null;
+    final Color? seed = coverBackdropSeed;
+    if (seed == null) return null;
+    return BoxDecoration(
+      gradient: coverBackdropGradient(
+        harmonizeBackdrop(seed, Theme.of(context).brightness),
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1250,8 +1250,14 @@ class _HomeDashboardPageState
     List<_ContinueEntry> entries, {
     bool videoLandscape = false,
   }) {
+    // BUG-2002 同款几何：悬停放大是纯绘制变换（以卡中心放大），行视口高度恰等于
+    // 卡高时，溢出的上下各 (scale-1)/2 会被 ListView 视口裁成平边——横滚行每张卡
+    // 都贴着视口上下沿，不像墙格只有视口边缘才裁。行高留出余量、卡片自身尺寸不变；
+    // 不能改用 Clip.none：懒加载 cacheExtent 里已构建的卡会画到行外。
+    final double rowHeight = _continueRowHeight(context, tokens);
+    final double liftHeadroom = rowHeight * (kFushiHoverLiftScale - 1) / 2;
     return SizedBox(
-      height: _continueRowHeight(context, tokens),
+      height: rowHeight + liftHeadroom * 2,
       // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
       // 用鼠标左右拖会毫无反应。共享件统一放开 mouse/trackpad/stylus 拖动
       // （与合集行 CollectionShelfRow 同款）；触屏行为不变。
@@ -1457,11 +1463,32 @@ class _HomeDashboardPageState
   /// 灰副标题一行。显示名规则（非合集上下文拼合集名）：合集成员标题=合集名、
   /// 副标题=「条目名 · 状态」；散卡标题=条目名、副标题=状态。状态：书=「阅读 ·
   /// x%」/ 视频=「观看」，远端条目再缀设备名。
+  ///
+  /// 悬停抬升与视频库 / 书架 / 游戏库同一个壳 [FushiHoverLift]（内含墨水屏与
+  /// 「减弱动态效果」两处降级，以及 BUG-2124 的滚动压制）。首页这一行原先只有
+  /// InkWell 水波纹，鼠标悬停毫无反馈，与其余库页不一致。
   Widget _buildContinueCard(
     FushiDesignTokens tokens,
     AppModel appModel,
     _ContinueEntry entry, {
     bool videoLandscape = false,
+  }) {
+    return FushiHoverLift(
+      builder: (BuildContext _, bool __) => _buildContinueCardForOrientation(
+        tokens,
+        appModel,
+        entry,
+        videoLandscape: videoLandscape,
+      ),
+    );
+  }
+
+  /// 朝向探测 + 卡体（[_buildContinueCard] 的内层，悬停壳之下）。
+  Widget _buildContinueCardForOrientation(
+    FushiDesignTokens tokens,
+    AppModel appModel,
+    _ContinueEntry entry, {
+    required bool videoLandscape,
   }) {
     // 首页横滑行的视频卡：单行允许横竖混排（用户拍板「继续观看只有一行，混排
     // 不破排版；书架里不可以」）——朝向随**选图链选中的那张图**探测：titleCard /

--- a/fushi/test/widgets/cover_backdrop_color_test.dart
+++ b/fushi/test/widgets/cover_backdrop_color_test.dart
@@ -76,10 +76,18 @@ void main() {
       final Color tuned = harmonizeBackdrop(vivid, Brightness.dark);
       final HSLColor tunedHsl = HSLColor.fromColor(tuned);
 
-      expect(tunedHsl.hue, closeTo(seedHsl.hue, 1.0),
+      // 容差 2°：调制要经 HSL→8bit RGB 往返，饱和度压得越低量化误差越大
+      // （实测暗色档 0.26 下偏 1.15°）。这个量级肉眼不可辨，色相仍是留住的。
+      expect(tunedHsl.hue, closeTo(seedHsl.hue, 2.0),
           reason: '色相是与前景协调的依据，必须留住');
+      expect(tunedHsl.saturation,
+          lessThanOrEqualTo(kBackdropMaxSaturationDark + 0.01));
+      // 暗色收得更紧：同一颗种子在亮色主题下允许更高的饱和度。
       expect(
-          tunedHsl.saturation, lessThanOrEqualTo(kBackdropMaxSaturation + 0.01));
+        HSLColor.fromColor(harmonizeBackdrop(vivid, Brightness.light))
+            .saturation,
+        greaterThan(tunedHsl.saturation),
+      );
       expect(tunedHsl.lightness, closeTo(kBackdropDarkLightness, 0.02));
     });
 

--- a/fushi/test/widgets/cover_backdrop_color_test.dart
+++ b/fushi/test/widgets/cover_backdrop_color_test.dart
@@ -1,0 +1,191 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/cover_ui/cover_aspect_probe.dart';
+import 'package:fushi/src/media/video/cover_ui/cover_backdrop_color.dart';
+import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
+
+/// 封面「模糊垫底」在图源自带透明区时的底色补全。
+///
+/// 原始失败路径：galgame 封面链末端是 exe 内嵌图标（PE 资源里解出的 PNG），
+/// 实测 256×256 方图、约一半像素全透明。方图两种槽向都判「不合槽」→ 走垫底；
+/// 而垫底是「同图放大 + 模糊」，透明的图模糊之后还是透明，于是那层
+/// `Color(0x59000000)` 的压暗直接涂在卡片底色上——用户看到的就是立绘四周一圈死灰。
+void main() {
+  /// 画一张 [width]×[height] 的图：左半边纯色、右半边**留空（全透明）**，
+  /// 用来模拟去背立绘。[opaque] 为 true 时整张铺满（对照组：普通不透明封面）。
+  Future<ui.Image> halfTransparentImage(
+    int width,
+    int height, {
+    required Color color,
+    bool opaque = false,
+  }) async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final ui.Canvas canvas = ui.Canvas(recorder);
+    canvas.drawRect(
+      ui.Rect.fromLTWH(
+        0,
+        0,
+        opaque ? width.toDouble() : width / 2,
+        height.toDouble(),
+      ),
+      ui.Paint()..color = color,
+    );
+    return recorder.endRecording().toImage(width, height);
+  }
+
+  group('sampleCoverBackdropSeed', () {
+    test('去背立绘：取到非透明区的主色，并报出真实不透明比例', () async {
+      final ui.Image image = await halfTransparentImage(
+        64,
+        64,
+        color: const Color(0xFFCC3366),
+      );
+      addTearDown(image.dispose);
+
+      final CoverBackdropSeed? seed = await sampleCoverBackdropSeed(image);
+
+      expect(seed, isNotNull, reason: '半透明图必须给出底色，否则垫底还是空的');
+      // 只统计非透明像素：主色应当就是画上去的那个颜色，而不是被透明区拉向黑。
+      expect(seed!.color.r, closeTo(0xCC / 255, 0.02));
+      expect(seed.color.g, closeTo(0x33 / 255, 0.02));
+      expect(seed.color.b, closeTo(0x66 / 255, 0.02));
+      expect(seed.opaqueRatio, closeTo(0.5, 0.05));
+    });
+
+    test('普通不透明封面：返回 null —— 模糊垫底本就能铺满，不必多铺一层', () async {
+      final ui.Image image = await halfTransparentImage(
+        64,
+        64,
+        color: const Color(0xFF2244AA),
+        opaque: true,
+      );
+      addTearDown(image.dispose);
+
+      expect(await sampleCoverBackdropSeed(image), isNull);
+    });
+  });
+
+  group('harmonizeBackdrop', () {
+    test('保留色相，收掉过高饱和度——立绘主色常常很艳，铺满整卡会喧宾夺主', () {
+      const Color vivid = Color(0xFFFF0080); // 饱和度 1.0 的荧光粉
+      final HSLColor seedHsl = HSLColor.fromColor(vivid);
+
+      final Color tuned = harmonizeBackdrop(vivid, Brightness.dark);
+      final HSLColor tunedHsl = HSLColor.fromColor(tuned);
+
+      expect(tunedHsl.hue, closeTo(seedHsl.hue, 1.0),
+          reason: '色相是与前景协调的依据，必须留住');
+      expect(
+          tunedHsl.saturation, lessThanOrEqualTo(kBackdropMaxSaturation + 0.01));
+      expect(tunedHsl.lightness, closeTo(kBackdropDarkLightness, 0.02));
+    });
+
+    test('亮度按主题钉死，不随图片明暗漂移', () {
+      const Color dark = Color(0xFF101014);
+      const Color light = Color(0xFFF2F0EC);
+      for (final Color seed in <Color>[dark, light]) {
+        expect(
+          HSLColor.fromColor(harmonizeBackdrop(seed, Brightness.light))
+              .lightness,
+          closeTo(kBackdropLightLightness, 0.02),
+        );
+        expect(
+          HSLColor.fromColor(harmonizeBackdrop(seed, Brightness.dark)).lightness,
+          closeTo(kBackdropDarkLightness, 0.02),
+        );
+      }
+    });
+  });
+
+  group('PortraitCoverImage 垫底层序', () {
+    /// 把 [image] 编码成 PNG 交给 [MemoryImage]（保留 alpha 通道）。
+    Future<Uint8List> pngOf(ui.Image image) async {
+      final ByteData? data =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      return data!.buffer.asUint8List();
+    }
+
+    /// 主色底层：带渐变的 [DecoratedBox]。
+    Iterable<DecoratedBox> tintedLayers(WidgetTester tester) => tester
+        .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+        .where((DecoratedBox b) =>
+            b.decoration is BoxDecoration &&
+            (b.decoration as BoxDecoration).gradient != null);
+
+    Future<void> pumpCover(WidgetTester tester, MemoryImage provider) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 100,
+              height: 150,
+              child: PortraitCoverImage(image: provider),
+            ),
+          ),
+        ),
+      );
+      // 真实解码 + 异步主色采样都在 runAsync 区里跑完，再 pump 应用 setState。
+      // 采样要 `toByteData` 走一趟引擎，不是一个微任务能等到的——轮着 pump，
+      // 直到底色层出现或超时（固定 delay 容易在慢机上假红）。
+      await tester.runAsync<void>(
+        () => precacheImage(provider, tester.element(find.byType(Image).first)),
+      );
+      await tester.pump();
+      for (int i = 0; i < 40; i++) {
+        await tester.runAsync<void>(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)),
+        );
+        await tester.pump();
+        if (tintedLayers(tester).isNotEmpty) break;
+      }
+    }
+
+    /// 找铺满槽位的纯压暗层：旧实现用它把 `Color(0x59000000)` 涂满整张卡。
+    Finder flatDimLayer() => find.byWidgetPredicate(
+          (Widget w) => w is ColoredBox && w.color == kCoverBackdropDimColor,
+        );
+
+    testWidgets('去背立绘：铺主色底，且压暗不再涂在透明区上', (WidgetTester tester) async {
+      final ui.Image raw = (await tester.runAsync<ui.Image>(
+        () => halfTransparentImage(64, 64, color: const Color(0xFFCC3366)),
+      ))!;
+      addTearDown(raw.dispose);
+      final MemoryImage provider =
+          MemoryImage((await tester.runAsync<Uint8List>(() => pngOf(raw)))!);
+
+      await pumpCover(tester, provider);
+
+      // 方图不合竖槽 → 走垫底路径。
+      expect(find.byType(ImageFiltered), findsOneWidget);
+      expect(
+        flatDimLayer(),
+        findsNothing,
+        reason: '压暗一旦铺成整层 ColoredBox，透明区就会被涂成死灰——正是本次修复的现象',
+      );
+      expect(
+        tintedLayers(tester),
+        isNotEmpty,
+        reason: '透明立绘必须拿到由自身主色算出的底色，否则背景仍是一片灰',
+      );
+    });
+
+    testWidgets('不透明封面：不额外铺底色（模糊垫底本就铺满，观感零变化）',
+        (WidgetTester tester) async {
+      final ui.Image raw = (await tester.runAsync<ui.Image>(
+        () => halfTransparentImage(64, 64,
+            color: const Color(0xFF2244AA), opaque: true),
+      ))!;
+      addTearDown(raw.dispose);
+      final MemoryImage provider =
+          MemoryImage((await tester.runAsync<Uint8List>(() => pngOf(raw)))!);
+
+      await pumpCover(tester, provider);
+
+      expect(find.byType(ImageFiltered), findsOneWidget);
+      expect(tintedLayers(tester), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 起因

用户两点诉求：
1. 首页的卡片也加上鼠标悬停放大；
2. 「柚子社这种能弄的更好看点」——附截图，游戏卡的立绘四周是一圈死灰。

## 1. 首页悬停放大

首页「继续 / 最近添加」两行原先只有 InkWell 水波纹，鼠标悬停毫无反馈，与视频库 /
书架 / 游戏库不一致。复用共享壳 `FushiHoverLift`（自带墨水屏与「减弱动态效果」两处
降级，以及 BUG-2124 的滚动压制），不另立动效数值。

行高按 BUG-2002 同款几何留出放大溢出余量——悬停放大是纯绘制变换、以卡中心放大，
行视口高度恰等于卡高时上下各 `(scale-1)/2` 会被 ListView 裁成平边。

## 2. 死灰底：根因两层

先用真实数据定位：那些封面是 galgame 封面链末端的 **exe 内嵌图标**
（`extractLargestIconPng` 从 PE 资源解出的 PNG），实测 **256×256 方图、约 52% 像素
全透明**。方图在两种槽向下都判「不合槽」→ 必走模糊垫底。

根因都在「模糊垫底」这套手法的隐含假设上——它默认图源是不透明的照片：

1. **压暗层铺成一整层 `ColoredBox` 盖在整个槽位上**。图不透明时它与「只压模糊图」
   逐像素等价，所以这个缺陷一直藏着；一旦图带透明区，那层 `Color(0x59000000)` 就
   直接涂在卡片底色上。
2. **垫底图本身就是同一张透明图**，模糊之后仍然透明，等于什么都没画。

### 修法（不给透明图另开分支）

- 压暗改成**只作用于模糊图自身**（`srcATop` 保留源 alpha）。嵌套是压暗在内、模糊在
  外：压暗作用于原图 alpha，透明区原样透出下层，边缘羽化也跟着自然衰减。
- 垫底补上它一直缺的底层：由图片非透明像素加权平均算出的**主色底**，收掉过高饱和度、
  亮度按主题钉死，摊成纵向渐变。色相取自立绘本身，因此与前景天然协调。
  **图片不透明时采样返回 null，不铺这一层，观感零变化。**

采样挂在宽高比探测的同一个 `ui.Image` 上（不额外解码），并由 `needsBackdropSeed`
门控——只有真会走垫底的图才采样，合槽 `cover` 的图看不到底色，白采就是浪费
（`toByteData` 要把整图 RGBA 拉出来，墙格几十张卡不是小数）。该判据与 build 的
mismatch 分支同源，避免两处漂移。

墨水屏不上色（灰阶屏上有色底只会削对比）。`LandscapeCoverImage`（宽幅 hero 槽）
是同一手法的镜像，同步修掉。

## 验证

- 全量 `flutter analyze`（含 test 目录）：No issues found。
- 定向测试：封面组件与消费方共 **96 条全绿**
  （`cover_backdrop_color` / `portrait_cover_image` / `cover_aspect_probe` /
  `collection_hero_cover_orientation` / `continue_cover_portrait_guard` /
  `home_dashboard_page` / `video_card_cover_aspect_guard` / `video_cover_fit_guard` /
  `games_library_cover_menu` / `home_video_collection_cover_card` /
  `video_episode_rail_cover` / `shelf_collection_cover_borrow_full_corpus_guard` /
  `home_video_hover_lift` / `fushi_hover_lift` / `home_dashboard_scroll_controller_wiring` /
  `home_video_wall_hover_scroll`）。
- 新增守卫 `test/widgets/cover_backdrop_color_test.dart`：采样语义（透明图给主色 +
  真实不透明比例／不透明图返回 null）、调制语义（留色相、收饱和、亮度按主题钉死）、
  以及层序（压暗不得再铺成整层 `ColoredBox`、透明图必须拿到主色底）。
- **观感取证**：拿用户库里的三张真实封面离屏渲染了修前/修后对比（亮色 + 暗色两版），
  已回传给用户确认。暗色档的饱和上限是照着这组图调的——沿用亮色的 0.42 时暖色相在
  0.22 亮度下会读成脏橄榄褐（柚子社那张全黄 logo 最明显），收到 0.26。

## 审查提示

`collection_hero_cover_orientation_test` 的层序守卫按类型在 Stack 直接子节点里找
`ImageFiltered`，这限制了两个滤镜的嵌套方向；代码里已注明，改动它时留意。
