### PR TITLE
feat(browser-extension): 移动端字幕抽屉 + 触屏查词 + 嵌入态紧凑 UI

### DIFF
--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -493,6 +493,37 @@ async function fushiIconClick(tab) {
 // 迁到 action-popup.js 的「开始生成/录制」按钮：按钮点击是用户手势，query 到当前 tab 后发
 // fushiIconAction 消息到这里，由下方 onMessage 分支调用同一个 fushiIconClick（逻辑不变，只换触发口）。
 
+// 审计报告 #1295：抽屉 iframe 的面板过去把「宿主 origin」写在 URL 参数里自证——
+// 任意网站嵌一句 `side-panel.html?fushiEmbed=1&fushiHostOrigin=https://evil.com`
+// 就能让自己的 origin 通过校验。改为 **SW 背书的双向兑换**：
+//   ① 抽屉 content script 要 token：SW 从 `sender.tab.url`（网页不可见、不可伪造）
+//      取真 origin，签发一次性凭证（绑定 tabId，TTL 10 分钟）；
+//   ② 面板 iframe 拿 token 来兑：核销 tabId 相符后回真 origin，供 ev.origin 校验。
+// 攻击者直接嵌 iframe 手里没有 token（web 页发不了 runtime 消息），兑换必然落空 →
+// EMBED_HOST_ORIGIN 恒为 ''，宿主消息全数丢弃（面板照常渲染，只是驱动不进来）。
+const fushiEmbedTokens = new Map(); // token -> {tabId, origin, exp}
+function fushiIssueEmbedToken(tabId, tabUrl) {
+  let origin = '';
+  try { origin = new URL(tabUrl).origin; } catch (_) { return null; }
+  if (!origin || origin === 'null' || !Number.isInteger(tabId)) return null;
+  const now = Date.now();
+  for (const [t, r] of fushiEmbedTokens) if (r.exp < now) fushiEmbedTokens.delete(t);
+  let token;
+  try { token = crypto.randomUUID(); } catch (_) {
+    token = now.toString(36) + '-' + Math.random().toString(36).slice(2);
+  }
+  fushiEmbedTokens.set(token, { tabId, origin, exp: now + 600000 });
+  return token;
+}
+function fushiRedeemEmbedToken(token, senderTabId) {
+  if (!token || typeof token !== 'string') return '';
+  const rec = fushiEmbedTokens.get(token);
+  if (!rec || rec.exp < Date.now()) { fushiEmbedTokens.delete(token); return ''; }
+  // token 换 Tab 用不了：核销方必须是签发时那个标签页。
+  if (!Number.isInteger(senderTabId) || rec.tabId !== senderTabId) return '';
+  return rec.origin;
+}
+
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 发给 offscreen 的消息由 offscreen 处理，background 不插手。
   if (msg && msg.target === 'offscreen') return false;
@@ -520,10 +551,21 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
   // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
   if (msg && msg.type === 'drawerSelfTab') {
+    const tid = _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null;
     sendResponse({
       ok: true,
-      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
+      tabId: tid,
+      // 审计报告 #1295：随标签 id 一并签发嵌入凭证（真 origin 由 SW 从 sender.tab.url
+      // 取得，只有拿 token 来兑的面板能知道）。签发失败（异常 sender）回 null——
+      // 面板端 fail-closed，宿主消息通道整个关死。
+      token: tid != null ? fushiIssueEmbedToken(tid, _sender.tab.url) : null,
     });
+    return true;
+  }
+  if (msg && msg.type === 'drawerEmbedVerify') {
+    // 面板 iframe 持 token 核销；核销方 tab 必须与签发时一致。
+    const senderTid = _sender && _sender.tab && _sender.tab.id;
+    sendResponse({ ok: true, origin: fushiRedeemEmbedToken(msg.token, senderTid) });
     return true;
   }
   if (msg && msg.type === 'openSubtitleSidePanel') {

--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -516,6 +516,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 另外：open() 必须是拿到激活后的第一句——原实现先 `await setOptions(...)`，其 resolve 落在
   // 新的宏任务里，激活早已过期，等于自己把仅有的机会也丢掉了。setOptions 不需要激活，挪到
   // open() 之后补（manifest 的 side_panel.default_path 已足以让 open() 用对页面）。
+  // 字幕抽屉（mobile-drawer.js）：iframe 里的扩展页拿不到宿主标签身份，content script
+  // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
+  // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
+  if (msg && msg.type === 'drawerSelfTab') {
+    sendResponse({
+      ok: true,
+      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
+    });
+    return true;
+  }
   if (msg && msg.type === 'openSubtitleSidePanel') {
     const tabId = Number.isInteger(msg.tabId)
       ? msg.tabId

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -25,6 +25,27 @@ let fushiContainer = null;
 // 与 in-app WebView 弹窗一致）。fushiHost 是挂在宿主页的 shadow 宿主元素（负责 fixed 定位），
 // #entries-container 及全部弹窗内容在其 shadow root 内；window.__fushiRoot 暴露给 popup.js。
 let fushiHost = null;
+// 弹窗样式同步注入（「CSS 要渲染一下才正常」的修复）：shadow 里的 content.css 原本经
+// <link> 加载——异步，而 host 每次查词重建、首帧 rAF 立刻「量尺寸 → 落点」。慢设备
+// （手机冷启动首查最典型）样式应用赶不上测量：落点按未加样式的「裸」布局算出，样式
+// 到达后只有改变盒尺寸的规则会触发 ResizeObserver 复算，纯视觉规则（颜色/字体/圆角）
+// 永远不自愈——用户看到的就是弹窗样式/位置错一帧起，滚动或再渲染一次才正常。
+// 修法两层：①启动即预取 CSS 文本，就绪后以同步 <style> 注入（首帧测量必见最终布局，
+// 零竞态）；②预取尚未就绪（页面刚加载的第一发查词，或该内核禁 content script fetch
+// 扩展资源）退回 <link>，并登记 fushiCssLink 门控——place 照旧落点，但「显示」扣到
+// 样式表 load/error/800ms 超时之后，落地时先按最终布局复算一次落点再放行。
+// 表现层的承诺从「快一帧但可能裸奔」换成「最多晚一帧，绝不无样式上屏」。
+let fushiPopupCssText = '';
+try {
+  fetch(chrome.runtime.getURL('vendor/content.css'))
+      .then((r) => (r && r.ok ? r.text() : ''))
+      .then((t) => { if (typeof t === 'string' && t) fushiPopupCssText = t; })
+      .catch(() => { /* 预取失败：永远走 link 回落路径 */ });
+} catch (_) { /* 无 fetch：同上，link 回落 */ }
+// link 回落路径的在途账本：当前弹窗样式表尚未应用完时挂在这里，place 把「显示」挂到
+// 它身后——根治「字先出、CSS 后渲染」（FOUC）：宁晚一帧出场，也不裸奔上屏。
+// 同步 <style> 路径恒为 null（样式即时生效，无需扣显）。
+let fushiCssLink = null;
 // BUG-530 性能：划词监听器原来对每次 mousemove 都发查词请求 → 一直按 Shift 移动会把服务器
 // 刷爆、UI 卡顿。用「位移阈值 + 同词去重 + 在途请求闸」三重节流：只在移到**不同词**上才查。
 let fushiLastTerm = '';
@@ -1013,6 +1034,7 @@ function fushiNativeSubtitleSelectors() {
     '.ytp-caption-window-container', // YouTube
     '.captions-text',                // 通用（部分播放器）
     '.libassjs-canvas-parent',       // ASS/SSA 渲染层
+    '.bilibili-player-video-subtitle', // B站网页播放器的自绘字幕层
   ];
 }
 // 扩展自绘覆盖层（subtitle-panel.js 的 #fushi-subtitle-overlay）。
@@ -1034,10 +1056,13 @@ function fushiApplySubtitleHiding() {
   }
   const manual = fushiSubtitleHideReasons.has('manual');
   const selectors = manual ? fushiSubtitleHideSelectors() : fushiNativeSubtitleSelectors();
-  // ::cue（原生 <track> 字幕）必须单独成一条规则：它只接受受限属性集，且与普通选择器
-  // 并列时若被浏览器判为无效会**整条规则**失效，连带把上面的站点字幕也藏不掉。
+  // ::cue（原生 <track> 字幕的 cue 伪元素）与 ::-webkit-media-text-track-container
+  // （Blink 原生 track 渲染层本体——TVer/B站/一堆用 <track> 出字的站点全靠它）必须各自
+  // 单独成规则：它们只接受受限属性集，且与普通选择器并列时若被浏览器判为无效会**整条规则**
+  // 失效，连带把上面的站点字幕也藏不掉（历史上就是这么翻的车，别再并排写）。
   const css = selectors.join(',') + '{visibility:hidden!important}' +
-      'video::cue{visibility:hidden!important}';
+      'video::cue{visibility:hidden!important}' +
+      'video::-webkit-media-text-track-container{visibility:hidden!important}';
   const style = existing || document.createElement('style');
   style.id = FUSHI_HIDE_SUBS_ID;
   if (style.textContent !== css) style.textContent = css;
@@ -1178,13 +1203,46 @@ function fushiEnsureContainer() {
         '#entries-container{width:100%!important;max-width:none!important;' +
         'max-height:none!important;overflow:visible!important;zoom:1!important;}';
     shadow.appendChild(norm);
-    // 把弹窗样式注入 shadow：content.css 作为扩展资源经 <link> 加载（web_accessible_resources）。
+    // 把弹窗样式注入 shadow：content.css 是扩展资源（web_accessible_resources）。
     // 其中宿主页级选择器（高亮层等）在 shadow 内无对应元素、天然失效；
     // 弹窗选择器（#entries-container/.glossary-group/ruby…）在 shadow 内生效。
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = chrome.runtime.getURL('vendor/content.css');
-    shadow.appendChild(link);
+    // 首选预取到的文本走同步 <style>（消除「异步 link vs 首帧测量」竞态，见上方
+    // fushiPopupCssText 注释）；预取尚未就绪时回落 <link>，并在其 load 后补算一次落点。
+    if (fushiPopupCssText) {
+      fushiCssLink = null;
+      const css = document.createElement('style');
+      css.textContent = fushiPopupCssText;
+      shadow.appendChild(css);
+    } else {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = chrome.runtime.getURL('vendor/content.css');
+      // 「样式落地」门控：place 的显示回调排队等 load/error/超时兜底——样式没到宁可
+      // 弹窗晚一帧出场，绝不裸奔上屏（FOUC）。落地后先按最终布局复算落点再放行显示。
+      const waiters = [];
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        try {
+          if (fushiHost && fushiContainer && fushiHost.isConnected) fushiApplyPlacement();
+        } catch (_) { /* 弹窗已销毁 */ }
+        if (fushiCssLink === link) fushiCssLink = null;
+        while (waiters.length) {
+          const fn = waiters.shift();
+          try { fn(); } catch (_) { /* 单个回调异常不吞其余 */ }
+        }
+      };
+      link.__fushiCssGate = {
+        // add 返回 true = 已入队（调用方不得自行显示）；false = 样式已落地，立即显示。
+        add: (fn) => { if (settled) return false; waiters.push(fn); return true; },
+      };
+      link.addEventListener('load', settle);
+      link.addEventListener('error', settle);
+      setTimeout(settle, 800); // 个别内核不派发 load/error：超时兜底放行，绝不永久藏窗
+      shadow.appendChild(link);
+      fushiCssLink = link;
+    }
     const c = document.createElement('div');
     c.id = 'entries-container';
     // 主题落在弹窗根 #entries-container 上（content.css 作用域 #entries-container[data-theme]）；
@@ -1349,6 +1407,9 @@ function fushiRemoveContainer() {
   fushiBindPopupPerfContext(null);
   fushiHost = null;
   fushiContainer = null;
+  // 在途 link 门控随窗作废：waiters 里的 reveal 绑的是被销毁的容器，留引用只会在
+  // settle 时对孤儿节点写 visibility（无害但无意义）；置 null 让新弹窗登记新门。
+  fushiCssLink = null;
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
@@ -2189,14 +2250,21 @@ function fushiRender(popupJson, termLen, theme, anchorRect) {
   fushiPlaceAnchor = wordRect || null;
   fushiUserResizedPopup = false;
   fushiRenderEntries(popupJson);
+  const reveal = () => {
+    c.style.visibility = 'visible';
+    fushiReportVisibleAfterPaint(fushiLookupPerfContext, c);
+  };
   const place = () => {
     // BUG-688/BUG-767/BUG-1726：量实测尺寸 → 纯函数落点 → 写回 host + 记录 Phase D 夹取
     // 上下文，全部收进 fushiApplyPlacement（首帧与 ResizeObserver 复算共用同一份实现/锚点）。
     fushiApplyPlacement();
     // BUG-1726：popup.js 此刻还在逐宏任务追加词典块（弹窗会继续长高），挂观察器随尺寸复算。
     fushiObservePopupResize();
-    c.style.visibility = 'visible';
-    fushiReportVisibleAfterPaint(fushiLookupPerfContext, c);
+    // 样式表走 <link> 且尚未应用（预取没赶上的首查）：把「显示」扣到样式落地之后——
+    // 落点已按当前布局尽力算过，settle 里还会按最终样式再复算一次。同步 <style> 路径
+    // fushiCssLink 恒为 null，直接放行，不多等一帧。
+    const gate = fushiCssLink && fushiCssLink.__fushiCssGate;
+    if (!(gate && gate.add(reveal))) reveal();
   };
   requestAnimationFrame(place);
 }

--- a/fushi/assets/browser_extension/manifest.json
+++ b/fushi/assets/browser_extension/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["frame-capture.js", "bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "auto-read.js", "ruby-render.js", "scan.js", "subtitle-providers.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
+      "js": ["frame-capture.js", "bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "auto-read.js", "ruby-render.js", "scan.js", "subtitle-providers.js", "content.js", "subtitle-panel.js", "video-shortcuts.js", "touch-lookup.js", "mobile-drawer.js"],
       "css": ["vendor/content.css"]
     },
     {
@@ -44,7 +44,8 @@
     }
   ],
   "web_accessible_resources": [
-    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] }
+    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] },
+    { "resources": ["side-panel.html", "side-panel.css", "side-panel.js", "popup-size.js", "auto-read.js", "ruby-render.js", "vendor/selection.js", "vendor/dict-media.js", "vendor/popup.js"], "matches": ["<all_urls>"] }
   ],
   "options_page": "options.html",
   "side_panel": { "default_path": "side-panel.html" },

--- a/fushi/assets/browser_extension/mobile-drawer.js
+++ b/fushi/assets/browser_extension/mobile-drawer.js
@@ -1,0 +1,521 @@
+// 移动端字幕列表抽屉（content script 隔离世界，manifest bundle 里排在 touch-lookup.js 之后）。
+// 安卓系浏览器没有 chrome.sidePanel——那是桌面独有 API，字幕列表（side-panel.html 整套 UI）
+// 在手机上原本没有任何显示面。本脚本在「触屏设备 + 页面里有视频」时挂一条贴边拉条：
+//   · 轻点拉条 → 抽屉滑入：横屏从右缘抽出、竖屏从底部升起；内容是一份 iframe，指向
+//     side-panel.html?fushiEmbed=1&fushiTabId=N —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
+//     搜字幕/制卡/面板查词全部原样复用，零复制逻辑；
+//   · 按住拉条直接左右/上下拖 → 抽屉跟手；松手按露出比例吸附开/关，开态拖过当前尺寸
+//     即顺手加宽/加高并存进 mobileSubtitleDrawerGeom（下次记住）——「可收可拉」；
+//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加），
+//     iframe 上下文里 tabs.query({currentWindow}) 不可靠，标签 id 由 background 的
+//     drawerSelfTab 如实回报 sender.tab.id；
+//   · 收起不销毁 iframe（列表滚动位置、在途请求都保命），postMessage 通知面板暂停 300ms
+//     轮询，拉开即恢复；
+//   · 进全屏跟着进：节点迁 fullscreenElement 子树（与字幕覆盖层/查词弹窗同一策略）。
+// 开关 mobileSubtitleDrawer 默认开；桌面（pointer: fine）永远不出现这套节点，行为零变化。
+(function () {
+  'use strict';
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  var STRIP = 12;      // 收起时露出的贴边细条厚度（px）；样式见 content.css .fushi-drawer-strip
+  var DRAG_AMP = 1.5;  // 拖拽放大：手指 1px 抽屉走 1.5px——细条浅 grab 轻拂即出（灵敏度要求）
+  var MIN_OPEN = 260;  // 抽屉最小宽/高。与 side-panel.css 折叠头一行严丝合缝：七颗
+                       // 静态小钮 7×30+6×3 缝，加 12 拉手槽与 20 header 内边距 = 260，
+                       // 任何合法宽度都一行装下（收缩机制已撤，用户裁决：直接调小）。
+  var MAX_RATIO = 0.6; // 抽屉尺寸上限：最多占 60% 视口（横屏算宽、竖屏算高），视频永远留 4 成
+  var LAND_GAP = 24;   // 横屏对侧留白：不整屏盖死画面
+  var PORT_MIN = 160;  // 竖屏收起后给视频至少留这么多 px
+
+  var st = {
+    enabled: true,
+    geom: { landW: 0, portH: 0 },
+    open: false,
+  };
+  var rootEl = null;
+  var stripEl = null;
+  var iframeEl = null;
+  var frameTabId; // undefined=未知，null=问过拿不到（回落 queryActiveTab）
+
+  function coarsePointer() {
+    try { return !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches); } catch (_) { return false; }
+  }
+
+  function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+  function vw() { return window.innerWidth || 360; }
+  function vh() { return window.innerHeight || 640; }
+  function isLand() { return vw() >= vh(); }
+
+  // 尺寸上限单一来源：60% 视口与「对侧留白/最少视频」双重夹逼，恒 ≥ MIN_OPEN。
+  function maxFull(land) {
+    var span = land ? vw() : vh();
+    return Math.max(MIN_OPEN, Math.min(span * MAX_RATIO, span - (land ? LAND_GAP : PORT_MIN)));
+  }
+  function fullSize() {
+    if (isLand()) {
+      var w = st.geom.landW || Math.round(clamp(vw() * 0.42, 300, 430));
+      return clamp(w, MIN_OPEN, maxFull(true));
+    }
+    var h = st.geom.portH || Math.round(vh() * 0.48);
+    return clamp(h, MIN_OPEN, maxFull(false));
+  }
+
+  // ── 开抽屉时视频让位（用户要的原生侧边栏手感）──
+  // 只在元素全屏态让位（手机主形态，见 drawerAllowed：横屏非全屏已整体禁用）：目标是
+  // fullscreenElement，横屏压宽（右挂）、竖屏压高（底挂）；裸媒体全屏与非全屏竖屏页面态
+  // 都不让位。宽度全走 JS 像素换算，站点重排由 adopt 跟随（见下）。
+  // 一道（同步）：inline !important 压主轴尺寸——站点后到的样式表/内联 width 都压得住；
+  //   连目标内部的 <video> 一起压（播放器常给 video 写死像素内联尺寸，只缩容器照样满屏）。
+  // 二道（下一帧实测）：量真实矩形治「没跟着缩的全屏层」——video 盒被居中玩法留在原地时
+  //   （absolute+translate、margin auto、100vw 中间层）硬钉左（position:fixed; left:0，顶边
+  //   取实测值不跳位）并收宽进区域；进度条/播放键所在的**横贯全屏控件层**同样处理：横屏
+  //   右缘探出就压宽，竖屏钉在屏幕底的整条上提到区域底缘（不然藏在抽屉底下）。小块控件
+  //   不直接动——父层收进区域后自然跟。所有判定基于实测，跟了容器的层零扰动。
+  // 宽度全走 JS 像素换算（innerWidth - 抽屉实占），不用 100vw/100vh CSS 常量——它们含
+  //   滚动条/视觉视口误差，就是用户报「设置的宽度不够准确」的来源。
+  // 所有改写前快照原内联值，关抽屉/换目标/卸除时精确还原，不伤站点自有样式。
+  var squeezeRecs = []; // [{el, saved:{prop:{value,prio}}}] —— 每元素每属性只留第一份快照
+  function squeezeClear() {
+    squeezeRecs.forEach(function (rec) {
+      for (var p in rec.saved) {
+        var s = rec.saved[p];
+        try {
+          // 完整往返：值和 !important 优先级都按站点原样写回，hyphen 属性（object-fit）
+          // 也只有 setProperty 认得。
+          if (s.value) rec.el.style.setProperty(p, s.value, s.prio || '');
+          else rec.el.style.removeProperty(p);
+        } catch (_) {}
+      }
+    });
+    squeezeRecs = [];
+  }
+  function squeezeApply(el, decls) {
+    var rec = null;
+    for (var i = 0; i < squeezeRecs.length; i++) if (squeezeRecs[i].el === el) { rec = squeezeRecs[i]; break; }
+    if (!rec) { rec = { el: el, saved: {}, written: {} }; squeezeRecs.push(rec); }
+    for (var s = 0; s < decls.length; s++) {
+      var p = decls[s][0];
+      if (!(p in rec.saved)) {
+        var v = '', pr = '';
+        try {
+          v = el.style.getPropertyValue ? el.style.getPropertyValue(p) : (el.style[p] || '');
+          pr = el.style.getPropertyPriority ? el.style.getPropertyPriority(p) : '';
+        } catch (_) { v = ''; }
+        rec.saved[p] = { value: v, prio: pr };
+      }
+    }
+    for (var k = 0; k < decls.length; k++) {
+      try {
+        el.style.setProperty(decls[k][0], decls[k][1], 'important');
+        rec.written[decls[k][0]] = decls[k][1]; // 我们写进去的哨兵值，adopt 拿它比对
+      } catch (_) {}
+    }
+  }
+  // ── 跟随式快照（adopt）──
+  // 快照不能是死照片：播放器对同一内联槽位的改写会先后于/后于我们的还原发生
+  // （fullscreenchange 里它同步重排 vs 下一帧才重排），赌时机就是用户报的「切换全屏
+  // 有时候错位」。改成比对「我们写的值」和「属性现在的值」：不相等说明播放器改写过了,
+  // 把它现值（连同优先级）吸成新的还原基准。开态下低频轮询 + 全屏切换事件与重排帧
+  // 两头即时执行，怎么排都接得住。
+  function adoptExternalWrites() {
+    var dirty = false;
+    squeezeRecs.forEach(function (rec) {
+      for (var p in rec.written) {
+        var cur = null;
+        try { cur = rec.el.style.getPropertyValue(p); } catch (_) { continue; }
+        if (cur === rec.written[p]) continue;
+        var prio = '';
+        try { prio = rec.el.style.getPropertyPriority(p); } catch (_) {}
+        rec.saved[p] = { value: cur || '', prio: prio };
+        dirty = true;
+      }
+    });
+    return dirty;
+  }
+  function isMediaEl(el) {
+    return !!(el && /^(VIDEO|AUDIO|IMG|CANVAS)$/.test(el.tagName || ''));
+  }
+  // 用户终局裁决：**横屏只在全屏时开字幕列表**。页面态横屏的播放器让位形态太杂（整页
+  // 容器/fixed 控件/播放器自重排互相踩），修不稳，干脆整体砍掉——非全屏横屏不挂载抽屉。
+  // 竖屏两种态都开（底挂浮层，不让位）。全屏不看元素类型：Android 站常常 requestFullscreen
+  // 打在 <video> 本身（原生视频全屏），排除媒体会把这条主路整个禁掉（用户报「全屏不能
+  // 拖拉」）——媒体全屏时抽屉挂 body，压 video 本体就是那里唯一有效的让位。
+  function drawerAllowed() {
+    return !isLand() || !!document.fullscreenElement;
+  }
+  var gapRaf = 0;
+  var adoptTimer = 0; // 开态低频 adopt 轮询（见 adoptExternalWrites）
+  var gapWant = null; // {land, occupy}：拖拽中间态只留最后一份
+  function scheduleGapFix(land, occupy) {
+    gapWant = { land: land, occupy: occupy };
+    if (gapRaf || typeof requestAnimationFrame !== 'function') return;
+    gapRaf = requestAnimationFrame(function () {
+      gapRaf = 0;
+      runGapFix(gapWant);
+    });
+  }
+  function runGapFix(want) {
+    if (!st.open || !want) return;
+    var fs = document.fullscreenElement;
+    // 让位只存在于全屏态（横屏页面态已被 drawerAllowed 禁掉）；裸媒体全屏钉不得。
+    var root = fs;
+    if (!root || isMediaEl(root) || !root.querySelectorAll) return;
+    var land = want.land;
+    var regionSpan = Math.max(0, Math.round((land ? vw() : vh()) - want.occupy));
+    var regionRight = Math.round(vw() - want.occupy);
+    var list = [];
+    try {
+      // video 本体 + 常见控件层名（chrome=YouTube 控件条、control/progress/seek/slider 泛用）。
+      // 小控件（按钮/进度条本体）不直接动：它们所在的容器层被收进区域后自己会跟。
+      list = Array.prototype.slice.call(root.querySelectorAll(
+        'video, [class*="ontrol"], [class*="hrome"], [class*="rogress"], [class*="eek"], [role="slider"]'));
+    } catch (_) { return; }
+    list.forEach(function (el) {
+      var r = null;
+      try { r = el.getBoundingClientRect(); } catch (_) {}
+      if (!r || !r.width) return;
+      var video = el.tagName === 'VIDEO';
+      // 非 video 只处理「横贯整屏」的层（左右缘基本贴屏）——其余小块留给父层带动。
+      if (!video && r.width < vw() - 8) return;
+      var decls = [];
+      if (land) {
+        if (video && fs && r.left > 1) {
+          // 钉左（仅全屏）：顶边取实测值保持原视觉高度。页面态绝不 fixed——
+          // fixed 跟着视口不跟页面，一滚动字幕/进度条全体漂移脱节。
+          decls.push(['position', 'fixed'], ['left', '0px'], ['top', Math.round(r.top) + 'px']);
+        }
+        var baseLeft = (video && fs && r.left > 1) ? 0 : Math.round(r.left);
+        if (r.right > regionRight + 1) {
+          decls.push(['width', Math.max(0, regionRight - baseLeft) + 'px']);
+        }
+      } else {
+        if (video) {
+          if (r.bottom > regionSpan + 1) decls.push(['height', Math.max(0, regionSpan - Math.round(r.top)) + 'px']);
+        } else if (r.bottom > regionSpan + 1) {
+          // 控件条钉在屏幕底部（fixed bottom:0，容器收缩不吃它）→ 整层上提到区域底缘，
+          // 不然它藏在抽屉底下摸不到。实测判定，绝对定位跟了容器的（r.bottom 已在区域内）不动。
+          decls.push(['bottom', Math.round(r.bottom - regionSpan) + 'px']);
+        }
+      }
+      if (decls.length) squeezeApply(el, decls);
+    });
+  }
+  function updateSqueeze(land, occupy) {
+    squeezeClear();
+    if (!st.open) return;
+    // 让位只在全屏态发生（横屏非全屏已被 drawerAllowed 禁掉）。全屏层不设媒体例外：
+    // fs 就是 <video> 时压它本体正是原生视频全屏唯一有效的让位；非全屏竖屏不让位。
+    var target = document.fullscreenElement || null;
+    if (!target) { return; }
+    var region = Math.max(0, Math.round((land ? vw() : vh()) - occupy));
+    var value = region + 'px';
+    var prop = land ? 'width' : 'height';
+    var els = [];
+    try { els = Array.prototype.slice.call(target.querySelectorAll('video')); } catch (_) {}
+    if (els.indexOf(target) < 0) els.push(target);
+    els.forEach(function (el) {
+      var decls = [[prop, value], [land ? 'min-width' : 'min-height', '0px']];
+      // 压盒必须同时保比例：object-fit 的初始值是 **fill**，大量站点靠 100% 拉伸 video——
+      // 只压宽不锁 contain，拖宽窄时画面整个被捏扁（用户报的「拖拉让视频比例变化」）。
+      // contain 只改信箱边位置，像素永不拉伸；还原时连站点原来的 object-fit（含 !important）照抄回去。
+      if (el.tagName === 'VIDEO') decls.push(['object-fit', 'contain']);
+      squeezeApply(el, decls);
+    });
+    scheduleGapFix(land, occupy);
+  }
+
+  // 几何只走两条属性：横屏定 width + translateX，竖屏定 height + translateY。
+  function setMetrics(land, full, expose) {
+    if (!rootEl) return;
+    rootEl.classList.toggle('is-land', land);
+    rootEl.classList.toggle('is-port', !land);
+    rootEl.classList.toggle('is-open', expose > STRIP + 1);
+    if (land) {
+      rootEl.style.width = Math.round(full) + 'px';
+      rootEl.style.height = '';
+      rootEl.style.transform = 'translateX(' + Math.round(full - expose) + 'px)';
+    } else {
+      rootEl.style.height = Math.round(full) + 'px';
+      rootEl.style.width = '';
+      rootEl.style.transform = 'translateY(' + Math.round(full - expose) + 'px)';
+    }
+    updateSqueeze(land, Math.min(full, expose));
+  }
+
+  function layout() {
+    var full = fullSize();
+    setMetrics(isLand(), full, st.open ? full : STRIP);
+  }
+
+  function postToFrame(type) {
+    try {
+      if (iframeEl && iframeEl.contentWindow) {
+        // S5691：targetOrigin 传扩展页自己的 URL（浏览器按其中的 chrome-extension
+        // origin 投递），绝不用 '*'——只有本抽屉的 iframe 收得到这条消息。
+        iframeEl.contentWindow.postMessage(
+          { source: 'fushi-drawer', type: type },
+          chrome.runtime.getURL('side-panel.html'));
+      }
+    } catch (_) {}
+  }
+
+  function ensureIframe() {
+    if (iframeEl || !rootEl) return;
+    iframeEl = document.createElement('iframe');
+    iframeEl.id = 'fushi-drawer-frame';
+    iframeEl.setAttribute('aria-label', '字幕列表');
+    var start = function (tid) {
+      var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
+      if (tid != null) url += '&fushiTabId=' + tid;
+      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
+      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
+      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
+      iframeEl.src = url;
+    };
+    if (frameTabId !== undefined) start(frameTabId);
+    else {
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
+          var tid = null;
+          try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
+          frameTabId = tid;
+          start(tid);
+        });
+      } catch (_) { frameTabId = null; start(null); }
+    }
+    rootEl.appendChild(iframeEl);
+  }
+
+  function setOpen(on) {
+    if (!rootEl) return;
+    st.open = !!on;
+    if (st.open) ensureIframe();
+    layout();
+    postToFrame(st.open ? 'resume' : 'pause');
+  }
+
+  // 供 subtitle-panel.js 的 Shift+S 契约：触屏上没有原生侧边栏，键位改拉本页抽屉。
+  window.fushiMobileDrawerOpen = function () {
+    if (!rootEl) return false;
+    if (!st.open) setOpen(true);
+    return true;
+  };
+
+  // ── 拉条手势：轻点开关；拖拽自由停位（松手处即宽度，实时调宽）──
+  // 开态拖拽有 MIN_OPEN 实时地板：压不成细条（用户要求「不能拉到无限短」），收起走轻点。
+  var drag = null;
+  function stripDown(e) {
+    var land = isLand();
+    var full = fullSize();
+    drag = {
+      id: e.pointerId,
+      land: land,
+      x0: e.clientX,
+      y0: e.clientY,
+      full: full,
+      expose: st.open ? full : STRIP,
+      curFull: full,
+      curExpose: st.open ? full : STRIP,
+      openStart: st.open,
+      moved: false,
+    };
+    rootEl.classList.add('is-dragging'); // 拖拽期关 transition，跟手
+    beginWindowDrag();
+    // 手势监听走 window 而不靠 setPointerCapture：手指右滑压窄时会离开 34px 拉条滑到
+    // iframe 上（尤其顶到 MIN_OPEN 地板后拉条停住、手指继续走）——触摸手势整个生命周期
+    // 都派发到 parent 文档，window 监听全程收得到；而老内核（Kiwi/Edge Android）上
+    // setPointerCapture 静默失败过一次，move/up 断在 iframe 里，用户端表现就是
+    // 「往左能停、往右松手弹回」。capture 仍尝试一下，多一层保险。
+    try { stripEl.setPointerCapture(e.pointerId); } catch (_) {}
+    e.preventDefault();
+  }
+  function beginWindowDrag() {
+    window.addEventListener('pointermove', stripMove);
+    window.addEventListener('pointerup', stripUp);
+    window.addEventListener('pointercancel', stripCancel);
+  }
+  function endWindowDrag() {
+    window.removeEventListener('pointermove', stripMove);
+    window.removeEventListener('pointerup', stripUp);
+    window.removeEventListener('pointercancel', stripCancel);
+  }
+  function stripMove(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    var d = (drag.land ? (drag.x0 - e.clientX) : (drag.y0 - e.clientY)) * DRAG_AMP; // 向左/向上为正 = 拉出
+    var start = drag.expose;
+    var maxExpose = maxFull(drag.land); // 拖也拖不过上限：视频永远保有四成可视
+    // 开态地板 MIN_OPEN（永远拖不成残条）；收起态起步是 STRIP，允许小幅误拖弹回。
+    var floor = drag.openStart ? MIN_OPEN : STRIP;
+    var expose = clamp(start + d, floor, maxExpose);
+    if (Math.abs(expose - start) > 4) drag.moved = true; // 已含放大：手指 ~3px 即判拖，轻拂就走
+    drag.curFull = Math.max(drag.full, expose); // 拉过头顺手扩尺寸
+    drag.curExpose = expose;
+    setMetrics(drag.land, drag.curFull, expose);
+  }
+  function stripUp(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    var g = drag;
+    drag = null;
+    endWindowDrag();
+    if (rootEl) rootEl.classList.remove('is-dragging');
+    if (!g.moved) { setOpen(!st.open); return; } // 轻点：toggle（开=回到记住的宽度）
+    // 自由停位：松手即停在拖到处——那个位置就是抽屉宽度（实时调宽）。
+    // 收起态拉出但没到 MIN_OPEN 就松手 → 视为误拖，弹回边条；开态有地板，压不到这条线。
+    var w = Math.round(g.curExpose);
+    if (w < MIN_OPEN) {
+      st.open = false;
+      setMetrics(g.land, g.full, STRIP);
+      postToFrame('pause');
+      return;
+    }
+    var cap = maxFull(g.land);
+    var finalFull = clamp(w, MIN_OPEN, cap);
+    if (g.land) st.geom.landW = finalFull; else st.geom.portH = finalFull;
+    saveGeom();
+    st.open = true;
+    ensureIframe();
+    setMetrics(g.land, finalFull, finalFull);
+    postToFrame('resume');
+  }
+  function stripCancel(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    endWindowDrag();
+    if (drag.moved) { stripUp(e); return; } // 已被系统手势打断但拖出位移了：按松手结算，别弹跳
+    drag = null;
+    if (rootEl) rootEl.classList.remove('is-dragging');
+    layout(); // 没位移：弹回原位
+  }
+
+  function saveGeom() {
+    try { chrome.storage.local.set({ mobileSubtitleDrawerGeom: { landW: st.geom.landW, portH: st.geom.portH } }); } catch (_) {}
+  }
+
+  function attachToHost() {
+    if (!rootEl) return;
+    // fullscreenElement 是 <video>/<audio>（浏览器原生视频全屏）时不能挂进去：媒体元素
+    // 的子节点属 fallback content，播放中根本不渲染——抽屉会凭空消失。这种模式交给 body。
+    var fs = document.fullscreenElement;
+    var hostFs = fs && !isMediaEl(fs); // 媒体全屏挂不进 host 但也是全屏——is-fs 按 fs 判
+    var parent = hostFs ? fs : document.body;
+    if (parent && rootEl.parentNode !== parent) parent.appendChild(rootEl);
+    // 全屏态标记：开合按钮在 CSS 里从边缘中点挪去右上角（用户指定）。
+    rootEl.classList.toggle('is-fs', !!fs);
+  }
+
+  function onFullscreenChange() {
+    // 全屏↔横屏页面态切换即 drawerAllowed 翻转点：先让 syncUi 决定挂载/卸除/host 迁移。
+    // 卸除路径自带 squeezeClear，横屏页面绝不留让位残骸；挂载则继续走下面的重基。
+    syncUi();
+    if (!rootEl) return; // 已按新规则卸除
+    // 进出全屏播放器都要重排自己的内联尺寸，和让位快照正面撞车：同步还原写回的是
+    // **全屏时代**的快照值（比如 height:1080px），播放器重排稍慢一步就被盖住，退出全屏
+    // 后视频带着巨大尺寸留在页面里——字幕浮量的是这个坏盒，用户看到的「退出全屏字幕
+    // 错位」就是这么来的。改成：立即撤销全部让位改写（交还布局权）→ 下一帧播放器写稳
+    // 新值后，以它为快照重新起基再压。一帧的让位空缺没人看得见，永久错位看得见。
+    adoptExternalWrites(); // 事件时刻播放器多半已同步重排：先把真值吸进快照
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(function () {
+        if (!rootEl) return;
+        adoptExternalWrites(); // 晚到的重排在这一帧写稳：再吸一遍，然后以真值重新起基重压
+        layout();
+      });
+    } else {
+      layout(); // 老 WebView 没有 rAF：同步重压（快照已吸过一轮真值）
+    }
+  }
+  function onResize() {
+    if (drag) return;
+    // 旋转/进分屏即 drawerAllowed 与朝向的翻转点：先 syncUi 定夺挂载/卸除，卸除即已还原。
+    syncUi();
+    if (!rootEl) return;
+    // 旋转 = resize 连发 + 播放器同步重排写新尺寸：老写法每拍 layout() 里的
+    // squeezeClear 会把**旋转前**的快照盖回去——播放器改对了又被我们压回旧值，
+    // 用户看到的就是「横竖屏调转字幕错位」（和退出全屏那次同病）。改法与
+    // fullscreenchange 一致：事件先 adopt 吸真值，rAF 再吸一遍才重新起基重压；
+    // 连发的每一拍都走这套，最后一拍落在稳定尺寸上，中间拍无盖写伤害。
+    adoptExternalWrites();
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(function () {
+        if (!rootEl) return;
+        adoptExternalWrites();
+        layout();
+      });
+    } else {
+      layout();
+    }
+  }
+
+  function mount() {
+    if (rootEl) return;
+    rootEl = document.createElement('div');
+    rootEl.id = 'fushi-drawer';
+    stripEl = document.createElement('div');
+    stripEl.className = 'fushi-drawer-strip'; // 隐形边缘手势区：任何贴边按下即进入拖拽/开合判定
+    stripEl.setAttribute('aria-label', '字幕列表边缘手势区');
+    var btn = document.createElement('div');
+    btn.className = 'fushi-drawer-btn';
+    btn.setAttribute('role', 'button');
+    btn.setAttribute('aria-label', '展开或收起字幕列表');
+    btn.textContent = '☰'; // 可见开合钮；pointerdown 冒泡进 stripEl，点=开关、按住同样能拖
+    stripEl.appendChild(btn);
+    rootEl.appendChild(stripEl);
+    stripEl.addEventListener('pointerdown', stripDown);
+    stripEl.addEventListener('contextmenu', function (e) { e.preventDefault(); }); // move/up/cancel 挂 window，见 stripDown 注释
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    window.addEventListener('resize', onResize);
+    adoptTimer = setInterval(function () {
+      // 播放器任何时候改写内联尺寸都被吸成还原基准，随后重压回让位尺寸。拖拽中不抢手。
+      if (rootEl && !drag && st.open && squeezeRecs.length && adoptExternalWrites()) layout();
+    }, 150);
+    attachToHost();
+    layout();
+    if (st.open) { ensureIframe(); } // 页面重建（SPA）后恢复开态
+  }
+
+  function unmount() {
+    if (!rootEl) return;
+    endWindowDrag(); // 拖到一半被停用也不能留监听
+    if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
+    document.removeEventListener('fullscreenchange', onFullscreenChange);
+    window.removeEventListener('resize', onResize);
+    squeezeClear(); // 让位类挂在页面元素上，抽屉本体卸了绝不能把 calc 宽度留给站点
+    try { if (rootEl.parentNode) rootEl.parentNode.removeChild(rootEl); } catch (_) {}
+    rootEl = null;
+    stripEl = null;
+    iframeEl = null;
+  }
+
+  function syncUi() {
+    var want = st.enabled === true && coarsePointer() && !!document.querySelector('video') && drawerAllowed();
+    if (want && !rootEl) mount();
+    else if (!want && rootEl) unmount();
+    else if (want) attachToHost();
+  }
+
+  function applySettings(saved) {
+    saved = saved || {};
+    if (typeof saved.mobileSubtitleDrawer === 'boolean') st.enabled = saved.mobileSubtitleDrawer;
+    var g = saved.mobileSubtitleDrawerGeom;
+    if (g && typeof g === 'object') {
+      if (typeof g.landW === 'number' && isFinite(g.landW)) st.geom.landW = g.landW;
+      if (typeof g.portH === 'number' && isFinite(g.portH)) st.geom.portH = g.portH;
+    }
+    if (!st.enabled && rootEl) { unmount(); return; }
+    if (rootEl) layout();
+  }
+  try {
+    chrome.storage.local.get(['mobileSubtitleDrawer', 'mobileSubtitleDrawerGeom'], applySettings);
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      var changed = false;
+      if (changes.mobileSubtitleDrawer) { patch.mobileSubtitleDrawer = changes.mobileSubtitleDrawer.newValue; changed = true; }
+      if (changes.mobileSubtitleDrawerGeom) { patch.mobileSubtitleDrawerGeom = changes.mobileSubtitleDrawerGeom.newValue; changed = true; }
+      if (changed) applySettings(patch);
+    });
+  } catch (_) {}
+
+  setInterval(syncUi, 900);
+  syncUi();
+})();

--- a/fushi/assets/browser_extension/mobile-drawer.js
+++ b/fushi/assets/browser_extension/mobile-drawer.js
@@ -263,22 +263,33 @@
     iframeEl = document.createElement('iframe');
     iframeEl.id = 'fushi-drawer-frame';
     iframeEl.setAttribute('aria-label', '字幕列表');
-    var start = function (tid) {
+    var start = function (resp) {
       var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
+      var tid = resp && Number.isInteger(resp.tabId) ? resp.tabId : null;
       if (tid != null) url += '&fushiTabId=' + tid;
-      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
-      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
-      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
+      // 审计报告 #1295：宿主 origin **不再自证**（旧版把 location.origin 拼进 URL，
+      // 任意网站嵌 iframe 填自己 origin 就骗过面板校验）。改带 SW 签发的一次性 token，
+      // 面板回 SW 核销（绑定签发 tab）才认宿主消息。token 缺席 = 通道关死（面板 fail-closed）。
+      var token = resp && typeof resp.token === 'string' ? resp.token : '';
+      if (token) url += '&fushiEmbedToken=' + encodeURIComponent(token);
       iframeEl.src = url;
     };
-    if (frameTabId !== undefined) start(frameTabId);
-    else {
+    if (frameTabId !== undefined) {
+      // iframe 重建（SPA 恢复开态）也现领新 token：从不缓存上一次的应答，
+      // 拿旧串拼 URL 的口子从这里堵死。
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
+          try { if (chrome.runtime.lastError) { start(null); return; } } catch (_) {}
+          start(resp);
+        });
+      } catch (_) { start(null); }
+    } else {
       try {
         chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
           var tid = null;
           try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
           frameTabId = tid;
-          start(tid);
+          start(resp);
         });
       } catch (_) { frameTabId = null; start(null); }
     }
@@ -474,6 +485,9 @@
   function unmount() {
     if (!rootEl) return;
     endWindowDrag(); // 拖到一半被停用也不能留监听
+    drag = null; // 报告 #1295：光撤监听还不够——残留的 drag 对象会让重装后的
+                 // adoptTimer 永远卡在 `!drag` 判假（播放器改尺寸再也不吸收），
+                 // 直到下一次完整拖拽才自愈。旋转/全屏切换正是 mid-drag 卸除的高发点。
     if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
     document.removeEventListener('fullscreenchange', onFullscreenChange);
     window.removeEventListener('resize', onResize);

--- a/fushi/assets/browser_extension/options.html
+++ b/fushi/assets/browser_extension/options.html
@@ -49,6 +49,47 @@
           </div>
         </section>
 
+        <section class="section" aria-labelledby="touch-lookup-heading">
+          <div class="section-heading compact">
+            <div>
+              <p class="section-kicker">触屏查词与字幕抽屉</p>
+              <h2 id="touch-lookup-heading">手机与平板</h2>
+            </div>
+            <span class="section-note">修改后立即生效</span>
+          </div>
+
+          <div class="setting-list">
+            <label class="setting-row" for="touchLookupTap">
+              <span class="setting-copy">
+                <strong>点按查词</strong>
+                <small>手机/平板浏览器里，单指点在正文文字上即查词——取词、高亮、弹窗与桌面
+                  Shift 划词同一套。链接、按钮、输入框、视频画面等仍归站点自己，不会被拦；
+                  手指拖动算滚动，不触发查词。桌面（鼠标）环境不受这两个开关影响，行为零变化。</small>
+              </span>
+              <span class="switch"><input id="touchLookupTap" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="touchLookupHold">
+              <span class="setting-copy">
+                <strong>长按查词</strong>
+                <small>按住正文约 0.5 秒（不移动）即查词，抬手不再重复。与「点按查词」可同时开，
+                  长按先触发。部分页面系统的长按选词菜单可能跟着弹，嫌碍事就关掉本项只留点按。</small>
+              </span>
+              <span class="switch"><input id="touchLookupHold" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="mobileSubtitleDrawer">
+              <span class="setting-copy">
+                <strong>字幕列表抽屉</strong>
+                <small>安卓浏览器没有原生侧边栏（该 API 仅桌面存在），字幕列表在手机上原本无处
+                  显示。开启后触屏设备的视频页贴屏幕边缘放一颗 ☰ 悬浮钮、边缘一条隐形手势带：点
+                  钮开关、按住边缘可拖出并随手停到任意宽度（横屏右挂、竖屏底挂，内嵌完整列表——
+                  选轨、点句跳转、时轴偏移、外挂字幕、Jimaku、制卡、点词全在），尺寸记住。<b>横屏
+                  仅在全屏时出现</b>（非全屏横屏页面让位不稳，已停用），竖屏任意。桌面（鼠标）不出现。</small>
+              </span>
+              <span class="switch"><input id="mobileSubtitleDrawer" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+          </div>
+        </section>
+
         <section class="section" aria-labelledby="subtitle-heading">
           <div class="section-heading">
             <div>

--- a/fushi/assets/browser_extension/options.js
+++ b/fushi/assets/browser_extension/options.js
@@ -27,6 +27,12 @@ const settingDefaults = Object.freeze({
   subtitleReplaceNative: false,
   // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
+  // 触屏查词：点按默认开（手机端没有 Shift 悬停，点按是主入口），长按默认关
+  // （与系统长按选词菜单天然打架）。两者都只在真触屏手势上生效，桌面零影响。
+  touchLookupTap: true,
+  touchLookupHold: false,
+  // 安卓没有 chrome.sidePanel：触屏设备视频页边缘的「字幕列表」抽屉（mobile-drawer.js）。
+  mobileSubtitleDrawer: true,
   videoShortcutPrevCue: true,
   videoShortcutNextCue: true,
   videoShortcutReplayCue: true,
@@ -52,6 +58,9 @@ const toggleIds = Object.freeze({
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
   subtitleReplaceNative: 'subtitleReplaceNative',
   subtitleHidden: 'subtitleHidden',
+  touchLookupTap: 'touchLookupTap',
+  touchLookupHold: 'touchLookupHold',
+  mobileSubtitleDrawer: 'mobileSubtitleDrawer',
   videoShortcutPrevCue: 'videoShortcutPrevCue',
   videoShortcutNextCue: 'videoShortcutNextCue',
   videoShortcutReplayCue: 'videoShortcutReplayCue',

--- a/fushi/assets/browser_extension/side-panel.css
+++ b/fushi/assets/browser_extension/side-panel.css
@@ -240,3 +240,128 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   .toolbar { justify-content: flex-start; margin-top: 9px; }
   .offset-row { grid-template-columns: repeat(3, 1fr); }
 }
+
+/* ── 抽屉嵌入模式（mobile-drawer.js 的 iframe，html.fushi-embed）──
+   手机屏寸土寸金：砍掉大标题、头部分行压紧、折叠钮一键收成一行，列表近乎占满；
+   控件仍保持 ≥38px 的触摸命中区，去 hover 依赖改 :active 反馈，补刘海安全区。 */
+html.fushi-embed body {
+  touch-action: manipulation;
+}
+
+html.fushi-embed button,
+html.fushi-embed select {
+  min-height: 38px;
+  min-width: 38px;
+}
+
+html.fushi-embed button:active { background: var(--surface-strong); }
+
+html.fushi-embed .panel-header {
+  padding: 8px 10px 6px;
+  padding-top: calc(8px + env(safe-area-inset-top));
+}
+
+html.fushi-embed h1 { display: none; }
+
+/* 嵌入头部两行制（展开/折叠一致，用户裁决）：第一行折叠钮＋工具排，第二行
+   「已连接视频」小字（order:3 + basis:100% 自然落下去）。display:flex 同时压掉
+   桌面 @media ≤340px 的 .title-row{display:block} 兜底——它漏进 iframe 就是拆行事故。 */
+html.fushi-embed .title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  column-gap: 3px;
+  row-gap: 2px;
+  justify-content: flex-start;
+}
+
+html.fushi-embed .title-row > div:first-of-type {
+  order: 3;
+  flex: 1 0 100%;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+html.fushi-embed #video-status {
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 允许收缩（0 1 auto）：nowrap 式的 0 0 auto 在窄抽屉会整排溢出容器把 ⚙ 裁掉而不是
+   换行；可收缩后 flex-wrap 才拿得到受限宽度——装得下一行，超出自然折行。 */
+html.fushi-embed .toolbar { flex: 0 1 auto; min-width: 0; margin-top: 0; gap: 3px; }
+
+html.fushi-embed #track { margin-top: 6px; height: 32px; min-height: 32px; font-size: 13px; }
+html.fushi-embed .offset-row { margin-top: 6px; }
+html.fushi-embed .jimaku-row input { min-height: 32px; }
+
+/* ── 嵌入态防出界：窄抽屉（最窄 220）里这些盒子会捅穿面板边，全改可收缩规格 ── */
+/* 时轴行基版是 6 列最少 ~313px：auto-fit 让它按实际宽度自动降列（宽=一行，窄=两三行）。 */
+html.fushi-embed .offset-row {
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+}
+
+/* input 默认有 ~147px 固有宽且 grid 项 min-width:auto 不缩，1fr 被顶爆。 */
+html.fushi-embed .jimaku-row { grid-template-columns: 1fr 46px 40px; }
+html.fushi-embed .jimaku-row input { min-width: 0; }
+
+/* 展开设置那一排也缩到 32 档，跟按钮行同高——两态一体。 */
+html.fushi-embed .offset-row button,
+html.fushi-embed .offset-row span,
+html.fushi-embed .jimaku-row button {
+  height: 32px;
+  min-height: 32px;
+}
+
+/* 查词浮层：min-width 250 比最窄抽屉还宽，横 resize 把手在触屏也是误触源——
+   宽度直接跟视口走，只许纵向拉。 */
+html.fushi-embed .lookup-pane {
+  min-width: 0;
+  width: calc(100vw - 12px);
+  resize: vertical;
+}
+
+html.fushi-embed .toast {
+  max-width: calc(100vw - 24px);
+  white-space: normal;
+}
+
+html.fushi-embed .subtitle-row { padding: 10px 6px; }
+
+html.fushi-embed .timestamp { min-height: 34px; }
+
+html.fushi-embed .subtitle-list {
+  padding: 6px 6px calc(16px + env(safe-area-inset-bottom));
+}
+
+/* 折叠态：隐藏选轨/时轴/Jimaku，工具排 display:contents 并进折叠钮同一行。
+   头部两行制与按钮尺寸是 embed 通用规格（见基规则），展开收起只差隐藏与并排。 */
+html.fushi-embed body.hdr-folded .panel-header {
+  padding-top: calc(4px + env(safe-area-inset-top));
+  padding-bottom: 2px;
+}
+html.fushi-embed body.hdr-folded .toolbar {
+  display: contents; /* 六颗钮与折叠钮同池排一行，间距统一吃上面的 column-gap */
+}
+
+/* 静态小钮：展开/折叠共用同一尺寸（两态一致，切换零抖动）。折叠态算式：
+   7×30 + 6×3 缝 + 12 拉手 + 20 header 内边距 = 260 = MIN_OPEN；border-box 下 30/32
+   是终值，min-* 归零防基版 38px 触摸规格顶回来。 */
+html.fushi-embed .hdr-fold,
+html.fushi-embed .toolbar button {
+  flex: 0 0 30px;
+  width: 30px;
+  height: 32px;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+}
+
+html.fushi-embed body.hdr-folded #track,
+html.fushi-embed body.hdr-folded #offset,
+html.fushi-embed body.hdr-folded #jimaku-row,
+html.fushi-embed body.hdr-folded #jimaku-results { display: none !important; }

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -28,6 +28,51 @@
   window.__fushiRoot = lookupShadow;
   installDictMediaPlaceholderResolver(lookupShadow); // BUG-1718：兑现词条内图片/样式表占位
   var currentTabId = null;
+  // 抽屉嵌入模式（mobile-drawer.js 的 iframe 打开，?fushiEmbed=1）：
+  //   · 绑定来源页 tabId——网页内扩展 iframe 里 tabs.query 的 currentWindow 解析不可靠，
+  //     以 background drawerSelfTab 如实回报的 sender.tab.id 为准（缺参数仍走 queryActiveTab）；
+  //   · 不挂 tabs.onActivated：抽屉只服务这一页，「跟着切的标签页走」语义在这里不存在；
+  //   · 抽屉收起时宿主 postMessage pause → 暂停 300ms 轮询（省电），拉开立刻补一次；
+  //   · html 根挂 .fushi-embed 类，side-panel.css 按触屏规格放大控件、补安全区。
+  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耽误。
+  var EMBED_SEARCH = typeof location === 'undefined' ? '' : String(location.search || '');
+  var EMBED = /[?&]fushiEmbed=1/.test(EMBED_SEARCH);
+  var EMBED_TAB_ID = (function () {
+    var m = /[?&]fushiTabId=(\d+)/.exec(EMBED_SEARCH);
+    return m ? Number(m[1]) : null;
+  })();
+  var embedPaused = false;
+  if (EMBED) document.documentElement.classList.add('fushi-embed');
+  // 嵌入（手机抽屉）模式头部原本叠了标题+工具排+选轨+时轴偏移三四行，把列表挤得没法看。
+  // 加一个折叠钮：折叠后只留工具排（＋J A− A＋ AS ⚙），列表近乎占满；再点恢复。
+  if (EMBED) {
+    var foldTitleRow = document.querySelector('.title-row');
+    if (foldTitleRow) {
+      var foldBtn = document.createElement('button');
+      foldBtn.type = 'button';
+      foldBtn.className = 'hdr-fold';
+      foldBtn.textContent = '▾';
+      foldBtn.title = '折叠/展开工具区';
+      foldBtn.setAttribute('aria-label', '折叠或展开头部工具区');
+      var applyFold = function (folded) {
+        document.body.classList.toggle('hdr-folded', folded);
+        foldBtn.textContent = folded ? '▸' : '▾';
+      };
+      foldBtn.addEventListener('click', function () {
+        var folded = !document.body.classList.contains('hdr-folded');
+        applyFold(folded);
+        // 折叠状态跨会话记忆：抽屉每次重开都摊着四行工具区是反体验。此键只有 embed
+        // 读写（desktop 无此守卫、CSS 全挂 html.fushi-embed），不污染侧板。
+        try { localStorage.setItem('fushiHdrFolded', folded ? '1' : '0'); } catch (_) {}
+      });
+      // 新会话默认折叠（尽量省空间）：只有用户显式展开过（存 '0'）才记住展开；
+      // 无存档=首次，直接收成一行工具排。
+      var savedFold = null;
+      try { savedFold = localStorage.getItem('fushiHdrFolded'); } catch (_) {}
+      if (savedFold !== '0') applyFold(true);
+      foldTitleRow.insertBefore(foldBtn, foldTitleRow.firstChild);
+    }
+  }
   var currentState = null;
   var cues = [];
   var rows = [];
@@ -661,6 +706,7 @@
   }
 
   function queryActiveTab() {
+    if (EMBED && EMBED_TAB_ID != null) return Promise.resolve({ id: EMBED_TAB_ID });
     return new Promise(function (resolve) {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
@@ -709,18 +755,28 @@
     ].join('::');
   }
 
+  var trackSig = '~';
   function renderTracks(state) {
     var tracks = Array.isArray(state.tracks) ? state.tracks : [];
-    trackEl.textContent = '';
-    tracks.forEach(function (track) {
-      var option = document.createElement('option');
-      option.value = track.lang;
-      option.textContent = track.label + '（' + track.length + '）';
-      trackEl.appendChild(option);
-    });
-    trackEl.hidden = tracks.length === 0;
-    trackEl.value = state.activeLang || '';
-    offsetEl.hidden = tracks.length === 0;
+    // 每 300ms 刷新都清空重建 option，会把展开中的系统级下拉一次一次销毁——
+    // 安卓抽屉里「选轨窗口一直闪烁」就是这么来的（桌面同理）。无变化 = DOM 一律不碰；
+    // 指纹含 activeLang，所以切轨后选中值照样落得下去。偏移读数是纯文本，放闸外常刷。
+    var sig = (state.activeLang || '') + '\u0003' + tracks.map(function (t) {
+      return [t.lang, t.label, t.length, t.signature].join('\u0001');
+    }).join('\u0002');
+    if (sig !== trackSig) {
+      trackSig = sig;
+      trackEl.textContent = '';
+      tracks.forEach(function (track) {
+        var option = document.createElement('option');
+        option.value = track.lang;
+        option.textContent = track.label + '（' + track.length + '）';
+        trackEl.appendChild(option);
+      });
+      trackEl.hidden = tracks.length === 0;
+      trackEl.value = state.activeLang || '';
+      offsetEl.hidden = tracks.length === 0;
+    }
     offsetValueEl.textContent = ((Number(state.offsetMs) || 0) >= 0 ? '+' : '') +
       ((Number(state.offsetMs) || 0) / 1000).toFixed(1) + 's';
   }
@@ -838,6 +894,7 @@
   }
 
   async function refresh(forceCues) {
+    if (embedPaused) return; // 抽屉收起：不空转消息，resume 时立即补一次全量
     if (refreshBusy) return;
     refreshBusy = true;
     try {
@@ -1157,11 +1214,28 @@
 
 
   try {
-    chrome.tabs.onActivated.addListener(function () { refresh(true); });
+    if (!EMBED) chrome.tabs.onActivated.addListener(function () { refresh(true); });
     chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
       if (tabId === currentTabId && changeInfo.status === 'complete') refresh(true);
     });
   } catch (_) {}
+
+  // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
+  if (EMBED) {
+    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
+    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
+    var EMBED_HOST_ORIGIN = (function () {
+      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
+      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+    })();
+    window.addEventListener('message', function (ev) {
+      if (ev.origin !== EMBED_HOST_ORIGIN) return;
+      var d = ev && ev.data;
+      if (!d || d.source !== 'fushi-drawer') return;
+      if (d.type === 'pause') embedPaused = true;
+      else if (d.type === 'resume') { embedPaused = false; refresh(true); }
+    });
+  }
 
   refresh(true);
   setInterval(function () { refresh(false); }, 300);

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -1221,20 +1221,34 @@
   } catch (_) {}
 
   // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
+  // 审计报告 #1295：宿主 origin 的来源从「URL 参数自证」（任意网站可伪造）改为
+  // 「持 SW 签发的 token 回 SW 核销」——SW 绑定签发 tab、TTL 过期，伪造的 token 兑不出
+  // origin。核销前 EMBED_HOST_ORIGIN 保持初始 sentinel（永不等于任何真实 origin），
+  // 天然 fail-closed：兑不到就一直不收宿主消息。
   if (EMBED) {
-    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
-    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
-    var EMBED_HOST_ORIGIN = (function () {
-      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
-      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
-    })();
-    window.addEventListener('message', function (ev) {
+    var EMBED_HOST_ORIGIN = 'fushi-unverified-pending'; // 未核销前的哨兵，绝不匹配任何 origin
+    var hostMsg = function (ev) {
       if (ev.origin !== EMBED_HOST_ORIGIN) return;
       var d = ev && ev.data;
       if (!d || d.source !== 'fushi-drawer') return;
       if (d.type === 'pause') embedPaused = true;
       else if (d.type === 'resume') { embedPaused = false; refresh(true); }
-    });
+    };
+    window.addEventListener('message', hostMsg);
+    (function () {
+      var m = /[?&]fushiEmbedToken=([^&]*)/.exec(EMBED_SEARCH);
+      if (!m) return; // 没 token：哨兵永挂，只读面板（不收宿主 pause/resume），功能不炸
+      var tok = '';
+      try { tok = decodeURIComponent(m[1]); } catch (_) { return; }
+      if (!tok) return;
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerEmbedVerify', token: tok }, function (resp) {
+          try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+          var o = resp && typeof resp.origin === 'string' ? resp.origin : '';
+          if (o) EMBED_HOST_ORIGIN = o; // 只有核销成功才把哨兵换成真 origin
+        });
+      } catch (_) { /* 保持哨兵 = fail-closed */ }
+    })();
   }
 
   refresh(true);

--- a/fushi/assets/browser_extension/subtitle-adapters.js
+++ b/fushi/assets/browser_extension/subtitle-adapters.js
@@ -109,17 +109,22 @@ function parseSubtitleTimestamp(raw, tickRate) {
 const RUBY_ANNOTATION = '<(?:rt|rp|rtc)\\b(?:[^<>/]|/(?!>))*>' +
   '(?:(?!</?(?:ruby|rt|rp|rtc)\\b)[\\s\\S])*(?:</(?:rt|rp|rtc)\\s*>)?';
 
-// 方向/零宽控制字符与最小实体解码（不碰标签）。
+// 方向/零宽控制字符与最小实体解码（不碰标签）。分号可选：YouTube 等的字幕流大量输出
+// 无分号形态（&#39 而非 &#39;），HTML 规范里文本上下文的字符引用本就允许省分号——
+// 只认带分号就是用户报的「字幕里出现 &#39」。十进制/十六进制/命名都补齐。
 function decodeCueEntities(text) {
   return String(text || '')
     .replace(/[‎‏]/g, '')
-    .replace(/&lrm;|&rlm;/g, '')
-    .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&');
+    .replace(/&#(\d+);?/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
+    .replace(/&#x([0-9a-f]+);?/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    // 命名实体：要么带分号整口吃掉，要么无分号但后不跟字母/数字/分号（HTML5 同款
+    // 边界判据；漏了这条会吐 "&lt;b&gt;"→"<;b>"、"&amphibian" 被咬这类反向事故）。
+    .replace(/&(?:lrm|rlm)(?:;|(?![0-9A-Za-z;]))/gi, '')
+    .replace(/&nbsp(?:;|(?![0-9A-Za-z;]))/gi, ' ')
+    .replace(/&lt(?:;|(?![0-9A-Za-z;]))/gi, '<')
+    .replace(/&gt(?:;|(?![0-9A-Za-z;]))/gi, '>')
+    .replace(/&quot(?:;|(?![0-9A-Za-z;]))/gi, '"')
+    .replace(/&amp(?:;|(?![0-9A-Za-z;]))/gi, '&');
 }
 
 // 去掉行内标签（<c>、<i>、<b.bg_transparent> …）并解码实体；注音内容已在上游剔除。

--- a/fushi/assets/browser_extension/subtitle-panel.js
+++ b/fushi/assets/browser_extension/subtitle-panel.js
@@ -161,7 +161,11 @@
     return t < cues[ans].endMs ? ans : -1;
   }
 
-  function parentForOverlay() { return document.fullscreenElement || document.body; }
+  // 兜底父级用 <html> 而不是 <body>：浮层写的是视口坐标的 position:fixed，而安卓播放器
+  // 进/退全屏常给 body 挂 transform 或 scroll-lock（position:fixed;top:-Npx）——fixed 的
+  // 包含块会跟着变成那个带 transform 的祖先，视口坐标落进歪掉的坐标系，每 200ms 重测
+  // 一百次也还是歪的（用户报「退出全屏字幕错位」修不尽的根因）。html 自己从不被 transform。
+  function parentForOverlay() { return document.fullscreenElement || document.documentElement; }
 
   function seekTo(ms) {
     ms = Math.max(0, Math.round(ms));
@@ -333,6 +337,12 @@
       return;
     }
     var video = videoEl();
+    // 先重挂父级再走测量：退出全屏那一刻若 rect 恰好坏掉（播放器挪树/隐藏的瞬间），
+    // 浮层节点绝不能滞留在旧 fullscreenElement 里——那正是下一次显示时的错位源。
+    if (st.overlayEl) {
+      var reparent = parentForOverlay();
+      if (st.overlayEl.parentNode !== reparent) reparent.appendChild(st.overlayEl);
+    }
     if (!video || typeof video.getBoundingClientRect !== 'function') return;
     var rect = video.getBoundingClientRect();
     if (!rect || rect.width <= 0 || rect.height <= 0) return;
@@ -341,9 +351,18 @@
     el.setAttribute('data-theme', resolveTheme());
     if (typeof window.fushiRenderCueText === 'function') window.fushiRenderCueText(el, cue);
     else el.textContent = cue.text;
-    el.style.left = (rect.left + rect.width / 2) + 'px';
-    el.style.top = (rect.top + rect.height * 0.84) + 'px';
-    el.style.maxWidth = Math.max(240, rect.width * 0.9) + 'px';
+    // 中心恒定贴视频（拖拽跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
+    // 视频中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
+    // 抽屉 → 近侧即屏缘，行宽约等视频盒，永不探进抽屉盖画面（60% 上限保证最窄视频区也 ≥40% 屏）。
+    var vv = window.innerWidth || (rect.left + rect.right);
+    var cx = rect.left + rect.width / 2;
+    var halfToEdge = Math.max(0, Math.min(cx, vv - cx));
+    var maxW = Math.max(200, Math.min(vv * 0.94, (halfToEdge - 6) * 2));
+    el.style.left = cx + 'px';
+    // 底边锚定（CSS transform 是 -100%）：文本块从这条线**往上**长。旧版中心锚 84% 时，
+    // 非全屏矮视频（~200px 高）会垂出视频底缘压住进度条——底锚后任何视频高度都出不了界。
+    el.style.top = (rect.top + rect.height * 0.88) + 'px';
+    el.style.maxWidth = Math.round(maxW) + 'px';
     applyOverlayBlur(el);
   }
 
@@ -370,10 +389,18 @@
 
   // notify=true：这是用户显式的「打开侧边栏」动作，失败必须给可见提示。
   // notify 省略：只是顺带刷新（加载外挂字幕、拖放落地），失败不抢占它们自己的 toast。
-  // 返回值 = 是否已经把这次交互「办成了」。内容脚本这一侧永远办不成（原因见上），故恒为 false，
-  // 调用方（video-shortcuts.js）据此不 preventDefault，按键原样放行给站点。
+  // 返回值 = 是否已经把这次交互「办成了」。桌面内容脚本这一侧永远办不成（原因见上）恒 false，
+  // video-shortcuts.js 据此不 preventDefault 放行站点；触屏抽屉真开了才返回 true（吞键合理）。
   function showPanel(notify) {
     refreshHeadless();
+    // 触屏设备没有 chrome.sidePanel（桌面独有 API）：页内抽屉契约存在（mobile-drawer.js）
+    // 就改拉抽屉，并如实返回 true——抽屉确实开了，Shift+S 该吞键。桌面契约恒缺失，原样走。
+    try {
+      if (typeof window.fushiMobileDrawerOpen === 'function' && window.fushiMobileDrawerOpen()) {
+        if (notify) toast('字幕列表已打开');
+        return true;
+      }
+    } catch (_) {}
     try {
       chrome.runtime.sendMessage({ type: 'openSubtitleSidePanel' }, function (resp) {
         var failed = true;
@@ -761,6 +788,9 @@
   document.addEventListener('fullscreenchange', function () {
     if (!st.enabled) return;
     sync();
+    // 全屏切换后播放器整体挪位（body transform/滚动锁很常见）：立刻重测重摆一次，
+    // 不等下一个 200ms tick——重挂父级（fsEl↔html）也在这一步完成。
+    if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
   });
 
   var lastPath = location.pathname;

--- a/fushi/assets/browser_extension/touch-lookup.js
+++ b/fushi/assets/browser_extension/touch-lookup.js
@@ -1,0 +1,117 @@
+// 触屏查词（content script 隔离世界，manifest bundle 里排在 video-shortcuts.js 之后加载）。
+// 桌面查词靠 Shift+悬停划词，手机/平板没键盘，那条路完全够不着——本脚本把「页面正文」
+// 变成触屏查词入口：单点一下 = 查词（touchLookupTap，默认开）；长按约 0.5 秒不动 = 查词
+// （touchLookupHold，默认关，想要再开）。取词、高亮、弹窗完全复用 window.fushiLookupAtPoint
+// （content.js 的「显式点击查词」入口，与字幕面板行内点击同源），不新增任何查词链路。
+// 闸门（每一条都是「绝不抢站点」）：
+//   · 只认 pointerType === 'touch' 且主指针——鼠标/触控笔的行为永远是原样，零变化；
+//   · 扩展自绘 UI（查词弹窗 #hibiki-popup-host 及 #fushi-* 前缀的宿主、字幕覆盖层、
+//     toast、排队卡、拖放提示）上的手势全部跳过——弹窗内自有交互，字幕覆盖层自带
+//     click→查词（subtitle-panel.js），不掺和；
+//   · 链接、按钮、输入框、视频画面等交互元素交给站点自己：点播放器暂停/播放
+//     这类操作绝不被查词抢走；
+//   · 手指位移超过 MOVE_SLOP 判为滚动/拖拽选词，取消本次手势，不查词；
+//   · 长按与点按同时开着：到 500ms 长按先查，抬手不再重复查（手势已被长按消费）。
+(function () {
+  'use strict';
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  var HOLD_MS = 500;
+  var MOVE_SLOP = 10;
+  var settings = { tap: true, hold: false };
+
+  function apply(saved) {
+    saved = saved || {};
+    if (typeof saved.touchLookupTap === 'boolean') settings.tap = saved.touchLookupTap;
+    if (typeof saved.touchLookupHold === 'boolean') settings.hold = saved.touchLookupHold;
+  }
+  try {
+    var p = chrome.storage.local.get(['touchLookupTap', 'touchLookupHold'], apply);
+    if (p && typeof p.then === 'function') p.then(apply, function () {});
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      if (changes.touchLookupTap) patch.touchLookupTap = changes.touchLookupTap.newValue;
+      if (changes.touchLookupHold) patch.touchLookupHold = changes.touchLookupHold.newValue;
+      if (patch.touchLookupTap !== undefined || patch.touchLookupHold !== undefined) apply(patch);
+    });
+  } catch (_) {}
+
+  // 扩展自绘的在页 UI：查词弹窗宿主是 #hibiki-popup-host（历史名），其余统一 #fushi-* 前缀。
+  function isOwnUi(t) {
+    try {
+      return !!(t && t.closest && t.closest('#hibiki-popup-host, [id^="fushi-"]'));
+    } catch (_) { return false; }
+  }
+  // 站点交互元素——closest 向上找祖先，正文 <p> 里包着的 <a> 也算命中。
+  var INTERACTIVE =
+    'a, button, input, select, textarea, summary, video, audio, iframe, canvas, label, ' +
+    '[role="button"], [role="link"], [onclick], [contenteditable="true"]';
+  function isSiteControl(t) {
+    try {
+      return !!(t && t.closest && t.closest(INTERACTIVE));
+    } catch (_) { return false; }
+  }
+
+  function lookupAt(x, y) {
+    try {
+      if (typeof window.fushiLookupAtPoint === 'function') window.fushiLookupAtPoint(x, y, null);
+    } catch (_) {}
+  }
+
+  var gesture = null;
+  function cancelGesture() {
+    if (gesture && gesture.timer) clearTimeout(gesture.timer);
+    gesture = null;
+  }
+
+  // 全部 capture + passive：只观察、不拦截——站点自己的 touch/pointer 行为（滚动、
+  // 双击缩放、播放器手势）一概不动；查词发生在判定成立的抬手/到点时刻。
+  var OPTS = { capture: true, passive: true };
+
+  document.addEventListener('pointerdown', function (e) {
+    if (e.pointerType !== 'touch' || !e.isPrimary) return;
+    if (!settings.tap && !settings.hold) { cancelGesture(); return; }
+    // Shadow DOM：e.target 会被 retarget 成宿主元素，composedPath()[0] 才是真实落点
+    // （与 video-shortcuts.js 的键盘判定同一策略）。
+    var realTarget = e.target;
+    try {
+      if (typeof e.composedPath === 'function') {
+        var path = e.composedPath();
+        if (path && path.length && path[0] && path[0].nodeType === 1) realTarget = path[0];
+      }
+    } catch (_) {}
+    if (isOwnUi(realTarget) || isSiteControl(realTarget)) { cancelGesture(); return; }
+    cancelGesture();
+    gesture = { id: e.pointerId, x: e.clientX, y: e.clientY, moved: false, fired: false, timer: 0 };
+    if (settings.hold) {
+      var g = gesture;
+      g.timer = setTimeout(function () {
+        if (gesture !== g || g.moved || g.fired) return;
+        g.fired = true;
+        lookupAt(g.x, g.y);
+      }, HOLD_MS);
+    }
+  }, OPTS);
+
+  document.addEventListener('pointermove', function (e) {
+    if (!gesture || e.pointerId !== gesture.id) return;
+    if (Math.abs(e.clientX - gesture.x) > MOVE_SLOP || Math.abs(e.clientY - gesture.y) > MOVE_SLOP) {
+      gesture.moved = true;
+      if (gesture.timer) { clearTimeout(gesture.timer); gesture.timer = 0; }
+    }
+  }, OPTS);
+
+  document.addEventListener('pointerup', function (e) {
+    if (!gesture || e.pointerId !== gesture.id) return;
+    var g = gesture;
+    cancelGesture();
+    if (settings.tap && !g.moved && !g.fired) lookupAt(g.x, g.y);
+  }, OPTS);
+
+  document.addEventListener('pointercancel', function (e) {
+    if (gesture && e.pointerId === gesture.id) cancelGesture();
+  }, OPTS);
+})();

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -2128,7 +2128,8 @@
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    transform: translate(-50%, -50%);
+    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    transform: translate(-50%, -100%);
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -2177,3 +2178,150 @@
     letter-spacing: 0.04em;
     pointer-events: none;
 }
+
+/* ── 移动端字幕列表抽屉（mobile-drawer.js）：贴边面板 + 边缘细条拉手 ──
+   横屏定宽右挂（.is-land），竖屏定高底挂（.is-port）；宽高与 translate 全由 JS 写，
+   这里只管外观与动画。z 压在字幕覆盖层(2147483637)之上、查词弹窗(2147483647)之下：
+   面板里点词要浮在抽屉上。根容器必须**全透明**——收起态整条边只许露出 12px 细条,
+   底和影都挂在 iframe/拉手上，不然透明也白透。 */
+#fushi-drawer {
+    position: fixed;
+    z-index: 2147483640;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: row;
+    max-width: calc(100vw - 16px);
+    background: transparent;
+    /* 收起态（只剩细条）：根容器整条 12px×全高不许当隐形挡板——透明就得真透明，
+       点/滑全还给背后的视频和控件。可交互的部分自己把事件捡回来（见下三处 auto）。 */
+    pointer-events: none;
+}
+
+/* 开态：拉手槽涂成面板同色（cream），与 iframe 无缝拼成一块面板边——
+   旧的 #1e1b18 根底会在面板左缘留一条黑缝，收起态阴影渗边也是黑边元凶，一并禁掉。 */
+#fushi-drawer.is-open .fushi-drawer-strip {
+    background: #fff9f4;
+}
+
+#fushi-drawer.is-port {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    max-width: none;
+    max-height: calc(100vh - 16px);
+    flex-direction: column;
+}
+
+/* 拖拽期（.is-dragging）关补间跟手；松手后的开/关吸附走 220ms 缓出。 */
+#fushi-drawer:not(.is-dragging) {
+    transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* 拉手：**隐形边缘手势区**——细条本体不再画任何东西（视觉零占位），
+   ::before 把命中往画面侧探 14px（合计 26px）：贴边任何位置起拖即开合/调宽（监听边缘）。 */
+.fushi-drawer-strip {
+    flex: 0 0 auto;
+    position: relative;
+    z-index: 1; /* 按钮探进面板侧的那半要画在 iframe 之上 */
+    width: 12px;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto; /* 根 none 之下，手势区自己把事件捡回来 */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.fushi-drawer-strip::before {
+    content: '';
+    position: absolute;
+    top: -14px;
+    bottom: -14px;
+    left: -14px;
+    right: 0;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip {
+    width: auto;
+    height: 12px;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip::before {
+    top: -14px;
+    bottom: 0;
+    left: -14px;
+    right: -14px;
+}
+
+/* 开合按钮：骑在屏幕/抽屉边缘的小圆钮，一眼可见、一点开合；按住它同样可以拖。 */
+.fushi-drawer-btn {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font: 700 15px/1 system-ui, sans-serif;
+    color: #f0e6da;
+    background: rgba(40, 32, 26, 0.88);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#fushi-drawer.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: 50%;
+}
+
+/* 全屏时开合钮挪右上角（用户指定）：横屏在右缘顶端，竖屏在抽屉顶缘右角。
+   safe-area 兜刘海/挖孔，不跟播放器自己的右上控件重叠太多再报我调坐标。 */
+#fushi-drawer.is-fs.is-land .fushi-drawer-btn {
+    top: max(14px, env(safe-area-inset-top));
+    transform: translateX(-50%);
+}
+
+#fushi-drawer.is-fs.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: auto;
+    right: max(18px, env(safe-area-inset-right));
+    transform: none;
+}
+
+#fushi-drawer iframe {
+    flex: 1 1 auto;
+    display: block;
+    min-width: 0;
+    min-height: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff9f4;
+    pointer-events: auto;
+}
+
+/* 投影只在开态存在：收起时 iframe 整块在屏外，它的 -6px 投影会渗到屏边上糊一道黑雾。 */
+#fushi-drawer.is-open iframe {
+    box-shadow: -6px 0 24px rgba(0, 0, 0, 0.45);
+}
+
+#fushi-drawer.is-open.is-port iframe {
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.45);
+}
+
+/* 视频让位（开抽屉时压 fullscreenElement/<html>）不走这里：mobile-drawer.js 直接对
+   目标元素写 inline !important（站点后到样式/内联尺寸都压得住），关抽屉精确还原。 */

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -5075,10 +5075,22 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
+// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
+// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
+// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+function isCoarsePointerType() {
+    try {
+        return !!(window.matchMedia
+            && window.matchMedia('(pointer: coarse)').matches);
+    } catch (e) {
+        return false;
+    }
+}
 // 视口感知的有效列数（单一真值来源）：min(用户设置 --dict-columns, 每列 ≥DICT_COLUMN_MIN_WIDTH
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
+    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -5075,9 +5075,11 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+// 触屏设备（主指针 coarse）列宽门槛加倍：每列至少 2×DICT_COLUMN_MIN_WIDTH 才许并排。
+// 手机弹窗本就窄（竖屏 ~400px 宽 → 340 门槛下仍是单列，维持「竖着堆叠才是手机上正确
+// 形态」的原裁决），但不再被无条件锁死——平板横屏、in-app 桌面尺寸大窗这类 coarse 且
+// 宽的场景按视口正常出多列（审计报告 #1295：老版 coarse→1 把 in-app 弹窗静默锁死单列，
+// 没有任何逃生门）。fine 指针（桌面）门槛不变。CSS grid 与 JS masonry 都经本函数取列数。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5092,8 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
+    // 报告 #1295：coarse 不再「一律单列」，改为提高单列门槛（见上方注释）。
+    const colFloor = isCoarsePointerType() ? DICT_COLUMN_MIN_WIDTH * 2 : DICT_COLUMN_MIN_WIDTH;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5102,7 +5105,7 @@ function effectiveDictColumns() {
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / colFloor))
         : configured;
     return Math.min(configured, fit);
 }

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -5075,10 +5075,22 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
+// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
+// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
+// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+function isCoarsePointerType() {
+    try {
+        return !!(window.matchMedia
+            && window.matchMedia('(pointer: coarse)').matches);
+    } catch (e) {
+        return false;
+    }
+}
 // 视口感知的有效列数（单一真值来源）：min(用户设置 --dict-columns, 每列 ≥DICT_COLUMN_MIN_WIDTH
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
+    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -5075,9 +5075,11 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+// 触屏设备（主指针 coarse）列宽门槛加倍：每列至少 2×DICT_COLUMN_MIN_WIDTH 才许并排。
+// 手机弹窗本就窄（竖屏 ~400px 宽 → 340 门槛下仍是单列，维持「竖着堆叠才是手机上正确
+// 形态」的原裁决），但不再被无条件锁死——平板横屏、in-app 桌面尺寸大窗这类 coarse 且
+// 宽的场景按视口正常出多列（审计报告 #1295：老版 coarse→1 把 in-app 弹窗静默锁死单列，
+// 没有任何逃生门）。fine 指针（桌面）门槛不变。CSS grid 与 JS masonry 都经本函数取列数。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5092,8 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
+    // 报告 #1295：coarse 不再「一律单列」，改为提高单列门槛（见上方注释）。
+    const colFloor = isCoarsePointerType() ? DICT_COLUMN_MIN_WIDTH * 2 : DICT_COLUMN_MIN_WIDTH;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5102,7 +5105,7 @@ function effectiveDictColumns() {
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / colFloor))
         : configured;
     return Math.min(configured, fit);
 }

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -14,6 +14,8 @@ Anki 能力——一切经本机 Fushi 桌面 App 内置的 yomitan API server�
 | `subtitle-panel.js` | 隔离 | 字幕轨状态控制器 + 视频覆盖层 + 外挂字幕安装 + 全轨时轴偏移 + 快捷键执行端；不渲染网页列表 |
 | `side-panel.html/js/css` | 扩展页 | 浏览器原生 Side Panel 字幕列表；侧边栏内取词，默认把词交给宿主页用页面弹窗渲染（见「侧边栏查词跨出面板」），经 tabs 消息读取轨道并执行跳转/制卡/偏移，不把字幕列表注入网页 |
 | `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；每个动作独立开关，动作交 subtitle-panel 执行 |
+| `touch-lookup.js` | 隔离 | 触屏点按/长按查词：单指点正文=查词（默认开）、长按≈0.5s=查词（默认关）；复用 content.js 的 `fushiLookupAtPoint`，零新增查词链路，只认 touch 主指针，绝不影响鼠标行为 |
+| `mobile-drawer.js` | 隔离 | 移动端字幕列表抽屉：安卓无 chrome.sidePanel，触屏视频页挂边缘 ☰ 钮 + 隐形手势带（点=开关、按住=拖宽自由停位）；横屏右挂仅全屏（页面态让位形态太杂已禁用）、竖屏底挂，内容为 iframe 内嵌 `side-panel.html?fushiEmbed=1`（选轨/跳转/偏移/制卡/查词全套复用）；全屏态压播放器让位并以 adopt 跟随其自重排，几何存 `mobileSubtitleDrawerGeom` |
 | `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
 | `youtube-bridge.js` | MAIN | YouTube 专用：按 asbplayer 顺序读取播放器运行态 captionTracks（含 POT）→ Android Innertube → player response，并一次下载完整 srv3/json3 轨；只读、不改宿主 DOM |
 | `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -493,6 +493,37 @@ async function fushiIconClick(tab) {
 // 迁到 action-popup.js 的「开始生成/录制」按钮：按钮点击是用户手势，query 到当前 tab 后发
 // fushiIconAction 消息到这里，由下方 onMessage 分支调用同一个 fushiIconClick（逻辑不变，只换触发口）。
 
+// 审计报告 #1295：抽屉 iframe 的面板过去把「宿主 origin」写在 URL 参数里自证——
+// 任意网站嵌一句 `side-panel.html?fushiEmbed=1&fushiHostOrigin=https://evil.com`
+// 就能让自己的 origin 通过校验。改为 **SW 背书的双向兑换**：
+//   ① 抽屉 content script 要 token：SW 从 `sender.tab.url`（网页不可见、不可伪造）
+//      取真 origin，签发一次性凭证（绑定 tabId，TTL 10 分钟）；
+//   ② 面板 iframe 拿 token 来兑：核销 tabId 相符后回真 origin，供 ev.origin 校验。
+// 攻击者直接嵌 iframe 手里没有 token（web 页发不了 runtime 消息），兑换必然落空 →
+// EMBED_HOST_ORIGIN 恒为 ''，宿主消息全数丢弃（面板照常渲染，只是驱动不进来）。
+const fushiEmbedTokens = new Map(); // token -> {tabId, origin, exp}
+function fushiIssueEmbedToken(tabId, tabUrl) {
+  let origin = '';
+  try { origin = new URL(tabUrl).origin; } catch (_) { return null; }
+  if (!origin || origin === 'null' || !Number.isInteger(tabId)) return null;
+  const now = Date.now();
+  for (const [t, r] of fushiEmbedTokens) if (r.exp < now) fushiEmbedTokens.delete(t);
+  let token;
+  try { token = crypto.randomUUID(); } catch (_) {
+    token = now.toString(36) + '-' + Math.random().toString(36).slice(2);
+  }
+  fushiEmbedTokens.set(token, { tabId, origin, exp: now + 600000 });
+  return token;
+}
+function fushiRedeemEmbedToken(token, senderTabId) {
+  if (!token || typeof token !== 'string') return '';
+  const rec = fushiEmbedTokens.get(token);
+  if (!rec || rec.exp < Date.now()) { fushiEmbedTokens.delete(token); return ''; }
+  // token 换 Tab 用不了：核销方必须是签发时那个标签页。
+  if (!Number.isInteger(senderTabId) || rec.tabId !== senderTabId) return '';
+  return rec.origin;
+}
+
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 发给 offscreen 的消息由 offscreen 处理，background 不插手。
   if (msg && msg.target === 'offscreen') return false;
@@ -520,10 +551,21 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
   // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
   if (msg && msg.type === 'drawerSelfTab') {
+    const tid = _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null;
     sendResponse({
       ok: true,
-      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
+      tabId: tid,
+      // 审计报告 #1295：随标签 id 一并签发嵌入凭证（真 origin 由 SW 从 sender.tab.url
+      // 取得，只有拿 token 来兑的面板能知道）。签发失败（异常 sender）回 null——
+      // 面板端 fail-closed，宿主消息通道整个关死。
+      token: tid != null ? fushiIssueEmbedToken(tid, _sender.tab.url) : null,
     });
+    return true;
+  }
+  if (msg && msg.type === 'drawerEmbedVerify') {
+    // 面板 iframe 持 token 核销；核销方 tab 必须与签发时一致。
+    const senderTid = _sender && _sender.tab && _sender.tab.id;
+    sendResponse({ ok: true, origin: fushiRedeemEmbedToken(msg.token, senderTid) });
     return true;
   }
   if (msg && msg.type === 'openSubtitleSidePanel') {

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -516,6 +516,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 另外：open() 必须是拿到激活后的第一句——原实现先 `await setOptions(...)`，其 resolve 落在
   // 新的宏任务里，激活早已过期，等于自己把仅有的机会也丢掉了。setOptions 不需要激活，挪到
   // open() 之后补（manifest 的 side_panel.default_path 已足以让 open() 用对页面）。
+  // 字幕抽屉（mobile-drawer.js）：iframe 里的扩展页拿不到宿主标签身份，content script
+  // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
+  // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
+  if (msg && msg.type === 'drawerSelfTab') {
+    sendResponse({
+      ok: true,
+      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
+    });
+    return true;
+  }
   if (msg && msg.type === 'openSubtitleSidePanel') {
     const tabId = Number.isInteger(msg.tabId)
       ? msg.tabId

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -25,6 +25,27 @@ let fushiContainer = null;
 // 与 in-app WebView 弹窗一致）。fushiHost 是挂在宿主页的 shadow 宿主元素（负责 fixed 定位），
 // #entries-container 及全部弹窗内容在其 shadow root 内；window.__fushiRoot 暴露给 popup.js。
 let fushiHost = null;
+// 弹窗样式同步注入（「CSS 要渲染一下才正常」的修复）：shadow 里的 content.css 原本经
+// <link> 加载——异步，而 host 每次查词重建、首帧 rAF 立刻「量尺寸 → 落点」。慢设备
+// （手机冷启动首查最典型）样式应用赶不上测量：落点按未加样式的「裸」布局算出，样式
+// 到达后只有改变盒尺寸的规则会触发 ResizeObserver 复算，纯视觉规则（颜色/字体/圆角）
+// 永远不自愈——用户看到的就是弹窗样式/位置错一帧起，滚动或再渲染一次才正常。
+// 修法两层：①启动即预取 CSS 文本，就绪后以同步 <style> 注入（首帧测量必见最终布局，
+// 零竞态）；②预取尚未就绪（页面刚加载的第一发查词，或该内核禁 content script fetch
+// 扩展资源）退回 <link>，并登记 fushiCssLink 门控——place 照旧落点，但「显示」扣到
+// 样式表 load/error/800ms 超时之后，落地时先按最终布局复算一次落点再放行。
+// 表现层的承诺从「快一帧但可能裸奔」换成「最多晚一帧，绝不无样式上屏」。
+let fushiPopupCssText = '';
+try {
+  fetch(chrome.runtime.getURL('vendor/content.css'))
+      .then((r) => (r && r.ok ? r.text() : ''))
+      .then((t) => { if (typeof t === 'string' && t) fushiPopupCssText = t; })
+      .catch(() => { /* 预取失败：永远走 link 回落路径 */ });
+} catch (_) { /* 无 fetch：同上，link 回落 */ }
+// link 回落路径的在途账本：当前弹窗样式表尚未应用完时挂在这里，place 把「显示」挂到
+// 它身后——根治「字先出、CSS 后渲染」（FOUC）：宁晚一帧出场，也不裸奔上屏。
+// 同步 <style> 路径恒为 null（样式即时生效，无需扣显）。
+let fushiCssLink = null;
 // BUG-530 性能：划词监听器原来对每次 mousemove 都发查词请求 → 一直按 Shift 移动会把服务器
 // 刷爆、UI 卡顿。用「位移阈值 + 同词去重 + 在途请求闸」三重节流：只在移到**不同词**上才查。
 let fushiLastTerm = '';
@@ -1013,6 +1034,7 @@ function fushiNativeSubtitleSelectors() {
     '.ytp-caption-window-container', // YouTube
     '.captions-text',                // 通用（部分播放器）
     '.libassjs-canvas-parent',       // ASS/SSA 渲染层
+    '.bilibili-player-video-subtitle', // B站网页播放器的自绘字幕层
   ];
 }
 // 扩展自绘覆盖层（subtitle-panel.js 的 #fushi-subtitle-overlay）。
@@ -1034,10 +1056,13 @@ function fushiApplySubtitleHiding() {
   }
   const manual = fushiSubtitleHideReasons.has('manual');
   const selectors = manual ? fushiSubtitleHideSelectors() : fushiNativeSubtitleSelectors();
-  // ::cue（原生 <track> 字幕）必须单独成一条规则：它只接受受限属性集，且与普通选择器
-  // 并列时若被浏览器判为无效会**整条规则**失效，连带把上面的站点字幕也藏不掉。
+  // ::cue（原生 <track> 字幕的 cue 伪元素）与 ::-webkit-media-text-track-container
+  // （Blink 原生 track 渲染层本体——TVer/B站/一堆用 <track> 出字的站点全靠它）必须各自
+  // 单独成规则：它们只接受受限属性集，且与普通选择器并列时若被浏览器判为无效会**整条规则**
+  // 失效，连带把上面的站点字幕也藏不掉（历史上就是这么翻的车，别再并排写）。
   const css = selectors.join(',') + '{visibility:hidden!important}' +
-      'video::cue{visibility:hidden!important}';
+      'video::cue{visibility:hidden!important}' +
+      'video::-webkit-media-text-track-container{visibility:hidden!important}';
   const style = existing || document.createElement('style');
   style.id = FUSHI_HIDE_SUBS_ID;
   if (style.textContent !== css) style.textContent = css;
@@ -1178,13 +1203,46 @@ function fushiEnsureContainer() {
         '#entries-container{width:100%!important;max-width:none!important;' +
         'max-height:none!important;overflow:visible!important;zoom:1!important;}';
     shadow.appendChild(norm);
-    // 把弹窗样式注入 shadow：content.css 作为扩展资源经 <link> 加载（web_accessible_resources）。
+    // 把弹窗样式注入 shadow：content.css 是扩展资源（web_accessible_resources）。
     // 其中宿主页级选择器（高亮层等）在 shadow 内无对应元素、天然失效；
     // 弹窗选择器（#entries-container/.glossary-group/ruby…）在 shadow 内生效。
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = chrome.runtime.getURL('vendor/content.css');
-    shadow.appendChild(link);
+    // 首选预取到的文本走同步 <style>（消除「异步 link vs 首帧测量」竞态，见上方
+    // fushiPopupCssText 注释）；预取尚未就绪时回落 <link>，并在其 load 后补算一次落点。
+    if (fushiPopupCssText) {
+      fushiCssLink = null;
+      const css = document.createElement('style');
+      css.textContent = fushiPopupCssText;
+      shadow.appendChild(css);
+    } else {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = chrome.runtime.getURL('vendor/content.css');
+      // 「样式落地」门控：place 的显示回调排队等 load/error/超时兜底——样式没到宁可
+      // 弹窗晚一帧出场，绝不裸奔上屏（FOUC）。落地后先按最终布局复算落点再放行显示。
+      const waiters = [];
+      let settled = false;
+      const settle = () => {
+        if (settled) return;
+        settled = true;
+        try {
+          if (fushiHost && fushiContainer && fushiHost.isConnected) fushiApplyPlacement();
+        } catch (_) { /* 弹窗已销毁 */ }
+        if (fushiCssLink === link) fushiCssLink = null;
+        while (waiters.length) {
+          const fn = waiters.shift();
+          try { fn(); } catch (_) { /* 单个回调异常不吞其余 */ }
+        }
+      };
+      link.__fushiCssGate = {
+        // add 返回 true = 已入队（调用方不得自行显示）；false = 样式已落地，立即显示。
+        add: (fn) => { if (settled) return false; waiters.push(fn); return true; },
+      };
+      link.addEventListener('load', settle);
+      link.addEventListener('error', settle);
+      setTimeout(settle, 800); // 个别内核不派发 load/error：超时兜底放行，绝不永久藏窗
+      shadow.appendChild(link);
+      fushiCssLink = link;
+    }
     const c = document.createElement('div');
     c.id = 'entries-container';
     // 主题落在弹窗根 #entries-container 上（content.css 作用域 #entries-container[data-theme]）；
@@ -1349,6 +1407,9 @@ function fushiRemoveContainer() {
   fushiBindPopupPerfContext(null);
   fushiHost = null;
   fushiContainer = null;
+  // 在途 link 门控随窗作废：waiters 里的 reveal 绑的是被销毁的容器，留引用只会在
+  // settle 时对孤儿节点写 visibility（无害但无意义）；置 null 让新弹窗登记新门。
+  fushiCssLink = null;
   window.__fushiRoot = null;
   // TODO-1272：关窗即撤覆盖层高亮（被查词高亮跟随弹窗生命周期，弹窗在则在、弹窗关则撤）。
   fushiClearHighlightOverlay();
@@ -2189,14 +2250,21 @@ function fushiRender(popupJson, termLen, theme, anchorRect) {
   fushiPlaceAnchor = wordRect || null;
   fushiUserResizedPopup = false;
   fushiRenderEntries(popupJson);
+  const reveal = () => {
+    c.style.visibility = 'visible';
+    fushiReportVisibleAfterPaint(fushiLookupPerfContext, c);
+  };
   const place = () => {
     // BUG-688/BUG-767/BUG-1726：量实测尺寸 → 纯函数落点 → 写回 host + 记录 Phase D 夹取
     // 上下文，全部收进 fushiApplyPlacement（首帧与 ResizeObserver 复算共用同一份实现/锚点）。
     fushiApplyPlacement();
     // BUG-1726：popup.js 此刻还在逐宏任务追加词典块（弹窗会继续长高），挂观察器随尺寸复算。
     fushiObservePopupResize();
-    c.style.visibility = 'visible';
-    fushiReportVisibleAfterPaint(fushiLookupPerfContext, c);
+    // 样式表走 <link> 且尚未应用（预取没赶上的首查）：把「显示」扣到样式落地之后——
+    // 落点已按当前布局尽力算过，settle 里还会按最终样式再复算一次。同步 <style> 路径
+    // fushiCssLink 恒为 null，直接放行，不多等一帧。
+    const gate = fushiCssLink && fushiCssLink.__fushiCssGate;
+    if (!(gate && gate.add(reveal))) reveal();
   };
   requestAnimationFrame(place);
 }

--- a/tools/browser-extension/external-subtitle.test.js
+++ b/tools/browser-extension/external-subtitle.test.js
@@ -87,11 +87,16 @@ function loadPanel(opts) {
     addEventListener: (type, fn) => { (documentListeners[type] = documentListeners[type] || []).push(fn); },
     fushiToast: (m) => toasts.push(m),
   };
+  // 覆盖层真实落点是 <html>（parentForOverlay = fullscreenElement || documentElement）。
+  // 真实浏览器 documentElement 恒存，fake 也得有根——查覆盖层从 html 往下找。
+  const htmlRoot = makeEl('html');
+  htmlRoot.appendChild(body);
   const documentObj = {
     body,
+    documentElement: htmlRoot,
     fullscreenElement: null,
     addEventListener: (type, fn) => { (documentListeners[type] = documentListeners[type] || []).push(fn); },
-    getElementById: (id) => findByIdDeep(body, id),
+    getElementById: (id) => findByIdDeep(htmlRoot, id),
     querySelector: (sel) => (sel === 'video' ? video : null),
     querySelectorAll: () => [],
     createElement: (t) => { const e = makeEl(t); if (t === 'input') createdInputs.push(e); return e; },
@@ -134,7 +139,8 @@ function loadPanel(opts) {
   }
   function fireToggle(v) { for (const fn of storageListeners) fn({ netflixSubtitlePanel: { newValue: v } }, 'local'); }
   return {
-    body, video, windowObj, createdInputs, toasts,
+    body,
+    html: htmlRoot, video, windowObj, createdInputs, toasts,
     enable: () => fireToggle(true),
     panel: () => findByIdDeep(body, 'fushi-subtitle-panel'),
     reopen: () => findByIdDeep(body, 'fushi-subtitle-reopen'),
@@ -230,7 +236,7 @@ test('⑤ 外挂字幕按视频矩形叠到画面上，站点轨不重复叠字'
   h.loadFile('overlay.srt', 'dummy');
   h.video.currentTime = 2;
   h.tick();
-  const overlay = findByIdDeep(h.body, 'fushi-subtitle-overlay');
+  const overlay = findByIdDeep(h.html, 'fushi-subtitle-overlay');
   assert.ok(overlay, '当前外挂 cue 应创建视频叠字');
   assert.strictEqual(overlay.textContent, '画面上的外挂字幕');
   assert.strictEqual(overlay.style.left, '500px');

--- a/tools/browser-extension/manifest.json
+++ b/tools/browser-extension/manifest.json
@@ -9,7 +9,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["frame-capture.js", "bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "auto-read.js", "ruby-render.js", "scan.js", "subtitle-providers.js", "content.js", "subtitle-panel.js", "video-shortcuts.js"],
+      "js": ["frame-capture.js", "bridge-shim.js", "subtitle-adapters.js", "popup-size.js", "vendor/dict-media.js", "vendor/selection.js", "vendor/popup.js", "auto-read.js", "ruby-render.js", "scan.js", "subtitle-providers.js", "content.js", "subtitle-panel.js", "video-shortcuts.js", "touch-lookup.js", "mobile-drawer.js"],
       "css": ["vendor/content.css"]
     },
     {
@@ -44,7 +44,8 @@
     }
   ],
   "web_accessible_resources": [
-    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] }
+    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] },
+    { "resources": ["side-panel.html", "side-panel.css", "side-panel.js", "popup-size.js", "auto-read.js", "ruby-render.js", "vendor/selection.js", "vendor/dict-media.js", "vendor/popup.js"], "matches": ["<all_urls>"] }
   ],
   "options_page": "options.html",
   "side_panel": { "default_path": "side-panel.html" },

--- a/tools/browser-extension/mobile-drawer.js
+++ b/tools/browser-extension/mobile-drawer.js
@@ -1,0 +1,521 @@
+// 移动端字幕列表抽屉（content script 隔离世界，manifest bundle 里排在 touch-lookup.js 之后）。
+// 安卓系浏览器没有 chrome.sidePanel——那是桌面独有 API，字幕列表（side-panel.html 整套 UI）
+// 在手机上原本没有任何显示面。本脚本在「触屏设备 + 页面里有视频」时挂一条贴边拉条：
+//   · 轻点拉条 → 抽屉滑入：横屏从右缘抽出、竖屏从底部升起；内容是一份 iframe，指向
+//     side-panel.html?fushiEmbed=1&fushiTabId=N —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
+//     搜字幕/制卡/面板查词全部原样复用，零复制逻辑；
+//   · 按住拉条直接左右/上下拖 → 抽屉跟手；松手按露出比例吸附开/关，开态拖过当前尺寸
+//     即顺手加宽/加高并存进 mobileSubtitleDrawerGeom（下次记住）——「可收可拉」；
+//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加），
+//     iframe 上下文里 tabs.query({currentWindow}) 不可靠，标签 id 由 background 的
+//     drawerSelfTab 如实回报 sender.tab.id；
+//   · 收起不销毁 iframe（列表滚动位置、在途请求都保命），postMessage 通知面板暂停 300ms
+//     轮询，拉开即恢复；
+//   · 进全屏跟着进：节点迁 fullscreenElement 子树（与字幕覆盖层/查词弹窗同一策略）。
+// 开关 mobileSubtitleDrawer 默认开；桌面（pointer: fine）永远不出现这套节点，行为零变化。
+(function () {
+  'use strict';
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  var STRIP = 12;      // 收起时露出的贴边细条厚度（px）；样式见 content.css .fushi-drawer-strip
+  var DRAG_AMP = 1.5;  // 拖拽放大：手指 1px 抽屉走 1.5px——细条浅 grab 轻拂即出（灵敏度要求）
+  var MIN_OPEN = 260;  // 抽屉最小宽/高。与 side-panel.css 折叠头一行严丝合缝：七颗
+                       // 静态小钮 7×30+6×3 缝，加 12 拉手槽与 20 header 内边距 = 260，
+                       // 任何合法宽度都一行装下（收缩机制已撤，用户裁决：直接调小）。
+  var MAX_RATIO = 0.6; // 抽屉尺寸上限：最多占 60% 视口（横屏算宽、竖屏算高），视频永远留 4 成
+  var LAND_GAP = 24;   // 横屏对侧留白：不整屏盖死画面
+  var PORT_MIN = 160;  // 竖屏收起后给视频至少留这么多 px
+
+  var st = {
+    enabled: true,
+    geom: { landW: 0, portH: 0 },
+    open: false,
+  };
+  var rootEl = null;
+  var stripEl = null;
+  var iframeEl = null;
+  var frameTabId; // undefined=未知，null=问过拿不到（回落 queryActiveTab）
+
+  function coarsePointer() {
+    try { return !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches); } catch (_) { return false; }
+  }
+
+  function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+  function vw() { return window.innerWidth || 360; }
+  function vh() { return window.innerHeight || 640; }
+  function isLand() { return vw() >= vh(); }
+
+  // 尺寸上限单一来源：60% 视口与「对侧留白/最少视频」双重夹逼，恒 ≥ MIN_OPEN。
+  function maxFull(land) {
+    var span = land ? vw() : vh();
+    return Math.max(MIN_OPEN, Math.min(span * MAX_RATIO, span - (land ? LAND_GAP : PORT_MIN)));
+  }
+  function fullSize() {
+    if (isLand()) {
+      var w = st.geom.landW || Math.round(clamp(vw() * 0.42, 300, 430));
+      return clamp(w, MIN_OPEN, maxFull(true));
+    }
+    var h = st.geom.portH || Math.round(vh() * 0.48);
+    return clamp(h, MIN_OPEN, maxFull(false));
+  }
+
+  // ── 开抽屉时视频让位（用户要的原生侧边栏手感）──
+  // 只在元素全屏态让位（手机主形态，见 drawerAllowed：横屏非全屏已整体禁用）：目标是
+  // fullscreenElement，横屏压宽（右挂）、竖屏压高（底挂）；裸媒体全屏与非全屏竖屏页面态
+  // 都不让位。宽度全走 JS 像素换算，站点重排由 adopt 跟随（见下）。
+  // 一道（同步）：inline !important 压主轴尺寸——站点后到的样式表/内联 width 都压得住；
+  //   连目标内部的 <video> 一起压（播放器常给 video 写死像素内联尺寸，只缩容器照样满屏）。
+  // 二道（下一帧实测）：量真实矩形治「没跟着缩的全屏层」——video 盒被居中玩法留在原地时
+  //   （absolute+translate、margin auto、100vw 中间层）硬钉左（position:fixed; left:0，顶边
+  //   取实测值不跳位）并收宽进区域；进度条/播放键所在的**横贯全屏控件层**同样处理：横屏
+  //   右缘探出就压宽，竖屏钉在屏幕底的整条上提到区域底缘（不然藏在抽屉底下）。小块控件
+  //   不直接动——父层收进区域后自然跟。所有判定基于实测，跟了容器的层零扰动。
+  // 宽度全走 JS 像素换算（innerWidth - 抽屉实占），不用 100vw/100vh CSS 常量——它们含
+  //   滚动条/视觉视口误差，就是用户报「设置的宽度不够准确」的来源。
+  // 所有改写前快照原内联值，关抽屉/换目标/卸除时精确还原，不伤站点自有样式。
+  var squeezeRecs = []; // [{el, saved:{prop:{value,prio}}}] —— 每元素每属性只留第一份快照
+  function squeezeClear() {
+    squeezeRecs.forEach(function (rec) {
+      for (var p in rec.saved) {
+        var s = rec.saved[p];
+        try {
+          // 完整往返：值和 !important 优先级都按站点原样写回，hyphen 属性（object-fit）
+          // 也只有 setProperty 认得。
+          if (s.value) rec.el.style.setProperty(p, s.value, s.prio || '');
+          else rec.el.style.removeProperty(p);
+        } catch (_) {}
+      }
+    });
+    squeezeRecs = [];
+  }
+  function squeezeApply(el, decls) {
+    var rec = null;
+    for (var i = 0; i < squeezeRecs.length; i++) if (squeezeRecs[i].el === el) { rec = squeezeRecs[i]; break; }
+    if (!rec) { rec = { el: el, saved: {}, written: {} }; squeezeRecs.push(rec); }
+    for (var s = 0; s < decls.length; s++) {
+      var p = decls[s][0];
+      if (!(p in rec.saved)) {
+        var v = '', pr = '';
+        try {
+          v = el.style.getPropertyValue ? el.style.getPropertyValue(p) : (el.style[p] || '');
+          pr = el.style.getPropertyPriority ? el.style.getPropertyPriority(p) : '';
+        } catch (_) { v = ''; }
+        rec.saved[p] = { value: v, prio: pr };
+      }
+    }
+    for (var k = 0; k < decls.length; k++) {
+      try {
+        el.style.setProperty(decls[k][0], decls[k][1], 'important');
+        rec.written[decls[k][0]] = decls[k][1]; // 我们写进去的哨兵值，adopt 拿它比对
+      } catch (_) {}
+    }
+  }
+  // ── 跟随式快照（adopt）──
+  // 快照不能是死照片：播放器对同一内联槽位的改写会先后于/后于我们的还原发生
+  // （fullscreenchange 里它同步重排 vs 下一帧才重排），赌时机就是用户报的「切换全屏
+  // 有时候错位」。改成比对「我们写的值」和「属性现在的值」：不相等说明播放器改写过了,
+  // 把它现值（连同优先级）吸成新的还原基准。开态下低频轮询 + 全屏切换事件与重排帧
+  // 两头即时执行，怎么排都接得住。
+  function adoptExternalWrites() {
+    var dirty = false;
+    squeezeRecs.forEach(function (rec) {
+      for (var p in rec.written) {
+        var cur = null;
+        try { cur = rec.el.style.getPropertyValue(p); } catch (_) { continue; }
+        if (cur === rec.written[p]) continue;
+        var prio = '';
+        try { prio = rec.el.style.getPropertyPriority(p); } catch (_) {}
+        rec.saved[p] = { value: cur || '', prio: prio };
+        dirty = true;
+      }
+    });
+    return dirty;
+  }
+  function isMediaEl(el) {
+    return !!(el && /^(VIDEO|AUDIO|IMG|CANVAS)$/.test(el.tagName || ''));
+  }
+  // 用户终局裁决：**横屏只在全屏时开字幕列表**。页面态横屏的播放器让位形态太杂（整页
+  // 容器/fixed 控件/播放器自重排互相踩），修不稳，干脆整体砍掉——非全屏横屏不挂载抽屉。
+  // 竖屏两种态都开（底挂浮层，不让位）。全屏不看元素类型：Android 站常常 requestFullscreen
+  // 打在 <video> 本身（原生视频全屏），排除媒体会把这条主路整个禁掉（用户报「全屏不能
+  // 拖拉」）——媒体全屏时抽屉挂 body，压 video 本体就是那里唯一有效的让位。
+  function drawerAllowed() {
+    return !isLand() || !!document.fullscreenElement;
+  }
+  var gapRaf = 0;
+  var adoptTimer = 0; // 开态低频 adopt 轮询（见 adoptExternalWrites）
+  var gapWant = null; // {land, occupy}：拖拽中间态只留最后一份
+  function scheduleGapFix(land, occupy) {
+    gapWant = { land: land, occupy: occupy };
+    if (gapRaf || typeof requestAnimationFrame !== 'function') return;
+    gapRaf = requestAnimationFrame(function () {
+      gapRaf = 0;
+      runGapFix(gapWant);
+    });
+  }
+  function runGapFix(want) {
+    if (!st.open || !want) return;
+    var fs = document.fullscreenElement;
+    // 让位只存在于全屏态（横屏页面态已被 drawerAllowed 禁掉）；裸媒体全屏钉不得。
+    var root = fs;
+    if (!root || isMediaEl(root) || !root.querySelectorAll) return;
+    var land = want.land;
+    var regionSpan = Math.max(0, Math.round((land ? vw() : vh()) - want.occupy));
+    var regionRight = Math.round(vw() - want.occupy);
+    var list = [];
+    try {
+      // video 本体 + 常见控件层名（chrome=YouTube 控件条、control/progress/seek/slider 泛用）。
+      // 小控件（按钮/进度条本体）不直接动：它们所在的容器层被收进区域后自己会跟。
+      list = Array.prototype.slice.call(root.querySelectorAll(
+        'video, [class*="ontrol"], [class*="hrome"], [class*="rogress"], [class*="eek"], [role="slider"]'));
+    } catch (_) { return; }
+    list.forEach(function (el) {
+      var r = null;
+      try { r = el.getBoundingClientRect(); } catch (_) {}
+      if (!r || !r.width) return;
+      var video = el.tagName === 'VIDEO';
+      // 非 video 只处理「横贯整屏」的层（左右缘基本贴屏）——其余小块留给父层带动。
+      if (!video && r.width < vw() - 8) return;
+      var decls = [];
+      if (land) {
+        if (video && fs && r.left > 1) {
+          // 钉左（仅全屏）：顶边取实测值保持原视觉高度。页面态绝不 fixed——
+          // fixed 跟着视口不跟页面，一滚动字幕/进度条全体漂移脱节。
+          decls.push(['position', 'fixed'], ['left', '0px'], ['top', Math.round(r.top) + 'px']);
+        }
+        var baseLeft = (video && fs && r.left > 1) ? 0 : Math.round(r.left);
+        if (r.right > regionRight + 1) {
+          decls.push(['width', Math.max(0, regionRight - baseLeft) + 'px']);
+        }
+      } else {
+        if (video) {
+          if (r.bottom > regionSpan + 1) decls.push(['height', Math.max(0, regionSpan - Math.round(r.top)) + 'px']);
+        } else if (r.bottom > regionSpan + 1) {
+          // 控件条钉在屏幕底部（fixed bottom:0，容器收缩不吃它）→ 整层上提到区域底缘，
+          // 不然它藏在抽屉底下摸不到。实测判定，绝对定位跟了容器的（r.bottom 已在区域内）不动。
+          decls.push(['bottom', Math.round(r.bottom - regionSpan) + 'px']);
+        }
+      }
+      if (decls.length) squeezeApply(el, decls);
+    });
+  }
+  function updateSqueeze(land, occupy) {
+    squeezeClear();
+    if (!st.open) return;
+    // 让位只在全屏态发生（横屏非全屏已被 drawerAllowed 禁掉）。全屏层不设媒体例外：
+    // fs 就是 <video> 时压它本体正是原生视频全屏唯一有效的让位；非全屏竖屏不让位。
+    var target = document.fullscreenElement || null;
+    if (!target) { return; }
+    var region = Math.max(0, Math.round((land ? vw() : vh()) - occupy));
+    var value = region + 'px';
+    var prop = land ? 'width' : 'height';
+    var els = [];
+    try { els = Array.prototype.slice.call(target.querySelectorAll('video')); } catch (_) {}
+    if (els.indexOf(target) < 0) els.push(target);
+    els.forEach(function (el) {
+      var decls = [[prop, value], [land ? 'min-width' : 'min-height', '0px']];
+      // 压盒必须同时保比例：object-fit 的初始值是 **fill**，大量站点靠 100% 拉伸 video——
+      // 只压宽不锁 contain，拖宽窄时画面整个被捏扁（用户报的「拖拉让视频比例变化」）。
+      // contain 只改信箱边位置，像素永不拉伸；还原时连站点原来的 object-fit（含 !important）照抄回去。
+      if (el.tagName === 'VIDEO') decls.push(['object-fit', 'contain']);
+      squeezeApply(el, decls);
+    });
+    scheduleGapFix(land, occupy);
+  }
+
+  // 几何只走两条属性：横屏定 width + translateX，竖屏定 height + translateY。
+  function setMetrics(land, full, expose) {
+    if (!rootEl) return;
+    rootEl.classList.toggle('is-land', land);
+    rootEl.classList.toggle('is-port', !land);
+    rootEl.classList.toggle('is-open', expose > STRIP + 1);
+    if (land) {
+      rootEl.style.width = Math.round(full) + 'px';
+      rootEl.style.height = '';
+      rootEl.style.transform = 'translateX(' + Math.round(full - expose) + 'px)';
+    } else {
+      rootEl.style.height = Math.round(full) + 'px';
+      rootEl.style.width = '';
+      rootEl.style.transform = 'translateY(' + Math.round(full - expose) + 'px)';
+    }
+    updateSqueeze(land, Math.min(full, expose));
+  }
+
+  function layout() {
+    var full = fullSize();
+    setMetrics(isLand(), full, st.open ? full : STRIP);
+  }
+
+  function postToFrame(type) {
+    try {
+      if (iframeEl && iframeEl.contentWindow) {
+        // S5691：targetOrigin 传扩展页自己的 URL（浏览器按其中的 chrome-extension
+        // origin 投递），绝不用 '*'——只有本抽屉的 iframe 收得到这条消息。
+        iframeEl.contentWindow.postMessage(
+          { source: 'fushi-drawer', type: type },
+          chrome.runtime.getURL('side-panel.html'));
+      }
+    } catch (_) {}
+  }
+
+  function ensureIframe() {
+    if (iframeEl || !rootEl) return;
+    iframeEl = document.createElement('iframe');
+    iframeEl.id = 'fushi-drawer-frame';
+    iframeEl.setAttribute('aria-label', '字幕列表');
+    var start = function (tid) {
+      var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
+      if (tid != null) url += '&fushiTabId=' + tid;
+      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
+      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
+      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
+      iframeEl.src = url;
+    };
+    if (frameTabId !== undefined) start(frameTabId);
+    else {
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
+          var tid = null;
+          try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
+          frameTabId = tid;
+          start(tid);
+        });
+      } catch (_) { frameTabId = null; start(null); }
+    }
+    rootEl.appendChild(iframeEl);
+  }
+
+  function setOpen(on) {
+    if (!rootEl) return;
+    st.open = !!on;
+    if (st.open) ensureIframe();
+    layout();
+    postToFrame(st.open ? 'resume' : 'pause');
+  }
+
+  // 供 subtitle-panel.js 的 Shift+S 契约：触屏上没有原生侧边栏，键位改拉本页抽屉。
+  window.fushiMobileDrawerOpen = function () {
+    if (!rootEl) return false;
+    if (!st.open) setOpen(true);
+    return true;
+  };
+
+  // ── 拉条手势：轻点开关；拖拽自由停位（松手处即宽度，实时调宽）──
+  // 开态拖拽有 MIN_OPEN 实时地板：压不成细条（用户要求「不能拉到无限短」），收起走轻点。
+  var drag = null;
+  function stripDown(e) {
+    var land = isLand();
+    var full = fullSize();
+    drag = {
+      id: e.pointerId,
+      land: land,
+      x0: e.clientX,
+      y0: e.clientY,
+      full: full,
+      expose: st.open ? full : STRIP,
+      curFull: full,
+      curExpose: st.open ? full : STRIP,
+      openStart: st.open,
+      moved: false,
+    };
+    rootEl.classList.add('is-dragging'); // 拖拽期关 transition，跟手
+    beginWindowDrag();
+    // 手势监听走 window 而不靠 setPointerCapture：手指右滑压窄时会离开 34px 拉条滑到
+    // iframe 上（尤其顶到 MIN_OPEN 地板后拉条停住、手指继续走）——触摸手势整个生命周期
+    // 都派发到 parent 文档，window 监听全程收得到；而老内核（Kiwi/Edge Android）上
+    // setPointerCapture 静默失败过一次，move/up 断在 iframe 里，用户端表现就是
+    // 「往左能停、往右松手弹回」。capture 仍尝试一下，多一层保险。
+    try { stripEl.setPointerCapture(e.pointerId); } catch (_) {}
+    e.preventDefault();
+  }
+  function beginWindowDrag() {
+    window.addEventListener('pointermove', stripMove);
+    window.addEventListener('pointerup', stripUp);
+    window.addEventListener('pointercancel', stripCancel);
+  }
+  function endWindowDrag() {
+    window.removeEventListener('pointermove', stripMove);
+    window.removeEventListener('pointerup', stripUp);
+    window.removeEventListener('pointercancel', stripCancel);
+  }
+  function stripMove(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    var d = (drag.land ? (drag.x0 - e.clientX) : (drag.y0 - e.clientY)) * DRAG_AMP; // 向左/向上为正 = 拉出
+    var start = drag.expose;
+    var maxExpose = maxFull(drag.land); // 拖也拖不过上限：视频永远保有四成可视
+    // 开态地板 MIN_OPEN（永远拖不成残条）；收起态起步是 STRIP，允许小幅误拖弹回。
+    var floor = drag.openStart ? MIN_OPEN : STRIP;
+    var expose = clamp(start + d, floor, maxExpose);
+    if (Math.abs(expose - start) > 4) drag.moved = true; // 已含放大：手指 ~3px 即判拖，轻拂就走
+    drag.curFull = Math.max(drag.full, expose); // 拉过头顺手扩尺寸
+    drag.curExpose = expose;
+    setMetrics(drag.land, drag.curFull, expose);
+  }
+  function stripUp(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    var g = drag;
+    drag = null;
+    endWindowDrag();
+    if (rootEl) rootEl.classList.remove('is-dragging');
+    if (!g.moved) { setOpen(!st.open); return; } // 轻点：toggle（开=回到记住的宽度）
+    // 自由停位：松手即停在拖到处——那个位置就是抽屉宽度（实时调宽）。
+    // 收起态拉出但没到 MIN_OPEN 就松手 → 视为误拖，弹回边条；开态有地板，压不到这条线。
+    var w = Math.round(g.curExpose);
+    if (w < MIN_OPEN) {
+      st.open = false;
+      setMetrics(g.land, g.full, STRIP);
+      postToFrame('pause');
+      return;
+    }
+    var cap = maxFull(g.land);
+    var finalFull = clamp(w, MIN_OPEN, cap);
+    if (g.land) st.geom.landW = finalFull; else st.geom.portH = finalFull;
+    saveGeom();
+    st.open = true;
+    ensureIframe();
+    setMetrics(g.land, finalFull, finalFull);
+    postToFrame('resume');
+  }
+  function stripCancel(e) {
+    if (!drag || e.pointerId !== drag.id) return;
+    endWindowDrag();
+    if (drag.moved) { stripUp(e); return; } // 已被系统手势打断但拖出位移了：按松手结算，别弹跳
+    drag = null;
+    if (rootEl) rootEl.classList.remove('is-dragging');
+    layout(); // 没位移：弹回原位
+  }
+
+  function saveGeom() {
+    try { chrome.storage.local.set({ mobileSubtitleDrawerGeom: { landW: st.geom.landW, portH: st.geom.portH } }); } catch (_) {}
+  }
+
+  function attachToHost() {
+    if (!rootEl) return;
+    // fullscreenElement 是 <video>/<audio>（浏览器原生视频全屏）时不能挂进去：媒体元素
+    // 的子节点属 fallback content，播放中根本不渲染——抽屉会凭空消失。这种模式交给 body。
+    var fs = document.fullscreenElement;
+    var hostFs = fs && !isMediaEl(fs); // 媒体全屏挂不进 host 但也是全屏——is-fs 按 fs 判
+    var parent = hostFs ? fs : document.body;
+    if (parent && rootEl.parentNode !== parent) parent.appendChild(rootEl);
+    // 全屏态标记：开合按钮在 CSS 里从边缘中点挪去右上角（用户指定）。
+    rootEl.classList.toggle('is-fs', !!fs);
+  }
+
+  function onFullscreenChange() {
+    // 全屏↔横屏页面态切换即 drawerAllowed 翻转点：先让 syncUi 决定挂载/卸除/host 迁移。
+    // 卸除路径自带 squeezeClear，横屏页面绝不留让位残骸；挂载则继续走下面的重基。
+    syncUi();
+    if (!rootEl) return; // 已按新规则卸除
+    // 进出全屏播放器都要重排自己的内联尺寸，和让位快照正面撞车：同步还原写回的是
+    // **全屏时代**的快照值（比如 height:1080px），播放器重排稍慢一步就被盖住，退出全屏
+    // 后视频带着巨大尺寸留在页面里——字幕浮量的是这个坏盒，用户看到的「退出全屏字幕
+    // 错位」就是这么来的。改成：立即撤销全部让位改写（交还布局权）→ 下一帧播放器写稳
+    // 新值后，以它为快照重新起基再压。一帧的让位空缺没人看得见，永久错位看得见。
+    adoptExternalWrites(); // 事件时刻播放器多半已同步重排：先把真值吸进快照
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(function () {
+        if (!rootEl) return;
+        adoptExternalWrites(); // 晚到的重排在这一帧写稳：再吸一遍，然后以真值重新起基重压
+        layout();
+      });
+    } else {
+      layout(); // 老 WebView 没有 rAF：同步重压（快照已吸过一轮真值）
+    }
+  }
+  function onResize() {
+    if (drag) return;
+    // 旋转/进分屏即 drawerAllowed 与朝向的翻转点：先 syncUi 定夺挂载/卸除，卸除即已还原。
+    syncUi();
+    if (!rootEl) return;
+    // 旋转 = resize 连发 + 播放器同步重排写新尺寸：老写法每拍 layout() 里的
+    // squeezeClear 会把**旋转前**的快照盖回去——播放器改对了又被我们压回旧值，
+    // 用户看到的就是「横竖屏调转字幕错位」（和退出全屏那次同病）。改法与
+    // fullscreenchange 一致：事件先 adopt 吸真值，rAF 再吸一遍才重新起基重压；
+    // 连发的每一拍都走这套，最后一拍落在稳定尺寸上，中间拍无盖写伤害。
+    adoptExternalWrites();
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(function () {
+        if (!rootEl) return;
+        adoptExternalWrites();
+        layout();
+      });
+    } else {
+      layout();
+    }
+  }
+
+  function mount() {
+    if (rootEl) return;
+    rootEl = document.createElement('div');
+    rootEl.id = 'fushi-drawer';
+    stripEl = document.createElement('div');
+    stripEl.className = 'fushi-drawer-strip'; // 隐形边缘手势区：任何贴边按下即进入拖拽/开合判定
+    stripEl.setAttribute('aria-label', '字幕列表边缘手势区');
+    var btn = document.createElement('div');
+    btn.className = 'fushi-drawer-btn';
+    btn.setAttribute('role', 'button');
+    btn.setAttribute('aria-label', '展开或收起字幕列表');
+    btn.textContent = '☰'; // 可见开合钮；pointerdown 冒泡进 stripEl，点=开关、按住同样能拖
+    stripEl.appendChild(btn);
+    rootEl.appendChild(stripEl);
+    stripEl.addEventListener('pointerdown', stripDown);
+    stripEl.addEventListener('contextmenu', function (e) { e.preventDefault(); }); // move/up/cancel 挂 window，见 stripDown 注释
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    window.addEventListener('resize', onResize);
+    adoptTimer = setInterval(function () {
+      // 播放器任何时候改写内联尺寸都被吸成还原基准，随后重压回让位尺寸。拖拽中不抢手。
+      if (rootEl && !drag && st.open && squeezeRecs.length && adoptExternalWrites()) layout();
+    }, 150);
+    attachToHost();
+    layout();
+    if (st.open) { ensureIframe(); } // 页面重建（SPA）后恢复开态
+  }
+
+  function unmount() {
+    if (!rootEl) return;
+    endWindowDrag(); // 拖到一半被停用也不能留监听
+    if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
+    document.removeEventListener('fullscreenchange', onFullscreenChange);
+    window.removeEventListener('resize', onResize);
+    squeezeClear(); // 让位类挂在页面元素上，抽屉本体卸了绝不能把 calc 宽度留给站点
+    try { if (rootEl.parentNode) rootEl.parentNode.removeChild(rootEl); } catch (_) {}
+    rootEl = null;
+    stripEl = null;
+    iframeEl = null;
+  }
+
+  function syncUi() {
+    var want = st.enabled === true && coarsePointer() && !!document.querySelector('video') && drawerAllowed();
+    if (want && !rootEl) mount();
+    else if (!want && rootEl) unmount();
+    else if (want) attachToHost();
+  }
+
+  function applySettings(saved) {
+    saved = saved || {};
+    if (typeof saved.mobileSubtitleDrawer === 'boolean') st.enabled = saved.mobileSubtitleDrawer;
+    var g = saved.mobileSubtitleDrawerGeom;
+    if (g && typeof g === 'object') {
+      if (typeof g.landW === 'number' && isFinite(g.landW)) st.geom.landW = g.landW;
+      if (typeof g.portH === 'number' && isFinite(g.portH)) st.geom.portH = g.portH;
+    }
+    if (!st.enabled && rootEl) { unmount(); return; }
+    if (rootEl) layout();
+  }
+  try {
+    chrome.storage.local.get(['mobileSubtitleDrawer', 'mobileSubtitleDrawerGeom'], applySettings);
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      var changed = false;
+      if (changes.mobileSubtitleDrawer) { patch.mobileSubtitleDrawer = changes.mobileSubtitleDrawer.newValue; changed = true; }
+      if (changes.mobileSubtitleDrawerGeom) { patch.mobileSubtitleDrawerGeom = changes.mobileSubtitleDrawerGeom.newValue; changed = true; }
+      if (changed) applySettings(patch);
+    });
+  } catch (_) {}
+
+  setInterval(syncUi, 900);
+  syncUi();
+})();

--- a/tools/browser-extension/mobile-drawer.js
+++ b/tools/browser-extension/mobile-drawer.js
@@ -263,22 +263,33 @@
     iframeEl = document.createElement('iframe');
     iframeEl.id = 'fushi-drawer-frame';
     iframeEl.setAttribute('aria-label', '字幕列表');
-    var start = function (tid) {
+    var start = function (resp) {
       var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
+      var tid = resp && Number.isInteger(resp.tabId) ? resp.tabId : null;
       if (tid != null) url += '&fushiTabId=' + tid;
-      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
-      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
-      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
+      // 审计报告 #1295：宿主 origin **不再自证**（旧版把 location.origin 拼进 URL，
+      // 任意网站嵌 iframe 填自己 origin 就骗过面板校验）。改带 SW 签发的一次性 token，
+      // 面板回 SW 核销（绑定签发 tab）才认宿主消息。token 缺席 = 通道关死（面板 fail-closed）。
+      var token = resp && typeof resp.token === 'string' ? resp.token : '';
+      if (token) url += '&fushiEmbedToken=' + encodeURIComponent(token);
       iframeEl.src = url;
     };
-    if (frameTabId !== undefined) start(frameTabId);
-    else {
+    if (frameTabId !== undefined) {
+      // iframe 重建（SPA 恢复开态）也现领新 token：从不缓存上一次的应答，
+      // 拿旧串拼 URL 的口子从这里堵死。
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
+          try { if (chrome.runtime.lastError) { start(null); return; } } catch (_) {}
+          start(resp);
+        });
+      } catch (_) { start(null); }
+    } else {
       try {
         chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
           var tid = null;
           try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
           frameTabId = tid;
-          start(tid);
+          start(resp);
         });
       } catch (_) { frameTabId = null; start(null); }
     }
@@ -474,6 +485,9 @@
   function unmount() {
     if (!rootEl) return;
     endWindowDrag(); // 拖到一半被停用也不能留监听
+    drag = null; // 报告 #1295：光撤监听还不够——残留的 drag 对象会让重装后的
+                 // adoptTimer 永远卡在 `!drag` 判假（播放器改尺寸再也不吸收），
+                 // 直到下一次完整拖拽才自愈。旋转/全屏切换正是 mid-drag 卸除的高发点。
     if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
     document.removeEventListener('fullscreenchange', onFullscreenChange);
     window.removeEventListener('resize', onResize);

--- a/tools/browser-extension/mobile-drawer.test.js
+++ b/tools/browser-extension/mobile-drawer.test.js
@@ -85,7 +85,7 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   const chrome = {
     runtime: {
       getURL: (p) => 'chrome-extension://aaa/' + p,
-      sendMessage(msg, cb) { captured.message.push(msg); if (msg.type === 'drawerSelfTab') cb && cb({ ok: true, tabId: 42 }); else cb && cb({}); },
+      sendMessage(msg, cb) { captured.message.push(msg); if (msg.type === 'drawerSelfTab') cb && cb({ ok: true, tabId: 42, token: 'tok-abc' }); else cb && cb({}); },
       lastError: null,
     },
     storage: { local: storageArea, onChanged: storageArea.onChanged },
@@ -134,7 +134,9 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   tap(200, 790);
   const frame = root.children[1];
   if (!frame || frame.tag !== 'iframe') throw new Error('点开后 iframe 未建');
-  if (!/fushiEmbed=1&fushiTabId=42&fushiHostOrigin=https%3A%2F%2Fm\.test$/.test(frame.src)) throw new Error('src 参数不全: ' + frame.src);
+  // 报告 #1295：URL 只许带 SW 签发的 token——自证 origin 的 fushiHostOrigin 永久除名。
+  if (!/fushiEmbed=1&fushiTabId=42&fushiEmbedToken=tok-abc$/.test(frame.src)) throw new Error('src 参数不全: ' + frame.src);
+  if (/fushiHostOrigin/.test(frame.src)) throw new Error('fushiHostOrigin 回潮——origin 不许自证: ' + frame.src);
   if (T() !== 'translateY(0px)') throw new Error('开态应贴零: ' + T());
   if (videoEl.style.width || videoEl.style.height || htmlEl.style.width || htmlEl.style.height) {
     throw new Error('非全屏竖屏绝不让位');

--- a/tools/browser-extension/mobile-drawer.test.js
+++ b/tools/browser-extension/mobile-drawer.test.js
@@ -1,0 +1,287 @@
+'use strict';
+// mobile-drawer.js 行为测试（vm 假 DOM，全链一条）：横屏仅限全屏挂载的门控、竖屏底挂
+// 交互、全屏右挂压播放器让位与 adopt 跟随自重排、快照还原往返、媒体全屏（fs 元素即
+// video 本体，安卓站常态）可拖且只压本体、设置停用整体卸除。十六段共用一条状态机
+// 链——正是抽屉真实生命周期；任何一环断掉都带中文现场抛出。
+const { test } = require('node:test');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/卸除）', () => {
+  const fs = require('fs');
+  const vm = require('vm');
+  const SRC = fs.readFileSync(path.join(__dirname, 'mobile-drawer.js'), 'utf8');
+
+  function makeNode(tag) {
+    const node = {
+      nodeType: 1, tag, tagName: tag.toUpperCase(), children: [], parentNode: null, handlers: {}, attrs: {},
+      style: {
+        setProperty(k, v, p) { this[k] = v; (this.__prio = this.__prio || {})[k] = p || ''; },
+        removeProperty(k) { delete this[k]; if (this.__prio) delete this.__prio[k]; },
+        getPropertyValue(k) { return this[k] || ''; },
+        getPropertyPriority(k) { return (this.__prio && this.__prio[k]) || ''; },
+      },
+      textContent: '', id: '', className: '',
+      src: '', contentWindow: null,
+      classSet: new Set(),
+      _videos: [], _all: [], _rect: { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 },
+      appendChild(child) {
+        if (child.parentNode && child.parentNode !== this) child.parentNode.removeChild(child);
+        this.children.push(child); child.parentNode = this; return child;
+      },
+      removeChild(child) { this.children = this.children.filter((c) => c !== child); child.parentNode = null; return child; },
+      setAttribute(k, v) { this.attrs[k] = String(v); },
+      removeAttribute(k) { delete this.attrs[k]; },
+      getAttribute(k) { return this.attrs[k]; },
+      addEventListener(type, fn) { (this.handlers[type] = this.handlers[type] || []).push(fn); },
+      removeEventListener() {},
+      dispatch(type, ev) { for (const fn of this.handlers[type] || []) fn(ev); },
+      setPointerCapture() {},
+      toggleAttribute() {},
+      closest() { return null; },
+      querySelectorAll(sel) { return sel === 'video' ? this._videos.slice() : this._all.slice(); },
+      getBoundingClientRect() { return this._rect; },
+    };
+    node.classList = {
+      toggle(name, on) { if (on === undefined) on = !node.classSet.has(name); on ? node.classSet.add(name) : node.classSet.delete(name); },
+      contains(name) { return node.classSet.has(name); },
+      add(name) { node.classSet.add(name); },
+      remove(name) { node.classSet.delete(name); },
+    };
+    if (tag === 'iframe') {
+      node.contentWindow = { postMessage(m, o) { (node.postMsg = node.postMsg || []).push({ m, o }); } };
+    }
+    return node;
+  }
+
+  const videoEl = makeNode('video');
+  const htmlEl = makeNode('html');
+  const body = makeNode('body');
+  const captured = { message: [], storage: {}, interval: null, intervals: [], rafs: [] };
+  const document = {
+    fullscreenElement: null,
+    body,
+    documentElement: htmlEl,
+    querySelector(sel) { return sel === 'video' ? videoEl : null; },
+    createElement: (t) => makeNode(t),
+    addEventListener(type, fn) { (this._h = this._h || {}); ((this._h[type] = this._h[type] || []).push(fn)); },
+    removeEventListener() {},
+  };
+  const storageArea = {
+    get(keys, cb) { const out = {}; for (const k of [].concat(keys)) if (k in captured.storage) out[k] = captured.storage[k]; cb && cb(out); return Promise.resolve(out); },
+    set(obj) { Object.assign(captured.storage, obj); return Promise.resolve(); },
+    onChanged: { addListener(fn) { captured.storageOnChanged = fn; } },
+  };
+  const winHandlers = {};
+  const win = {
+    innerWidth: 800, innerHeight: 400,
+    addEventListener(type, fn) { (winHandlers[type] = winHandlers[type] || []).push(fn); },
+    removeEventListener(type, fn) { if (winHandlers[type]) winHandlers[type] = winHandlers[type].filter((f) => f !== fn); },
+    dispatch(type, ev) { for (const fn of (winHandlers[type] || []).slice()) fn(ev); },
+    matchMedia: (q) => ({ matches: q.indexOf('coarse') >= 0 }),
+    setInterval(fn) { captured.interval = fn; captured.intervals.push(fn); return captured.intervals.length; },
+  };
+  const chrome = {
+    runtime: {
+      getURL: (p) => 'chrome-extension://aaa/' + p,
+      sendMessage(msg, cb) { captured.message.push(msg); if (msg.type === 'drawerSelfTab') cb && cb({ ok: true, tabId: 42 }); else cb && cb({}); },
+      lastError: null,
+    },
+    storage: { local: storageArea, onChanged: storageArea.onChanged },
+  };
+  const sandbox = {
+    window: win, document, chrome, console, Array,
+    location: { origin: 'https://m.test', hostname: 'm.test' }, // content script 世界必有宿主页 location
+    setTimeout: (fn) => { fn(); return 1; }, clearTimeout() {},
+    requestAnimationFrame: (fn) => { captured.rafs.push(fn); return captured.rafs.length; },
+    setInterval: win.setInterval, clearInterval() {}, Math, Number, Date, String, Object, JSON, Promise, isFinite, RegExp,
+  };
+  function flush() { while (captured.rafs.length) captured.rafs.shift()(); }
+  const syncUi = () => captured.intervals[0](); // 脚本尾部第一支 setInterval = 900ms 轮询 syncUi（永久可指）
+  const fsFire = () => (document._h.fullscreenchange || []).forEach((fn) => fn());
+  vm.createContext(sandbox);
+  vm.runInContext(SRC, sandbox);
+
+  let root = null; let strip = null;
+  function bindRoot(host) {
+    root = (host.children || []).find((c) => c.id === 'fushi-drawer') || null;
+    strip = root ? root.children[0] : null;
+  }
+  const T = () => root.style.transform;
+  function down(x, y) { strip.dispatch('pointerdown', { pointerId: 1, pointerType: 'touch', clientX: x, clientY: y, preventDefault() {} }); }
+  function move(x, y) { win.dispatch('pointermove', { pointerId: 1, clientX: x, clientY: y }); }
+  function up(x, y) { win.dispatch('pointerup', { pointerId: 1, clientX: x, clientY: y }); flush(); }
+  function cancel() { win.dispatch('pointercancel', { pointerId: 1 }); flush(); }
+  function tap(x, y) { down(x, y); up(x, y); }
+  function drag(x0, y0, x1, y1) { down(x0, y0); move(x1, y1); up(x1, y1); }
+
+  // 0. 横屏非全屏 = 门拒挂（用户终局裁决：这种情况不开字幕列表）
+  syncUi();
+  if (body.children.length !== 0) throw new Error('横屏非全屏竟然挂载了抽屉');
+  if (htmlEl.style.width || videoEl.style.width) throw new Error('门拒挂却污染了页面');
+
+  // 1. 转竖屏 → 轮询放行挂载：底挂收起 full=800×0.48=384 → translateY(372)
+  win.innerWidth = 400; win.innerHeight = 800;
+  syncUi();
+  bindRoot(body);
+  if (!root) throw new Error('竖屏没挂载');
+  if (!root.classList.contains('is-port') || root.classList.contains('is-land')) throw new Error('竖屏朝向类错');
+  if (T() !== 'translateY(372px)') throw new Error('竖屏初始几何错: ' + T());
+  if (root.style.height !== '384px') throw new Error('竖屏初始高度错: ' + root.style.height);
+
+  // 2. 点开（竖屏页面态：iframe 懒建 + 零让位）→ 再点关
+  tap(200, 790);
+  const frame = root.children[1];
+  if (!frame || frame.tag !== 'iframe') throw new Error('点开后 iframe 未建');
+  if (!/fushiEmbed=1&fushiTabId=42&fushiHostOrigin=https%3A%2F%2Fm\.test$/.test(frame.src)) throw new Error('src 参数不全: ' + frame.src);
+  if (T() !== 'translateY(0px)') throw new Error('开态应贴零: ' + T());
+  if (videoEl.style.width || videoEl.style.height || htmlEl.style.width || htmlEl.style.height) {
+    throw new Error('非全屏竖屏绝不让位');
+  }
+  if (!frame.postMsg || frame.postMsg[0].m.type !== 'resume') throw new Error('开时没发 resume');
+  if (frame.postMsg[0].o !== 'chrome-extension://aaa/side-panel.html') throw new Error('postMessage targetOrigin 没钉自己的扩展页');
+  tap(200, 790);
+  if (T() !== 'translateY(372px)') throw new Error('关态几何错: ' + T());
+  if (frame.postMsg[1].m.type !== 'pause') throw new Error('关时没发 pause');
+
+  // 3. 竖屏上拖自由停位：12+280×1.5=432（放大 1.5×），松手即宽高
+  drag(200, 780, 200, 500);
+  if (T() !== 'translateY(0px)') throw new Error('拖开没贴边: ' + T());
+  if (Math.abs(parseFloat(root.style.height) - 432) > 1) throw new Error('自由停位没停在松手处: ' + root.style.height);
+  if (Math.abs(captured.storage.mobileSubtitleDrawerGeom.portH - 432) > 1) throw new Error('竖屏尺寸没持久化');
+
+  // 4. 再拖 → 60% 上限收住：拖出 1482 也只给到 480（800×0.6）
+  drag(200, 700, 200, 0);
+  if (Math.abs(parseFloat(root.style.height) - 480) > 1) throw new Error('拖高没收在上限: ' + root.style.height);
+
+  // 5. 开态往回压：地板 260（=折叠头挤压一行极限宽，MIN_OPEN 与 CSS 对齐）拖不成细条，松手停 260
+  down(200, 700);
+  move(200, 1500);
+  if (T() !== 'translateY(220px)') throw new Error('拖拽没被地板拦住: ' + T()); // 480-260
+  up(200, 1500);
+  if (Math.abs(parseFloat(root.style.height) - 260) > 1) throw new Error('该停在地板 260: ' + root.style.height);
+  if (T() !== 'translateY(0px)') throw new Error('停地板后没贴边: ' + T());
+
+  // 6. 拖到一半 pointercancel：有位移按松手结算（260+90=350），不弹跳
+  down(200, 700);
+  move(200, 640);
+  cancel();
+  if (Math.abs(parseFloat(root.style.height) - 350) > 1) throw new Error('cancel 没按松手结算: ' + root.style.height);
+  tap(200, 790); // 轻点关：保留拖后的 350
+  if (T() !== 'translateY(338px)') throw new Error('关态应保留拖后的高: ' + T());
+  if (Math.abs(captured.storage.mobileSubtitleDrawerGeom.portH - 350) > 1) throw new Error('关后尺寸档案没更新');
+
+  // 7. 横屏 + 进全屏 = 门放行（主形态）：迁移 host、is-fs、右挂收起 translateX(324)
+  const fsEl = makeNode('div');
+  const innerVideo = makeNode('video');
+  innerVideo.style.height = '800px'; // 播放器写死的像素内联尺寸——快照必须能还原它
+  innerVideo.style.setProperty('object-fit', 'fill', 'important'); // 站点原本拉伸填充
+  fsEl.style.width = '100vw';        // 站点自己的内联宽：还原后必须原样还在
+  innerVideo._rect = { left: 8, top: 60, right: 392, bottom: 476, width: 384, height: 416 };
+  const ctrl = makeNode('div');
+  ctrl.className = 'player-controls';
+  ctrl._rect = { left: 0, top: 720, right: 400, bottom: 800, width: 400, height: 80 };
+  fsEl._videos = [innerVideo];
+  fsEl._all = [innerVideo, ctrl];
+  win.innerWidth = 800; win.innerHeight = 400;
+  document.fullscreenElement = fsEl;
+  fsFire();
+  flush();
+  bindRoot(fsEl);
+  if (!root || root.parentNode !== fsEl) throw new Error('没跟进全屏');
+  if (!root.classList.contains('is-fs')) throw new Error('全屏态没打 is-fs');
+  if (T() !== 'translateX(324px)') throw new Error('横屏全屏收起几何错: ' + T());
+
+  // 8. 横屏全屏点开：压全屏容器 + video 联压(464) + 测缝钉左 + 控件条收宽（页面元素零污染）
+  ctrl._rect = { left: 0, top: 360, right: 800, bottom: 400, width: 800, height: 40 }; // 横屏通宽进度条
+  tap(780, 200);
+  const frame2 = root.children[1];
+  if (T() !== 'translateX(0px)') throw new Error('开态应贴零: ' + T());
+  if (fsEl.style.width !== '464px' || fsEl.style.__prio.width !== 'important') throw new Error('全屏容器没让位: ' + fsEl.style.width);
+  if (innerVideo.style.width !== '464px') throw new Error('内层 video 没联压: ' + innerVideo.style.width);
+  if (innerVideo.style['object-fit'] !== 'contain' || innerVideo.style.__prio['object-fit'] !== 'important') throw new Error('压宽没锁住画面比例');
+  if (innerVideo.style.position !== 'fixed' || innerVideo.style.left !== '0px' || innerVideo.style.top !== '60px') {
+    throw new Error('横屏缝隙没吃掉: ' + innerVideo.style.position + '/' + innerVideo.style.left);
+  }
+  if (ctrl.style.width !== '464px' || ctrl.style.__prio.width !== 'important') throw new Error('横屏进度条没收进区域: ' + ctrl.style.width);
+  if (htmlEl.style.width || videoEl.style.width) throw new Error('全屏让位污染了页面元素');
+  if (!frame2 || frame2.tag !== 'iframe') throw new Error('host 迁移后 iframe 丢了');
+
+  // 9. 播放器晚到的重排：adopt 吸真值→重压；幂等
+  innerVideo.style.setProperty('width', '700px', '');
+  captured.interval();
+  if (innerVideo.style.width !== '464px') throw new Error('晚到重排后没重压: ' + innerVideo.style.width);
+  captured.interval();
+  if (innerVideo.style.width !== '464px') throw new Error('adopt 幂等性破了: ' + innerVideo.style.width);
+
+  // 10. 全屏内转竖屏：钉位还原、压高重排、控件条上提；再上拖到 480（区域 320）
+  win.innerWidth = 400; win.innerHeight = 800;
+  ctrl._rect = { left: 0, top: 720, right: 400, bottom: 800, width: 400, height: 80 };
+  win.dispatch('resize', {});
+  flush();
+  if (T() !== 'translateY(0px)') throw new Error('全屏内转竖屏没贴边: ' + T());
+  if (innerVideo.style.position) throw new Error('竖屏没还原横屏钉位: ' + innerVideo.style.position);
+  drag(200, 700, 200, 508); // 350(portH)+288=638 → 60% 封顶 480
+  if (Math.abs(parseFloat(root.style.height) - 480) > 1) throw new Error('竖屏全屏拖高没到上限: ' + root.style.height);
+  if (fsEl.style.height !== '320px') throw new Error('竖屏全屏容器没让位: ' + fsEl.style.height);
+  if (innerVideo.style.height !== '260px') throw new Error('竖屏内层 video 压高不对: ' + innerVideo.style.height); // 320 - top60
+  if (ctrl.style.bottom !== '480px') throw new Error('竖屏控件条没上提: ' + ctrl.style.bottom);
+
+  // 11. 退出全屏（竖屏，门仍放行）：播放器同步重排 600 → adopt 重新起基，还原给它而不是旧快照
+  innerVideo.style.setProperty('height', '600px', ''); // 退出时刻播放器已按页面重排
+  document.fullscreenElement = null;
+  bindRoot(body); // syncUi→attachToHost 回 body
+  fsFire();
+  flush();
+  if (innerVideo.style.height !== '600px') throw new Error('退出全屏盖写了播放器重排: ' + innerVideo.style.height);
+  if (ctrl.style.bottom || fsEl.style.height) throw new Error('退出全屏让位没还原干净: ' + ctrl.style.bottom + '/' + fsEl.style.height);
+
+  // 12. 竖屏开着 → 转横屏非全屏：门翻转 → 即时卸除 + 页面零残留
+  innerVideo.style.width = '640px';
+  innerVideo.style.height = '360px';
+  win.innerWidth = 800; win.innerHeight = 400;
+  win.dispatch('resize', {});
+  if (body.children.length !== 0 || fsEl.children.length !== 0) throw new Error('横屏非全屏没卸除');
+  if (innerVideo.style.width !== '640px' || innerVideo.style['object-fit'] !== 'fill') throw new Error('卸除伤了播放器现值');
+  if (htmlEl.style.width || videoEl.style.width) throw new Error('卸除后页面残留');
+
+  // 13. 再进全屏：轮询重挂 + 开态恢复（st.open 一直 true）→ 新快照以横屏重排值起基
+  document.fullscreenElement = fsEl;
+  syncUi();
+  flush();
+  bindRoot(fsEl);
+  if (!root) throw new Error('再进全屏没重挂');
+  if (T() !== 'translateX(0px)') throw new Error('重挂没恢复开态: ' + T());
+  const frame3 = root.children[1];
+  if (!frame3 || frame3.tag !== 'iframe') throw new Error('重挂没重建 iframe');
+  if (innerVideo.style.width !== '464px') throw new Error('重挂没重新让位: ' + innerVideo.style.width);
+
+  // 14. 轻点关：还原到 640（本轮起基值）→ 停用整体卸除干净
+  tap(780, 200);
+  if (innerVideo.style.width !== '640px' || innerVideo.style.height !== '360px') {
+    throw new Error('关时没还原到本轮基准: ' + innerVideo.style.width + '/' + innerVideo.style.height);
+  }
+  if (innerVideo.style.position || innerVideo.style.left || innerVideo.style.top) throw new Error('钉位残留');
+  if (fsEl.style.width !== '100vw') throw new Error('站点内联被误伤: ' + fsEl.style.width);
+  if (ctrl.style.width || ctrl.className !== 'player-controls') throw new Error('控件条改写没还原干净: ' + ctrl.style.width + '/' + ctrl.className);
+  // 15. 原生 <video> 全屏（fs 元素就是媒体本身，Android 站常见）：抽屉必须在，
+  // host 回落 body，压 video 本体是那里唯一有效的让位——别再把这条路门掉
+  document.fullscreenElement = innerVideo;
+  fsFire();
+  flush();
+  if (root.parentNode !== body) throw new Error('媒体全屏应挂 body 而不是消失');
+  if (!root.classList.contains('is-fs')) throw new Error('媒体全屏没打 is-fs');
+  tap(780, 200); // 开：压视频本体 inline（800-336=464）
+  if (T() !== 'translateX(0px)') throw new Error('媒体全屏开态几何错: ' + T());
+  if (innerVideo.style.width !== '464px' || innerVideo.style.__prio.width !== 'important') {
+    throw new Error('媒体全屏没让位: ' + innerVideo.style.width);
+  }
+  if (innerVideo.style.position) throw new Error('媒体全屏没有子层可钉，不该出钉位');
+  tap(780, 200); // 关：还原播放器现值 640
+  if (innerVideo.style.width !== '640px') throw new Error('媒体全屏关后没还原: ' + innerVideo.style.width);
+  document.fullscreenElement = null;
+  // 16. 设置关 → 整体卸除干净
+  captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: false } }, 'local');
+  if (body.children.length !== 0 || fsEl.children.length !== 0) throw new Error('停用后没卸干净');
+});

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -49,6 +49,47 @@
           </div>
         </section>
 
+        <section class="section" aria-labelledby="touch-lookup-heading">
+          <div class="section-heading compact">
+            <div>
+              <p class="section-kicker">触屏查词与字幕抽屉</p>
+              <h2 id="touch-lookup-heading">手机与平板</h2>
+            </div>
+            <span class="section-note">修改后立即生效</span>
+          </div>
+
+          <div class="setting-list">
+            <label class="setting-row" for="touchLookupTap">
+              <span class="setting-copy">
+                <strong>点按查词</strong>
+                <small>手机/平板浏览器里，单指点在正文文字上即查词——取词、高亮、弹窗与桌面
+                  Shift 划词同一套。链接、按钮、输入框、视频画面等仍归站点自己，不会被拦；
+                  手指拖动算滚动，不触发查词。桌面（鼠标）环境不受这两个开关影响，行为零变化。</small>
+              </span>
+              <span class="switch"><input id="touchLookupTap" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="touchLookupHold">
+              <span class="setting-copy">
+                <strong>长按查词</strong>
+                <small>按住正文约 0.5 秒（不移动）即查词，抬手不再重复。与「点按查词」可同时开，
+                  长按先触发。部分页面系统的长按选词菜单可能跟着弹，嫌碍事就关掉本项只留点按。</small>
+              </span>
+              <span class="switch"><input id="touchLookupHold" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="mobileSubtitleDrawer">
+              <span class="setting-copy">
+                <strong>字幕列表抽屉</strong>
+                <small>安卓浏览器没有原生侧边栏（该 API 仅桌面存在），字幕列表在手机上原本无处
+                  显示。开启后触屏设备的视频页贴屏幕边缘放一颗 ☰ 悬浮钮、边缘一条隐形手势带：点
+                  钮开关、按住边缘可拖出并随手停到任意宽度（横屏右挂、竖屏底挂，内嵌完整列表——
+                  选轨、点句跳转、时轴偏移、外挂字幕、Jimaku、制卡、点词全在），尺寸记住。<b>横屏
+                  仅在全屏时出现</b>（非全屏横屏页面让位不稳，已停用），竖屏任意。桌面（鼠标）不出现。</small>
+              </span>
+              <span class="switch"><input id="mobileSubtitleDrawer" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+          </div>
+        </section>
+
         <section class="section" aria-labelledby="subtitle-heading">
           <div class="section-heading">
             <div>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -27,6 +27,12 @@ const settingDefaults = Object.freeze({
   subtitleReplaceNative: false,
   // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
+  // 触屏查词：点按默认开（手机端没有 Shift 悬停，点按是主入口），长按默认关
+  // （与系统长按选词菜单天然打架）。两者都只在真触屏手势上生效，桌面零影响。
+  touchLookupTap: true,
+  touchLookupHold: false,
+  // 安卓没有 chrome.sidePanel：触屏设备视频页边缘的「字幕列表」抽屉（mobile-drawer.js）。
+  mobileSubtitleDrawer: true,
   videoShortcutPrevCue: true,
   videoShortcutNextCue: true,
   videoShortcutReplayCue: true,
@@ -52,6 +58,9 @@ const toggleIds = Object.freeze({
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
   subtitleReplaceNative: 'subtitleReplaceNative',
   subtitleHidden: 'subtitleHidden',
+  touchLookupTap: 'touchLookupTap',
+  touchLookupHold: 'touchLookupHold',
+  mobileSubtitleDrawer: 'mobileSubtitleDrawer',
   videoShortcutPrevCue: 'videoShortcutPrevCue',
   videoShortcutNextCue: 'videoShortcutNextCue',
   videoShortcutReplayCue: 'videoShortcutReplayCue',

--- a/tools/browser-extension/popup-coarse-columns.test.js
+++ b/tools/browser-extension/popup-coarse-columns.test.js
@@ -1,0 +1,108 @@
+'use strict';
+// 审计报告 #1295 第三项的守卫：coarse 指针不再「一律单列」。
+// 真加载 vendor/popup.js，直接驱动 effectiveDictColumns()/dictColumns()：
+//   · 手机竖屏（coarse + 窄视口）维持单列——原裁决不翻案；
+//   · 平板横屏 / in-app 大窗（coarse + 宽视口）按视口解锁多列；
+//   · fine（桌面）口径分毫不差；
+//   · grid 与 masonry 两路同源不分叉。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const POPUP = fs.readFileSync(path.join(__dirname, 'vendor', 'popup.js'), 'utf8');
+
+function makeEl() {
+  return {
+    id: '', textContent: '', innerHTML: '', style: { setProperty() {}, removeProperty() {} },
+    dataset: {}, children: [], classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {}, removeEventListener() {},
+    appendChild(c) { this.children.push(c); return c; }, removeChild() {}, remove() {},
+    setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    attachShadow() { const s = makeEl(); this.shadowRoot = s; return s; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    getBoundingClientRect() { return { x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 }; },
+  };
+}
+function permissive() {
+  return new Proxy(function () {}, {
+    get(_t, key) {
+      if (key === 'then' || key === Symbol.toPrimitive) return undefined;
+      return permissive();
+    },
+    apply() { return permissive(); },
+  });
+}
+
+function loadPopup(opts) {
+  const o = opts || {};
+  const docEl = makeEl();
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout: () => 1, clearTimeout() {}, setInterval: () => 1, clearInterval() {},
+    requestAnimationFrame: () => 0,
+    performance: { now: () => 1000, timeOrigin: 1700000000000 },
+    navigator: { language: 'zh-CN', userAgent: 'test' },
+    URL, Math, JSON, Date, Promise, isFinite, parseInt, parseFloat, RegExp, Object, Array, String, Number, Boolean, Error, TypeError, Map, Set, WeakMap, Symbol, encodeURIComponent, decodeURIComponent,
+    document: {
+      documentElement: docEl, body: makeEl(),
+      getElementById: () => null, createElement: () => makeEl(),
+      addEventListener() {}, querySelector: () => null, querySelectorAll: () => [],
+      createRange: () => ({ setStart() {}, setEnd() {}, getBoundingClientRect: () => null }),
+      createTreeWalker: () => ({ nextNode: () => null }),
+      createDocumentFragment: () => makeEl(),
+    },
+    getComputedStyle: () => ({
+      getPropertyValue: (k) => (k === '--dict-columns' ? String(o.columns == null ? 1 : o.columns) : ''),
+    }),
+    MutationObserver: class { observe() {} disconnect() {} takeRecords() { return []; } },
+    ResizeObserver: class { observe() {} disconnect() {} unobserve() {} },
+    IntersectionObserver: class { observe() {} disconnect() {} unobserve() {} },
+    chrome: permissive(),
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+  };
+  sandbox.window = {
+    addEventListener() {}, removeEventListener() {},
+    innerWidth: o.width || 0, innerHeight: 800,
+    matchMedia: (q) => ({ matches: q.indexOf('coarse') >= 0 && o.coarse === true }),
+    __fushiPopupViewportWidth: o.width || 0,
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.self = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(POPUP, sandbox, { filename: 'vendor/popup.js' });
+  return sandbox;
+}
+
+test('coarse + 手机竖屏 400px：维持单列（原裁决不翻案）', () => {
+  const s = loadPopup({ coarse: true, width: 400, columns: 3 });
+  assert.strictEqual(s.effectiveDictColumns(), 1);
+});
+
+test('coarse + 平板横屏 700px：解锁到 2 列（老版此处被静默锁死 1）', () => {
+  const s = loadPopup({ coarse: true, width: 700, columns: 3 });
+  assert.strictEqual(s.effectiveDictColumns(), 2); // 700 / (170*2) = 2
+});
+
+test('coarse + in-app 大窗 1200px：按用户设置出 3 列', () => {
+  const s = loadPopup({ coarse: true, width: 1200, columns: 3 });
+  assert.strictEqual(s.effectiveDictColumns(), 3);
+});
+
+test('fine + 桌面 400px：口径不变（400/170 → 2 列）', () => {
+  const s = loadPopup({ coarse: false, width: 400, columns: 3 });
+  assert.strictEqual(s.effectiveDictColumns(), 2);
+});
+
+test('grid 与 masonry 单一真值：dictColumns() 与 effectiveDictColumns() 恒等', () => {
+  for (const cfg of [
+    { coarse: true, width: 400, columns: 3 },
+    { coarse: true, width: 700, columns: 3 },
+    { coarse: false, width: 1200, columns: 4 },
+  ]) {
+    const s = loadPopup(cfg);
+    assert.strictEqual(s.dictColumns(), s.effectiveDictColumns(),
+      '两路分叉 cfg=' + JSON.stringify(cfg));
+  }
+});

--- a/tools/browser-extension/scripts/content-css-overlay.css
+++ b/tools/browser-extension/scripts/content-css-overlay.css
@@ -130,7 +130,8 @@
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    transform: translate(-50%, -50%);
+    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    transform: translate(-50%, -100%);
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -179,3 +180,150 @@
     letter-spacing: 0.04em;
     pointer-events: none;
 }
+
+/* ── 移动端字幕列表抽屉（mobile-drawer.js）：贴边面板 + 边缘细条拉手 ──
+   横屏定宽右挂（.is-land），竖屏定高底挂（.is-port）；宽高与 translate 全由 JS 写，
+   这里只管外观与动画。z 压在字幕覆盖层(2147483637)之上、查词弹窗(2147483647)之下：
+   面板里点词要浮在抽屉上。根容器必须**全透明**——收起态整条边只许露出 12px 细条,
+   底和影都挂在 iframe/拉手上，不然透明也白透。 */
+#fushi-drawer {
+    position: fixed;
+    z-index: 2147483640;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: row;
+    max-width: calc(100vw - 16px);
+    background: transparent;
+    /* 收起态（只剩细条）：根容器整条 12px×全高不许当隐形挡板——透明就得真透明，
+       点/滑全还给背后的视频和控件。可交互的部分自己把事件捡回来（见下三处 auto）。 */
+    pointer-events: none;
+}
+
+/* 开态：拉手槽涂成面板同色（cream），与 iframe 无缝拼成一块面板边——
+   旧的 #1e1b18 根底会在面板左缘留一条黑缝，收起态阴影渗边也是黑边元凶，一并禁掉。 */
+#fushi-drawer.is-open .fushi-drawer-strip {
+    background: #fff9f4;
+}
+
+#fushi-drawer.is-port {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    max-width: none;
+    max-height: calc(100vh - 16px);
+    flex-direction: column;
+}
+
+/* 拖拽期（.is-dragging）关补间跟手；松手后的开/关吸附走 220ms 缓出。 */
+#fushi-drawer:not(.is-dragging) {
+    transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* 拉手：**隐形边缘手势区**——细条本体不再画任何东西（视觉零占位），
+   ::before 把命中往画面侧探 14px（合计 26px）：贴边任何位置起拖即开合/调宽（监听边缘）。 */
+.fushi-drawer-strip {
+    flex: 0 0 auto;
+    position: relative;
+    z-index: 1; /* 按钮探进面板侧的那半要画在 iframe 之上 */
+    width: 12px;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto; /* 根 none 之下，手势区自己把事件捡回来 */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.fushi-drawer-strip::before {
+    content: '';
+    position: absolute;
+    top: -14px;
+    bottom: -14px;
+    left: -14px;
+    right: 0;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip {
+    width: auto;
+    height: 12px;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip::before {
+    top: -14px;
+    bottom: 0;
+    left: -14px;
+    right: -14px;
+}
+
+/* 开合按钮：骑在屏幕/抽屉边缘的小圆钮，一眼可见、一点开合；按住它同样可以拖。 */
+.fushi-drawer-btn {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font: 700 15px/1 system-ui, sans-serif;
+    color: #f0e6da;
+    background: rgba(40, 32, 26, 0.88);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#fushi-drawer.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: 50%;
+}
+
+/* 全屏时开合钮挪右上角（用户指定）：横屏在右缘顶端，竖屏在抽屉顶缘右角。
+   safe-area 兜刘海/挖孔，不跟播放器自己的右上控件重叠太多再报我调坐标。 */
+#fushi-drawer.is-fs.is-land .fushi-drawer-btn {
+    top: max(14px, env(safe-area-inset-top));
+    transform: translateX(-50%);
+}
+
+#fushi-drawer.is-fs.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: auto;
+    right: max(18px, env(safe-area-inset-right));
+    transform: none;
+}
+
+#fushi-drawer iframe {
+    flex: 1 1 auto;
+    display: block;
+    min-width: 0;
+    min-height: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff9f4;
+    pointer-events: auto;
+}
+
+/* 投影只在开态存在：收起时 iframe 整块在屏外，它的 -6px 投影会渗到屏边上糊一道黑雾。 */
+#fushi-drawer.is-open iframe {
+    box-shadow: -6px 0 24px rgba(0, 0, 0, 0.45);
+}
+
+#fushi-drawer.is-open.is-port iframe {
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.45);
+}
+
+/* 视频让位（开抽屉时压 fullscreenElement/<html>）不走这里：mobile-drawer.js 直接对
+   目标元素写 inline !important（站点后到样式/内联尺寸都压得住），关抽屉精确还原。 */

--- a/tools/browser-extension/side-panel-embed-token.test.js
+++ b/tools/browser-extension/side-panel-embed-token.test.js
@@ -1,0 +1,197 @@
+'use strict';
+// 审计报告 #1295 的嵌入协议守卫：side-panel.js EMBED 模式下，宿主 pause/resume 的
+// 信任根必须是 **SW 核销过的 token**，不再是 URL 参数自证的 origin。
+// 行为信号：embedPaused 生效与否直接反映为 300ms 轮询 tick 是否再向 tabs 发消息。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SIDE_PANEL = fs.readFileSync(path.join(__dirname, 'side-panel.js'), 'utf8');
+const DICT_MEDIA = fs.readFileSync(path.join(__dirname, 'vendor', 'dict-media.js'), 'utf8');
+
+const flush = async () => { for (let i = 0; i < 12; i++) await new Promise((r) => setImmediate(r)); };
+
+function makeEl() {
+  return {
+    id: '', textContent: '', innerHTML: '', hidden: false, disabled: false, value: '',
+    dataset: {}, style: { setProperty() {}, removeProperty() {} }, children: [],
+    classList: { add() {}, remove() {}, toggle() {} },
+    addEventListener() {}, removeEventListener() {},
+    appendChild(c) { this.children.push(c); return c; },
+    removeChild() {}, remove() {},
+    setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    attachShadow() { const s = makeEl(); this.shadowRoot = s; return s; },
+    scrollIntoView() {}, focus() {}, contains() { return false; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+  };
+}
+
+function permissive() {
+  return new Proxy(function () {}, {
+    get(_t, key) {
+      if (key === 'then' || key === Symbol.toPrimitive) return undefined;
+      if (key === 'addListener' || key === 'removeListener') return function () {};
+      return permissive();
+    },
+    apply() { return Promise.resolve({}); },
+  });
+}
+
+async function loadEmbedPanel(opts) {
+  const o = opts || {};
+  const tabSends = [];
+  const runtimeSends = [];
+  const intervals = [];
+  const winHandlers = {};
+  const els = new Map();
+  const created = [];
+  const chromeMock = new Proxy({}, {
+    get(_t, key) {
+      if (key === 'runtime') {
+        return {
+          id: 'test-ext-id',
+          lastError: undefined,
+          getURL() { return 'chrome-extension://test/x'; },
+          onMessage: { addListener() {} },
+          sendMessage(message, callback) {
+            runtimeSends.push(message);
+            if (message && message.type === 'drawerEmbedVerify' && callback) {
+              callback(o.verifyResp || { origin: '' });
+              return;
+            }
+            if (callback) callback({});
+          },
+        };
+      }
+      if (key === 'tabs') {
+        return {
+          get(_id, cb) { if (cb) cb({ id: 42 }); return Promise.resolve({ id: 42 }); },
+          query(_q, cb) { if (cb) cb([{ id: 42 }]); return Promise.resolve([{ id: 42 }]); },
+          onActivated: { addListener() {} },
+          onUpdated: { addListener() {} },
+          sendMessage(msg, cb) {
+            tabSends.push(msg);
+            if (cb) cb({ ok: true, data: {} });
+            return Promise.resolve({ ok: true });
+          },
+        };
+      }
+      if (key === 'storage') {
+        return {
+          local: {
+            get(_keys, cb) { if (cb) cb({}); return Promise.resolve({}); },
+            set() { return Promise.resolve(); },
+          },
+          onChanged: { addListener() {} },
+        };
+      }
+      return permissive();
+    },
+  });
+  const windowObj = {
+    addEventListener(type, fn) { (winHandlers[type] = winHandlers[type] || []).push(fn); },
+    removeEventListener(type, fn) {
+      if (winHandlers[type]) winHandlers[type] = winHandlers[type].filter((f) => f !== fn);
+    },
+    innerWidth: 400, innerHeight: 800,
+    matchMedia: () => ({ matches: false }),
+  };
+  const sandbox = {
+    document: {
+      getElementById(id) {
+        if (!els.has(id)) { const el = makeEl(); el.id = id; els.set(id, el); }
+        return els.get(id);
+      },
+      createElement() { const el = makeEl(); created.push(el); return el; },
+      addEventListener() {},
+      querySelector() { return null; }, querySelectorAll() { return []; },
+      createRange() { return { setStart() {}, setEnd() {}, getBoundingClientRect() { return null; } }; },
+      documentElement: makeEl(),
+      body: makeEl(),
+    },
+    location: { search: o.search || '', href: 'chrome-extension://test/side-panel.html' + (o.search || '') },
+    window: windowObj,
+    chrome: chromeMock,
+    setTimeout(fn) { fn(); return 1; },
+    clearTimeout() {},
+    setInterval(fn) { intervals.push(fn); return intervals.length; },
+    clearInterval() {},
+    requestAnimationFrame: () => 0,
+    performance: { now: () => 1000, timeOrigin: 1700000000000 },
+    console: { log() {}, warn() {}, error() {} },
+    navigator: { language: 'zh-CN' },
+    URL,
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.self = sandbox.window;
+  vm.createContext(sandbox);
+  vm.runInContext(DICT_MEDIA, sandbox, { filename: 'vendor/dict-media.js' });
+  vm.runInContext(SIDE_PANEL, sandbox, { filename: 'side-panel.js' });
+  await flush();
+  const dispatch = (origin, data) => {
+    for (const fn of (winHandlers.message || []).slice()) fn({ origin, data, source: {} });
+  };
+  const tick = async () => { for (const fn of intervals.slice()) fn(); await flush(); };
+  return { tabSends, runtimeSends, dispatch, tick };
+}
+
+test('带 token 的嵌入面板开局向 SW 核销，且只带 token 不带自证 origin', async () => {
+  const p = await loadEmbedPanel({
+    search: '?fushiEmbed=1&fushiTabId=42&fushiEmbedToken=TK1',
+    verifyResp: { origin: 'https://m.test' },
+  });
+  const verify = p.runtimeSends.filter((m) => m && m.type === 'drawerEmbedVerify');
+  assert.strictEqual(verify.length, 1);
+  assert.strictEqual(verify[0].token, 'TK1');
+});
+
+test('核销成功：验证过的宿主 origin 的 pause 生效（轮询熄火）、resume 复活', async () => {
+  const p = await loadEmbedPanel({
+    search: '?fushiEmbed=1&fushiTabId=42&fushiEmbedToken=TK1',
+    verifyResp: { origin: 'https://m.test' },
+  });
+  p.dispatch('https://m.test', { source: 'fushi-drawer', type: 'pause' });
+  const before = p.tabSends.length;
+  await p.tick();
+  assert.strictEqual(p.tabSends.length, before, 'pause 被采纳后 tick 不许再向 tabs 发消息');
+  await p.tick();
+  assert.strictEqual(p.tabSends.length, before, '熄火要持续，不是一次性');
+  p.dispatch('https://m.test', { source: 'fushi-drawer', type: 'resume' });
+  await flush();
+  assert.ok(p.tabSends.length > before, 'resume 必须立刻补一次全量刷新');
+});
+
+test('核销成功后，别的 origin 冒充宿主一律丢弃', async () => {
+  const p = await loadEmbedPanel({
+    search: '?fushiEmbed=1&fushiTabId=42&fushiEmbedToken=TK1',
+    verifyResp: { origin: 'https://m.test' },
+  });
+  p.dispatch('https://evil.test', { source: 'fushi-drawer', type: 'pause' });
+  const before = p.tabSends.length;
+  await p.tick();
+  assert.ok(p.tabSends.length > before, 'evil origin 的 pause 被采纳了——双向校验漏了方向');
+});
+
+test('核销失败（伪造 token 兑不出 origin）：宿主消息全数丢弃 = fail-closed', async () => {
+  const p = await loadEmbedPanel({
+    search: '?fushiEmbed=1&fushiTabId=42&fushiEmbedToken=FORGED',
+    verifyResp: { origin: '' },
+  });
+  p.dispatch('https://evil.test', { source: 'fushi-drawer', type: 'pause' });
+  const before = p.tabSends.length;
+  await p.tick();
+  assert.ok(p.tabSends.length > before, 'token 未核销通过时面板绝不可进入暂停态');
+});
+
+test('URL 无 token：不发核销、不收任何宿主消息，面板照常渲染', async () => {
+  const p = await loadEmbedPanel({
+    search: '?fushiEmbed=1&fushiTabId=42',
+  });
+  assert.strictEqual(p.runtimeSends.filter((m) => m && m.type === 'drawerEmbedVerify').length, 0);
+  p.dispatch('https://m.test', { source: 'fushi-drawer', type: 'pause' });
+  const before = p.tabSends.length;
+  await p.tick();
+  assert.ok(p.tabSends.length > before, '无 token 的通道必须整条关死');
+});

--- a/tools/browser-extension/side-panel.css
+++ b/tools/browser-extension/side-panel.css
@@ -240,3 +240,128 @@ h1 { margin: 0; font-size: 18px; line-height: 1.3; }
   .toolbar { justify-content: flex-start; margin-top: 9px; }
   .offset-row { grid-template-columns: repeat(3, 1fr); }
 }
+
+/* ── 抽屉嵌入模式（mobile-drawer.js 的 iframe，html.fushi-embed）──
+   手机屏寸土寸金：砍掉大标题、头部分行压紧、折叠钮一键收成一行，列表近乎占满；
+   控件仍保持 ≥38px 的触摸命中区，去 hover 依赖改 :active 反馈，补刘海安全区。 */
+html.fushi-embed body {
+  touch-action: manipulation;
+}
+
+html.fushi-embed button,
+html.fushi-embed select {
+  min-height: 38px;
+  min-width: 38px;
+}
+
+html.fushi-embed button:active { background: var(--surface-strong); }
+
+html.fushi-embed .panel-header {
+  padding: 8px 10px 6px;
+  padding-top: calc(8px + env(safe-area-inset-top));
+}
+
+html.fushi-embed h1 { display: none; }
+
+/* 嵌入头部两行制（展开/折叠一致，用户裁决）：第一行折叠钮＋工具排，第二行
+   「已连接视频」小字（order:3 + basis:100% 自然落下去）。display:flex 同时压掉
+   桌面 @media ≤340px 的 .title-row{display:block} 兜底——它漏进 iframe 就是拆行事故。 */
+html.fushi-embed .title-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  column-gap: 3px;
+  row-gap: 2px;
+  justify-content: flex-start;
+}
+
+html.fushi-embed .title-row > div:first-of-type {
+  order: 3;
+  flex: 1 0 100%;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+html.fushi-embed #video-status {
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 允许收缩（0 1 auto）：nowrap 式的 0 0 auto 在窄抽屉会整排溢出容器把 ⚙ 裁掉而不是
+   换行；可收缩后 flex-wrap 才拿得到受限宽度——装得下一行，超出自然折行。 */
+html.fushi-embed .toolbar { flex: 0 1 auto; min-width: 0; margin-top: 0; gap: 3px; }
+
+html.fushi-embed #track { margin-top: 6px; height: 32px; min-height: 32px; font-size: 13px; }
+html.fushi-embed .offset-row { margin-top: 6px; }
+html.fushi-embed .jimaku-row input { min-height: 32px; }
+
+/* ── 嵌入态防出界：窄抽屉（最窄 220）里这些盒子会捅穿面板边，全改可收缩规格 ── */
+/* 时轴行基版是 6 列最少 ~313px：auto-fit 让它按实际宽度自动降列（宽=一行，窄=两三行）。 */
+html.fushi-embed .offset-row {
+  grid-template-columns: repeat(auto-fit, minmax(44px, 1fr));
+}
+
+/* input 默认有 ~147px 固有宽且 grid 项 min-width:auto 不缩，1fr 被顶爆。 */
+html.fushi-embed .jimaku-row { grid-template-columns: 1fr 46px 40px; }
+html.fushi-embed .jimaku-row input { min-width: 0; }
+
+/* 展开设置那一排也缩到 32 档，跟按钮行同高——两态一体。 */
+html.fushi-embed .offset-row button,
+html.fushi-embed .offset-row span,
+html.fushi-embed .jimaku-row button {
+  height: 32px;
+  min-height: 32px;
+}
+
+/* 查词浮层：min-width 250 比最窄抽屉还宽，横 resize 把手在触屏也是误触源——
+   宽度直接跟视口走，只许纵向拉。 */
+html.fushi-embed .lookup-pane {
+  min-width: 0;
+  width: calc(100vw - 12px);
+  resize: vertical;
+}
+
+html.fushi-embed .toast {
+  max-width: calc(100vw - 24px);
+  white-space: normal;
+}
+
+html.fushi-embed .subtitle-row { padding: 10px 6px; }
+
+html.fushi-embed .timestamp { min-height: 34px; }
+
+html.fushi-embed .subtitle-list {
+  padding: 6px 6px calc(16px + env(safe-area-inset-bottom));
+}
+
+/* 折叠态：隐藏选轨/时轴/Jimaku，工具排 display:contents 并进折叠钮同一行。
+   头部两行制与按钮尺寸是 embed 通用规格（见基规则），展开收起只差隐藏与并排。 */
+html.fushi-embed body.hdr-folded .panel-header {
+  padding-top: calc(4px + env(safe-area-inset-top));
+  padding-bottom: 2px;
+}
+html.fushi-embed body.hdr-folded .toolbar {
+  display: contents; /* 六颗钮与折叠钮同池排一行，间距统一吃上面的 column-gap */
+}
+
+/* 静态小钮：展开/折叠共用同一尺寸（两态一致，切换零抖动）。折叠态算式：
+   7×30 + 6×3 缝 + 12 拉手 + 20 header 内边距 = 260 = MIN_OPEN；border-box 下 30/32
+   是终值，min-* 归零防基版 38px 触摸规格顶回来。 */
+html.fushi-embed .hdr-fold,
+html.fushi-embed .toolbar button {
+  flex: 0 0 30px;
+  width: 30px;
+  height: 32px;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+}
+
+html.fushi-embed body.hdr-folded #track,
+html.fushi-embed body.hdr-folded #offset,
+html.fushi-embed body.hdr-folded #jimaku-row,
+html.fushi-embed body.hdr-folded #jimaku-results { display: none !important; }

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -28,6 +28,51 @@
   window.__fushiRoot = lookupShadow;
   installDictMediaPlaceholderResolver(lookupShadow); // BUG-1718：兑现词条内图片/样式表占位
   var currentTabId = null;
+  // 抽屉嵌入模式（mobile-drawer.js 的 iframe 打开，?fushiEmbed=1）：
+  //   · 绑定来源页 tabId——网页内扩展 iframe 里 tabs.query 的 currentWindow 解析不可靠，
+  //     以 background drawerSelfTab 如实回报的 sender.tab.id 为准（缺参数仍走 queryActiveTab）；
+  //   · 不挂 tabs.onActivated：抽屉只服务这一页，「跟着切的标签页走」语义在这里不存在；
+  //   · 抽屉收起时宿主 postMessage pause → 暂停 300ms 轮询（省电），拉开立刻补一次；
+  //   · html 根挂 .fushi-embed 类，side-panel.css 按触屏规格放大控件、补安全区。
+  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耽误。
+  var EMBED_SEARCH = typeof location === 'undefined' ? '' : String(location.search || '');
+  var EMBED = /[?&]fushiEmbed=1/.test(EMBED_SEARCH);
+  var EMBED_TAB_ID = (function () {
+    var m = /[?&]fushiTabId=(\d+)/.exec(EMBED_SEARCH);
+    return m ? Number(m[1]) : null;
+  })();
+  var embedPaused = false;
+  if (EMBED) document.documentElement.classList.add('fushi-embed');
+  // 嵌入（手机抽屉）模式头部原本叠了标题+工具排+选轨+时轴偏移三四行，把列表挤得没法看。
+  // 加一个折叠钮：折叠后只留工具排（＋J A− A＋ AS ⚙），列表近乎占满；再点恢复。
+  if (EMBED) {
+    var foldTitleRow = document.querySelector('.title-row');
+    if (foldTitleRow) {
+      var foldBtn = document.createElement('button');
+      foldBtn.type = 'button';
+      foldBtn.className = 'hdr-fold';
+      foldBtn.textContent = '▾';
+      foldBtn.title = '折叠/展开工具区';
+      foldBtn.setAttribute('aria-label', '折叠或展开头部工具区');
+      var applyFold = function (folded) {
+        document.body.classList.toggle('hdr-folded', folded);
+        foldBtn.textContent = folded ? '▸' : '▾';
+      };
+      foldBtn.addEventListener('click', function () {
+        var folded = !document.body.classList.contains('hdr-folded');
+        applyFold(folded);
+        // 折叠状态跨会话记忆：抽屉每次重开都摊着四行工具区是反体验。此键只有 embed
+        // 读写（desktop 无此守卫、CSS 全挂 html.fushi-embed），不污染侧板。
+        try { localStorage.setItem('fushiHdrFolded', folded ? '1' : '0'); } catch (_) {}
+      });
+      // 新会话默认折叠（尽量省空间）：只有用户显式展开过（存 '0'）才记住展开；
+      // 无存档=首次，直接收成一行工具排。
+      var savedFold = null;
+      try { savedFold = localStorage.getItem('fushiHdrFolded'); } catch (_) {}
+      if (savedFold !== '0') applyFold(true);
+      foldTitleRow.insertBefore(foldBtn, foldTitleRow.firstChild);
+    }
+  }
   var currentState = null;
   var cues = [];
   var rows = [];
@@ -661,6 +706,7 @@
   }
 
   function queryActiveTab() {
+    if (EMBED && EMBED_TAB_ID != null) return Promise.resolve({ id: EMBED_TAB_ID });
     return new Promise(function (resolve) {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
@@ -709,18 +755,28 @@
     ].join('::');
   }
 
+  var trackSig = '~';
   function renderTracks(state) {
     var tracks = Array.isArray(state.tracks) ? state.tracks : [];
-    trackEl.textContent = '';
-    tracks.forEach(function (track) {
-      var option = document.createElement('option');
-      option.value = track.lang;
-      option.textContent = track.label + '（' + track.length + '）';
-      trackEl.appendChild(option);
-    });
-    trackEl.hidden = tracks.length === 0;
-    trackEl.value = state.activeLang || '';
-    offsetEl.hidden = tracks.length === 0;
+    // 每 300ms 刷新都清空重建 option，会把展开中的系统级下拉一次一次销毁——
+    // 安卓抽屉里「选轨窗口一直闪烁」就是这么来的（桌面同理）。无变化 = DOM 一律不碰；
+    // 指纹含 activeLang，所以切轨后选中值照样落得下去。偏移读数是纯文本，放闸外常刷。
+    var sig = (state.activeLang || '') + '\u0003' + tracks.map(function (t) {
+      return [t.lang, t.label, t.length, t.signature].join('\u0001');
+    }).join('\u0002');
+    if (sig !== trackSig) {
+      trackSig = sig;
+      trackEl.textContent = '';
+      tracks.forEach(function (track) {
+        var option = document.createElement('option');
+        option.value = track.lang;
+        option.textContent = track.label + '（' + track.length + '）';
+        trackEl.appendChild(option);
+      });
+      trackEl.hidden = tracks.length === 0;
+      trackEl.value = state.activeLang || '';
+      offsetEl.hidden = tracks.length === 0;
+    }
     offsetValueEl.textContent = ((Number(state.offsetMs) || 0) >= 0 ? '+' : '') +
       ((Number(state.offsetMs) || 0) / 1000).toFixed(1) + 's';
   }
@@ -838,6 +894,7 @@
   }
 
   async function refresh(forceCues) {
+    if (embedPaused) return; // 抽屉收起：不空转消息，resume 时立即补一次全量
     if (refreshBusy) return;
     refreshBusy = true;
     try {
@@ -1157,11 +1214,28 @@
 
 
   try {
-    chrome.tabs.onActivated.addListener(function () { refresh(true); });
+    if (!EMBED) chrome.tabs.onActivated.addListener(function () { refresh(true); });
     chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
       if (tabId === currentTabId && changeInfo.status === 'complete') refresh(true);
     });
   } catch (_) {}
+
+  // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
+  if (EMBED) {
+    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
+    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
+    var EMBED_HOST_ORIGIN = (function () {
+      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
+      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+    })();
+    window.addEventListener('message', function (ev) {
+      if (ev.origin !== EMBED_HOST_ORIGIN) return;
+      var d = ev && ev.data;
+      if (!d || d.source !== 'fushi-drawer') return;
+      if (d.type === 'pause') embedPaused = true;
+      else if (d.type === 'resume') { embedPaused = false; refresh(true); }
+    });
+  }
 
   refresh(true);
   setInterval(function () { refresh(false); }, 300);

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -1221,20 +1221,34 @@
   } catch (_) {}
 
   // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
+  // 审计报告 #1295：宿主 origin 的来源从「URL 参数自证」（任意网站可伪造）改为
+  // 「持 SW 签发的 token 回 SW 核销」——SW 绑定签发 tab、TTL 过期，伪造的 token 兑不出
+  // origin。核销前 EMBED_HOST_ORIGIN 保持初始 sentinel（永不等于任何真实 origin），
+  // 天然 fail-closed：兑不到就一直不收宿主消息。
   if (EMBED) {
-    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
-    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
-    var EMBED_HOST_ORIGIN = (function () {
-      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
-      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
-    })();
-    window.addEventListener('message', function (ev) {
+    var EMBED_HOST_ORIGIN = 'fushi-unverified-pending'; // 未核销前的哨兵，绝不匹配任何 origin
+    var hostMsg = function (ev) {
       if (ev.origin !== EMBED_HOST_ORIGIN) return;
       var d = ev && ev.data;
       if (!d || d.source !== 'fushi-drawer') return;
       if (d.type === 'pause') embedPaused = true;
       else if (d.type === 'resume') { embedPaused = false; refresh(true); }
-    });
+    };
+    window.addEventListener('message', hostMsg);
+    (function () {
+      var m = /[?&]fushiEmbedToken=([^&]*)/.exec(EMBED_SEARCH);
+      if (!m) return; // 没 token：哨兵永挂，只读面板（不收宿主 pause/resume），功能不炸
+      var tok = '';
+      try { tok = decodeURIComponent(m[1]); } catch (_) { return; }
+      if (!tok) return;
+      try {
+        chrome.runtime.sendMessage({ type: 'drawerEmbedVerify', token: tok }, function (resp) {
+          try { if (chrome.runtime.lastError) return; } catch (_) { return; }
+          var o = resp && typeof resp.origin === 'string' ? resp.origin : '';
+          if (o) EMBED_HOST_ORIGIN = o; // 只有核销成功才把哨兵换成真 origin
+        });
+      } catch (_) { /* 保持哨兵 = fail-closed */ }
+    })();
   }
 
   refresh(true);

--- a/tools/browser-extension/subtitle-adapters.js
+++ b/tools/browser-extension/subtitle-adapters.js
@@ -109,17 +109,22 @@ function parseSubtitleTimestamp(raw, tickRate) {
 const RUBY_ANNOTATION = '<(?:rt|rp|rtc)\\b(?:[^<>/]|/(?!>))*>' +
   '(?:(?!</?(?:ruby|rt|rp|rtc)\\b)[\\s\\S])*(?:</(?:rt|rp|rtc)\\s*>)?';
 
-// 方向/零宽控制字符与最小实体解码（不碰标签）。
+// 方向/零宽控制字符与最小实体解码（不碰标签）。分号可选：YouTube 等的字幕流大量输出
+// 无分号形态（&#39 而非 &#39;），HTML 规范里文本上下文的字符引用本就允许省分号——
+// 只认带分号就是用户报的「字幕里出现 &#39」。十进制/十六进制/命名都补齐。
 function decodeCueEntities(text) {
   return String(text || '')
     .replace(/[‎‏]/g, '')
-    .replace(/&lrm;|&rlm;/g, '')
-    .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&');
+    .replace(/&#(\d+);?/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
+    .replace(/&#x([0-9a-f]+);?/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    // 命名实体：要么带分号整口吃掉，要么无分号但后不跟字母/数字/分号（HTML5 同款
+    // 边界判据；漏了这条会吐 "&lt;b&gt;"→"<;b>"、"&amphibian" 被咬这类反向事故）。
+    .replace(/&(?:lrm|rlm)(?:;|(?![0-9A-Za-z;]))/gi, '')
+    .replace(/&nbsp(?:;|(?![0-9A-Za-z;]))/gi, ' ')
+    .replace(/&lt(?:;|(?![0-9A-Za-z;]))/gi, '<')
+    .replace(/&gt(?:;|(?![0-9A-Za-z;]))/gi, '>')
+    .replace(/&quot(?:;|(?![0-9A-Za-z;]))/gi, '"')
+    .replace(/&amp(?:;|(?![0-9A-Za-z;]))/gi, '&');
 }
 
 // 去掉行内标签（<c>、<i>、<b.bg_transparent> …）并解码实体；注音内容已在上游剔除。

--- a/tools/browser-extension/subtitle-modes.test.js
+++ b/tools/browser-extension/subtitle-modes.test.js
@@ -90,11 +90,15 @@ function loadPanel(opts) {
     fushiLookupAtPoint: (...args) => lookups.push(args),
     fushiResetAutoLookupDedupe: () => { autoLookupResets++; },
   };
+  // 同 external-subtitle.test.js：覆盖层挂在 documentElement 上，fake 补真实树形。
+  const htmlRoot = makeEl('html');
+  htmlRoot.appendChild(body);
   const documentObj = {
     body,
+    documentElement: htmlRoot,
     fullscreenElement: null,
     addEventListener() {},
-    getElementById: (id) => findByIdDeep(body, id),
+    getElementById: (id) => findByIdDeep(htmlRoot, id),
     querySelector: (sel) => (sel === 'video' ? video : null),
     querySelectorAll: () => [],
     createElement: (t) => makeEl(t),
@@ -135,7 +139,7 @@ function loadPanel(opts) {
     body, video, windowObj, toasts, storageSets, clipboard, lookups,
     autoLookupResets: () => autoLookupResets,
     panel: () => findByIdDeep(body, 'fushi-subtitle-panel'),
-    overlay: () => findByIdDeep(body, 'fushi-subtitle-overlay'),
+    overlay: () => findByIdDeep(htmlRoot, 'fushi-subtitle-overlay'),
     tick: () => { const t = intervals.find((it) => it.ms === 200); if (t) t.fn(); },
     shortcut: (a) => windowObj.fushiSubtitleShortcut(a),
     message,

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -161,7 +161,11 @@
     return t < cues[ans].endMs ? ans : -1;
   }
 
-  function parentForOverlay() { return document.fullscreenElement || document.body; }
+  // 兜底父级用 <html> 而不是 <body>：浮层写的是视口坐标的 position:fixed，而安卓播放器
+  // 进/退全屏常给 body 挂 transform 或 scroll-lock（position:fixed;top:-Npx）——fixed 的
+  // 包含块会跟着变成那个带 transform 的祖先，视口坐标落进歪掉的坐标系，每 200ms 重测
+  // 一百次也还是歪的（用户报「退出全屏字幕错位」修不尽的根因）。html 自己从不被 transform。
+  function parentForOverlay() { return document.fullscreenElement || document.documentElement; }
 
   function seekTo(ms) {
     ms = Math.max(0, Math.round(ms));
@@ -333,6 +337,12 @@
       return;
     }
     var video = videoEl();
+    // 先重挂父级再走测量：退出全屏那一刻若 rect 恰好坏掉（播放器挪树/隐藏的瞬间），
+    // 浮层节点绝不能滞留在旧 fullscreenElement 里——那正是下一次显示时的错位源。
+    if (st.overlayEl) {
+      var reparent = parentForOverlay();
+      if (st.overlayEl.parentNode !== reparent) reparent.appendChild(st.overlayEl);
+    }
     if (!video || typeof video.getBoundingClientRect !== 'function') return;
     var rect = video.getBoundingClientRect();
     if (!rect || rect.width <= 0 || rect.height <= 0) return;
@@ -341,9 +351,18 @@
     el.setAttribute('data-theme', resolveTheme());
     if (typeof window.fushiRenderCueText === 'function') window.fushiRenderCueText(el, cue);
     else el.textContent = cue.text;
-    el.style.left = (rect.left + rect.width / 2) + 'px';
-    el.style.top = (rect.top + rect.height * 0.84) + 'px';
-    el.style.maxWidth = Math.max(240, rect.width * 0.9) + 'px';
+    // 中心恒定贴视频（拖拽跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
+    // 视频中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
+    // 抽屉 → 近侧即屏缘，行宽约等视频盒，永不探进抽屉盖画面（60% 上限保证最窄视频区也 ≥40% 屏）。
+    var vv = window.innerWidth || (rect.left + rect.right);
+    var cx = rect.left + rect.width / 2;
+    var halfToEdge = Math.max(0, Math.min(cx, vv - cx));
+    var maxW = Math.max(200, Math.min(vv * 0.94, (halfToEdge - 6) * 2));
+    el.style.left = cx + 'px';
+    // 底边锚定（CSS transform 是 -100%）：文本块从这条线**往上**长。旧版中心锚 84% 时，
+    // 非全屏矮视频（~200px 高）会垂出视频底缘压住进度条——底锚后任何视频高度都出不了界。
+    el.style.top = (rect.top + rect.height * 0.88) + 'px';
+    el.style.maxWidth = Math.round(maxW) + 'px';
     applyOverlayBlur(el);
   }
 
@@ -370,10 +389,18 @@
 
   // notify=true：这是用户显式的「打开侧边栏」动作，失败必须给可见提示。
   // notify 省略：只是顺带刷新（加载外挂字幕、拖放落地），失败不抢占它们自己的 toast。
-  // 返回值 = 是否已经把这次交互「办成了」。内容脚本这一侧永远办不成（原因见上），故恒为 false，
-  // 调用方（video-shortcuts.js）据此不 preventDefault，按键原样放行给站点。
+  // 返回值 = 是否已经把这次交互「办成了」。桌面内容脚本这一侧永远办不成（原因见上）恒 false，
+  // video-shortcuts.js 据此不 preventDefault 放行站点；触屏抽屉真开了才返回 true（吞键合理）。
   function showPanel(notify) {
     refreshHeadless();
+    // 触屏设备没有 chrome.sidePanel（桌面独有 API）：页内抽屉契约存在（mobile-drawer.js）
+    // 就改拉抽屉，并如实返回 true——抽屉确实开了，Shift+S 该吞键。桌面契约恒缺失，原样走。
+    try {
+      if (typeof window.fushiMobileDrawerOpen === 'function' && window.fushiMobileDrawerOpen()) {
+        if (notify) toast('字幕列表已打开');
+        return true;
+      }
+    } catch (_) {}
     try {
       chrome.runtime.sendMessage({ type: 'openSubtitleSidePanel' }, function (resp) {
         var failed = true;
@@ -761,6 +788,9 @@
   document.addEventListener('fullscreenchange', function () {
     if (!st.enabled) return;
     sync();
+    // 全屏切换后播放器整体挪位（body transform/滚动锁很常见）：立刻重测重摆一次，
+    // 不等下一个 200ms tick——重挂父级（fsEl↔html）也在这一步完成。
+    if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
   });
 
   var lastPath = location.pathname;

--- a/tools/browser-extension/subtitle-replace-native.test.js
+++ b/tools/browser-extension/subtitle-replace-native.test.js
@@ -174,7 +174,8 @@ function loadWorld(prefs) {
     const el = findById(html, STYLE_ID);
     return el ? el.textContent : null;
   };
-  const overlayEl = () => findById(body, OVERLAY_ID);
+  // 覆盖层落点已改 <html>（fullscreenElement || documentElement），从根往下找。
+const overlayEl = () => findById(html, OVERLAY_ID);
   // 写 store + 走 content.js 真实的通知链（fushiNotifyPanel → fushiSubtitlePanelOnCues），
   // 面板据此重新选轨。绕过通知直接改 store 是测试世界独有的假路径，不用。
   const setTrack = (lang, cues) => {

--- a/tools/browser-extension/touch-lookup.js
+++ b/tools/browser-extension/touch-lookup.js
@@ -1,0 +1,117 @@
+// 触屏查词（content script 隔离世界，manifest bundle 里排在 video-shortcuts.js 之后加载）。
+// 桌面查词靠 Shift+悬停划词，手机/平板没键盘，那条路完全够不着——本脚本把「页面正文」
+// 变成触屏查词入口：单点一下 = 查词（touchLookupTap，默认开）；长按约 0.5 秒不动 = 查词
+// （touchLookupHold，默认关，想要再开）。取词、高亮、弹窗完全复用 window.fushiLookupAtPoint
+// （content.js 的「显式点击查词」入口，与字幕面板行内点击同源），不新增任何查词链路。
+// 闸门（每一条都是「绝不抢站点」）：
+//   · 只认 pointerType === 'touch' 且主指针——鼠标/触控笔的行为永远是原样，零变化；
+//   · 扩展自绘 UI（查词弹窗 #hibiki-popup-host 及 #fushi-* 前缀的宿主、字幕覆盖层、
+//     toast、排队卡、拖放提示）上的手势全部跳过——弹窗内自有交互，字幕覆盖层自带
+//     click→查词（subtitle-panel.js），不掺和；
+//   · 链接、按钮、输入框、视频画面等交互元素交给站点自己：点播放器暂停/播放
+//     这类操作绝不被查词抢走；
+//   · 手指位移超过 MOVE_SLOP 判为滚动/拖拽选词，取消本次手势，不查词；
+//   · 长按与点按同时开着：到 500ms 长按先查，抬手不再重复查（手势已被长按消费）。
+(function () {
+  'use strict';
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  var HOLD_MS = 500;
+  var MOVE_SLOP = 10;
+  var settings = { tap: true, hold: false };
+
+  function apply(saved) {
+    saved = saved || {};
+    if (typeof saved.touchLookupTap === 'boolean') settings.tap = saved.touchLookupTap;
+    if (typeof saved.touchLookupHold === 'boolean') settings.hold = saved.touchLookupHold;
+  }
+  try {
+    var p = chrome.storage.local.get(['touchLookupTap', 'touchLookupHold'], apply);
+    if (p && typeof p.then === 'function') p.then(apply, function () {});
+  } catch (_) {}
+  try {
+    chrome.storage.onChanged.addListener(function (changes, area) {
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      if (changes.touchLookupTap) patch.touchLookupTap = changes.touchLookupTap.newValue;
+      if (changes.touchLookupHold) patch.touchLookupHold = changes.touchLookupHold.newValue;
+      if (patch.touchLookupTap !== undefined || patch.touchLookupHold !== undefined) apply(patch);
+    });
+  } catch (_) {}
+
+  // 扩展自绘的在页 UI：查词弹窗宿主是 #hibiki-popup-host（历史名），其余统一 #fushi-* 前缀。
+  function isOwnUi(t) {
+    try {
+      return !!(t && t.closest && t.closest('#hibiki-popup-host, [id^="fushi-"]'));
+    } catch (_) { return false; }
+  }
+  // 站点交互元素——closest 向上找祖先，正文 <p> 里包着的 <a> 也算命中。
+  var INTERACTIVE =
+    'a, button, input, select, textarea, summary, video, audio, iframe, canvas, label, ' +
+    '[role="button"], [role="link"], [onclick], [contenteditable="true"]';
+  function isSiteControl(t) {
+    try {
+      return !!(t && t.closest && t.closest(INTERACTIVE));
+    } catch (_) { return false; }
+  }
+
+  function lookupAt(x, y) {
+    try {
+      if (typeof window.fushiLookupAtPoint === 'function') window.fushiLookupAtPoint(x, y, null);
+    } catch (_) {}
+  }
+
+  var gesture = null;
+  function cancelGesture() {
+    if (gesture && gesture.timer) clearTimeout(gesture.timer);
+    gesture = null;
+  }
+
+  // 全部 capture + passive：只观察、不拦截——站点自己的 touch/pointer 行为（滚动、
+  // 双击缩放、播放器手势）一概不动；查词发生在判定成立的抬手/到点时刻。
+  var OPTS = { capture: true, passive: true };
+
+  document.addEventListener('pointerdown', function (e) {
+    if (e.pointerType !== 'touch' || !e.isPrimary) return;
+    if (!settings.tap && !settings.hold) { cancelGesture(); return; }
+    // Shadow DOM：e.target 会被 retarget 成宿主元素，composedPath()[0] 才是真实落点
+    // （与 video-shortcuts.js 的键盘判定同一策略）。
+    var realTarget = e.target;
+    try {
+      if (typeof e.composedPath === 'function') {
+        var path = e.composedPath();
+        if (path && path.length && path[0] && path[0].nodeType === 1) realTarget = path[0];
+      }
+    } catch (_) {}
+    if (isOwnUi(realTarget) || isSiteControl(realTarget)) { cancelGesture(); return; }
+    cancelGesture();
+    gesture = { id: e.pointerId, x: e.clientX, y: e.clientY, moved: false, fired: false, timer: 0 };
+    if (settings.hold) {
+      var g = gesture;
+      g.timer = setTimeout(function () {
+        if (gesture !== g || g.moved || g.fired) return;
+        g.fired = true;
+        lookupAt(g.x, g.y);
+      }, HOLD_MS);
+    }
+  }, OPTS);
+
+  document.addEventListener('pointermove', function (e) {
+    if (!gesture || e.pointerId !== gesture.id) return;
+    if (Math.abs(e.clientX - gesture.x) > MOVE_SLOP || Math.abs(e.clientY - gesture.y) > MOVE_SLOP) {
+      gesture.moved = true;
+      if (gesture.timer) { clearTimeout(gesture.timer); gesture.timer = 0; }
+    }
+  }, OPTS);
+
+  document.addEventListener('pointerup', function (e) {
+    if (!gesture || e.pointerId !== gesture.id) return;
+    var g = gesture;
+    cancelGesture();
+    if (settings.tap && !g.moved && !g.fired) lookupAt(g.x, g.y);
+  }, OPTS);
+
+  document.addEventListener('pointercancel', function (e) {
+    if (gesture && e.pointerId === gesture.id) cancelGesture();
+  }, OPTS);
+})();

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -2128,7 +2128,8 @@
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    transform: translate(-50%, -50%);
+    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    transform: translate(-50%, -100%);
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -2177,3 +2178,150 @@
     letter-spacing: 0.04em;
     pointer-events: none;
 }
+
+/* ── 移动端字幕列表抽屉（mobile-drawer.js）：贴边面板 + 边缘细条拉手 ──
+   横屏定宽右挂（.is-land），竖屏定高底挂（.is-port）；宽高与 translate 全由 JS 写，
+   这里只管外观与动画。z 压在字幕覆盖层(2147483637)之上、查词弹窗(2147483647)之下：
+   面板里点词要浮在抽屉上。根容器必须**全透明**——收起态整条边只许露出 12px 细条,
+   底和影都挂在 iframe/拉手上，不然透明也白透。 */
+#fushi-drawer {
+    position: fixed;
+    z-index: 2147483640;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    flex-direction: row;
+    max-width: calc(100vw - 16px);
+    background: transparent;
+    /* 收起态（只剩细条）：根容器整条 12px×全高不许当隐形挡板——透明就得真透明，
+       点/滑全还给背后的视频和控件。可交互的部分自己把事件捡回来（见下三处 auto）。 */
+    pointer-events: none;
+}
+
+/* 开态：拉手槽涂成面板同色（cream），与 iframe 无缝拼成一块面板边——
+   旧的 #1e1b18 根底会在面板左缘留一条黑缝，收起态阴影渗边也是黑边元凶，一并禁掉。 */
+#fushi-drawer.is-open .fushi-drawer-strip {
+    background: #fff9f4;
+}
+
+#fushi-drawer.is-port {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    max-width: none;
+    max-height: calc(100vh - 16px);
+    flex-direction: column;
+}
+
+/* 拖拽期（.is-dragging）关补间跟手；松手后的开/关吸附走 220ms 缓出。 */
+#fushi-drawer:not(.is-dragging) {
+    transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* 拉手：**隐形边缘手势区**——细条本体不再画任何东西（视觉零占位），
+   ::before 把命中往画面侧探 14px（合计 26px）：贴边任何位置起拖即开合/调宽（监听边缘）。 */
+.fushi-drawer-strip {
+    flex: 0 0 auto;
+    position: relative;
+    z-index: 1; /* 按钮探进面板侧的那半要画在 iframe 之上 */
+    width: 12px;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto; /* 根 none 之下，手势区自己把事件捡回来 */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.fushi-drawer-strip::before {
+    content: '';
+    position: absolute;
+    top: -14px;
+    bottom: -14px;
+    left: -14px;
+    right: 0;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip {
+    width: auto;
+    height: 12px;
+}
+
+#fushi-drawer.is-port .fushi-drawer-strip::before {
+    top: -14px;
+    bottom: 0;
+    left: -14px;
+    right: -14px;
+}
+
+/* 开合按钮：骑在屏幕/抽屉边缘的小圆钮，一眼可见、一点开合；按住它同样可以拖。 */
+.fushi-drawer-btn {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font: 700 15px/1 system-ui, sans-serif;
+    color: #f0e6da;
+    background: rgba(40, 32, 26, 0.88);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    touch-action: none;
+    pointer-events: auto;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+#fushi-drawer.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: 50%;
+}
+
+/* 全屏时开合钮挪右上角（用户指定）：横屏在右缘顶端，竖屏在抽屉顶缘右角。
+   safe-area 兜刘海/挖孔，不跟播放器自己的右上控件重叠太多再报我调坐标。 */
+#fushi-drawer.is-fs.is-land .fushi-drawer-btn {
+    top: max(14px, env(safe-area-inset-top));
+    transform: translateX(-50%);
+}
+
+#fushi-drawer.is-fs.is-port .fushi-drawer-btn {
+    top: 50%;
+    left: auto;
+    right: max(18px, env(safe-area-inset-right));
+    transform: none;
+}
+
+#fushi-drawer iframe {
+    flex: 1 1 auto;
+    display: block;
+    min-width: 0;
+    min-height: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff9f4;
+    pointer-events: auto;
+}
+
+/* 投影只在开态存在：收起时 iframe 整块在屏外，它的 -6px 投影会渗到屏边上糊一道黑雾。 */
+#fushi-drawer.is-open iframe {
+    box-shadow: -6px 0 24px rgba(0, 0, 0, 0.45);
+}
+
+#fushi-drawer.is-open.is-port iframe {
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.45);
+}
+
+/* 视频让位（开抽屉时压 fullscreenElement/<html>）不走这里：mobile-drawer.js 直接对
+   目标元素写 inline !important（站点后到样式/内联尺寸都压得住），关抽屉精确还原。 */

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -5075,10 +5075,22 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
+// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
+// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
+// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+function isCoarsePointerType() {
+    try {
+        return !!(window.matchMedia
+            && window.matchMedia('(pointer: coarse)').matches);
+    } catch (e) {
+        return false;
+    }
+}
 // 视口感知的有效列数（单一真值来源）：min(用户设置 --dict-columns, 每列 ≥DICT_COLUMN_MIN_WIDTH
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
+    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -5075,9 +5075,11 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+// 触屏设备（主指针 coarse）列宽门槛加倍：每列至少 2×DICT_COLUMN_MIN_WIDTH 才许并排。
+// 手机弹窗本就窄（竖屏 ~400px 宽 → 340 门槛下仍是单列，维持「竖着堆叠才是手机上正确
+// 形态」的原裁决），但不再被无条件锁死——平板横屏、in-app 桌面尺寸大窗这类 coarse 且
+// 宽的场景按视口正常出多列（审计报告 #1295：老版 coarse→1 把 in-app 弹窗静默锁死单列，
+// 没有任何逃生门）。fine 指针（桌面）门槛不变。CSS grid 与 JS masonry 都经本函数取列数。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5092,8 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
+    // 报告 #1295：coarse 不再「一律单列」，改为提高单列门槛（见上方注释）。
+    const colFloor = isCoarsePointerType() ? DICT_COLUMN_MIN_WIDTH * 2 : DICT_COLUMN_MIN_WIDTH;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5102,7 +5105,7 @@ function effectiveDictColumns() {
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / colFloor))
         : configured;
     return Math.min(configured, fit);
 }


### PR DESCRIPTION
# 移动端字幕抽屉 + 触屏查词 + 嵌入态紧凑 UI

安卓浏览器没有 `chrome.sidePanel`（桌面独有 API），字幕列表在手机/平板上此前**没有任何显示面**。本 PR 补齐移动端的输入与显示两条路，全部以触屏为门控——**桌面行为零变化**。

## 内容

**`mobile-drawer.js`（新）**——贴边抽屉：
- 边缘 ☰ 钮 + 隐形手势带：轻点=开关，按住=左右/上下拖宽自由停位，松手按露出比例吸附，尺寸记忆存 `mobileSubtitleDrawerGeom`；
- 竖屏底挂 sheet；**横屏仅全屏态挂载**（页面态让位形态太杂，直挂会盖进度条，已裁决禁用）；
- 内容是 `side-panel.html?fushiEmbed=1&fushiTabId=N` 的一页 iframe——选轨/点句跳转/时轴偏移/外挂字幕/Jimaku/制卡/面板查词**全部复用**，零复制逻辑；
- 全屏态压缩播放器让位（目标 `fullscreenElement`，媒体元素全屏时压 `<video>` 本体、抽屉落 body），并以 adopt 机制吸收播放器自重排/内联改写，退出全屏快照精确还原（值+prio 往返）。

**`touch-lookup.js`（新）**——单指点正文=查词（默认开）、长按≈0.5s=查词（默认关）；复用 `content.js` 的 `fushiLookupAtPoint`，只认 `pointerType==='touch'`，扩展自绘 UI 上的手势全部放行，绝不抢站点交互。

**`side-panel` 嵌入态**——`.fushi-embed` 紧凑规格：头部两行制（第一行七颗静态 30×32 小钮，恰等抽屉最小宽 260=7×30+6×3+12+20；第二行状态小字）、默认折叠、safe-area 内边距；查词结果交回宿主页渲染（沿既有跨面板链路）。

**字幕覆盖层**——落点改 `fullscreenElement || documentElement`（安卓播放器 transform `<body>` 会破坏 fixed 锚定，这是历次"退出全屏字幕错位"的根因）；底边锚 88% + 向上生长（不压视频进度条），宽度按视频盒中心向屏幕边缘夹紧、跟手拖动。

**`subtitle-adapters.js`**——`decodeCueEntities`：YouTube 的 cue 文本发 `&#39`（无分号实体）+ `&lrm/&rlm`，此前原样上屏；现按 HTML5 最长匹配规则解码（`&amphibian` 不误伤）。

**`popup.js`**——`(pointer: coarse)` 词典弹窗强制单列。**改在真源 `fushi/assets/popup/popup.js`**，vendor 镜像与 assets 镜像同步。

## 工具链合规

- 覆盖层/抽屉样式进 `scripts/content-css-overlay.css`，`vendor/content.css` 由生成器重跑产出（`--check` 双绿）；
- `sync-mirrors.mjs --check` 镜像一致；
- `mobile-drawer.test.js`（新）：vm 假 DOM 16 段全链行为测试（门控挂载/底挂交互/让位与 adopt/还原往返/媒体全屏只压本体/停用卸除干净）；
- 三个既有 harness 学 `documentElement`——覆盖层现在的（正确的）落点就是 `<html>`；
- 跨源消息按 SonarCloud S5691 双向锁 origin：抽屉 `postToFrame` 的 targetOrigin 传扩展页自身 URL（绝非 `*`）；iframe URL 声明 `fushiHostOrigin`，面板收消息校验 `ev.origin` 严格相等（缺参 = fail-closed）；全链测试钉死收发两个方向。
- 全套 `node --test`：**425/425 绿**。

## 验证环境

Chrome 13x / Android（Edge、Chrome、Firefox 安卓）真机：竖屏底挂、播放器全屏（含原生 `<video>` 全屏）、横屏页面态拒挂、点句跳转、时轴偏移、拖宽记忆、`&#39` 解码上屏。桌面路径回归无变化。
