### PR TITLE
fix(test): 嵌套查词搬进独立 iframe 后，CSS 尾段守卫改为逐文件精确计数

### DIFF
--- a/fushi/test/sync/remote_lookup_dictionary_css_test.dart
+++ b/fushi/test/sync/remote_lookup_dictionary_css_test.dart
@@ -171,10 +171,21 @@ void main() {
             reason: '[$name] background.js 没把 CSS 尾段并进缓存并回填给页面');
 
         final String content = File('$root/content.js').readAsStringSync();
-        // 两处：首次查词渲染 + 嵌套查词渲染。只数「有没有」会被另一处顶着，删掉其中一处
-        // 照样绿（实测：删首次查词那处，contains 仍命中嵌套那处）——所以必须数够 2 次。
-        expect('applyFushiPopupCss(resp.data)'.allMatches(content).length, 2,
-            reason: '[$name] content.js 的首次查词 / 嵌套查词两条渲染路径都必须落 CSS 尾段');
+        // 仍然是两条渲染路径都必须落 CSS 尾段，但它们不再同住 content.js：
+        // 嵌套查词自 BUG-2245 起搬进了独立 iframe（nested-popup.js），content.js
+        // 里只剩首次查词那一处。所以改成**逐文件精确计数**，而不是在 content.js
+        // 里数 2 次。
+        //
+        // 为什么坚持数个数而不是 contains：只问「有没有」时，两处里删掉任一处
+        // 都还能被另一处顶着照样绿（原注释记的就是这次实测）。拆成两个文件后
+        // 这个风险还在——各自都必须恰好命中一次。
+        expect('applyFushiPopupCss(resp.data)'.allMatches(content).length, 1,
+            reason: '[$name] content.js 的首次查词渲染路径必须落 CSS 尾段');
+        final String nestedPopup =
+            File('$root/nested-popup.js').readAsStringSync();
+        expect('applyFushiPopupCss('.allMatches(nestedPopup).length, 1,
+            reason: '[$name] nested-popup.js 的嵌套查词渲染路径必须落 CSS 尾段'
+                '（嵌套结果在独立 iframe 里渲染，拿不到父层的 CSS 尾段就会裸样式）');
         expect(content, contains('installDictMediaPlaceholderResolver(shadow)'),
             reason: '[$name] content.js 没在弹窗 shadow 上装占位兑现器');
 


### PR DESCRIPTION
## 症状

`fushi/test/sync/remote_lookup_dictionary_css_test.dart` 的「扩展两镜像都接上了 CSS 尾段与词条资源占位的兑现方」自 #1284 合入起在 develop 上是红的：

```
Expected: <2>
  Actual: <1>
[assets] content.js 的首次查词 / 嵌套查词两条渲染路径都必须落 CSS 尾段
```

## 根因

#1284（BUG-2245）把嵌套查词弹窗改成**独立 iframe**，嵌套渲染路径随之从 `content.js` 搬进了 `nested-popup.js`：

| 路径 | 改动前 | 改动后 |
|---|---|---|
| 首次查词渲染 | `content.js` | `content.js:2032` |
| 嵌套查词渲染 | `content.js` | `nested-popup.js:92` |

守卫还在 `content.js` 里数 `applyFushiPopupCss(resp.data)` 必须出现 2 次，实际只剩 1 处。两个镜像（`fushi/assets/browser_extension` 与 `tools/browser-extension`）情况一致。

**为什么合 #1284 时没抓到**：这条守卫在 `test/sync/` 下。当时按功能域跑的是 popup 相关的 `test/build`、`test/dictionary`、`test/anki`，加上扩展的 490 条 node 测试和镜像一致性守卫 —— 都绿。一条断言浏览器扩展文件内容的测试住在 `test/sync`，按功能域挑挑不到它。

## 改动

守卫的**不变式没变**——两条渲染路径都必须落 CSS 尾段，否则嵌套结果在 iframe 里拿不到父层样式、裸样式显示。变的只是它们不再同住一个文件，所以改成逐文件各断言恰好一次。

仍然数个数而不是 `contains`：只问「有没有」时，删掉任一处都会被另一处顶着照样绿（原注释记录的正是这次实测）；拆成两个文件后这个风险依旧存在，所以各自都必须恰好命中一次。

## 验证

- 修复后 `test/sync/remote_lookup_dictionary_css_test.dart`：8 条全过
- **变异实测**：把 `nested-popup.js` 里那处 `applyFushiPopupCss(data)` 删掉，守卫立刻红并指名「nested-popup.js 的嵌套查词渲染路径必须落 CSS 尾段」；恢复后转绿
- 在纯 develop 上复现过原始失败（`DEVELOP_EXIT=1`），确认这条红先于本 PR 存在、且与同期在审的 #1272 无关

https://claude.ai/code/session_01BZdF3pXPF98x7LYJmZaG4J
