### PR TITLE
fix(video): 查词浮层重播本句时字幕不再被遮回去（BUG-2235）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2064 条。点号进各自文件。
+> 共 2065 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2235](bugs/BUG-2235-subtitle-hide-lookup-replay-reobscures.md) | ✅ | ✅ | 隐藏字幕在查词浮层重播时又被遮回去 |
 | [BUG-2230](bugs/BUG-2230-video-web-and-work-detail-loading-no-exit.md) | ✅ | ✅ | 网页流媒体页与作品详情页的加载态没有返回入口，且 init 异常无归宿 |
 | [BUG-2229](bugs/BUG-2229-video-missing-resource-no-back.md) | ✅ | ✅ | 视频资源缺失态没有返回入口，进入后无法退出 |
 | [BUG-2204](bugs/BUG-2204-srt-cue-tail-overlap-jumps-to-later-sentence.md) | ✅ | ✅ | 听书 ASR 字幕前句多吃下一句首字，后句跳到远处同前缀句、中间十几句全未匹配 |

--- a/docs/bugs/BUG-2235-subtitle-hide-lookup-replay-reobscures.md
+++ b/docs/bugs/BUG-2235-subtitle-hide-lookup-replay-reobscures.md
@@ -1,0 +1,30 @@
+## BUG-2235 · 隐藏字幕在查词浮层重播时又被遮回去
+- **报告**：2026-09-07（用户：「隐藏字幕、暂停、查词点重播按钮会让字幕隐藏」）
+- **真实性**：✅ 真 bug — 根因 `fushi/lib/src/media/video/video_subtitle_overlay.dart:1906`（修前）：
+  `final bool obscureActive = !revealed && widget.controller.isPlaying;`。
+  这是 BUG-2198 统一模糊 / 隐藏两条门时留下的判据，但 `isPlaying` 只是「用户已经停下来
+  在看这句」的**近似**——查词让位靠的是「查词第一步 `controller.pause()`」这个副作用，
+  而不是「查词中」本身。查词浮层顶栏的「重播本句」
+  （`fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart:216`
+  `_replayLookupCue` → `VideoPlayerController.replayCue`）会把播放拉起来，于是刚让位的
+  字幕在重播那几秒当场被遮回去：用户正对着浮层核对原句，字幕消失。
+  同一个 `obscureActive` 还门控着 `registerHits`（`video_subtitle_overlay.dart` 的
+  `hidden`）——遮回去的同时字符也不再登记查词命中，浮层里想点旁边的词换一个都点不到。
+  两种视觉（模糊 / 隐藏）、主 / 副字幕四种组合同此一门，故全部中招。
+- **[x] ① 已修复** — 把让位的判据从「没在播」换成它真正要表达的东西：**用户在看** =
+  暂停（含查词自动暂停）**或**查词浮层还开着。
+  `video_subtitle_overlay.dart` 新增输入 `lookupPopupVisible`（默认 false = 无查词浮层的
+  宿主行为不变），门变成 `obscureActive = !revealed && !userIsReading`，
+  `userIsReading = !isPlaying || lookupPopupVisible`；判据仍只有一份，模糊 / 隐藏、
+  主 / 副字幕共用，不新增分支。页面侧 `video_fushi/layout.part.dart` 传既有派生真相源
+  `_hasVisiblePopup`（与 BUG-2091 高亮同一个信号，栈全关自动复位，不存在只在成功路径
+  复位的布尔镜像）。关栈那一帧遮蔽自动回来，不需要复位显形态。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_lookup_replay_reveal_test.dart`
+  （7 条：隐藏 / 模糊 / 副字幕在「播放中 + 浮层可见」时让位、浮层关掉照常遮蔽的防伪修复
+  基准、关栈下一帧遮回、让位期间字符仍可点选查词、layout 接线与「重播确实起播」的源码
+  守卫）。变异实测：把门改回 `!widget.controller.isPlaying`，5 条断言红（隐藏 / 模糊 /
+  副字幕 / registerHits / 跨帧），不是空壳断言。既有 BUG-2198 / TODO-1382 守卫同批复跑，
+  47 条全绿。
+- **备注**：与 BUG-2198 是同一处门的两次收敛——2198 修的是「暂停不让位」，本条修的是
+  「让位判据用了暂停这个代理量」。若日后「重播本句」改成不起播（或另开静音预听），本门
+  仍然正确，只是那条前提守卫会提示复核。

--- a/fushi/lib/src/media/video/video_subtitle_overlay.dart
+++ b/fushi/lib/src/media/video/video_subtitle_overlay.dart
@@ -461,6 +461,7 @@ class VideoSubtitleOverlay extends StatefulWidget {
     this.secondaryBlurEnabled = false,
     this.secondaryHidden = false,
     this.obscureRevealOnInteraction = true,
+    this.lookupPopupVisible = false,
     this.fontSize = 36,
     this.textColor,
     this.fontWeight = VideoSubtitleStyle.defaultFontWeight,
@@ -548,8 +549,9 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 未显形时不登记查词命中（看不见的字不可点选），仍不影响查词浮层 / 字幕列表 /
   /// cue 同步等其它文本通道。
   ///
-  /// BUG-2198：与 [blurEnabled] 一样只在**播放中**遮蔽——暂停（含查词自动暂停）时
-  /// 字幕照常显示、字符也照常可点选查词，恢复播放即自动遮回去。
+  /// BUG-2198：与 [blurEnabled] 一样只在**用户没在看**时遮蔽——暂停（含查词自动暂停）
+  /// 时字幕照常显示、字符也照常可点选查词，恢复播放即自动遮回去。BUG-2235：查词浮层
+  /// 开着（[lookupPopupVisible]）也算「在看」，浮层里「重播本句」起播不再遮回去。
   final bool subtitleHidden;
 
   /// 副字幕「模糊」（TODO-1382，镜像 [blurEnabled]）：为 true 时**副字幕层**默认高斯模糊，
@@ -560,7 +562,7 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 不绘制（[Opacity] 为 0），与 [secondaryBlurEnabled] 正交且优先级更高。默认 false。
   /// 与主字幕同构：悬停 / 点击可临时显形，未显形时不登记查词命中。隐藏只针对副字幕
   /// overlay，不影响查词 / 字幕列表 / cue 同步等其它通道。BUG-2198：同样只在播放中
-  /// 遮蔽（暂停 / 查词时显示），与 [subtitleHidden] 一条门。
+  /// 遮蔽（暂停 / 查词浮层开着时显示），与 [subtitleHidden] 一条门。
   final bool secondaryHidden;
 
   /// 遮蔽态是否允许「悬停 / 点击临时显形」（默认 true = 历史行为）。
@@ -575,6 +577,16 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// 态字符仍登记在查词表里，撤掉热区就成了「点不可见的字也能查词」）。主 / 副字幕共用
   /// 本开关（用户诉求是「显形这个行为」的总闸，不是逐层设置）。
   final bool obscureRevealOnInteraction;
+
+  /// 查词浮层栈此刻是否还有可见层（BUG-2235，页面侧 `_hasVisiblePopup` 的派生值）。
+  ///
+  /// 遮蔽让位的真值是「用户已经停下来在看这句」，[VideoPlayerController.isPlaying]
+  /// 只是它的**近似**：查词浮层顶栏的「重播本句」（`_replayLookupCue`）会把播放拉起来，
+  /// 于是 BUG-2198 刚让位的字幕在重播那几秒里又被遮回去——用户正对着浮层核对原句，
+  /// 字幕却当场消失，同一条门还连带把字符命中登记（`registerHits`）关掉、点都点不到。
+  /// 查词会话期间字幕恒定让位，关栈下一帧自动遮回去。
+  /// false（有声书 / 测试 / 无查词浮层的宿主）= 只由播放状态决定，行为与历史一致。
+  final bool lookupPopupVisible;
 
   /// 字幕字号（外观设置）。
   final double fontSize;
@@ -1260,8 +1272,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     List<AudioCue> cues, {
     required bool isSecondary,
   }) {
-    // 遮蔽只在播放中生效（暂停 / 查词时清晰，BUG-199 / BUG-2198）：模糊与隐藏共用
-    // **同一条**门——该层开着遮蔽、当前未显形、且正在播放。历史上隐藏单独绕过
+    // 遮蔽只在「用户没在看」时生效（暂停 / 查词时清晰，BUG-199 / BUG-2198 / BUG-2235）：
+    // 模糊与隐藏共用**同一条**门——该层开着遮蔽、当前未显形、且用户没在看。历史上隐藏单独绕过
     // isPlaying（「暂停时自己冒出来才是惊吓」），实测这条特例正是用户报的两个症状：
     // ① 查词必先 `controller.pause()`（`lookup_favorite.part.dart`），暂停不解遮蔽
     //    就等于「查词时字幕仍然看不见」，而 registerHits 又按 [hidden] 关掉了字符命中
@@ -1274,7 +1286,11 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     final bool revealed = _revealedFor(isSecondary: isSecondary);
     // 该层此刻是否应遮蔽（与具体视觉无关的共同门）：模糊与隐藏只在这一处分叉成两种
     // 视觉，判据本身不再有第二份。
-    final bool obscureActive = !revealed && widget.controller.isPlaying;
+    // 「用户在看」= 暂停（含查词自动暂停）**或**查词浮层还开着（BUG-2235：浮层里点
+    // 「重播本句」会起播，只看 isPlaying 会在重播期间把字幕遮回去）。
+    final bool userIsReading =
+        !widget.controller.isPlaying || widget.lookupPopupVisible;
+    final bool obscureActive = !revealed && !userIsReading;
     final bool blurred = obscureBlurEnabled && obscureActive;
     // 隐藏态（该层开着「隐藏」且该遮蔽）。与 [blurred] 互斥（两者来自互斥的
     // VideoSubtitleObscureMode），但共用同一个显形态：悬停 / 点击即显形。

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -466,6 +466,10 @@ extension _VideoLayout on _VideoFushiPageState {
                             // 隐藏不再被悬停或点击临时揭开，主 / 副字幕同时生效。
                             obscureRevealOnInteraction:
                                 appModel.videoSubtitleObscureReveal,
+                            // BUG-2235：查词浮层还开着就算「用户在看」，遮蔽让位到
+                            // 关栈为止——否则浮层顶栏「重播本句」一起播，刚让位的
+                            // 字幕在重播那几秒又被遮回去（用户正对着浮层核对原句）。
+                            lookupPopupVisible: _hasVisiblePopup,
                             // TODO-1199：字幕字号=用户基准 × 屏幕自适应因子。用户设置的
                             // fontSize 仍是基准（手动可调、不被改写），渲染时乘按视口短边
                             // 算出的 [subtitleScreenScaleFactor]，使字幕占屏比例在小屏手机 /

--- a/fushi/test/media/video/video_subtitle_lookup_replay_reveal_test.dart
+++ b/fushi/test/media/video/video_subtitle_lookup_replay_reveal_test.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_overlay.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+/// BUG-2235：遮蔽字幕在**查词浮层的「重播本句」**期间又被遮回去。
+///
+/// 用户诉求原话：「隐藏字幕、暂停、查词点重播按钮会让字幕隐藏」。
+///
+/// 根因：BUG-2198 把「遮蔽让位」的判据统一成了 `!revealed && controller.isPlaying`，
+/// 而 `isPlaying` 只是「用户已经停下来在看这句」的**近似**。查词浮层顶栏的「重播本句」
+/// （`video_fushi/lookup_favorite.part.dart` 的 `_replayLookupCue` → `replayCue`）会把
+/// 播放拉起来，于是查词刚让位的字幕在重播那几秒当场消失——用户正对着浮层核对原句。
+/// 且同一条门还门控着 `registerHits`：遮回去的同时字符也不再可点，浮层里换词都点不到。
+///
+/// 修法：让位的真值改成「用户在看」= 暂停 **或** 查词浮层还开着
+/// （[VideoSubtitleOverlay.lookupPopupVisible] ← 页面 `_hasVisiblePopup`）。判据仍只有
+/// 一份，模糊 / 隐藏、主 / 副字幕共用。
+///
+/// 分两层验证：
+///  ① overlay 真行为——播放中 + 浮层可见 = 不遮蔽；浮层关掉立刻遮回去（防「一刀关掉遮蔽」
+///     式伪修复）；模糊 / 副字幕同一条门；显形期间字符照常登记查词命中。
+///  ② 接线守卫（源码扫描）——layout 必须把 `_hasVisiblePopup` 传进 overlay，且重播确实
+///     会起播（本 bug 成立的前提，改掉重播语义时本条提醒同步复核）。
+AudioCue _cue(String text, int startMs, int endMs) => AudioCue()
+  ..bookKey = 'b'
+  ..chapterHref = 'ch'
+  ..sentenceIndex = 0
+  ..textFragmentId = ''
+  ..text = text
+  ..startMs = startMs
+  ..endMs = endMs
+  ..audioFileIndex = 0;
+
+/// 该 widget 是否被某个 `opacity == 0` 的 [Opacity] 祖先包住（= 布局在、不绘制）。
+bool _obscured(WidgetTester tester, Finder of) => tester
+    .widgetList<Opacity>(
+        find.ancestor(of: of.first, matching: find.byType(Opacity)))
+    .any((Opacity o) => o.opacity == 0);
+
+/// 该 widget 是否被 [ImageFiltered] 祖先包住（= 模糊态的视觉）。测试 cue 不带 ASS
+/// `\blur`，字幕树里唯一的 ImageFiltered 只可能是遮蔽层。
+bool _blurred(WidgetTester tester, Finder of) => tester
+    .widgetList<ImageFiltered>(
+        find.ancestor(of: of.first, matching: find.byType(ImageFiltered)))
+    .isNotEmpty;
+
+/// 重播中的控制器：**正在播放**（这正是本 bug 的触发条件——暂停态早被 BUG-2198 覆盖）。
+VideoPlayerController _playingController(
+  WidgetTester tester, {
+  String main = '主',
+  String? secondary,
+}) {
+  final VideoPlayerController c = VideoPlayerController();
+  addTearDown(c.dispose);
+  c.setCues(<AudioCue>[_cue(main, 0, 6000)]);
+  if (secondary != null) {
+    c.setSecondaryCues(<AudioCue>[_cue(secondary, 0, 6000)]);
+  }
+  c.debugUpdateCueForPosition(1000);
+  c.debugSetIsPlayingForTesting(true);
+  return c;
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  VideoPlayerController c, {
+  bool subtitleHidden = false,
+  bool secondaryHidden = false,
+  bool blurEnabled = false,
+  bool lookupPopupVisible = false,
+  void Function(
+          String sentence, int graphemeIndex, Rect charRect, AudioCue cue)?
+      onCharTap,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(
+        controller: c,
+        subtitleHidden: subtitleHidden,
+        secondaryHidden: secondaryHidden,
+        blurEnabled: blurEnabled,
+        lookupPopupVisible: lookupPopupVisible,
+        onCharTap: onCharTap,
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+void main() {
+  group('BUG-2235 ① 查词浮层开着时遮蔽让位（哪怕在播放）', () {
+    testWidgets('hidden + 播放中 + 浮层可见：字幕可见（重播本句不再把它遮回去）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+
+      await _pump(tester, c, subtitleHidden: true, lookupPopupVisible: true);
+
+      expect(find.text('主'), findsWidgets);
+      expect(_obscured(tester, find.text('主')), isFalse,
+          reason: '查词会话期间字幕恒定让位——重播起播不是「用户不看了」');
+    });
+
+    testWidgets('hidden + 播放中 + 浮层已关：照常遮蔽（防一刀关掉遮蔽的伪修复）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+
+      await _pump(tester, c, subtitleHidden: true);
+
+      expect(_obscured(tester, find.text('主')), isTrue,
+          reason: '让位只在查词会话内；关栈恢复播放后该遮还得遮');
+    });
+
+    testWidgets('关掉浮层的那一帧立刻遮回去（同一 controller 仍在播）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+
+      await _pump(tester, c, subtitleHidden: true, lookupPopupVisible: true);
+      expect(_obscured(tester, find.text('主')), isFalse, reason: '前置：查词中可见');
+
+      await _pump(tester, c, subtitleHidden: true);
+
+      expect(_obscured(tester, find.text('主')), isTrue,
+          reason: '关栈 = 查词结束，遮蔽下一帧自动回来（不靠复位显形态）');
+    });
+
+    testWidgets('blur 走同一条门：播放中 + 浮层可见不糊（模糊 / 隐藏对称）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+
+      await _pump(tester, c, blurEnabled: true, lookupPopupVisible: true);
+
+      expect(_blurred(tester, find.text('主')), isFalse,
+          reason: '两种视觉共用一条判据，不得再长出第二份');
+    });
+
+    testWidgets('blur + 浮层已关：照常模糊（对称基准）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+
+      await _pump(tester, c, blurEnabled: true);
+
+      expect(_blurred(tester, find.text('主')), isTrue);
+    });
+
+    testWidgets('副字幕同一条门：播放中 + 浮层可见时也让位', (tester) async {
+      final VideoPlayerController c =
+          _playingController(tester, secondary: '副');
+
+      await _pump(tester, c,
+          subtitleHidden: true,
+          secondaryHidden: true,
+          lookupPopupVisible: true);
+
+      expect(_obscured(tester, find.text('副')), isFalse,
+          reason: '副字幕的遮蔽与主字幕共用「用户在看」判据');
+      expect(_obscured(tester, find.text('主')), isFalse);
+    });
+
+    testWidgets('让位期间字符照常可点选查词（registerHits 同一条门）', (tester) async {
+      final VideoPlayerController c = _playingController(tester);
+      final List<String> taps = <String>[];
+
+      await _pump(
+        tester,
+        c,
+        subtitleHidden: true,
+        lookupPopupVisible: true,
+        onCharTap: (String sentence, int index, Rect rect, AudioCue cue) =>
+            taps.add('$sentence@$index'),
+      );
+      await tester.tap(find.text('主').first, warnIfMissed: false);
+      await tester.pump();
+
+      expect(taps, isNotEmpty, reason: '看得见就必须点得到——浮层里换词全靠这条命中登记');
+    });
+  });
+
+  group('BUG-2235 ② 接线守卫（源码扫描）', () {
+    String readSrc(String path) => File(path).readAsStringSync();
+
+    test('layout 把查词浮层可见性传进字幕 overlay', () {
+      final String src =
+          readSrc('lib/src/pages/implementations/video_fushi/layout.part.dart');
+      expect(src, contains('lookupPopupVisible: _hasVisiblePopup'),
+          reason: 'overlay 侧修好了但页面不传 = 用户侧毫无变化');
+    });
+
+    test('查词浮层「重播本句」确实会起播（本 bug 成立的前提）', () {
+      final String src = readSrc(
+          'lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart');
+      expect(src, contains('_replayLookupCue'));
+      expect(src, contains('controller.replayCue(cue)'),
+          reason: '重播语义若改动，需同步复核「查词中让位」这条门是否仍必要');
+    });
+  });
+}


### PR DESCRIPTION
## BUG-2235 · 隐藏字幕在查词浮层「重播本句」时又被遮回去

用户报：「隐藏字幕、暂停、查词点重播按钮会让字幕隐藏」。

### 根因
BUG-2198 把遮蔽让位的判据统一成 `!revealed && controller.isPlaying`
（`fushi/lib/src/media/video/video_subtitle_overlay.dart`），但 `isPlaying` 只是
「用户已经停下来在看这句」的**近似**——查词能让位，靠的是「查词第一步 `controller.pause()`」
这个副作用，而不是「查词中」本身。

查词浮层顶栏的「重播本句」（`video_fushi/lookup_favorite.part.dart` 的
`_replayLookupCue` → `VideoPlayerController.replayCue`）会把播放拉起来，于是刚让位的字幕
在重播那几秒当场被遮回去；同一个判据还门控着 `registerHits`，遮回去的同时字符不再登记
查词命中——浮层里想点旁边的词换一个都点不到。模糊/隐藏 × 主/副字幕四种组合同此一门。

### 修法
把判据换成它真正要表达的东西：**用户在看** = 暂停（含查词自动暂停）**或**查词浮层还开着。

- overlay 新增输入 `lookupPopupVisible`（默认 false = 无查词浮层的宿主行为不变）；
  门变成 `obscureActive = !revealed && !userIsReading`，
  `userIsReading = !isPlaying || lookupPopupVisible`。判据仍只有一份，不新增分支。
- 页面侧 `video_fushi/layout.part.dart` 传既有派生真相源 `_hasVisiblePopup`
  （与 BUG-2091 高亮同一个信号，栈全关自动复位，不是只在成功路径复位的布尔镜像）。
- 关栈那一帧遮蔽自动回来，不需要复位显形态。

### 验证
- 新增 `fushi/test/media/video/video_subtitle_lookup_replay_reveal_test.dart` 7 条：
  隐藏/模糊/副字幕在「播放中 + 浮层可见」时让位、浮层关掉照常遮蔽的防伪修复基准、
  关栈下一帧遮回、让位期间字符仍可点选查词、layout 接线 + 「重播确实起播」源码守卫。
- **变异实测**：把门改回 `!widget.controller.isPlaying` → 5 条断言红（隐藏/模糊/副字幕/
  registerHits/跨帧），不是空壳断言。
- 本域定向 73 条绿（含既有 BUG-2198 / TODO-1382 守卫），`flutter analyze` 零问题。

真机复测未做（本轮为纯 widget 层门控改动，overlay 行为已由 widget 测试直接钉住）。

https://claude.ai/code/session_01Kte3UBNY6f9p23B61WKBVv
