### PR TITLE
fix(ci): OpenSubtitles key 桩改产单引号字面量，修 develop 上的 analyze 必红

### DIFF
--- a/.github/actions/provide-baked-secrets/action.yml
+++ b/.github/actions/provide-baked-secrets/action.yml
@@ -57,16 +57,23 @@ inputs:
 runs:
   using: composite
   steps:
+    # opensubtitles_default_key.dart 入库的是**空占位**（key = ''）且**不在**
+    # fushi/analysis_options.yaml 的 analyzer.exclude 里，所以写进去的必须是
+    # **单引号** Dart 字面量：json.dumps 那种双引号会触发 prefer_single_quotes
+    # （info），而 CI 的 analyze 门把 info 也当失败（exit 1）——本地
+    # `flutter analyze` 看到的是入库的单引号占位，所以本地恒绿、只有 CI 红。
+    # 下面几步的 google_oauth_secret.dart / log_upload_secret.dart 能用双引号，
+    # 只因为那两个文件在 exclude 列表里；别把它们的写法照抄到不在 exclude 的
+    # 文件上。转义（\ ' 与 $ 三者，$ 在单引号串里仍是插值符）交给独立脚本，
+    # 免去 YAML→bash→sed 三层转义。守卫：
+    # fushi/test/tools/baked_secret_stub_quotes_guard_test.dart
     - name: Provide OpenSubtitles API key stub
       shell: bash
       env:
         OPENSUBTITLES_API_KEY: ${{ inputs.opensubtitles-api-key }}
       run: |
         dst=fushi/lib/src/media/video/subtitle/opensubtitles_default_key.dart
-        if [ -n "$OPENSUBTITLES_API_KEY" ]; then
-          key_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["OPENSUBTITLES_API_KEY"]).replace("$", "\\$"))')"
-          printf 'const String kBuiltinOpenSubtitlesApiKey = %s;\n' "$key_literal" > "$dst"
-        fi
+        python3 "$GITHUB_ACTION_PATH/write_opensubtitles_key.py" "$dst"
     # google_oauth_secret.dart 是 gitignored 的（真值只存在于仓库 secret 与本机），
     # 所以这里连占位都可能不存在，缺文件时才从 .example.dart 复制。
     - name: Provide gitignored Google OAuth secret stub

--- a/.github/actions/provide-baked-secrets/write_opensubtitles_key.py
+++ b/.github/actions/provide-baked-secrets/write_opensubtitles_key.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""把 OPENSUBTITLES_API_KEY 写成 opensubtitles_default_key.dart。
+
+为什么不像 google_oauth_secret.dart 那样直接 `json.dumps` 打一行：
+json.dumps 产出的是**双引号** Dart 字面量，而本文件**不在**
+fushi/analysis_options.yaml 的 analyzer.exclude 里，双引号会触发
+prefer_single_quotes（info）——CI 的 analyze 门把 info 也当失败（exit 1），
+于是每个带 OPENSUBTITLES_API_KEY secret 的 run 都必红。
+google_oauth_secret.dart / log_upload_secret.dart 能用双引号，只因为那两个
+文件在 exclude 列表里；别把它们的写法照抄到不在 exclude 的文件上。
+
+key 走环境变量而不是 argv，避免出现在进程列表里。
+"""
+
+import os
+import sys
+
+# 与入库占位逐字一致：CI 只替换 const 那一行的值，注释保持不变。
+_HEADER = (
+    "/// Application API key supplied by CI, never a user's personal credential.\n"
+    "/// An empty source stub keeps unconfigured builds unavailable.\n"
+)
+_CONST = "const String kBuiltinOpenSubtitlesApiKey = '%s';\n"
+
+
+def dart_single_quoted(value: str) -> str:
+    """转义成可放进 Dart **单引号**字符串的内容。
+
+    单引号字符串不做转义序列以外的解释，但 `$` 仍是插值符，必须一起转义，
+    否则形如 `abc$id` 的 key 会被当成变量插值、编译失败。
+    """
+    return (
+        value.replace('\\', r'\\')
+        .replace("'", r"\'")
+        .replace('$', r'\$')
+    )
+
+
+def main() -> int:
+    dst = sys.argv[1]
+    key = os.environ.get('OPENSUBTITLES_API_KEY', '')
+    if not key:
+        return 0
+    with open(dst, 'w', encoding='utf-8', newline='\n') as handle:
+        handle.write(_HEADER)
+        handle.write(_CONST % dart_single_quoted(key))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2084 条。点号进各自文件。
+> 共 2085 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2250](bugs/BUG-2250-reader-brightness-selector.md) | ✅ | ✅ | 阅读器主题卡遗漏日间跟随系统夜间选择器 |
 | [BUG-2249](bugs/BUG-2249-reader-gallery-blur.md) | ✅ | ✅ | 插图画廊未同步正文图片模糊设置 |
 | [BUG-2248](bugs/BUG-2248-audiobook-narrow-transport.md) | ✅ | ✅ | 有声书窄屏封面挤压播放按钮导致越界 |

--- a/docs/bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md
+++ b/docs/bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md
@@ -1,0 +1,58 @@
+## BUG-2252 · CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红
+- **报告**：2026-09-07（合并 PR 时在 develop 上发现）
+- **真实性**：✅ 真 bug。根因 `.github/actions/provide-baked-secrets/action.yml:73`（修复前）
+
+  `Build Release APK` 的 `tests` job 在 develop 上连红两条提交（`b08e028b` 合入
+  #1286、`fef9a09a` 合入 #1284），失败步骤都是 `Run dart analyze`，而它前一条
+  `30b9070f` 是绿的。CI 报的是**一条 info**：
+
+  ```
+  info • Unnecessary use of double quotes. Try using single quotes unless the
+         string contains single quotes
+       • lib/src/media/video/subtitle/opensubtitles_default_key.dart:1:44
+       • prefer_single_quotes
+  1 issue found.  →  exit code 1
+  ```
+
+  #1286 引入的 OpenSubtitles 注入步骤照抄了 `google_oauth_secret.dart` 的写法：
+
+  ```bash
+  key_literal="$(python3 -c '... json.dumps(os.environ["OPENSUBTITLES_API_KEY"]) ...')"
+  printf 'const String kBuiltinOpenSubtitlesApiKey = %s;\n' "$key_literal" > "$dst"
+  ```
+
+  `json.dumps` 产出的是**双引号** Dart 字面量，`>` 又把整个文件覆写掉（连入库的
+  两行注释一起），于是 CI 上该文件第 1 行就是 `const String ... = "<key>";`——
+  报错位置 `1:44` 正是那个双引号。
+
+  能照抄成立的前提被漏掉了：`google_oauth_secret.dart` 与 `log_upload_secret.dart`
+  **在 `fushi/analysis_options.yaml` 的 `analyzer.exclude` 里**，双引号不会被检查；
+  `opensubtitles_default_key.dart` 不在。同类的 `tmdb_default_key.dart` 也不在
+  exclude 里，所以它一直用 `sed` 只替换 const 那一行、保持单引号——那才是对的范式。
+
+  **为什么本地测不出来**：本地 `flutter analyze` 看到的是入库的单引号空占位，
+  永远绿；双引号只在 CI 注入 secret 之后才存在。加上 CI 的 analyze 门把 info
+  也当失败（`dart analyze` 语义），这条 info 就成了硬红。
+
+- **[x] ① 已修复** — `.github/actions/provide-baked-secrets/action.yml` 改为调用新增的
+  `.github/actions/provide-baked-secrets/write_opensubtitles_key.py`：保留入库的两行
+  注释、只重写 const 那一行，产出**单引号**字面量，并转义 `\`、`'` 与 `$`（单引号
+  Dart 字符串里 `$` 仍是插值符，`abc$id` 形态的 key 不转义会编译失败）。
+  转义放进独立 python 脚本而不是内联，是因为 YAML→bash→sed 三层里 `\$` 会被逐层
+  吃掉——实测 `${VAR//'$'/'\$'}` 交给 sed 后反斜杠必然丢失，写不出正确结果。
+  key 走环境变量而非 argv，不进进程列表。
+
+  实测（三种输入 + 真 Dart 编译器回环）：未配 secret 时文件原样不动；正常 key 正确写入；
+  含 `$ ' \` 的 key 写成 `'a\$id\'q\\b'`，`dart` 跑起来 `== r"""a$id'q\b"""` 为真
+  （ROUNDTRIP_OK）。
+
+- **[x] ② 已加自动化测试** — `fushi/test/tools/baked_secret_stub_quotes_guard_test.dart`：
+  按 `dst=` 切出 action 里每个写 Dart 文件的步骤，凡目标不在 `analyzer.exclude`
+  名单里的，断言该步骤不得产出双引号字面量；另断言 exclude 名单解析器自身有效
+  （否则断言会变成恒真），以及生成脚本存在、模板是单引号、含 `$` 转义。
+  **变异实测**：把原写法改回 `json.dumps` + `printf > "$dst"`，守卫立刻红并指名
+  `opensubtitles_default_key.dart`；改回修复版后转绿。
+
+- **备注**：这条只有 CI 能抓、本地恒绿，属于「合并后必跑目录枚举型守卫」也覆盖不到的
+  盲区（它不在 `lib/`/`test/` 扫描面上，而在 `.github/`）。新增「烘进包的密钥」时，
+  先确认目标文件在不在 `analyzer.exclude` 里，再决定能不能用 `json.dumps` 那套写法。

--- a/fushi/test/tools/baked_secret_stub_quotes_guard_test.dart
+++ b/fushi/test/tools/baked_secret_stub_quotes_guard_test.dart
@@ -1,0 +1,140 @@
+// CI 注入 secret 时生成的 Dart 源码，**必须**能过 analyze 门。
+//
+// 真实事故（2026-09-07，develop 连红两条 PR）：provide-baked-secrets 里
+// OpenSubtitles 那一步照抄了 google_oauth_secret.dart 的 `json.dumps` 写法，
+// 产出双引号字面量并整份覆写文件：
+//
+//     const String kBuiltinOpenSubtitlesApiKey = "<key>";
+//
+// google_oauth_secret.dart / log_upload_secret.dart 这么写没事，**只因为**它们
+// 在 fushi/analysis_options.yaml 的 analyzer.exclude 里。opensubtitles_default_key.dart
+// 不在 exclude 里，于是双引号触发 prefer_single_quotes（info），而 CI 的
+// analyze 门把 info 也当失败 → 每个带该 secret 的 run 必红。本地
+// `flutter analyze` 看到的是**入库的单引号占位**，所以本地永远绿、只有 CI 红。
+//
+// 这条守卫钉死那个不变式：composite action 每个写 Dart 文件的步骤，其目标要么
+// 在 analyzer.exclude 名单里，要么不得产生双引号字面量。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 仓库根（本测试从 `fushi/` 下跑）。
+Directory get _repoRoot => Directory.current.path.endsWith('fushi')
+    ? Directory.current.parent
+    : Directory.current;
+
+File get _actionFile => File(
+      '${_repoRoot.path}/.github/actions/provide-baked-secrets/action.yml',
+    );
+
+File get _analysisOptions =>
+    File('${_repoRoot.path}/fushi/analysis_options.yaml');
+
+/// analysis_options.yaml 的 `analyzer.exclude` 里列出的文件名（basename）。
+Set<String> _excludedBasenames() {
+  final List<String> lines = _analysisOptions.readAsLinesSync();
+  final Set<String> out = <String>{};
+  bool inExclude = false;
+  for (final String raw in lines) {
+    final String line = raw.trimRight();
+    if (line.trimLeft().startsWith('exclude:')) {
+      inExclude = true;
+      continue;
+    }
+    if (inExclude) {
+      final String t = line.trim();
+      if (!t.startsWith('- ')) {
+        // 缩进回退到下一个 key，exclude 段结束。
+        if (t.isNotEmpty) inExclude = false;
+        continue;
+      }
+      out.add(t.substring(2).replaceAll("'", '').replaceAll('**/', ''));
+    }
+  }
+  return out;
+}
+
+/// 去掉 python 源码里的模块 docstring 与 `#` 注释，只留可执行代码。
+///
+/// 守卫要判的是「脚本**做**了什么」，不是「注释里**提**到什么」——解释本 bug
+/// 成因的那段说明必然会写到 json.dumps，裸字串匹配会把它自己判成违规。
+String _stripPythonComments(String source) {
+  String out = source;
+  final int open = out.indexOf('"""');
+  if (open >= 0) {
+    final int close = out.indexOf('"""', open + 3);
+    if (close > open) out = out.substring(close + 3);
+  }
+  return out
+      .split('\n')
+      .where((String l) => !l.trimLeft().startsWith('#'))
+      .join('\n');
+}
+
+void main() {
+  test('action.yml 存在（路径没被挪走，守卫不会静默失效）', () {
+    expect(_actionFile.existsSync(), isTrue,
+        reason: '${_actionFile.path} 不在了；守卫失去扫描对象');
+    expect(_analysisOptions.existsSync(), isTrue);
+  });
+
+  test('exclude 名单解析出了 google_oauth / log_upload（解析器自身没坏）', () {
+    final Set<String> excluded = _excludedBasenames();
+    expect(excluded, contains('google_oauth_secret.dart'),
+        reason: '解析 analyzer.exclude 失败，后面的断言会变成恒真');
+    expect(excluded, contains('log_upload_secret.dart'));
+  });
+
+  test('写入不在 analyzer.exclude 里的 Dart 文件时，不得产生双引号字面量', () {
+    final String yaml = _actionFile.readAsStringSync();
+    final Set<String> excluded = _excludedBasenames();
+
+    // 每个步骤都以 `dst=<路径>` 声明目标文件；按 dst 切段，逐段判定。
+    final RegExp dstPattern = RegExp(r'dst=(\S+\.dart)');
+    final List<RegExpMatch> hits = dstPattern.allMatches(yaml).toList();
+    expect(hits, isNotEmpty, reason: '没扫到任何 dst=，守卫恒真了');
+
+    final List<String> offenders = <String>[];
+    for (int i = 0; i < hits.length; i++) {
+      final String dst = hits[i].group(1)!;
+      final String basename = dst.split('/').last;
+      if (excluded.contains(basename)) continue;
+
+      final int start = hits[i].start;
+      final int end = i + 1 < hits.length ? hits[i + 1].start : yaml.length;
+      final String body = yaml.substring(start, end);
+
+      // json.dumps 一定产出双引号；printf 模板里直接写 `= "` 同理。
+      if (body.contains('json.dumps') ||
+          body.contains(r'kBuiltin') && body.contains('= \\"')) {
+        offenders.add(
+          '$dst：该文件不在 analyzer.exclude 里，写它的步骤却会产出双引号字面量'
+          '（prefer_single_quotes → CI analyze 门 exit 1）',
+        );
+      }
+    }
+
+    expect(offenders, isEmpty, reason: offenders.join('\n'));
+  });
+
+  test('OpenSubtitles key 走独立脚本，且脚本产出单引号', () {
+    final File writer = File(
+      '${_repoRoot.path}/.github/actions/provide-baked-secrets/'
+      'write_opensubtitles_key.py',
+    );
+    expect(writer.existsSync(), isTrue,
+        reason: '生成脚本不在了；action.yml 会在 CI 上直接报 file not found');
+
+    final String src = writer.readAsStringSync();
+    expect(src.contains("kBuiltinOpenSubtitlesApiKey = '%s'"), isTrue,
+        reason: '生成模板必须是单引号 Dart 字面量');
+    // 只看**真实代码**：脚本的文档注释本来就要解释「为什么不用 json.dumps」，
+    // 拿裸字串判定会把那段说明本身判成违规。
+    expect(_stripPythonComments(src).contains('json.dumps('), isFalse,
+        reason: 'json.dumps 产出双引号，正是本 bug 的成因');
+    // 单引号字符串里 $ 仍是插值符，必须转义，否则 `abc$id` 形态的 key 编译失败。
+    expect(src.contains(r"replace('$'"), isTrue,
+        reason: '缺 \$ 转义：含 \$ 的 key 会被当成 Dart 插值');
+  });
+}


### PR DESCRIPTION
## 症状

`Build Release APK` 的 `tests` job 在 develop 上**连红两条提交**——`b08e028b`（合入 #1286）、`fef9a09a`（合入 #1284），而此前的 `30b9070f` 是绿的。失败步骤都是 `Run dart analyze`，而它报的只是**一条 info**：

```
info • Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes
     • lib/src/media/video/subtitle/opensubtitles_default_key.dart:1:44 • prefer_single_quotes
1 issue found.   →   exit code 1
```

## 根因

#1286 引入的 OpenSubtitles 注入步骤照抄了 `google_oauth_secret.dart` 的写法：

```bash
key_literal="$(python3 -c '... json.dumps(os.environ["OPENSUBTITLES_API_KEY"]) ...')"
printf 'const String kBuiltinOpenSubtitlesApiKey = %s;\n' "$key_literal" > "$dst"
```

`json.dumps` 产出**双引号** Dart 字面量，`>` 又把文件整份覆写（连入库的两行注释一起）。所以 CI 上该文件第 1 行就是 `const String ... = "<key>";`——报错位置 `1:44` 正是那个双引号。

**照抄成立的前提被漏掉了**：`google_oauth_secret.dart` 与 `log_upload_secret.dart` 在 `fushi/analysis_options.yaml` 的 `analyzer.exclude` 里，双引号不会被检查；`opensubtitles_default_key.dart` 不在。同类的 `tmdb_default_key.dart` 也不在 exclude 里，所以它一直用 `sed` 只替换 const 那一行、保持单引号——那才是对的范式。

**为什么本地测不出来**：本地 `flutter analyze` 看到的是入库的单引号空占位，恒绿；双引号只在 CI 注入 secret 之后才存在。加上 CI 的 analyze 门把 info 也当失败，这条 info 就成了硬红。

## 改动

`action.yml` 改为调用新增的 `write_opensubtitles_key.py`：保留入库的两行注释、只重写 const 那一行、产出**单引号**，并转义 `\`、`'` 与 `$`（单引号 Dart 串里 `$` 仍是插值符，`abc$id` 形态的 key 不转义会编译失败）。key 走环境变量而非 argv，不进进程列表。

转义放独立脚本而非内联，是因为 YAML→bash→sed 三层会把反斜杠逐层吃掉：实测 `${VAR//'$'/'\$'}` 交给 sed 后反斜杠必然丢失，内联写不出正确结果。

## 验证

- **三种输入实测**：未配 secret → 文件原样不动；正常 key → 正确写入；含 `$ ' \` 的 key → 写成 `'a\$id\'q\b'`
- **真 Dart 编译器回环**：把生成的文件喂给 `dart`，断言 `== r"""a$id'q\b"""` → `ROUNDTRIP_OK`
- **守卫 + 变异实测**：`fushi/test/tools/baked_secret_stub_quotes_guard_test.dart` 按 `dst=` 切段，凡目标不在 `analyzer.exclude` 名单里的步骤，断言不得产出双引号字面量。把原写法改回 `json.dumps`，守卫立刻红并指名 `opensubtitles_default_key.dart`；改回修复版转绿。守卫另断言 exclude 名单解析器自身有效，避免断言退化成恒真。
- `flutter analyze --no-pub`（含 test）：No issues found
- `dart run tool/bug.dart check`：2085 条，号唯一、索引同步

真正的判绿要看这条 PR 自己的 `Build Release APK` —— 这个 bug 只有带 `OPENSUBTITLES_API_KEY` 的 CI run 能暴露。

BUG-2252

https://claude.ai/code/session_01BZdF3pXPF98x7LYJmZaG4J
