### PR TITLE
fix(library): 书架/视频页搜索补齐 SRT 有声书卡与远端占位卡的过滤（BUG-2259）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2115 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2259](bugs/BUG-2259-library-search-skips-srt-remote.md) | ✅ | ✅ | 库页搜索漏过 SRT 有声书卡与远端占位卡 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2259-library-search-skips-srt-remote.md
+++ b/docs/bugs/BUG-2259-library-search-skips-srt-remote.md
@@ -1,0 +1,6 @@
+## BUG-2259 · 库页搜索漏过 SRT 有声书卡与远端占位卡
+- **报告**：2026-09-08（用户：「书架等搜索不生效」）
+- **真实性**：✅ 真 bug。书架（`reader_fushi_history_page.dart`）P5-A 搜索只裁**本地 EPUB** `MediaItem` 列表（`filtered = filtered.where(matchesMediaSearch…)`），渲染层 `_buildBodyWithSrtBooks` 另外三路卡源走的是**未过滤源**：本地 SRT 卡 `srtBooks = allSrtBooks`（origin/develop `reader_fushi_history_page.dart:1311`）、远端 EPUB 占位 `showRemote ? remoteState.books`（`:1337`）、远端 SRT 占位 `showRemote ? remoteState.srtAudiobooks`（`:1341`）。挂了有声书的 EPUB 本身就被 `srtBookKeys` 从 EPUB 列表剔除、只以 SRT 卡渲染，所以这类书搜索**完全不生效**；有声书为主的书架看起来就是「搜索没反应」。视频页同病：远端占位 `_visibleRemoteVideos(...)` 列表推导只过年份/系列/看完筛选，不过搜索（`home_video_page.dart:3003`）。另书架搜索零命中落到 `buildPlaceholder()`（`:1501` 只认 `hasActiveFilter`）——「书架为空、去导入」的占位，语义错。
+- **[x] ① 已修复** — 书架加统一判据 `_matchesShelfSearch(Iterable<String> titles)`（`matchesMediaSearch` 空查询恒命中），四路卡源同口径：本地 EPUB（显示名 + 原名）、本地 SRT（`_srtDisplayTitle` + 原名，标签筛选之后）、远端 EPUB（title）、远端 SRT（title ?? identity）；搜索零命中与标签筛选零命中同走「没有符合筛选的书」空态。视频页远端占位列表推导补 `matchesMediaSearch(query: _searchQuery, titles: [v.title])`。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/reader_shelf_search_srt_remote_test.dart`（3 条：SRT 卡随搜索裁剪 / 零命中走空态 / 远端 EPUB + 远端 SRT 占位随搜索裁剪，修前全红）、`fushi/test/pages/home_video_remote_mixed_grid_test.dart` 新增「BUG-2259：搜索同口径裁掉不命中的远端占位卡」。
+- **备注**：游戏库页（`galgame_library_query.dart`）本就单路数据、无此问题。书架顶部「继续阅读 hero」沿用 P5-A 起的行为（喂搜索过滤后的 EPUB 列表），本次不动。

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -3002,12 +3002,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             final List<RemoteVideoInfo> remoteVideos = <RemoteVideoInfo>[
               for (final RemoteVideoInfo v in _visibleRemoteVideos(
                   snapState ?? _lastRemoteState, filter))
+                // BUG-2259：远端占位卡与本地卡同口径过搜索（此前只裁本地列表，
+                // 搜索时远端占位卡照样满屏）。
                 // 远端占位与本地同规则过系列归属筛选，判据同样取**在系列墙上的
                 // 折叠形态**：host 下发的 membership 还要能解析到本机存在的合集
                 // （[_remoteCollectionId]，解析不到系列墙就按散卡降级）。只看
                 // `collection != null` 会让「host 有、本机没有同名合集」的占位卡
                 // 在系列墙上是散卡、在这里却算系列成员。
-                if (_yearFilter.matches(null) &&
+                if (matchesMediaSearch(
+                      query: _searchQuery,
+                      titles: <String>[v.title],
+                    ) &&
+                    _yearFilter.matches(null) &&
                     matchesVideoSeriesFilter(
                       filter: _effectiveSeriesFilter,
                       inSeries: _remoteCollectionId(v) != null,

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -269,6 +269,13 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   String _searchQuery = '';
   final TextEditingController _searchController = TextEditingController();
 
+  /// BUG-2259：书架搜索命中判据，**四路**卡源（本地 EPUB / 本地 SRT / 远端 EPUB
+  /// 占位 / 远端 SRT 占位）共用同一口径 [matchesMediaSearch]（空查询恒命中）。
+  /// 此前只裁本地 EPUB 列表，其余三路走未过滤源——挂了有声书的书本身就以 SRT 卡
+  /// 渲染，用户实报「书架搜索不生效」。
+  bool _matchesShelfSearch(Iterable<String> titles) =>
+      matchesMediaSearch(query: _searchQuery, titles: titles);
+
   /// 层次 C：`'mediaType|entryKey' → 该条目在其主折叠合集里的 sortIndex`（组内序
   /// 真相源，与详情页 `getCollectionItems` 同源）。
   Map<String, int> _memberSortIndex = const <String, int>{};
@@ -625,14 +632,11 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
                         // [matchesMediaSearch]（全角/片假名/标点折叠）。
                         if (_searchQuery.trim().isNotEmpty) {
                           filtered = filtered.where((MediaItem item) {
-                            return matchesMediaSearch(
-                              query: _searchQuery,
-                              titles: <String>[
-                                ReaderFushiSource.instance
-                                    .getDisplayTitleFromMediaItem(item),
-                                item.title,
-                              ],
-                            );
+                            return _matchesShelfSearch(<String>[
+                              ReaderFushiSource.instance
+                                  .getDisplayTitleFromMediaItem(item),
+                              item.title,
+                            ]);
                           }).toList();
                         }
                         return FutureBuilder<Map<String, _AudiobookInfo>>(
@@ -1295,9 +1299,9 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     // 时 srt 成员被剥光、折叠不出合集组。
     final Set<int>? collectionFilter =
         ref.watch(filteredCollectionIdsProvider).valueOrNull;
-    final List<SrtBook> srtBooks;
+    final List<SrtBook> tagFilteredSrtBooks;
     if (srtFilterSet != null) {
-      srtBooks = allSrtBooks
+      tagFilteredSrtBooks = allSrtBooks
           .where((b) => keepMemberUnderTagFilter(
                 memberMatched: srtFilterSet.contains(b.uid),
                 primaryCollectionId: _primaryCollectionByEntry[
@@ -1306,10 +1310,15 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
               ))
           .toList();
     } else if (hasActiveFilter) {
-      srtBooks = const [];
+      tagFilteredSrtBooks = const [];
     } else {
-      srtBooks = allSrtBooks;
+      tagFilteredSrtBooks = allSrtBooks;
     }
+    // BUG-2259：SRT 卡与 EPUB 卡同口径过搜索（显示名 + DB 原名双匹配）。
+    final List<SrtBook> srtBooks = <SrtBook>[
+      for (final SrtBook b in tagFilteredSrtBooks)
+        if (_matchesShelfSearch(<String>[_srtDisplayTitle(b), b.title])) b,
+    ];
     // 视频归「视频」tab（HomeVideoPage）独占，书架不再显示视频分区（用户反馈：
     // 书架是书的地方）。已导入视频只在视频 tab 呈现；书架拖入视频仍可导入（经
     // _handleShelfDrop → VideoImportDialog），落库后同样只在视频 tab 可见。
@@ -1333,12 +1342,20 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
         !remoteState.failed &&
         !hasActiveFilter &&
         appModel.prefsRepo.showRemoteEntries;
-    final List<RemoteBookInfo> remoteBooks =
-        showRemote ? remoteState.books : const <RemoteBookInfo>[];
+    // BUG-2259：远端占位卡同样过搜索——它们与本地卡混排在同一网格里，搜索时
+    // 本地卡被裁、远端卡还满屏，用户看到的就是「搜索不生效」。
+    final List<RemoteBookInfo> remoteBooks = <RemoteBookInfo>[
+      if (showRemote)
+        for (final RemoteBookInfo b in remoteState.books)
+          if (_matchesShelfSearch(<String>[b.title])) b,
+    ];
     // 纯 SRT（standalone）远端有声书占位（互联后端 listRemoteAudiobooks 的 standalone
     // 项，本地无同 uid SrtBook）——与远端 EPUB 书同门控混排进主网格。
-    final List<RemoteAudiobookInfo> remoteSrtBooks =
-        showRemote ? remoteState.srtAudiobooks : const <RemoteAudiobookInfo>[];
+    final List<RemoteAudiobookInfo> remoteSrtBooks = <RemoteAudiobookInfo>[
+      if (showRemote)
+        for (final RemoteAudiobookInfo b in remoteState.srtAudiobooks)
+          if (_matchesShelfSearch(<String>[b.title ?? b.identity])) b,
+    ];
     // 统一合集：把 SRT + EPUB 混排序列经 groupByCollections 折叠——散书每条单独成
     // group、同合集折叠成一组（组内序 = 合集 sortIndex，与详情页同源），再按当前
     // 排序方式排 group（散书与合集行同层混排）。「最近阅读」量纲 = 最后阅读时间
@@ -1494,11 +1511,14 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     // 无条件叠「无匹配」空态文案，且丢 RefreshIndicator / 合集横排行 / 书库概览。
     // 筛选态与常态统一走下方主分支组装（shelfGroups 已能承载纯 SRT 命中结果），
     // 特殊分支消灭。
+    // BUG-2259：搜索零命中与标签筛选零命中同一空态（「没有符合筛选的书」），
+    // 不能落到「书架为空」占位——那会把用户引去导入。
+    final bool searching = _searchQuery.trim().isNotEmpty;
     if (epubBooks.isEmpty &&
         srtBooks.isEmpty &&
         remoteBooks.isEmpty &&
         remoteSrtBooks.isEmpty) {
-      return hasActiveFilter
+      return hasActiveFilter || searching
           ? Center(
               child: FushiPlaceholderMessage(
                 icon: Icons.filter_list_off,

--- a/fushi/test/pages/home_video_remote_mixed_grid_test.dart
+++ b/fushi/test/pages/home_video_remote_mixed_grid_test.dart
@@ -278,6 +278,61 @@ void main() {
       reason: '远端目录拉取失败时占位卡不出现',
     );
   });
+
+  testWidgets('BUG-2259：搜索同口径裁掉不命中的远端占位卡，本地与远端命中都保留',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('video/local-hit'),
+      title: Value('Local Sakamoto'),
+      videoPath: Value('/abs/local-hit.mp4'),
+    ));
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value('video/local-miss'),
+      title: Value('Local Other'),
+      videoPath: Value('/abs/local-miss.mp4'),
+    ));
+
+    await tester.pumpWidget(buildApp(_ListFakeRemoteVideoClient(
+      <RemoteVideoInfo>[
+        RemoteVideoInfo(id: 'remote/hit', title: 'Remote Sakamoto'),
+        RemoteVideoInfo(id: 'remote/miss', title: 'Remote Other'),
+      ],
+    )));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_remote_miss')),
+      findsOneWidget,
+      reason: '空查询不过滤',
+    );
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('video_search_field')),
+      'sakamoto',
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('home_video_video/local-hit')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_remote_hit')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('home_video_video/local-miss')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_remote_miss')),
+      findsNothing,
+      reason: '不命中的远端占位卡必须被搜索裁掉（BUG-2259）',
+    );
+  });
 }
 
 class _ListFakeRemoteVideoClient implements RemoteVideoClient {

--- a/fushi/test/pages/reader_shelf_search_srt_remote_test.dart
+++ b/fushi/test/pages/reader_shelf_search_srt_remote_test.dart
@@ -1,0 +1,243 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/pages/implementations/reader_fushi_history_page.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+import 'package:fushi/src/sync/remote_book_client.dart';
+import 'package:fushi/src/sync/ttu_filename.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-2259：书架搜索只裁 EPUB 列表，SRT 有声书卡与远端占位卡走的是未过滤源，
+/// 用户实报「书架搜索不生效」——挂了有声书的书本身就以 SRT 卡渲染，等于整批
+/// 搜不到。修复 = 搜索在 [_buildBodyWithSrtBooks] 内对 SRT / 远端 EPUB / 远端
+/// SRT 三路同口径过滤（[matchesMediaSearch]）。
+///
+/// 渲染层说明（与 reader_shelf_tag_filter_empty_state_test 同源）：
+/// [fushiBooksProvider] 真实实现会 `await` 封面 `File.exists()`，假时钟下永不
+/// 完成，故覆写成受控列表；远端占位走 [RemoteBookClient] 假实现。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_shelf_search_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late AppModel appModel;
+  late Directory storeDir;
+  late List<MediaItem> epubItems;
+  late List<SrtBook> srtItems;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_shelf_search');
+    appModel = AppModel(testPlatformServices())
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+    appModel.populateLanguages();
+    epubItems = <MediaItem>[];
+    srtItems = <SrtBook>[];
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) {
+      try {
+        storeDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  Future<void> seedEpub(String bookKey, String title) async {
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: title,
+      epubPath: '${pathProviderDir.path}/$bookKey.epub',
+      extractDir: pathProviderDir.path,
+      chapterCount: 1,
+      chaptersJson: '["a"]',
+      importedAt: 0,
+    ));
+    epubItems.add(MediaItem(
+      mediaIdentifier: ReaderFushiSource.mediaIdentifierFor(bookKey),
+      title: title,
+      mediaTypeIdentifier: ReaderFushiSource.instance.mediaType.uniqueKey,
+      mediaSourceIdentifier: ReaderFushiSource.instance.uniqueKey,
+      position: 0,
+      duration: 1,
+      canDelete: false,
+      canEdit: true,
+    ));
+  }
+
+  Future<SrtBook> seedSrt(String uid, String title) async {
+    final SrtBook book = SrtBook()
+      ..uid = uid
+      ..title = title
+      ..srtPath = '${pathProviderDir.path}/$uid.srt'
+      ..importedAt = 0
+      ..bookKey = '';
+    await SrtBookRepository(db).save(book);
+    final SrtBook? saved = await SrtBookRepository(db).findByUid(uid);
+    srtItems.add(saved ?? book);
+    return saved ?? book;
+  }
+
+  Widget buildApp(RemoteBookClient? client) => ProviderScope(
+        overrides: <Override>[
+          appProvider.overrideWith((ref) => appModel),
+          fushiBooksProvider.overrideWith(
+            (ref, language) => Future<List<MediaItem>>.value(epubItems),
+          ),
+          srtBooksProvider.overrideWith(
+            (ref) => Future<List<SrtBook>>.value(srtItems),
+          ),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            builder: (BuildContext context, Widget? child) =>
+                child ?? const SizedBox.shrink(),
+            home: Scaffold(
+              body: ReaderFushiHistoryPage(
+                remoteBookClientLoader: () async => client,
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Future<void> pumpPage(WidgetTester tester, {RemoteBookClient? client}) async {
+    tester.view.physicalSize = const Size(1400, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(buildApp(client));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> search(WidgetTester tester, String query) async {
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('shelf_search_field')),
+      query,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  String safeKey(String title) =>
+      sanitizeTtuFilename(title).replaceAll(RegExp(r'[^A-Za-z0-9._-]+'), '_');
+
+  Finder epubCard(String bookKey) => find.byKey(ValueKey<String>(
+      'book_entry_${ReaderFushiSource.mediaIdentifierFor(bookKey)}'));
+  Finder srtCard(String uid) => find.byKey(ValueKey<String>('srt_entry_$uid'));
+  Finder remoteBookCard(String title) =>
+      find.byKey(ValueKey<String>('remote_book_card_${safeKey(title)}'));
+  Finder remoteSrtCard(String title) =>
+      find.byKey(ValueKey<String>('remote_srt_card_${safeKey(title)}'));
+
+  testWidgets('BUG-2259：搜索同口径裁掉不命中的 SRT 有声书卡，EPUB 与 SRT 命中都保留',
+      (WidgetTester tester) async {
+    await seedSrt('srtHit', '坂本ですが');
+    await seedSrt('srtMiss', '無関係の本');
+    await seedEpub('epubHit', '坂本 第二巻');
+    await seedEpub('epubMiss', '別の本');
+
+    await pumpPage(tester);
+    expect(srtCard('srtMiss'), findsOneWidget, reason: '空查询不过滤');
+
+    await search(tester, '坂本');
+
+    expect(srtCard('srtHit'), findsOneWidget, reason: '命中的 SRT 卡保留');
+    expect(epubCard('epubHit'), findsOneWidget, reason: '命中的 EPUB 卡保留');
+    expect(srtCard('srtMiss'), findsNothing, reason: '不命中的 SRT 卡必须被搜索裁掉');
+    expect(epubCard('epubMiss'), findsNothing, reason: '不命中的 EPUB 卡被裁掉');
+  });
+
+  testWidgets('BUG-2259：搜索全不命中 → 空态而非渲染全部 SRT 卡', (WidgetTester tester) async {
+    await seedSrt('srtOnly', '有声書だけ');
+
+    await pumpPage(tester);
+    await search(tester, 'zzz-no-such-title');
+
+    expect(srtCard('srtOnly'), findsNothing);
+    expect(find.byType(RefreshIndicator), findsNothing,
+        reason: '零命中走空态分支，不再渲染网格');
+  });
+
+  testWidgets('BUG-2259：远端 EPUB / 纯 SRT 占位卡同样随搜索过滤',
+      (WidgetTester tester) async {
+    await pumpPage(
+      tester,
+      client: _ListFakeRemoteBookClient(
+        const <RemoteBookInfo>[
+          RemoteBookInfo(title: 'Remote Sakamoto', hasContent: true),
+          RemoteBookInfo(title: 'Remote Other', hasContent: true),
+        ],
+        const <RemoteAudiobookInfo>[
+          RemoteAudiobookInfo(
+              bookKey: '', uid: 'rsHit', title: 'Audio Sakamoto'),
+          RemoteAudiobookInfo(bookKey: '', uid: 'rsMiss', title: 'Audio Other'),
+        ],
+      ),
+    );
+    expect(remoteBookCard('Remote Other'), findsOneWidget);
+    expect(remoteSrtCard('Audio Other'), findsOneWidget);
+
+    await search(tester, 'sakamoto');
+
+    expect(remoteBookCard('Remote Sakamoto'), findsOneWidget);
+    expect(remoteSrtCard('Audio Sakamoto'), findsOneWidget);
+    expect(remoteBookCard('Remote Other'), findsNothing,
+        reason: '不命中的远端 EPUB 占位卡必须被裁掉');
+    expect(remoteSrtCard('Audio Other'), findsNothing,
+        reason: '不命中的远端 SRT 占位卡必须被裁掉');
+  });
+}
+
+/// 互联后端假实现：standalone SRT 占位卡只对 [InterconnectSyncBackend] 类型开放，
+/// 普通 [RemoteBookClient] fake 进不了这条路（与 reader_remote_download_failure_badge_test 同源）。
+class _ListFakeRemoteBookClient extends InterconnectSyncBackend {
+  _ListFakeRemoteBookClient(this._books, this._audiobooks)
+      : super.withProbe((String url, String token) async => true);
+  final List<RemoteBookInfo> _books;
+  final List<RemoteAudiobookInfo> _audiobooks;
+
+  @override
+  Future<List<RemoteBookInfo>> listRemoteBooks() async => _books;
+
+  @override
+  Future<List<RemoteAudiobookInfo>> listRemoteAudiobooks() async => _audiobooks;
+}


### PR DESCRIPTION
## 问题

用户实报「书架等搜索不生效」（BUG-2259）。

书架搜索（P5-A）只裁本地 EPUB `MediaItem` 列表，渲染层 `_buildBodyWithSrtBooks` 另外三路卡源走的是未过滤源：

- 本地 SRT 有声书卡：`srtBooks = allSrtBooks`
- 远端 EPUB 占位卡：`showRemote ? remoteState.books`
- 远端 SRT 占位卡：`showRemote ? remoteState.srtAudiobooks`

挂了有声书的 EPUB 本身就被从 EPUB 列表剔除、只以 SRT 卡渲染，所以这类书搜索完全不生效。视频页远端占位卡同病（列表推导只过年份/系列/看完，不过搜索）。另外书架搜索零命中落到「书架为空、去导入」占位，语义错。

## 修复

- 书架加统一判据 `_matchesShelfSearch`（`matchesMediaSearch` 同口径，空查询恒命中），四路卡源同过：本地 EPUB（显示名 + 原名）、本地 SRT（显示名 + 原名，标签筛选之后）、远端 EPUB、远端 SRT。
- 搜索零命中与标签筛选零命中同走「没有符合筛选的书」空态。
- 视频页远端占位列表推导补 `matchesMediaSearch`。

## 测试

- 新增 `fushi/test/pages/reader_shelf_search_srt_remote_test.dart` 3 条（修前全红）。
- `fushi/test/pages/home_video_remote_mixed_grid_test.dart` 新增 1 条。
- 全量 `flutter analyze` 零问题；触及两页/搜索匹配器的 108 个测试文件 732 条全绿。

https://claude.ai/code/session_01RZqsRUXYPBWBvp9Rq5hPCR
