### PR TITLE
docs(readme): 致谢补齐引擎/端上模型/内容源三张表（17 语同步）

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The three lanes are the update channels the app itself offers, and each is scale
 
 Fushi builds on the following projects and ecosystem:
 
+### Learning tools and prior art
+
 | Project | Description |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Japanese immersive learning tool |
@@ -151,6 +153,48 @@ Fushi builds on the following projects and ecosystem:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Reader, statistics, and sync compatibility reference |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter video playback framework (libmpv core) |
 | [Niratan](https://github.com/W1ght/Niratan) | Immersion language learning suite for macOS |
+
+### Engines and native components
+
+| Project | Description |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Galgame text hooking engine (vendored DLLs loaded by the injector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Inline hooking library used by the galgame injector |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Built-in torrent download engine |
+| [mpv](https://github.com/mpv-player/mpv) | libmpv playback core behind media_kit |
+| [FFmpeg](https://ffmpeg.org) | Media probing, clipping, and audio extraction |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU video shaders and HDR tone mapping |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | WebView engine that renders the EPUB reader |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | On-device inference for speech recognition and OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dictionary engine dependencies |
+
+### On-device models
+
+| Project | Description |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer speech recognition model packages and VAD builds |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Japanese speech recognition model |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Multilingual CTC speech recognition model |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Voice activity detection model |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Manga OCR model |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Manga text and speech bubble detection model |
+
+### Content sources and integrations
+
+| Project | Description |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Manga source extension ecosystem |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Manga extension runtime for desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | Manga source runtime ABI |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Streaming subtitle bridge reference for the browser extension |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Anime identification and scraping architecture reference |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Galgame library information architecture reference |
+| [AniDB](https://anidb.net) | Anime, episode, and file identity |
+| [TMDB](https://www.themoviedb.org) | Supplementary metadata and artwork |
+| [Jimaku](https://jimaku.cc) | Japanese subtitle source |
+| [OpenSubtitles](https://www.opensubtitles.com) | Subtitle source |
+
+> This application uses TMDB and the TMDB APIs but is not endorsed, certified, or otherwise approved by TMDB.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,6 +137,8 @@ Fushi 将导入的书籍、词典、字体、有声书数据、视频、阅读�
 
 Fushi 基于以下项目与生态：
 
+### 学习工具与前作参考
+
 | 项目 | 说明 |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | 日语沉浸式学习工具 |
@@ -151,6 +153,48 @@ Fushi 基于以下项目与生态：
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | 阅读器、统计与同步兼容性参考 |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter 视频播放框架（libmpv 内核） |
 | [Niratan](https://github.com/W1ght/Niratan) | macOS 沉浸式语言学习套件 |
+
+### 引擎与原生组件
+
+| 项目 | 说明 |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | galgame 文本 hook 引擎（vendored DLL，由注入器加载） |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | galgame 注入器使用的 inline hook 库 |
+| [libtorrent](https://github.com/arvidn/libtorrent) | 内置 torrent 下载引擎 |
+| [mpv](https://github.com/mpv-player/mpv) | media_kit 背后的 libmpv 播放内核 |
+| [FFmpeg](https://ffmpeg.org) | 媒体探测、切片与音频抽取 |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU 视频着色器与 HDR 色调映射 |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | 渲染 EPUB 阅读器的 WebView 引擎 |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | 语音识别与 OCR 的端上推理 |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | 词典引擎依赖 |
+
+### 端上模型
+
+| 项目 | 说明 |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer 语音识别模型包与 VAD 构建 |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | 日语语音识别模型 |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | 多语言 CTC 语音识别模型 |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | 人声活动检测模型 |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | 漫画 OCR 模型 |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | 漫画文本与对话气泡检测模型 |
+
+### 内容源与集成
+
+| 项目 | 说明 |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | 漫画源扩展生态 |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | 桌面端漫画扩展运行时 |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | 漫画源运行时 ABI |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | 浏览器扩展流媒体字幕桥接参考 |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | 动画识别与刮削架构参考 |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | galgame 库信息架构参考 |
+| [AniDB](https://anidb.net) | 动画、分集与文件身份 |
+| [TMDB](https://www.themoviedb.org) | 补充元数据与图片 |
+| [Jimaku](https://jimaku.cc) | 日语字幕源 |
+| [OpenSubtitles](https://www.opensubtitles.com) | 字幕源 |
+
+> 本应用使用 TMDB 及 TMDB API，但未获得 TMDB 的认可、认证或以其他方式批准。
 
 ## 许可证
 

--- a/docs/readme/README.ar.md
+++ b/docs/readme/README.ar.md
@@ -102,6 +102,8 @@ Fushi/                      # Repository root (Melos workspace: fushi_workspace)
 
 يُبنى Fushi على المشاريع والمنظومة التالية:
 
+### أدوات التعلم والمشاريع المرجعية
+
 | المشروع | الوصف |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | أداة تعلّم اللغة اليابانية بأسلوب الانغماس |
@@ -116,6 +118,48 @@ Fushi/                      # Repository root (Melos workspace: fushi_workspace)
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | مرجع القارئ والإحصاءات وتوافق المزامنة |
 | [media_kit](https://github.com/media-kit/media-kit) | إطار تشغيل الفيديو في Flutter (نواة libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | مجموعة تعلّم اللغات بأسلوب الانغماس لنظام macOS |
+
+### المحركات والمكونات الأصلية
+
+| المشروع | الوصف |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | محرك اعتراض نصوص الـ galgame (ملفات DLL مرفقة يحمّلها الحاقن) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | مكتبة اعتراض inline يستخدمها حاقن الـ galgame |
+| [libtorrent](https://github.com/arvidn/libtorrent) | محرك تنزيل التورنت المدمج |
+| [mpv](https://github.com/mpv-player/mpv) | نواة التشغيل libmpv خلف media_kit |
+| [FFmpeg](https://ffmpeg.org) | فحص الوسائط والاقتصاص واستخراج الصوت |
+| [libplacebo](https://github.com/haasn/libplacebo) | مظللات الفيديو على الـ GPU وتعيين ألوان HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | محرك WebView الذي يعرض قارئ EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | الاستدلال على الجهاز للتعرف على الكلام و OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | اعتماديات محرك القواميس |
+
+### النماذج على الجهاز
+
+| المشروع | الوصف |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | حزم نماذج التعرف على الكلام Zipformer وبنى VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | نموذج التعرف على الكلام الياباني |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | نموذج تعرف على الكلام متعدد اللغات بتقنية CTC |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | نموذج كشف نشاط الصوت |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | نموذج OCR للمانغا |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | نموذج كشف نصوص وفقاعات حوار المانغا |
+
+### مصادر المحتوى والتكاملات
+
+| المشروع | الوصف |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | منظومة إضافات مصادر المانغا |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | بيئة تشغيل إضافات المانغا لسطح المكتب |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | واجهة ABI لبيئة تشغيل مصادر المانغا |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | مرجع جسر ترجمات البث لإضافة المتصفح |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | مرجع معماري لتعريف الأنمي وجمع بياناته |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | مرجع معمارية معلومات مكتبة الـ galgame |
+| [AniDB](https://anidb.net) | هوية الأنمي والحلقات والملفات |
+| [TMDB](https://www.themoviedb.org) | بيانات وصفية وصور تكميلية |
+| [Jimaku](https://jimaku.cc) | مصدر ترجمات يابانية |
+| [OpenSubtitles](https://www.opensubtitles.com) | مصدر ترجمات |
+
+> يستخدم هذا التطبيق TMDB وواجهات TMDB البرمجية لكنه غير معتمد أو مُصدّق أو موافق عليه من TMDB.
 
 ## الترخيص
 

--- a/docs/readme/README.de.md
+++ b/docs/readme/README.de.md
@@ -102,6 +102,8 @@ Cloud-Sync (Google Drive / OneDrive / Dropbox) verwendet vom Benutzer konfigurie
 
 Fushi baut auf den folgenden Projekten und dem folgenden Ökosystem auf:
 
+### Lernwerkzeuge und Vorbilder
+
 | Projekt | Beschreibung |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Japanisches immersives Lernwerkzeug |
@@ -116,6 +118,48 @@ Fushi baut auf den folgenden Projekten und dem folgenden Ökosystem auf:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Referenz für Reader, Statistiken und Sync-Kompatibilität |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter-Videowiedergabe-Framework (libmpv-Kern) |
 | [Niratan](https://github.com/W1ght/Niratan) | Immersive Sprachlern-Suite für macOS |
+
+### Engines und native Komponenten
+
+| Projekt | Beschreibung |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Text-Hooking-Engine für Galgames (mitgelieferte DLLs, vom Injector geladen) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Inline-Hooking-Bibliothek des Galgame-Injectors |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Integrierte Torrent-Download-Engine |
+| [mpv](https://github.com/mpv-player/mpv) | libmpv-Wiedergabekern hinter media_kit |
+| [FFmpeg](https://ffmpeg.org) | Medienanalyse, Zuschnitt und Audioextraktion |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU-Video-Shader und HDR-Tone-Mapping |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | WebView-Engine, die den EPUB-Reader rendert |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferenz auf dem Gerät für Spracherkennung und OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Abhängigkeiten der Wörterbuch-Engine |
+
+### Modelle auf dem Gerät
+
+| Projekt | Beschreibung |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer-Spracherkennungsmodellpakete und VAD-Builds |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Japanisches Spracherkennungsmodell |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Mehrsprachiges CTC-Spracherkennungsmodell |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Modell zur Sprachaktivitätserkennung |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Manga-OCR-Modell |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Modell zur Erkennung von Manga-Text und Sprechblasen |
+
+### Inhaltsquellen und Integrationen
+
+| Projekt | Beschreibung |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ökosystem der Manga-Quellen-Erweiterungen |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Manga-Erweiterungs-Runtime für den Desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI der Manga-Quellen-Runtime |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Referenz für die Streaming-Untertitelbrücke der Browser-Erweiterung |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Architekturreferenz für Anime-Identifikation und -Scraping |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Referenz für die Informationsarchitektur der Galgame-Bibliothek |
+| [AniDB](https://anidb.net) | Identität von Anime, Episoden und Dateien |
+| [TMDB](https://www.themoviedb.org) | Ergänzende Metadaten und Bilder |
+| [Jimaku](https://jimaku.cc) | Japanische Untertitelquelle |
+| [OpenSubtitles](https://www.opensubtitles.com) | Untertitelquelle |
+
+> Diese Anwendung verwendet TMDB und die TMDB-APIs, ist jedoch nicht von TMDB unterstützt, zertifiziert oder anderweitig genehmigt.
 
 ## Lizenz
 

--- a/docs/readme/README.es.md
+++ b/docs/readme/README.es.md
@@ -102,6 +102,8 @@ La sincronización en la nube (Google Drive / OneDrive / Dropbox) utiliza creden
 
 Fushi se apoya en los siguientes proyectos y ecosistema:
 
+### Herramientas de aprendizaje y referencias previas
+
 | Proyecto | Descripción |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Herramienta de aprendizaje inmersivo de japonés |
@@ -116,6 +118,48 @@ Fushi se apoya en los siguientes proyectos y ecosistema:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Referencia de compatibilidad de lector, estadísticas y sincronización |
 | [media_kit](https://github.com/media-kit/media-kit) | Framework de reproducción de vídeo de Flutter (núcleo libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Suite de aprendizaje inmersivo de idiomas para macOS |
+
+### Motores y componentes nativos
+
+| Proyecto | Descripción |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Motor de hooking de texto para galgames (DLL incluidas, cargadas por el inyector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Biblioteca de inline hooking usada por el inyector de galgames |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Motor de descargas torrent integrado |
+| [mpv](https://github.com/mpv-player/mpv) | Núcleo de reproducción libmpv detrás de media_kit |
+| [FFmpeg](https://ffmpeg.org) | Análisis de medios, recortes y extracción de audio |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shaders de vídeo por GPU y mapeo de tonos HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Motor WebView que renderiza el lector EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferencia en el dispositivo para reconocimiento de voz y OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dependencias del motor de diccionarios |
+
+### Modelos en el dispositivo
+
+| Proyecto | Descripción |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Paquetes de modelos Zipformer de reconocimiento de voz y compilaciones de VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Modelo de reconocimiento de voz en japonés |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Modelo multilingüe de reconocimiento de voz CTC |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Modelo de detección de actividad de voz |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Modelo de OCR para manga |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Modelo de detección de texto y bocadillos en manga |
+
+### Fuentes de contenido e integraciones
+
+| Proyecto | Descripción |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ecosistema de extensiones de fuentes de manga |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime de extensiones de manga para escritorio |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI del runtime de fuentes de manga |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Referencia del puente de subtítulos en streaming para la extensión de navegador |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Referencia de arquitectura para identificación y scraping de anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Referencia de arquitectura de información de la biblioteca de galgames |
+| [AniDB](https://anidb.net) | Identidad de anime, episodios y archivos |
+| [TMDB](https://www.themoviedb.org) | Metadatos e imágenes complementarios |
+| [Jimaku](https://jimaku.cc) | Fuente de subtítulos en japonés |
+| [OpenSubtitles](https://www.opensubtitles.com) | Fuente de subtítulos |
+
+> Esta aplicación utiliza TMDB y las APIs de TMDB pero no está respaldada, certificada ni aprobada por TMDB.
 
 ## Licencia
 

--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -102,6 +102,8 @@ La synchronisation cloud (Google Drive / OneDrive / Dropbox) utilise des identif
 
 Fushi s'appuie sur les projets et l'écosystème suivants :
 
+### Outils d'apprentissage et travaux antérieurs
+
 | Projet | Description |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Outil d'apprentissage immersif du japonais |
@@ -116,6 +118,48 @@ Fushi s'appuie sur les projets et l'écosystème suivants :
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Référence de compatibilité de lecteur, statistiques et synchronisation |
 | [media_kit](https://github.com/media-kit/media-kit) | Framework de lecture vidéo de Flutter (cœur libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Suite d'apprentissage immersif des langues pour macOS |
+
+### Moteurs et composants natifs
+
+| Projet | Description |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Moteur de hook de texte pour galgames (DLL fournies, chargées par l'injecteur) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Bibliothèque de hooking inline utilisée par l'injecteur galgame |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Moteur de téléchargement torrent intégré |
+| [mpv](https://github.com/mpv-player/mpv) | Cœur de lecture libmpv derrière media_kit |
+| [FFmpeg](https://ffmpeg.org) | Analyse des médias, découpage et extraction audio |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shaders vidéo GPU et mappage tonal HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Moteur WebView qui rend le lecteur EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inférence embarquée pour la reconnaissance vocale et l'OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dépendances du moteur de dictionnaires |
+
+### Modèles embarqués
+
+| Projet | Description |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Paquets de modèles de reconnaissance vocale Zipformer et builds VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Modèle de reconnaissance vocale japonaise |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Modèle multilingue de reconnaissance vocale CTC |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Modèle de détection d'activité vocale |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Modèle d'OCR pour manga |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Modèle de détection du texte et des bulles de manga |
+
+### Sources de contenu et intégrations
+
+| Projet | Description |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Écosystème d'extensions de sources manga |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime d'extensions manga pour le bureau |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI du runtime de sources manga |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Référence du pont de sous-titres en streaming pour l'extension navigateur |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Référence d'architecture pour l'identification et le scraping d'anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Référence d'architecture d'information de la bibliothèque galgame |
+| [AniDB](https://anidb.net) | Identité des animes, épisodes et fichiers |
+| [TMDB](https://www.themoviedb.org) | Métadonnées et visuels complémentaires |
+| [Jimaku](https://jimaku.cc) | Source de sous-titres japonais |
+| [OpenSubtitles](https://www.opensubtitles.com) | Source de sous-titres |
+
+> Cette application utilise TMDB et les API TMDB mais n'est pas approuvée, certifiée ou autrement autorisée par TMDB.
 
 ## Licence
 

--- a/docs/readme/README.id.md
+++ b/docs/readme/README.id.md
@@ -102,6 +102,8 @@ Sinkronisasi awan (Google Drive / OneDrive / Dropbox) menggunakan kredensial OAu
 
 Fushi dibangun di atas proyek dan ekosistem berikut:
 
+### Alat belajar dan rujukan terdahulu
+
 | Proyek | Deskripsi |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Alat belajar imersif bahasa Jepang |
@@ -116,6 +118,48 @@ Fushi dibangun di atas proyek dan ekosistem berikut:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Referensi pembaca, statistik, dan kompatibilitas sinkronisasi |
 | [media_kit](https://github.com/media-kit/media-kit) | Kerangka pemutaran video Flutter (inti libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Rangkaian belajar bahasa imersif untuk macOS |
+
+### Mesin dan komponen native
+
+| Proyek | Deskripsi |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Mesin hook teks galgame (DLL bawaan, dimuat oleh injector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Pustaka inline hook yang dipakai injector galgame |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Mesin unduhan torrent bawaan |
+| [mpv](https://github.com/mpv-player/mpv) | Inti pemutaran libmpv di balik media_kit |
+| [FFmpeg](https://ffmpeg.org) | Pemeriksaan media, pemotongan, dan ekstraksi audio |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shader video GPU dan tone mapping HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Mesin WebView yang merender pembaca EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferensi di perangkat untuk pengenalan suara dan OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dependensi mesin kamus |
+
+### Model di perangkat
+
+| Proyek | Deskripsi |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Paket model pengenalan suara Zipformer dan build VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Model pengenalan suara bahasa Jepang |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Model pengenalan suara CTC multibahasa |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Model deteksi aktivitas suara |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Model OCR manga |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Model deteksi teks dan balon percakapan manga |
+
+### Sumber konten dan integrasi
+
+| Proyek | Deskripsi |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ekosistem ekstensi sumber manga |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime ekstensi manga untuk desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI runtime sumber manga |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Rujukan jembatan subtitle streaming untuk ekstensi peramban |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Rujukan arsitektur identifikasi dan scraping anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Rujukan arsitektur informasi pustaka galgame |
+| [AniDB](https://anidb.net) | Identitas anime, episode, dan berkas |
+| [TMDB](https://www.themoviedb.org) | Metadata dan gambar pelengkap |
+| [Jimaku](https://jimaku.cc) | Sumber subtitle bahasa Jepang |
+| [OpenSubtitles](https://www.opensubtitles.com) | Sumber subtitle |
+
+> Aplikasi ini menggunakan TMDB dan API TMDB tetapi tidak didukung, disertifikasi, atau disetujui oleh TMDB.
 
 ## Lisensi
 

--- a/docs/readme/README.it.md
+++ b/docs/readme/README.it.md
@@ -102,6 +102,8 @@ La sincronizzazione nel cloud (Google Drive / OneDrive / Dropbox) utilizza crede
 
 Fushi si basa sui seguenti progetti ed ecosistema:
 
+### Strumenti di apprendimento e riferimenti
+
 | Progetto | Descrizione |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Strumento di apprendimento immersivo del giapponese |
@@ -116,6 +118,48 @@ Fushi si basa sui seguenti progetti ed ecosistema:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Riferimento per compatibilità di lettore, statistiche e sincronizzazione |
 | [media_kit](https://github.com/media-kit/media-kit) | Framework di riproduzione video di Flutter (core libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Suite di apprendimento immersivo delle lingue per macOS |
+
+### Motori e componenti nativi
+
+| Progetto | Descrizione |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Motore di hooking del testo per galgame (DLL incluse, caricate dall'injector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Libreria di inline hooking usata dall'injector galgame |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Motore di download torrent integrato |
+| [mpv](https://github.com/mpv-player/mpv) | Core di riproduzione libmpv alla base di media_kit |
+| [FFmpeg](https://ffmpeg.org) | Analisi dei media, ritaglio ed estrazione audio |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shader video su GPU e tone mapping HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Motore WebView che disegna il lettore EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferenza sul dispositivo per riconoscimento vocale e OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dipendenze del motore dei dizionari |
+
+### Modelli sul dispositivo
+
+| Progetto | Descrizione |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Pacchetti di modelli Zipformer per il riconoscimento vocale e build VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Modello di riconoscimento vocale giapponese |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Modello multilingue di riconoscimento vocale CTC |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Modello di rilevamento dell'attività vocale |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Modello OCR per manga |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Modello di rilevamento di testo e nuvolette nei manga |
+
+### Fonti di contenuti e integrazioni
+
+| Progetto | Descrizione |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ecosistema di estensioni per fonti manga |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime delle estensioni manga per desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI del runtime delle fonti manga |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Riferimento del bridge dei sottotitoli in streaming per l'estensione del browser |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Riferimento architetturale per identificazione e scraping degli anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Riferimento di architettura informativa della libreria galgame |
+| [AniDB](https://anidb.net) | Identità di anime, episodi e file |
+| [TMDB](https://www.themoviedb.org) | Metadati e immagini supplementari |
+| [Jimaku](https://jimaku.cc) | Fonte di sottotitoli giapponesi |
+| [OpenSubtitles](https://www.opensubtitles.com) | Fonte di sottotitoli |
+
+> Questa applicazione utilizza TMDB e le API TMDB ma non è approvata, certificata o altrimenti autorizzata da TMDB.
 
 ## Licenza
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -102,6 +102,8 @@ Fushi は、インポートした書籍、辞書、フォント、オーディ�
 
 Fushi は以下のプロジェクトとエコシステムを基盤としています。
 
+### 学習ツールと先行事例
+
 | プロジェクト | 説明 |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | 日本語没入型学習ツール |
@@ -116,6 +118,48 @@ Fushi は以下のプロジェクトとエコシステムを基盤としてい�
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | リーダー、統計、同期の互換性の参考 |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter 動画再生フレームワーク（libmpv コア） |
 | [Niratan](https://github.com/W1ght/Niratan) | macOS 向け没入型言語学習スイート |
+
+### エンジンとネイティブコンポーネント
+
+| プロジェクト | 説明 |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | ギャルゲーのテキストフックエンジン（vendored DLL、インジェクターが読み込み） |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | ギャルゲーインジェクターが使うインラインフックライブラリ |
+| [libtorrent](https://github.com/arvidn/libtorrent) | 内蔵 torrent ダウンロードエンジン |
+| [mpv](https://github.com/mpv-player/mpv) | media_kit の基盤となる libmpv 再生コア |
+| [FFmpeg](https://ffmpeg.org) | メディア解析、切り出し、音声抽出 |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU 映像シェーダーと HDR トーンマッピング |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | EPUB リーダーを描画する WebView エンジン |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | 音声認識と OCR の端末内推論 |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | 辞書エンジンの依存ライブラリ |
+
+### 端末内モデル
+
+| プロジェクト | 説明 |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer 音声認識モデルパッケージと VAD ビルド |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | 日本語音声認識モデル |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | 多言語 CTC 音声認識モデル |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | 音声区間検出モデル |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | マンガ OCR モデル |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | マンガのテキストと吹き出し検出モデル |
+
+### コンテンツソースと連携
+
+| プロジェクト | 説明 |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | マンガソース拡張のエコシステム |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | デスクトップ向けマンガ拡張ランタイム |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | マンガソースランタイムの ABI |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | ブラウザ拡張のストリーミング字幕ブリッジの参考 |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | アニメ識別とスクレイピング設計の参考 |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | ギャルゲーライブラリの情報設計の参考 |
+| [AniDB](https://anidb.net) | アニメ・エピソード・ファイルの同定 |
+| [TMDB](https://www.themoviedb.org) | 補助的なメタデータと画像 |
+| [Jimaku](https://jimaku.cc) | 日本語字幕ソース |
+| [OpenSubtitles](https://www.opensubtitles.com) | 字幕ソース |
+
+> このアプリケーションはTMDBおよびTMDB APIを使用していますが、TMDBによる推奨、認証、その他の承認を受けたものではありません。
 
 ## ライセンス
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -102,6 +102,8 @@ Fushi는 가져온 책, 사전, 글꼴, 오디오북 데이터, 동영상, 독�
 
 Fushi는 다음 프로젝트와 생태계를 기반으로 합니다.
 
+### 학습 도구 및 선행 프로젝트
+
 | 프로젝트 | 설명 |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | 일본어 몰입형 학습 도구 |
@@ -116,6 +118,48 @@ Fushi는 다음 프로젝트와 생태계를 기반으로 합니다.
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | 리더, 통계, 동기화 호환성 참고 |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter 동영상 재생 프레임워크(libmpv 코어) |
 | [Niratan](https://github.com/W1ght/Niratan) | macOS용 몰입형 언어 학습 도구 모음 |
+
+### 엔진 및 네이티브 구성 요소
+
+| 프로젝트 | 설명 |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | 갈게임 텍스트 후킹 엔진(인젝터가 로드하는 벤더링된 DLL) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | 갈게임 인젝터가 사용하는 인라인 후킹 라이브러리 |
+| [libtorrent](https://github.com/arvidn/libtorrent) | 내장 토렌트 다운로드 엔진 |
+| [mpv](https://github.com/mpv-player/mpv) | media_kit 기반의 libmpv 재생 코어 |
+| [FFmpeg](https://ffmpeg.org) | 미디어 분석, 구간 추출, 오디오 추출 |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU 비디오 셰이더 및 HDR 톤 매핑 |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | EPUB 리더를 렌더링하는 WebView 엔진 |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | 음성 인식과 OCR의 온디바이스 추론 |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | 사전 엔진 의존 라이브러리 |
+
+### 온디바이스 모델
+
+| 프로젝트 | 설명 |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer 음성 인식 모델 패키지 및 VAD 빌드 |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | 일본어 음성 인식 모델 |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | 다국어 CTC 음성 인식 모델 |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | 음성 구간 검출 모델 |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | 만화 OCR 모델 |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | 만화 텍스트 및 말풍선 검출 모델 |
+
+### 콘텐츠 소스 및 연동
+
+| 프로젝트 | 설명 |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | 만화 소스 확장 생태계 |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | 데스크톱용 만화 확장 런타임 |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | 만화 소스 런타임 ABI |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | 브라우저 확장의 스트리밍 자막 브리지 참고 |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | 애니메이션 식별 및 스크래핑 아키텍처 참고 |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | 갈게임 라이브러리 정보 구조 참고 |
+| [AniDB](https://anidb.net) | 애니메이션, 에피소드, 파일 식별 |
+| [TMDB](https://www.themoviedb.org) | 보조 메타데이터 및 이미지 |
+| [Jimaku](https://jimaku.cc) | 일본어 자막 소스 |
+| [OpenSubtitles](https://www.opensubtitles.com) | 자막 소스 |
+
+> 이 애플리케이션은 TMDB 및 TMDB API를 사용하지만, TMDB가 보증, 인증 또는 승인하지 않습니다.
 
 ## 라이선스
 

--- a/docs/readme/README.nl.md
+++ b/docs/readme/README.nl.md
@@ -102,6 +102,8 @@ Cloud-synchronisatie (Google Drive / OneDrive / Dropbox) gebruikt door de gebrui
 
 Fushi bouwt voort op de volgende projecten en het volgende ecosysteem:
 
+### Leermiddelen en voorlopers
+
 | Project | Beschrijving |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Japanse immersieve leertool |
@@ -116,6 +118,48 @@ Fushi bouwt voort op de volgende projecten en het volgende ecosysteem:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Referentie voor lezer, statistieken en sync-compatibiliteit |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter-videoweergaveframework (libmpv-kern) |
 | [Niratan](https://github.com/W1ght/Niratan) | Immersieve taalleersuite voor macOS |
+
+### Engines en native componenten
+
+| Project | Beschrijving |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Tekst-hookengine voor galgames (meegeleverde DLL's, geladen door de injector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Inline-hookbibliotheek die de galgame-injector gebruikt |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Ingebouwde torrent-downloadengine |
+| [mpv](https://github.com/mpv-player/mpv) | libmpv-afspeelkern achter media_kit |
+| [FFmpeg](https://ffmpeg.org) | Media-analyse, knippen en audio-extractie |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU-videoshaders en HDR-tonemapping |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | WebView-engine die de EPUB-lezer rendert |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferentie op het apparaat voor spraakherkenning en OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Afhankelijkheden van de woordenboekengine |
+
+### Modellen op het apparaat
+
+| Project | Beschrijving |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer-spraakherkenningsmodelpakketten en VAD-builds |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Japans spraakherkenningsmodel |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Meertalig CTC-spraakherkenningsmodel |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Model voor detectie van spraakactiviteit |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Manga-OCR-model |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Model voor detectie van manga-tekst en tekstballonnen |
+
+### Contentbronnen en integraties
+
+| Project | Beschrijving |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ecosysteem van manga-bronextensies |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Manga-extensieruntime voor desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI van de manga-bronruntime |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Referentie voor de streaming-ondertitelbrug van de browserextensie |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Architectuurreferentie voor anime-identificatie en -scraping |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Referentie voor de informatiearchitectuur van de galgamebibliotheek |
+| [AniDB](https://anidb.net) | Identiteit van anime, afleveringen en bestanden |
+| [TMDB](https://www.themoviedb.org) | Aanvullende metadata en beeldmateriaal |
+| [Jimaku](https://jimaku.cc) | Bron voor Japanse ondertitels |
+| [OpenSubtitles](https://www.opensubtitles.com) | Ondertitelbron |
+
+> Deze applicatie maakt gebruik van TMDB en de TMDB API's maar is niet goedgekeurd, gecertificeerd of anderszins geautoriseerd door TMDB.
 
 ## Licentie
 

--- a/docs/readme/README.pt-BR.md
+++ b/docs/readme/README.pt-BR.md
@@ -102,6 +102,8 @@ A sincronização na nuvem (Google Drive / OneDrive / Dropbox) usa credenciais O
 
 O Fushi baseia-se nos seguintes projetos e ecossistema:
 
+### Ferramentas de aprendizado e referências anteriores
+
 | Projeto | Descrição |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Ferramenta de aprendizado imersivo de japonês |
@@ -116,6 +118,48 @@ O Fushi baseia-se nos seguintes projetos e ecossistema:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Referência de compatibilidade de leitor, estatísticas e sincronização |
 | [media_kit](https://github.com/media-kit/media-kit) | Framework de reprodução de vídeo do Flutter (núcleo libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Suíte de aprendizado imersivo de idiomas para macOS |
+
+### Motores e componentes nativos
+
+| Projeto | Descrição |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Motor de hooking de texto para galgames (DLLs incluídas, carregadas pelo injetor) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Biblioteca de inline hooking usada pelo injetor de galgames |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Motor de download torrent integrado |
+| [mpv](https://github.com/mpv-player/mpv) | Núcleo de reprodução libmpv por trás do media_kit |
+| [FFmpeg](https://ffmpeg.org) | Análise de mídia, recorte e extração de áudio |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shaders de vídeo por GPU e mapeamento de tons HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Motor WebView que renderiza o leitor EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Inferência no dispositivo para reconhecimento de fala e OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Dependências do motor de dicionários |
+
+### Modelos no dispositivo
+
+| Projeto | Descrição |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Pacotes de modelos Zipformer de reconhecimento de fala e builds de VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Modelo de reconhecimento de fala em japonês |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Modelo multilíngue de reconhecimento de fala CTC |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Modelo de detecção de atividade de voz |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Modelo de OCR para mangá |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Modelo de detecção de texto e balões de fala em mangá |
+
+### Fontes de conteúdo e integrações
+
+| Projeto | Descrição |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Ecossistema de extensões de fontes de mangá |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime de extensões de mangá para desktop |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI do runtime de fontes de mangá |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Referência da ponte de legendas de streaming para a extensão de navegador |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Referência de arquitetura para identificação e scraping de anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Referência de arquitetura de informação da biblioteca de galgames |
+| [AniDB](https://anidb.net) | Identidade de anime, episódios e arquivos |
+| [TMDB](https://www.themoviedb.org) | Metadados e imagens complementares |
+| [Jimaku](https://jimaku.cc) | Fonte de legendas em japonês |
+| [OpenSubtitles](https://www.opensubtitles.com) | Fonte de legendas |
+
+> Este aplicativo usa o TMDB e as APIs do TMDB, mas não é endossado, certificado ou aprovado pelo TMDB.
 
 ## Licença
 

--- a/docs/readme/README.ru.md
+++ b/docs/readme/README.ru.md
@@ -102,6 +102,8 @@ Fushi хранит импортированные книги, словари, ш
 
 Fushi опирается на следующие проекты и экосистему:
 
+### Инструменты изучения и предшественники
+
 | Проект | Описание |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Инструмент иммерсивного изучения японского |
@@ -116,6 +118,48 @@ Fushi опирается на следующие проекты и экосис�
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Референс совместимости читалки, статистики и синхронизации |
 | [media_kit](https://github.com/media-kit/media-kit) | Фреймворк воспроизведения видео для Flutter (ядро libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Набор для иммерсивного изучения языков для macOS |
+
+### Движки и нативные компоненты
+
+| Проект | Описание |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Движок перехвата текста в galgame (поставляемые DLL, загружаются инжектором) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Библиотека inline-перехвата, используемая инжектором galgame |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Встроенный движок torrent-загрузок |
+| [mpv](https://github.com/mpv-player/mpv) | Ядро воспроизведения libmpv в основе media_kit |
+| [FFmpeg](https://ffmpeg.org) | Анализ медиа, нарезка и извлечение аудио |
+| [libplacebo](https://github.com/haasn/libplacebo) | Видеошейдеры на GPU и тональная компрессия HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Движок WebView, отрисовывающий читалку EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Локальный вывод для распознавания речи и OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Зависимости словарного движка |
+
+### Модели на устройстве
+
+| Проект | Описание |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Пакеты моделей распознавания речи Zipformer и сборки VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Модель распознавания японской речи |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Многоязычная CTC-модель распознавания речи |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Модель детекции речевой активности |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Модель OCR для манги |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Модель детекции текста и «облачков» в манге |
+
+### Источники контента и интеграции
+
+| Проект | Описание |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Экосистема расширений источников манги |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Среда выполнения расширений манги для десктопа |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI среды выполнения источников манги |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Референс моста субтитров стриминга для расширения браузера |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Референс архитектуры идентификации и скрейпинга аниме |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Референс информационной архитектуры библиотеки galgame |
+| [AniDB](https://anidb.net) | Идентификация аниме, эпизодов и файлов |
+| [TMDB](https://www.themoviedb.org) | Дополнительные метаданные и изображения |
+| [Jimaku](https://jimaku.cc) | Источник японских субтитров |
+| [OpenSubtitles](https://www.opensubtitles.com) | Источник субтитров |
+
+> Это приложение использует TMDB и API TMDB, но не одобрено, не сертифицировано и никак не поддержано TMDB.
 
 ## Лицензия
 

--- a/docs/readme/README.th.md
+++ b/docs/readme/README.th.md
@@ -102,6 +102,8 @@ Fushi จัดเก็บหนังสือ พจนานุกรม แ
 
 Fushi ต่อยอดจากโปรเจกต์และระบบนิเวศต่อไปนี้:
 
+### เครื่องมือการเรียนรู้และงานอ้างอิง
+
 | โปรเจกต์ | คำอธิบาย |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | เครื่องมือเรียนภาษาญี่ปุ่นแบบ immersive |
@@ -116,6 +118,48 @@ Fushi ต่อยอดจากโปรเจกต์และระบบ�
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | แหล่งอ้างอิงโปรแกรมอ่าน สถิติ และความเข้ากันได้ของการซิงก์ |
 | [media_kit](https://github.com/media-kit/media-kit) | เฟรมเวิร์กการเล่นวิดีโอของ Flutter (แกนหลัก libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | ชุดเครื่องมือเรียนภาษาแบบ immersive สำหรับ macOS |
+
+### เอนจินและคอมโพเนนต์เนทีฟ
+
+| โปรเจกต์ | คำอธิบาย |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | เอนจิน hook ข้อความสำหรับ galgame (DLL ที่รวมมา โหลดโดยตัว injector) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | ไลบรารี inline hook ที่ injector ของ galgame ใช้ |
+| [libtorrent](https://github.com/arvidn/libtorrent) | เอนจินดาวน์โหลด torrent ในตัว |
+| [mpv](https://github.com/mpv-player/mpv) | แกนเล่นสื่อ libmpv ที่อยู่เบื้องหลัง media_kit |
+| [FFmpeg](https://ffmpeg.org) | ตรวจสอบสื่อ ตัดคลิป และแยกเสียง |
+| [libplacebo](https://github.com/haasn/libplacebo) | เชเดอร์วิดีโอบน GPU และการทำ HDR tone mapping |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | เอนจิน WebView ที่เรนเดอร์โปรแกรมอ่าน EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | การประมวลผลบนอุปกรณ์สำหรับรู้จำเสียงพูดและ OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | ไลบรารีที่เอนจินพจนานุกรมใช้ |
+
+### โมเดลบนอุปกรณ์
+
+| โปรเจกต์ | คำอธิบาย |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | ชุดโมเดลรู้จำเสียงพูด Zipformer และบิลด์ VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | โมเดลรู้จำเสียงพูดภาษาญี่ปุ่น |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | โมเดลรู้จำเสียงพูด CTC หลายภาษา |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | โมเดลตรวจจับช่วงที่มีเสียงพูด |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | โมเดล OCR สำหรับมังงะ |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | โมเดลตรวจจับข้อความและช่องคำพูดในมังงะ |
+
+### แหล่งเนื้อหาและการเชื่อมต่อ
+
+| โปรเจกต์ | คำอธิบาย |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | ระบบนิเวศส่วนขยายแหล่งมังงะ |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | รันไทม์ส่วนขยายมังงะสำหรับเดสก์ท็อป |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI ของรันไทม์แหล่งมังงะ |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | ต้นแบบสะพานเชื่อมซับไตเติลสตรีมมิงสำหรับส่วนขยายเบราว์เซอร์ |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | ต้นแบบสถาปัตยกรรมการระบุและดึงข้อมูลอนิเมะ |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | ต้นแบบสถาปัตยกรรมข้อมูลคลัง galgame |
+| [AniDB](https://anidb.net) | การระบุตัวตนของอนิเมะ ตอน และไฟล์ |
+| [TMDB](https://www.themoviedb.org) | ข้อมูลเมตาและภาพประกอบเพิ่มเติม |
+| [Jimaku](https://jimaku.cc) | แหล่งซับไตเติลภาษาญี่ปุ่น |
+| [OpenSubtitles](https://www.opensubtitles.com) | แหล่งซับไตเติล |
+
+> แอปพลิเคชันนี้ใช้ TMDB และ TMDB API แต่ไม่ได้รับการรับรอง การรับรอง หรือการอนุมัติจาก TMDB
 
 ## สัญญาอนุญาต
 

--- a/docs/readme/README.tr.md
+++ b/docs/readme/README.tr.md
@@ -102,6 +102,8 @@ Bulut eşitleme (Google Drive / OneDrive / Dropbox), kullanıcı tarafından yap
 
 Fushi aşağıdaki projeler ve ekosistem üzerine kuruludur:
 
+### Öğrenme araçları ve önceki projeler
+
 | Proje | Açıklama |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Japonca sürükleyici öğrenme aracı |
@@ -116,6 +118,48 @@ Fushi aşağıdaki projeler ve ekosistem üzerine kuruludur:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Okuyucu, istatistik ve eşitleme uyumluluğu referansı |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter video oynatma çerçevesi (libmpv çekirdeği) |
 | [Niratan](https://github.com/W1ght/Niratan) | macOS için sürükleyici dil öğrenme paketi |
+
+### Motorlar ve yerel bileşenler
+
+| Proje | Açıklama |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Galgame metin hook motoru (paketlenmiş DLL'ler, injector tarafından yüklenir) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Galgame injector'ının kullandığı inline hook kütüphanesi |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Dahili torrent indirme motoru |
+| [mpv](https://github.com/mpv-player/mpv) | media_kit'in arkasındaki libmpv oynatma çekirdeği |
+| [FFmpeg](https://ffmpeg.org) | Medya inceleme, kırpma ve ses çıkarma |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU video gölgelendiricileri ve HDR ton eşleme |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | EPUB okuyucuyu çizen WebView motoru |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Konuşma tanıma ve OCR için cihaz üstü çıkarım |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Sözlük motoru bağımlılıkları |
+
+### Cihaz üstü modeller
+
+| Proje | Açıklama |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer konuşma tanıma model paketleri ve VAD derlemeleri |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Japonca konuşma tanıma modeli |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Çok dilli CTC konuşma tanıma modeli |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Ses etkinliği algılama modeli |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Manga OCR modeli |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Manga metni ve konuşma balonu algılama modeli |
+
+### İçerik kaynakları ve entegrasyonlar
+
+| Proje | Açıklama |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Manga kaynak eklentisi ekosistemi |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Masaüstü için manga eklenti çalışma zamanı |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | Manga kaynak çalışma zamanı ABI'si |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Tarayıcı eklentisi için akış altyazı köprüsü referansı |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Anime tanımlama ve kazıma mimarisi referansı |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Galgame kitaplığı bilgi mimarisi referansı |
+| [AniDB](https://anidb.net) | Anime, bölüm ve dosya kimliği |
+| [TMDB](https://www.themoviedb.org) | Tamamlayıcı meta veriler ve görseller |
+| [Jimaku](https://jimaku.cc) | Japonca altyazı kaynağı |
+| [OpenSubtitles](https://www.opensubtitles.com) | Altyazı kaynağı |
+
+> Bu uygulama TMDB ve TMDB API'lerini kullanır ancak TMDB tarafından onaylanmamış, sertifikalandırılmamış veya başka şekilde desteklenmemiştir.
 
 ## Lisans
 

--- a/docs/readme/README.vi.md
+++ b/docs/readme/README.vi.md
@@ -102,6 +102,8 @@ Fushi lưu trữ sách, từ điển, phông chữ, dữ liệu sách nói, vide
 
 Fushi được xây dựng dựa trên các dự án và hệ sinh thái sau:
 
+### Công cụ học tập và các dự án tham khảo
+
 | Dự án | Mô tả |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | Công cụ học tiếng Nhật chuyên sâu |
@@ -116,6 +118,48 @@ Fushi được xây dựng dựa trên các dự án và hệ sinh thái sau:
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | Tham chiếu khả năng tương thích trình đọc, thống kê và đồng bộ |
 | [media_kit](https://github.com/media-kit/media-kit) | Framework phát video cho Flutter (lõi libmpv) |
 | [Niratan](https://github.com/W1ght/Niratan) | Bộ công cụ học ngôn ngữ chuyên sâu cho macOS |
+
+### Engine và thành phần native
+
+| Dự án | Mô tả |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | Engine hook văn bản galgame (DLL đi kèm, do injector nạp) |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | Thư viện inline hook mà injector galgame sử dụng |
+| [libtorrent](https://github.com/arvidn/libtorrent) | Engine tải torrent tích hợp |
+| [mpv](https://github.com/mpv-player/mpv) | Lõi phát libmpv phía sau media_kit |
+| [FFmpeg](https://ffmpeg.org) | Phân tích media, cắt đoạn và trích xuất âm thanh |
+| [libplacebo](https://github.com/haasn/libplacebo) | Shader video GPU và tone mapping HDR |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | Engine WebView dựng trình đọc EPUB |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | Suy luận trên thiết bị cho nhận dạng giọng nói và OCR |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | Phụ thuộc của engine từ điển |
+
+### Mô hình chạy trên thiết bị
+
+| Dự án | Mô tả |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Gói mô hình nhận dạng giọng nói Zipformer và bản dựng VAD |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | Mô hình nhận dạng giọng nói tiếng Nhật |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | Mô hình nhận dạng giọng nói CTC đa ngôn ngữ |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | Mô hình phát hiện hoạt động giọng nói |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | Mô hình OCR cho manga |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | Mô hình phát hiện văn bản và bong bóng thoại trong manga |
+
+### Nguồn nội dung và tích hợp
+
+| Dự án | Mô tả |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | Hệ sinh thái tiện ích nguồn manga |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | Runtime tiện ích mở rộng manga cho máy tính |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | ABI runtime nguồn manga |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | Tham khảo cầu nối phụ đề streaming cho tiện ích trình duyệt |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | Tham khảo kiến trúc nhận dạng và thu thập dữ liệu anime |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | Tham khảo kiến trúc thông tin thư viện galgame |
+| [AniDB](https://anidb.net) | Định danh anime, tập phim và tệp |
+| [TMDB](https://www.themoviedb.org) | Siêu dữ liệu và hình ảnh bổ sung |
+| [Jimaku](https://jimaku.cc) | Nguồn phụ đề tiếng Nhật |
+| [OpenSubtitles](https://www.opensubtitles.com) | Nguồn phụ đề |
+
+> Ứng dụng này sử dụng TMDB và các API của TMDB nhưng không được xác nhận, chứng nhận hay phê duyệt bởi TMDB.
 
 ## Giấy phép
 

--- a/docs/readme/README.zh-Hant.md
+++ b/docs/readme/README.zh-Hant.md
@@ -108,6 +108,8 @@ Fushi 將匯入的書籍、詞典、字型、有聲書資料、影片、閱讀�
 
 Fushi 基於以下專案與生態：
 
+### 學習工具與前作參考
+
 | 專案 | 說明 |
 |---|---|
 | [jidoujisho](https://github.com/arianneorpilla/jidoujisho) | 日語沉浸式學習工具 |
@@ -122,6 +124,48 @@ Fushi 基於以下專案與生態：
 | [ッツ Ebook Reader](https://github.com/ttu-ttu/ebook-reader) | 閱讀器、統計與同步相容性參考 |
 | [media_kit](https://github.com/media-kit/media-kit) | Flutter 影片播放框架（libmpv 核心） |
 | [Niratan](https://github.com/W1ght/Niratan) | macOS 沉浸式語言學習套件 |
+
+### 引擎與原生元件
+
+| 專案 | 說明 |
+|---|---|
+| [LunaHook](https://github.com/HIllya51/LunaTranslator) | galgame 文字 hook 引擎（vendored DLL，由注入器載入） |
+| [MinHook](https://github.com/TsudaKageyu/minhook) | galgame 注入器使用的 inline hook 函式庫 |
+| [libtorrent](https://github.com/arvidn/libtorrent) | 內建 torrent 下載引擎 |
+| [mpv](https://github.com/mpv-player/mpv) | media_kit 背後的 libmpv 播放核心 |
+| [FFmpeg](https://ffmpeg.org) | 媒體探測、剪輯與音訊擷取 |
+| [libplacebo](https://github.com/haasn/libplacebo) | GPU 影片著色器與 HDR 色調映射 |
+| [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) | 渲染 EPUB 閱讀器的 WebView 引擎 |
+| [ONNX Runtime](https://github.com/microsoft/onnxruntime) | 語音辨識與 OCR 的裝置端推論 |
+| [zstd](https://github.com/facebook/zstd) · [xxHash](https://github.com/Cyan4973/xxHash) · [libdeflate](https://github.com/ebiggers/libdeflate) · [glaze](https://github.com/stephenberry/glaze) · [unordered_dense](https://github.com/martinus/unordered_dense) · [utf8proc](https://github.com/JuliaStrings/utf8proc) · [utfcpp](https://github.com/nemtrif/utfcpp) | 辭典引擎相依套件 |
+
+### 裝置端模型
+
+| 專案 | 說明 |
+|---|---|
+| [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) | Zipformer 語音辨識模型包與 VAD 建置 |
+| [ReazonSpeech k2-v2](https://huggingface.co/reazon-research/reazonspeech-k2-v2) | 日語語音辨識模型 |
+| [Omnilingual ASR](https://github.com/facebookresearch/omnilingual-asr) | 多語言 CTC 語音辨識模型 |
+| [Silero VAD](https://github.com/snakers4/silero-vad) | 人聲活動偵測模型 |
+| [manga-ocr](https://github.com/kha-white/manga-ocr) / [manga-ocr-onnx](https://huggingface.co/mayocream/manga-ocr-onnx) | 漫畫 OCR 模型 |
+| [comic-text-and-bubble-detector](https://huggingface.co/ogkalu/comic-text-and-bubble-detector) | 漫畫文字與對話框偵測模型 |
+
+### 內容來源與整合
+
+| 專案 | 說明 |
+|---|---|
+| [Mihon](https://github.com/mihonapp/mihon) | 漫畫來源擴充生態 |
+| [M-Extension-Server](https://github.com/kodjodevf/M-Extension-Server) | 桌面端漫畫擴充執行環境 |
+| [aidoku-rs](https://github.com/Aidoku/aidoku-rs) | 漫畫來源執行環境 ABI |
+| [asbplayer](https://github.com/asbplayer/asbplayer) | 瀏覽器擴充功能串流字幕橋接參考 |
+| [Shoko Server](https://github.com/ShokoAnime/ShokoServer) | 動畫辨識與刮削架構參考 |
+| [ReinaManager](https://github.com/huoshen80/ReinaManager) | galgame 庫資訊架構參考 |
+| [AniDB](https://anidb.net) | 動畫、分集與檔案身分 |
+| [TMDB](https://www.themoviedb.org) | 補充中繼資料與圖片 |
+| [Jimaku](https://jimaku.cc) | 日語字幕來源 |
+| [OpenSubtitles](https://www.opensubtitles.com) | 字幕來源 |
+
+> 本應用程式使用 TMDB 及 TMDB API，但未獲得 TMDB 的認可、認證或以其他方式批准。
 
 ## 授權條款
 


### PR DESCRIPTION
## 改了什么

原 Acknowledgments 表只列了学习工具与前作参考（jidoujisho / Hoshi Reader / Yomitan …），
实际依赖的 vendored 原生组件、端上模型和内容源一条没写。按仓库真实事实补 25 条，
分成三张新表，17 份 README（英/简/繁 + docs/readme 下 14 语）同步。

### 引擎与原生组件
LunaHook（vendored DLL，injector 加载）、MinHook、libtorrent、mpv、FFmpeg、
libplacebo、flutter_inappwebview、ONNX Runtime，以及 fushidicts 的 7 个 C++ 依赖
（zstd / xxHash / libdeflate / glaze / unordered_dense / utf8proc / utfcpp）。

### 端上模型
sherpa-onnx、ReazonSpeech k2-v2、Omnilingual ASR、Silero VAD、
manga-ocr（+ mayocream ONNX 构建）、comic-text-and-bubble-detector。

### 内容源与集成
Mihon、M-Extension-Server、aidoku-rs、asbplayer、Shoko Server、ReinaManager、
AniDB、TMDB、Jimaku、OpenSubtitles。

另补 TMDB 署名引用行——它是 Terms of Use 第 3 节的合约义务，不是可选致谢；
各语言文案直接取自 i18n 的 `about_tmdb_attribution`，与设置页显示一致。

## 事实依据

每条都对得上仓库里的东西，不是凭印象列的：

- LunaHook：`native/galgame_hook/third_party/lunahook/VERSION.json`（HIllya51/LunaTranslator v10.16.1.2）
- MinHook：`native/galgame_hook/third_party/minhook/`
- 词典依赖：`native/fushidicts/fushidicts_external/` 下 7 个目录
- 模型：`fushi/lib/src/asr/asr_model_manifest.dart` 与 `fushi/lib/src/ocr/manga_ocr_model_manifest.dart` 的 sourceUrl
- aidoku-rs：`native/aidoku_runtime/NOTICE`
- asbplayer：`fushi/assets/browser_extension/THIRD_PARTY_LICENSES.md`
- Shoko / ReinaManager：`.gitmodules`

两条链接做了修正：libplacebo 用仓库 `third_party/libplacebo-win/UPSTREAM.md` 记录的
`haasn/libplacebo`（`code.videolan.org` 经代理不可达）；`miru-project/M-Extension-Server`
上游已删（404），改链 `UPSTREAM` 里记录的镜像 `kodjodevf`。

## 验证

- 31 条新增链接逐条 curl：除 anidb.net / opensubtitles.com 反爬 403（站点存在）外全部 200
- 17 份 README 结构逐份核对一致：4 小节 / 4 表头 / 37 数据行 / 每行 2 列 / 均有 TMDB 声明行
- `git diff --check` 干净；纯新增 748 行、0 删除
- 文档改动，未跑 Flutter 测试

https://claude.ai/code/session_01JVDQgkD8d5k7CepbPYkrfK
