### PR TITLE
fix(reader): 修复从本句播放偶尔跳到上一句

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2111 条。点号进各自文件。
+> 共 2112 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/bugs/BUG-2255-reader-sentence-seek-dom-identity.md
+++ b/docs/bugs/BUG-2255-reader-sentence-seek-dom-identity.md
@@ -1,0 +1,7 @@
+## BUG-2255 · 正文从本句播放误取上一条字幕
+- **报告**：2026-09-07，用户提供《86》第一卷 SRT 与 EPUB，正文从本句播放偶尔跳到上一句。
+- **真实性**：✅ 真 bug。`reader_selection_scripts.dart:1769` 的 `getNormalizedOffset` 返回学习单位数，旧 `reader_fushi/audiobook.part.dart:895` 的 `_findCueForOffset` 却把它当成字幕归一化字符偏移。数字、英文串分别按一个词与多个字符计数，导致选择位置向前漂移。`reader_fushi/lookup.part.dart:228` 和 `reader_fushi/chrome.part.dart:738` 两处消费受影响。
+- **[x] ① 已修复** — 点词、拖选和原生选区回传实时 DOM 对应的 cue 标识，Dart 通过既有 `cueForPointerPayload` 解析。复用正文高亮的实际映射，删除混用坐标的查找；中键共享同一 DOM 查询，并将 Range 末端排除出前句。提交见本文件所在提交。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reader_audio_cue_identity_test.dart`、`reader_audio_cue_identity_harness.mjs`：真实 Chrome 中执行两种生产 shell 的 reader 对象及 selection 脚本，共 24 个场景，包含数字/英文、点选/原生选区、句首、ruby、合成 cue 和无 cue；`reader_selection_data_test.dart` 覆盖桥接解析。定向 10 项、相邻 90 项通过；全量 `flutter analyze --no-pub` 无问题。
+- **真实输入证据**：9533 条字幕中匹配 9487 条。第 17 条 `02:02.845` 的匹配起点为 83，学习单位起点却为 73，落入第 16 条 `02:00.563`。序章同一文本节点中的 `ＲＭＩ Ｍ１Ａ４` 与 `ＯＳ Ｖｅｒ８．１５` 累积少计 10。第 18 条也错落第 17 条。真实文件 matcher 探针 1 项通过；本地证据 `.codex-test/86-probe.json`，原书正文不入库。
+- **备注**：上述浏览器测试验证 DOM→选区→cue 标识，未运行完整 Windows App 的原始点击到实际音频起音 E2E；用户本次只提供 SRT/EPUB。学习统计、收藏/制卡的现有偏移字段和字幕匹配结果不在本次变更范围。独立分支交集成负责人合入，未修改原工作区。

--- a/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
@@ -892,25 +892,6 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     return _currentChapter;
   }
 
-  AudioCue? _findCueForOffset(int normalizedOffset) {
-    final AudiobookPlayerController? ctrl = _audiobookController;
-    if (ctrl == null) return null;
-    final List<AudioCue> cues = ctrl.sentenceAudioCuesForSection(
-      _currentChapter,
-    );
-    for (final AudioCue cue in cues) {
-      final SubtitleRematchFragment? frag = SubtitleRematchCodec.tryDecode(
-        cue.textFragmentId,
-      );
-      if (frag == null) continue;
-      if (frag.normCharStart <= normalizedOffset &&
-          frag.normCharEnd > normalizedOffset) {
-        return cue;
-      }
-    }
-    return null;
-  }
-
   AudioCue? _findCueForSentence(String sentence) {
     if (_srtBookUid == null) return null;
     final List<AudioCue>? allCues = _cachedAllCues;

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -735,8 +735,9 @@ extension _ReaderChrome on _ReaderFushiPageState {
       ),
     );
     _cachedSentenceOffset = data.sentenceOffset;
-    _lookupCue = data.normalizedOffset != null
-        ? _findCueForOffset(data.normalizedOffset!)
+    final List<AudioCue>? allCues = _cachedAllCues;
+    _lookupCue = data.audioCuePayload != null && allCues != null
+        ? cueForPointerPayload(data.audioCuePayload!, allCues)
         : null;
     if (_lookupCue == null && _srtBookUid != null) {
       _lookupCue = _findCueForSentence(data.sentence);

--- a/fushi/lib/src/pages/implementations/reader_fushi/lookup.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/lookup.part.dart
@@ -225,8 +225,9 @@ extension _ReaderLookup on _ReaderFushiPageState {
       return;
     }
 
-    _lookupCue = data.normalizedOffset != null
-        ? _findCueForOffset(data.normalizedOffset!)
+    final List<AudioCue>? allCues = _cachedAllCues;
+    _lookupCue = data.audioCuePayload != null && allCues != null
+        ? cueForPointerPayload(data.audioCuePayload!, allCues)
         : null;
     if (_lookupCue == null && _srtBookUid != null) {
       _lookupCue = _findCueForSentence(data.sentence);

--- a/fushi/lib/src/reader/reader_pagination_scripts.dart
+++ b/fushi/lib/src/reader/reader_pagination_scripts.dart
@@ -1638,13 +1638,26 @@ window.__fushiInstallShell = function(C) {
     if (!window.fushiSelection || !window.fushiSelection.getCaretRange) return null;
     var caret = window.fushiSelection.getCaretRange(x, y);
     if (!caret) return null;
-    var node = caret.startContainer, off = caret.startOffset;
+    return this.cueIdAtDomPoint(caret.startContainer, caret.startOffset);
+  },
+  // Resolve the actual rendered cue, shared by pointer seek and lookup payloads.
+  // Study-unit offsets are not subtitle-normalized character offsets.
+  cueIdAtDomPoint: function(node, off) {
+    var el = node && node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+    var sidEl = el && el.closest ? el.closest('[data-cue-id]') : null;
+    if (sidEl) return JSON.stringify({ type: 'sid', id: sidEl.getAttribute('data-cue-id') });
     var found = null;
     if (this.cueRangesMap && this.cueRangesMap.size) {
       this.cueRangesMap.forEach(function(ranges, id) {
         if (found) return;
         for (var i = 0; i < ranges.length; i++) {
-          try { if (ranges[i].comparePoint(node, off) === 0) { found = id; break; } }
+          try {
+            var r = ranges[i];
+            if (r.comparePoint(node, off) === 0 &&
+                !(r.endContainer === node && r.endOffset === off)) {
+              found = id; break;
+            }
+          }
           catch (e) {}
         }
       });

--- a/fushi/lib/src/reader/reader_selection_data.dart
+++ b/fushi/lib/src/reader/reader_selection_data.dart
@@ -10,6 +10,7 @@ class ReaderSelectionData {
     this.sentenceNormalizedLength,
     this.verticalWriting = false,
     this.mangaPageIndex,
+    this.audioCuePayload,
   });
 
   factory ReaderSelectionData.fromJson(Map<String, dynamic> json) {
@@ -30,16 +31,20 @@ class ReaderSelectionData {
       normalizedOffset: (json['normalizedOffset'] as num?)?.toInt(),
       normalizedLength: (json['normalizedLength'] as num?)?.toInt(),
       sentenceOffset: (json['sentenceOffset'] as num?)?.toInt() ?? 0,
-      sentenceNormalizedOffset:
-          (json['sentenceNormalizedOffset'] as num?)?.toInt(),
-      sentenceNormalizedLength:
-          (json['sentenceNormalizedLength'] as num?)?.toInt(),
+      sentenceNormalizedOffset: (json['sentenceNormalizedOffset'] as num?)
+          ?.toInt(),
+      sentenceNormalizedLength: (json['sentenceNormalizedLength'] as num?)
+          ?.toInt(),
       verticalWriting: json['verticalWriting'] as bool? ?? false,
       mangaPageIndex: (json['mangaPageIndex'] as num?)?.toInt(),
+      audioCuePayload: json['audioCuePayload'] as String?,
     );
   }
 
   final String text;
+
+  /// Cue identity from the rendered DOM, independent of study-unit offsets.
+  final String? audioCuePayload;
   final String sentence;
   final Map<String, double>? rect;
   final int? normalizedOffset;

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -1010,6 +1010,8 @@ window.fushiSelection = {
     return {
       text: text,
       sentence: sentence,
+      audioCuePayload: window.fushiReader && window.fushiReader.cueIdAtDomPoint
+        ? window.fushiReader.cueIdAtDomPoint(startNode, startOffset) : null,
       normalizedOffset: normalizedOffset,
       normalizedLength: normalizedLength,
       sentenceOffset: sentenceOffset,
@@ -1316,6 +1318,8 @@ window.fushiSelection = {
       sentence: mangaSentence !== null && mangaSentence !== ''
         ? mangaSentence : sentenceContext.sentence,
       rect: mangaGroupRect || this.getSelectionRect(x, y),
+      audioCuePayload: window.fushiReader && window.fushiReader.cueIdAtDomPoint
+        ? window.fushiReader.cueIdAtDomPoint(startNode, startOffset) : null,
       normalizedOffset: normalizedOffset,
       normalizedLength: normalizedLength,
       sentenceOffset: mangaSentence !== null && mangaSentence !== ''

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1247
+version: 2.3.0+1248
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/reader/reader_audio_cue_identity_harness.mjs
+++ b/fushi/test/reader/reader_audio_cue_identity_harness.mjs
@@ -1,0 +1,102 @@
+// Executes generated production reader/selection objects against Chrome Range,
+// Selection and wrapper DOM; only the Flutter bridge is replaced by a recorder.
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+import { launchChromeDriver, resolveChrome } from '../../../tool/reader_pitch_headless/cdp_client.mjs';
+
+if (!resolveChrome()) {
+  console.log('Chrome unavailable');
+  process.exit(77);
+}
+const scripts = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const driver = await launchChromeDriver();
+let count = 0;
+try {
+  for (const shell of scripts.shells) {
+    const start = shell.indexOf('window.fushiReader = {');
+    const end = shell.indexOf('\n};', start);
+    assert.ok(start >= 0 && end > start, 'production reader object exists');
+    const source = 'const C = {};\n' + scripts.units + '\n' +
+      shell.slice(start, end + 3) + '\n' + scripts.selection;
+    const result = await driver.evalOnPage('<!doctype html><meta charset="utf-8"><body>', `(() => {
+      (0, eval)(${JSON.stringify(source)});
+      window.flutter_inappwebview = {callHandler: (name, payload) => {
+        window.lastPayload = JSON.parse(payload);
+      }};
+      window.__fushiCssHighlightsSupported = true;
+      const reader = window.fushiReader;
+      const selection = window.fushiSelection;
+      const results = [];
+      function check(condition, label) {
+        if (!condition) throw Error(label);
+        results.push(label);
+      }
+      function native(node, start, end) {
+        const range = document.createRange();
+        range.setStart(node, start); range.setEnd(node, end);
+        window.getSelection().removeAllRanges();
+        window.getSelection().addRange(range);
+        return selection.nativeSelectionSentenceRange();
+      }
+      function cue(payload) { return payload.audioCuePayload ? JSON.parse(payload.audioCuePayload) : {}; }
+      document.body.innerHTML = '<p>西暦2148年。Eighty Six部隊。次の文。</p>';
+      reader.applySentenceAudioCues([
+        {id:'previous', text:'西暦2148年。', start:0, length:7},
+        {id:'current', text:'Eighty Six部隊。', start:7, length:11},
+        {id:'next', text:'次の文。', start:18, length:3}
+      ]);
+      const current = reader.cueWrappers.get('current')[0].firstChild;
+      selection.selectFromPosition(current, 0, 1);
+      check(cue(window.lastPayload).id === 'current', 'tap targets rendered English cue');
+      check(window.lastPayload.normalizedOffset === 4 &&
+        reader.buildSentenceAudioNormIndex().full.indexOf('eighty') === 7,
+        'digit run makes study offset 4 differ from subtitle offset 7');
+      check(cue(native(current, 0, 1)).id === 'current', 'native selection targets same cue');
+      const hitRange = document.createRange(); hitRange.setStart(current, 0); hitRange.setEnd(current, 1);
+      const rect = hitRange.getBoundingClientRect();
+      check(JSON.parse(reader.cueIdAtPoint(rect.left + rect.width / 3, rect.top + rect.height / 2)).id === 'current',
+        'real glyph pointer seek agrees with lookup payload');
+      const next = reader.cueWrappers.get('next')[0].firstChild;
+      selection.selectFromPosition(next, 0, 1);
+      check(cue(window.lastPayload).id === 'next' && window.lastPayload.normalizedOffset === 8,
+        'English words compress study offsets without moving next sentence seek');
+      reader.resetSentenceAudioCues();
+      document.body.innerHTML = '<p>前文次文</p>';
+      const node = document.querySelector('p').firstChild;
+      const previous = document.createRange(); previous.setStart(node, 0); previous.setEnd(node, 2);
+      const following = document.createRange(); following.setStart(node, 2); following.setEnd(node, 4);
+      reader.cueRangesMap.set('previous', [previous]);
+      reader.cueRangesMap.set('current', [following]);
+      reader.buildNodeOffsets();
+      selection.selectFromPosition(node, 2, 1);
+      check(cue(window.lastPayload).id === 'current', 'tap at shared Range boundary excludes previous cue');
+      check(cue(native(node, 2, 3)).id === 'current', 'native Range boundary excludes previous cue');
+      reader.resetSentenceAudioCues();
+      document.body.innerHTML = '<p><ruby>次<rt>つぎ</rt></ruby>の文。</p>';
+      reader.applySentenceAudioCues([{id:'ruby', text:'次の文。', start:0, length:3}]);
+      const ruby = document.querySelector('ruby');
+      selection.selectFromPosition(ruby.firstChild, 0, 1);
+      check(cue(window.lastPayload).id === 'ruby' &&
+        JSON.parse(reader.cueIdAtDomPoint(ruby.querySelector('rt').firstChild, 0)).id === 'ruby',
+        'ruby base lookup and annotation pointer keep cue identity');
+      check(cue(native(ruby.firstChild, 0, 1)).id === 'ruby', 'ruby native selection preserves cue');
+      reader.resetSentenceAudioCues();
+      document.body.innerHTML = '<p data-cue-id="12">合成文。</p><p id="missing">字幕なし。</p>';
+      reader.buildNodeOffsets();
+      const synthetic = document.querySelector('p').firstChild;
+      selection.selectFromPosition(synthetic, 0, 1);
+      check(cue(window.lastPayload).type === 'sid' && cue(window.lastPayload).id === '12',
+        'synthetic tap preserves sid identity');
+      check(cue(native(synthetic, 0, 1)).type === 'sid', 'synthetic native selection preserves sid');
+      const missing = document.querySelector('#missing').firstChild;
+      selection.selectFromPosition(missing, 0, 1);
+      check(window.lastPayload.audioCuePayload === null && native(missing, 0, 1).audioCuePayload === null,
+        'unmapped text has no previous-cue fallback');
+      return results;
+    })()`);
+    count += result.length;
+  }
+  console.log('PASS ' + count + ' browser cases');
+} finally {
+  driver.close();
+}

--- a/fushi/test/reader/reader_audio_cue_identity_test.dart
+++ b/fushi/test/reader/reader_audio_cue_identity_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_pagination_scripts.dart';
+import 'package:fushi/src/reader/reader_selection_scripts.dart';
+import 'package:fushi/src/reader/reader_study_unit_script.dart';
+
+void main() {
+  test(
+    'lookup retains rendered cue identity in real Chrome DOM',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped('node not found on PATH; skipping JS execution');
+        return;
+      }
+      final Directory temp = Directory.systemTemp.createTempSync('reader-cue-');
+      try {
+        final File payload = File('${temp.path}/scripts.json')
+          ..writeAsStringSync(
+            jsonEncode(<String, Object>{
+              'shells': <String>[
+                ReaderPaginationScripts.paginatedShellSource(),
+                ReaderPaginationScripts.continuousShellSource(),
+              ],
+              'selection': ReaderSelectionScripts.source(),
+              'units': kStudyUnitJs,
+            }),
+          );
+        final ProcessResult result = await Process.run(nodeExe, <String>[
+          'test/reader/reader_audio_cue_identity_harness.mjs',
+          payload.path,
+        ]);
+        if (result.exitCode == 77) {
+          markTestSkipped('Chrome unavailable: ${result.stdout}');
+          return;
+        }
+        expect(
+          result.exitCode,
+          0,
+          reason: '${result.stdout}\n${result.stderr}',
+        );
+        expect(result.stdout, contains('PASS 24 browser cases'));
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 90)),
+  );
+}
+
+/// Resolve Node before launching the browser harness so missing CI tools skip.
+String? _resolveNode() {
+  final List<String> candidates = Platform.isWindows
+      ? <String>['node.exe', 'node']
+      : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) return name;
+    } on ProcessException {
+      // Try the next executable name.
+    }
+  }
+  return null;
+}

--- a/fushi/test/reader/reader_selection_data_test.dart
+++ b/fushi/test/reader/reader_selection_data_test.dart
@@ -3,6 +3,19 @@ import 'package:fushi/src/reader/reader_selection_data.dart';
 
 void main() {
   group('ReaderSelectionData.fromJson', () {
+    test(
+      'preserves synthetic cue identity independent of normalized offset',
+      () {
+        final ReaderSelectionData data =
+            ReaderSelectionData.fromJson(<String, dynamic>{
+              'text': '次',
+              'normalizedOffset': 4,
+              'audioCuePayload': '{"type":"sid","id":"12"}',
+            });
+        expect(data.audioCuePayload, '{"type":"sid","id":"12"}');
+        expect(data.normalizedOffset, 4);
+      },
+    );
     test('parses full JSON with all fields', () {
       final json = <String, dynamic>{
         'text': '猫',
@@ -15,6 +28,7 @@ void main() {
         'mangaPageIndex': 2,
         'sentenceNormalizedOffset': 10,
         'sentenceNormalizedLength': 8,
+        'audioCuePayload': '{"type":"frag","id":"cue-2"}',
       };
 
       final data = ReaderSelectionData.fromJson(json);
@@ -33,6 +47,7 @@ void main() {
       expect(data.mangaPageIndex, 2);
       expect(data.sentenceNormalizedOffset, 10);
       expect(data.sentenceNormalizedLength, 8);
+      expect(data.audioCuePayload, '{"type":"frag","id":"cue-2"}');
     });
 
     test('missing optional fields default correctly', () {
@@ -53,6 +68,7 @@ void main() {
       expect(data.mangaPageIndex, isNull);
       expect(data.sentenceNormalizedOffset, isNull);
       expect(data.sentenceNormalizedLength, isNull);
+      expect(data.audioCuePayload, isNull);
     });
 
     test('empty JSON defaults text and sentence to empty strings', () {


### PR DESCRIPTION
点正文后使用“从本句播放”时，数字和英文会让学习单位偏移小于字幕归一化字符偏移，导致误选上一条字幕。用用户提供的《86》第一卷 SRT/EPUB 复现：第 17 条应跳到 02:02.845，旧逻辑却选中第 16 条的 02:00.563。

点词、拖选及原生选区现在直接回传正文实际对应的字幕标识，并复用既有 cue 解析；中键跳播共享同一 DOM 查询，句首边界排除前句末端。记录 BUG-2255，build 升至 2.3.0+1248。

验证：
- 100 项定向及相邻测试通过，其中真实 Chrome 覆盖分页/连续模式共 24 个场景。
- 真实 SRT/EPUB 匹配探针 1 项通过；移除生成载荷中的修复后，浏览器回归断言按预期失败。
- 全量 flutter analyze --no-pub、BUG 编号检查、git diff --check 通过。

未验证：完整 Windows App 中原始点击到实际音频起音的 E2E，本次输入只有 SRT/EPUB；未运行本地全量测试及安装包构建。
