### PR TITLE
fix(netflix): 分级提示 overlay 选择器漂移 + 内置播放器换集后 chrome 隐藏丢失（BUG-2260）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2115 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2260](bugs/BUG-2260-netflix-advisory-overlay-selector-drift.md) | ✅ | ✅ | Netflix 分级提示 overlay 改用 .watch-video--advisories-container，三处隐藏选择器全部静默失效；内置播放器换集重载后 chrome 隐藏丢失 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2260-netflix-advisory-overlay-selector-drift.md
+++ b/docs/bugs/BUG-2260-netflix-advisory-overlay-selector-drift.md
@@ -1,0 +1,51 @@
+## BUG-2260 · Netflix 分级提示 overlay 改用 .watch-video--advisories-container，三处隐藏选择器全部静默失效；内置播放器换集重载后 chrome 隐藏丢失
+
+- **报告**：2026-09-08（用户：截图为 Netflix 播放画面左上角 "RATED 13+ / 暴力, 自杀"，
+  「在 Netflix 视频内进行跳转制卡时，会出现此提示 can't you hide it with some js or css」）
+- **真实性**：✅ 真 bug，两个根因。
+  1. **选择器漂移（扩展 + 内置播放器都中）**。2026-09-08 用保留登录态的 pywebview/WebView2
+     探针（`nf_dom_probe.py`，每 300 ms 扫 `[class*=evidence|maturity|rating|advisor]` +
+     `RATED` 文本节点）实测 `/watch/81236554`，提示出现时的 DOM 是：
+     ```
+     div.watch-video--advisories-container
+       div.advisory-container            （隐藏态加 .advisory-hidden，节点常驻不摘）
+         div.advisory-background.advisory-transition-enter-done
+         div.advisory.advisory-transition-appear-done
+           div.advisory-bar
+           div.advisory-content[data-uia="advisory-content"]
+             h4.advisory-header[data-uia="advisory-header"]   "RATED 7+"
+     ```
+     仓库里三处隐藏用的选择器——扩展常驻清单 `fushiNetflixNextEpisodeSelectors()`
+     （`tools/browser-extension/content.js:1329`，`.watch-video--evidence-overlay-container` +
+     三条 `*maturity*`）、扩展录制期 `hideStyle`（`content.js:876`）、内置播放器
+     `HIDE_CHROME_CSS`（`fushi/assets/web_video/web_video_glue.js:134`）——全文没有一个
+     `evidence` / `maturity` 节点可命中，三处**同时静默失效**（BUG-2170 备注里预言过的
+     「站点换类名整条静默失效」正是这次）。BUG-2170 的时间门只管**开播窗**，逐句 seek
+     后重弹的提示不在它的覆盖面里。
+  2. **内置播放器换集后隐藏态丢失**。`_runMineQueue`（`web_video_fushi_page.dart:903`）只在
+     队列开跑前调一次 `_setPlayerChromeHidden(true)`；队列行属于别的集时 `_navigateForMining`
+     走 `web.loadUrl` **整页重载**，上一份文档里的 `<style id=fushi-web-video-hide-chrome>` 随
+     文档一起没了，而 `onLoadStop`（`:1831`）只重挂了字幕隐藏、没重挂 chrome 隐藏——此后
+     每张卡都带控制条 + 分级提示。隐藏态的拥有者是 Dart，却没在新文档里重新落地。
+- **[x] ① 已修复** —
+  - `fushi/assets/web_video/web_video_glue.js`：集中定义 `NETFLIX_ADVISORY_SELECTORS`
+    （advisories 容器 + `[class*="watch-video--advisories"]` 哈希兜底 + 旧 evidence 选择器作
+    回滚兜底）；Netflix 页 document-start 常驻注入 `#fushi-web-video-hide-advisory`
+    （`display:none`，glue 每份文档重新跑，整页换集不丢）；`HIDE_CHROME_CSS` 拼入同一组。
+  - `web_video_fushi_page.dart`：`onLoadStop` 按 `_mineRunning` 重挂 chrome 隐藏（与字幕隐藏
+    同款）；`_navigateForMining` 画面就绪后开录前再挂一次（页面侧按 style id 幂等）。
+  - `tools/browser-extension/content.js`（+ `fushi/assets/browser_extension/` 镜像，
+    `dart run tool/sync_browser_extension.dart` 同步）：常驻清单与录制期 `hideStyle` 都补
+    advisories 两条；版本横幅 v47 → v48。
+- **[x] ② 已加自动化测试** — `fushi/test/mining/netflix_bug2260_advisory_overlay_guard_test.dart`
+  （源码扫描，扩展两镜像 × 2 + glue × 2 + Dart 页 × 2）：常驻清单 / 录制作用域 / glue 常驻
+  display:none / chrome 清单复用同一常量 / onLoadStop 重挂 / 换集就绪重挂。版本守卫
+  `netflix_bug685_seek_gate_guard_test.dart` / `netflix_mining_robustness_guard_test.dart` 随
+  v48 更新。
+- **备注**：
+  - 探针里视频未真正推进（软件 DRM 档下 `currentTime` 停在续播点 1037 s），所以「seek 后是否
+    重弹」本次未量到；用户报告的就是 seek 制卡时出现，按常驻隐藏处理不依赖这一点。
+  - 旧的 `.watch-video--evidence-overlay-container` / `*maturity*` 选择器**保留**：Netflix 分区域
+    灰度或回滚时仍有用，且删掉会牵动 BUG-702 / BUG-2170 守卫，不值得。
+  - 下次再漂移的判别办法就是本次探针：用 `%APPDATA%\pywebview` 登录态 profile 开 watch 页，
+    扫 `RATED` 文本节点的祖先链，别再猜类名。

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -1,10 +1,10 @@
 // 取词扫描 + 弹窗注入。修饰键默认 Shift。普通 DOM（popup.js 依赖顶层 #entries-container）。
 // 样式经 content.css 注入，全部作用域到 #entries-container，不污染宿主页（TODO-1090）。
 // 版本标记：加载后在 Console 打一行，用户可据此确认加载的是**新版**扩展（排查缓存旧版）。
-console.log('[Fushi] content script v47 loaded (BUG-688: popup Shadow DOM isolation + theme single-sourced from app; TODO-1219/1363: subtitle cue replay + universal subtitle-list providers; TODO-1391: hide Netflix start-of-episode maturity/age-rating overlay; BUG-2170: play past that overlay before batch capture)');
+console.log('[Fushi] content script v48 loaded (BUG-688: popup Shadow DOM isolation + theme single-sourced from app; TODO-1219/1363: subtitle cue replay + universal subtitle-list providers; TODO-1391: hide Netflix start-of-episode maturity/age-rating overlay; BUG-2170: play past that overlay before batch capture; BUG-2260: Netflix advisories-container selector drift)');
 // 诊断标记：写进 <html> 的 data-*，页面 Console（主世界）可读，用来隔空排查划词为何不触发
 // （隔离世界的全局变量在页面 console 里看不到，故用 DOM 属性桥接）。
-try { document.documentElement.setAttribute('data-fushi-cs', 'v47'); } catch (_) {}
+try { document.documentElement.setAttribute('data-fushi-cs', 'v48'); } catch (_) {}
 // TODO-1190：网页源文里高亮被查的词。selection.js 默认走 CSS Custom Highlight API
 // （CSS.highlights.set('fushi-selection', …) + content.css 的 ::highlight(fushi-selection)）。
 // 但 content script 跑在**隔离世界**：在隔离世界注册的 highlight 不会被页面渲染引擎绘制
@@ -889,6 +889,10 @@ async function fushiRunNetflixBatch(introGate) {
     // 受用户开关 netflixHideNextEpisode 门控——用户为了留住 Netflix 的「下一集」按钮把它关掉时，
     // 分级提示就会照录进卡片。录制期无条件藏，用户可见作用域仍归那个开关管。与本 style 同策
     // 用 visibility/opacity（不用 display:none，理由见本文件字幕隐藏那节）。
+    // BUG-2260：2026-09-08 实测 Netflix 当前 DOM 是 .watch-video--advisories-container
+    // （见 fushiNetflixNextEpisodeSelectors 注释），旧 evidence/maturity 选择器全部失配。
+    '.watch-video--advisories-container,[class*="watch-video--advisories"],' +
+    '.watch-video--evidence-overlay-container,' +
     '[class*="watch-video--maturity-rating"],.watch-video [data-uia*="maturity"],' +
     '.watch-video [class*="maturity-rating"]{opacity:0!important;visibility:hidden!important}';
   try { document.head.appendChild(hideStyle); } catch (_) {}
@@ -1335,6 +1339,13 @@ function fushiNetflixNextEpisodeSelectors() {
     '[class*="watch-video--maturity-rating"]',
     '.watch-video [data-uia*="maturity"]',
     '.watch-video [class*="maturity-rating"]',
+    // BUG-2260：2026-09-08 登录态 WebView2 探针实测，Netflix 当前分级提示 DOM 为
+    //   div.watch-video--advisories-container > div.advisory-container > div.advisory >
+    //   [data-uia="advisory-content"] > h4.advisory-header("RATED 7+")
+    // 上面 evidence/maturity 三组选择器一个都不再命中（静默失效，用户截图「RATED 13+ / 暴力, 自杀」
+    // 照旧出现）。子串匹配兜住哈希类名变体；旧选择器保留作 Netflix 回滚时的兜底。
+    '.watch-video--advisories-container',
+    '[class*="watch-video--advisories"]',
   ];
 }
 function fushiApplyNetflixNextEpisodeHiding(hide) {

--- a/fushi/assets/web_video/web_video_glue.js
+++ b/fushi/assets/web_video/web_video_glue.js
@@ -128,12 +128,33 @@
   }
   // 全屏元素换了父节点时 <style> 仍在 head 里全局生效，无需迁移。
 
+  // ── Netflix 年龄分级/内容提示 overlay（左上角 "RATED 13+ / 暴力, 自杀"）：常驻隐藏 ──
+  // BUG-2260：2026-09-08 用登录态 WebView2 探针实测，当前 DOM 是
+  //   div.watch-video--advisories-container > div.advisory-container > div.advisory >
+  //   [data-uia="advisory-content"] > h4.advisory-header
+  // 旧的 .watch-video--evidence-overlay-container / *maturity* 选择器一个都不再命中（静默失效）。
+  // Netflix 在开播和 seek 后都会重弹，制卡逐句 seek 时每张卡都可能撞上，所以不只在录制期藏，
+  // 而是 document-start 就常驻藏（本文件每份文档都重新注入，整页换集也不会丢）。
+  // 旧选择器保留作兜底，Netflix 回滚类名时仍生效。
+  var NETFLIX_ADVISORY_SELECTORS =
+    '.watch-video--advisories-container,[class*="watch-video--advisories"],' +
+    '.watch-video--evidence-overlay-container';
+  var HIDE_ADVISORY_ID = 'fushi-web-video-hide-advisory';
+  if (site() === 'netflix' && !document.getElementById(HIDE_ADVISORY_ID)) {
+    var advisoryStyle = document.createElement('style');
+    advisoryStyle.id = HIDE_ADVISORY_ID;
+    advisoryStyle.textContent = NETFLIX_ADVISORY_SELECTORS + '{display:none !important}';
+    (document.head || document.documentElement).appendChild(advisoryStyle);
+  }
+
   // 制卡重放期间隐藏站点播放器 chrome（进度条 / 按钮 / 顶栏）：Dart 驱动的 seek/pause 会让
   // 控件浮出来，cue 中点截的封面就带一条控制栏。只藏 chrome 不藏 <video>；字幕层另有开关。
+  // 注意：这段 <style> 属于当前文档，整页导航（换集 loadUrl）后就没了——Dart 侧 onLoadStop
+  // 必须按 _mineRunning 重挂（BUG-2260 第二根因），与 setNativeSubtitlesHidden 同款。
   var HIDE_CHROME_ID = 'fushi-web-video-hide-chrome';
   var HIDE_CHROME_CSS =
     '.watch-video--bottom-controls-container,.watch-video--back-container,' +
-    '.watch-video--flag-container,.watch-video--evidence-overlay-container,' +
+    '.watch-video--flag-container,' + NETFLIX_ADVISORY_SELECTORS + ',' +
     '[data-uia="player-controls"],[data-uia="controls-standard"],' +
     '.ytp-chrome-bottom,.ytp-chrome-top,.ytp-gradient-bottom,.ytp-gradient-top,' +
     '.bpx-player-control-wrap,.bpx-player-sending-bar,.vjs-control-bar,.shaka-controls-container' +

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -877,7 +877,11 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
     final DateTime until = DateTime.now().add(const Duration(seconds: 30));
     while (DateTime.now().isBefore(until)) {
       if (!mounted || _mineStopRequested) return false;
-      if (_videoKey == row.videoKey && (_state?.hasVideo ?? false)) return true;
+      if (_videoKey == row.videoKey && (_state?.hasVideo ?? false)) {
+        // 画面就绪可能早于 onLoadStop；开录前再挂一次（页面侧按 style id 幂等）。
+        await _setPlayerChromeHidden(true);
+        return true;
+      }
       await Future<void>.delayed(const Duration(milliseconds: 250));
     }
     return false;
@@ -1831,6 +1835,9 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
       },
       onLoadStop: (InAppWebViewController controller, WebUri? url) {
         unawaited(_setNativeSubtitlesHidden(_hideNativeSubtitles));
+        // BUG-2260：队列换集走 loadUrl 整页重载，上一份文档里的 chrome 隐藏 <style> 随之消失，
+        // 之后每张卡都带控制条/分级提示。隐藏态归 Dart 所有，新文档就绪时按 _mineRunning 重挂。
+        unawaited(_setPlayerChromeHidden(_mineRunning));
         unawaited(_js('window.__fushiWebVideo.replayCues()'));
         unawaited(_syncDomSubtitles());
       },

--- a/fushi/test/mining/netflix_bug2260_advisory_overlay_guard_test.dart
+++ b/fushi/test/mining/netflix_bug2260_advisory_overlay_guard_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2260 守卫：Netflix 年龄分级/内容提示 overlay（左上角 "RATED 13+ / 暴力, 自杀"）的
+/// DOM 已改为
+///   div.watch-video--advisories-container > div.advisory-container > div.advisory >
+///   [data-uia="advisory-content"] > h4.advisory-header
+/// （2026-09-08 登录态 WebView2 探针实测）。仓库里原有的三组选择器
+/// （`.watch-video--evidence-overlay-container` / `*maturity*`）一个都不再命中，于是扩展的
+/// 常驻隐藏、录制期隐藏和内置播放器的 chrome 隐藏对它全部**静默**失效。
+///
+/// 第二根因在内置播放器：队列换集走 `loadUrl` 整页重载，上一份文档里的 chrome 隐藏 `<style>`
+/// 随之消失，而 Dart 只在队列开跑前挂过一次——之后每张卡都带控制条。
+///
+/// 本守卫钉四处：扩展两镜像的常驻清单 + 录制作用域、内置播放器 glue 的 document-start 常驻隐藏
+/// + chrome 清单、Dart 页 onLoadStop / 换集就绪后的重挂。
+/// flutter test cwd is the fushi package root.
+void main() {
+  const String advisorySelector = '.watch-video--advisories-container';
+  const String advisoryHashSelector = '[class*="watch-video--advisories"]';
+
+  const Map<String, String> mirrors = <String, String>{
+    'assets': 'assets/browser_extension',
+    'tools': '../tools/browser-extension',
+  };
+
+  mirrors.forEach((String name, String root) {
+    group('[$name] 扩展 content.js', () {
+      final String src = File('$root/content.js').readAsStringSync();
+
+      test('常驻隐藏清单含 advisories 容器（含哈希类名兜底）', () {
+        final int listStart =
+            src.indexOf('function fushiNetflixNextEpisodeSelectors()');
+        expect(listStart, greaterThanOrEqualTo(0));
+        final int listEnd = src.indexOf('];', listStart);
+        final String list = src.substring(listStart, listEnd);
+        expect(list.contains("'$advisorySelector'"), isTrue,
+            reason: '$root content.js 常驻清单必须含 $advisorySelector');
+        expect(list.contains("'$advisoryHashSelector'"), isTrue,
+            reason: '$root content.js 常驻清单必须含哈希类名兜底 $advisoryHashSelector');
+      });
+
+      test('录制作用域 hideStyle 无条件藏 advisories 容器', () {
+        final int start = src.indexOf('hideStyle.textContent =');
+        expect(start, greaterThanOrEqualTo(0));
+        final int end =
+            src.indexOf('document.head.appendChild(hideStyle)', start);
+        expect(end, greaterThan(start));
+        final String block = src.substring(start, end);
+        expect(block.contains(advisorySelector), isTrue,
+            reason: '$root content.js 录制期 hideStyle 必须含 $advisorySelector——'
+                '常驻隐藏受 netflixHideNextEpisode 开关门控，关掉后提示会照录进卡片');
+        expect(block.contains(advisoryHashSelector), isTrue,
+            reason: '$root content.js 录制期 hideStyle 必须含哈希类名兜底');
+      });
+    });
+  });
+
+  group('内置网页播放器 glue', () {
+    final String glue =
+        File('assets/web_video/web_video_glue.js').readAsStringSync();
+
+    test('document-start 常驻隐藏 advisories 容器（display:none，每份文档重新注入）', () {
+      final int start = glue.indexOf('NETFLIX_ADVISORY_SELECTORS =');
+      expect(start, greaterThanOrEqualTo(0),
+          reason: 'glue 必须集中定义 NETFLIX_ADVISORY_SELECTORS');
+      final int end = glue.indexOf(';', start);
+      final String selectors = glue.substring(start, end);
+      expect(selectors.contains(advisorySelector), isTrue);
+      expect(selectors.contains(advisoryHashSelector), isTrue);
+      expect(glue.contains('fushi-web-video-hide-advisory'), isTrue,
+          reason: '常驻隐藏 style 必须有稳定 id（幂等注入）');
+      final int styleAt = glue.indexOf('fushi-web-video-hide-advisory');
+      final String block = glue.substring(
+          styleAt, glue.indexOf('appendChild(advisoryStyle)', styleAt));
+      expect(block.contains('display:none !important'), isTrue,
+          reason: '常驻隐藏要用 display:none——分级提示不参与取词，摘出布局最干净');
+    });
+
+    test('制卡期 chrome 清单复用同一组 advisories 选择器', () {
+      final int start = glue.indexOf('HIDE_CHROME_CSS =');
+      expect(start, greaterThanOrEqualTo(0));
+      final int end = glue.indexOf("'{visibility:hidden !important}';", start);
+      expect(end, greaterThan(start));
+      expect(glue.substring(start, end).contains('NETFLIX_ADVISORY_SELECTORS'),
+          isTrue,
+          reason: 'HIDE_CHROME_CSS 必须拼入 NETFLIX_ADVISORY_SELECTORS，别再各抄一份');
+    });
+  });
+
+  group('内置网页播放器 Dart 页', () {
+    final String page = File(
+      'lib/src/pages/implementations/web_video_fushi_page.dart',
+    ).readAsStringSync();
+
+    test('onLoadStop 按 _mineRunning 重挂 chrome 隐藏（整页换集不丢）', () {
+      final int start = page.indexOf('onLoadStop:');
+      expect(start, greaterThanOrEqualTo(0));
+      final int end = page.indexOf('onRenderProcessGone:', start);
+      expect(end, greaterThan(start));
+      expect(
+          page
+              .substring(start, end)
+              .contains('_setPlayerChromeHidden(_mineRunning)'),
+          isTrue,
+          reason: '换集 loadUrl 后上一份文档的 <style> 已没了，隐藏态归 Dart 所有，新文档必须重挂');
+    });
+
+    test('换集就绪后开录前再挂一次（画面就绪可能早于 onLoadStop）', () {
+      final int start = page.indexOf('Future<bool> _navigateForMining(');
+      expect(start, greaterThanOrEqualTo(0));
+      final int end = page.indexOf('Future<void> _runMineQueue()', start);
+      expect(end, greaterThan(start));
+      expect(
+          page.substring(start, end).contains('_setPlayerChromeHidden(true)'),
+          isTrue);
+    });
+  });
+}

--- a/fushi/test/mining/netflix_bug685_seek_gate_guard_test.dart
+++ b/fushi/test/mining/netflix_bug685_seek_gate_guard_test.dart
@@ -79,9 +79,9 @@ void main() {
 
       // Content-script version marker bumped so a stale cached extension is
       // visibly distinguishable.
-      expect(content.contains("data-fushi-cs', 'v47'"), isTrue,
-          reason: '$root content.js version marker must be bumped to v47 '
-              '(v44=seek gate, v45=BUG-688 shadow-DOM popup + TODO-1219/1363 subtitle list replay/universal providers, v46=TODO-1391 hide Netflix maturity-rating overlay, v47=BUG-2170 play past that overlay before batch capture)');
+      expect(content.contains("data-fushi-cs', 'v48'"), isTrue,
+          reason: '$root content.js version marker must be bumped to v48 '
+              '(v44=seek gate, v45=BUG-688 shadow-DOM popup + TODO-1219/1363 subtitle list replay/universal providers, v46=TODO-1391 hide Netflix maturity-rating overlay, v47=BUG-2170 play past that overlay before batch capture, v48=BUG-2260 Netflix advisories-container selector drift)');
 
       // Adjacent BUG-681 tail-pad fix must remain intact (no regression).
       expect(content.contains('kNfClipTailPadSec'), isTrue,

--- a/fushi/test/mining/netflix_mining_robustness_guard_test.dart
+++ b/fushi/test/mining/netflix_mining_robustness_guard_test.dart
@@ -299,12 +299,12 @@ void main() {
               reason: '${content.path} 位置还原未与光标还原同处外层 finally');
         });
 
-        test('内容脚本版本标记 bump 到 v47（用户可确认新版）', () {
+        test('内容脚本版本标记 bump 到 v48（用户可确认新版）', () {
           final String src = content.readAsStringSync();
-          expect(src.contains("'data-fushi-cs', 'v47'"), isTrue,
-              reason: '${content.path} 版本标记未 bump 到 v47');
-          expect(src.contains('content script v47 loaded'), isTrue,
-              reason: '${content.path} 加载日志版本未 bump 到 v47');
+          expect(src.contains("'data-fushi-cs', 'v48'"), isTrue,
+              reason: '${content.path} 版本标记未 bump 到 v48');
+          expect(src.contains('content script v48 loaded'), isTrue,
+              reason: '${content.path} 加载日志版本未 bump 到 v48');
         });
       });
     }

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -1,10 +1,10 @@
 // 取词扫描 + 弹窗注入。修饰键默认 Shift。普通 DOM（popup.js 依赖顶层 #entries-container）。
 // 样式经 content.css 注入，全部作用域到 #entries-container，不污染宿主页（TODO-1090）。
 // 版本标记：加载后在 Console 打一行，用户可据此确认加载的是**新版**扩展（排查缓存旧版）。
-console.log('[Fushi] content script v47 loaded (BUG-688: popup Shadow DOM isolation + theme single-sourced from app; TODO-1219/1363: subtitle cue replay + universal subtitle-list providers; TODO-1391: hide Netflix start-of-episode maturity/age-rating overlay; BUG-2170: play past that overlay before batch capture)');
+console.log('[Fushi] content script v48 loaded (BUG-688: popup Shadow DOM isolation + theme single-sourced from app; TODO-1219/1363: subtitle cue replay + universal subtitle-list providers; TODO-1391: hide Netflix start-of-episode maturity/age-rating overlay; BUG-2170: play past that overlay before batch capture; BUG-2260: Netflix advisories-container selector drift)');
 // 诊断标记：写进 <html> 的 data-*，页面 Console（主世界）可读，用来隔空排查划词为何不触发
 // （隔离世界的全局变量在页面 console 里看不到，故用 DOM 属性桥接）。
-try { document.documentElement.setAttribute('data-fushi-cs', 'v47'); } catch (_) {}
+try { document.documentElement.setAttribute('data-fushi-cs', 'v48'); } catch (_) {}
 // TODO-1190：网页源文里高亮被查的词。selection.js 默认走 CSS Custom Highlight API
 // （CSS.highlights.set('fushi-selection', …) + content.css 的 ::highlight(fushi-selection)）。
 // 但 content script 跑在**隔离世界**：在隔离世界注册的 highlight 不会被页面渲染引擎绘制
@@ -889,6 +889,10 @@ async function fushiRunNetflixBatch(introGate) {
     // 受用户开关 netflixHideNextEpisode 门控——用户为了留住 Netflix 的「下一集」按钮把它关掉时，
     // 分级提示就会照录进卡片。录制期无条件藏，用户可见作用域仍归那个开关管。与本 style 同策
     // 用 visibility/opacity（不用 display:none，理由见本文件字幕隐藏那节）。
+    // BUG-2260：2026-09-08 实测 Netflix 当前 DOM 是 .watch-video--advisories-container
+    // （见 fushiNetflixNextEpisodeSelectors 注释），旧 evidence/maturity 选择器全部失配。
+    '.watch-video--advisories-container,[class*="watch-video--advisories"],' +
+    '.watch-video--evidence-overlay-container,' +
     '[class*="watch-video--maturity-rating"],.watch-video [data-uia*="maturity"],' +
     '.watch-video [class*="maturity-rating"]{opacity:0!important;visibility:hidden!important}';
   try { document.head.appendChild(hideStyle); } catch (_) {}
@@ -1335,6 +1339,13 @@ function fushiNetflixNextEpisodeSelectors() {
     '[class*="watch-video--maturity-rating"]',
     '.watch-video [data-uia*="maturity"]',
     '.watch-video [class*="maturity-rating"]',
+    // BUG-2260：2026-09-08 登录态 WebView2 探针实测，Netflix 当前分级提示 DOM 为
+    //   div.watch-video--advisories-container > div.advisory-container > div.advisory >
+    //   [data-uia="advisory-content"] > h4.advisory-header("RATED 7+")
+    // 上面 evidence/maturity 三组选择器一个都不再命中（静默失效，用户截图「RATED 13+ / 暴力, 自杀」
+    // 照旧出现）。子串匹配兜住哈希类名变体；旧选择器保留作 Netflix 回滚时的兜底。
+    '.watch-video--advisories-container',
+    '[class*="watch-video--advisories"]',
   ];
 }
 function fushiApplyNetflixNextEpisodeHiding(hide) {


### PR DESCRIPTION
## 问题

用户在 Netflix 跳转制卡时，画面左上角照旧出现 "RATED 13+ / 暴力, 自杀" 分级提示（BUG-2260）。

## 根因（两个）

1. **选择器漂移，三处隐藏同时静默失效。** 2026-09-08 用登录态 WebView2 探针实测，Netflix 当前提示 DOM 是
   `div.watch-video--advisories-container > .advisory-container > .advisory > [data-uia=advisory-content] > h4.advisory-header`。
   扩展常驻清单、扩展录制期 hideStyle、内置播放器 `HIDE_CHROME_CSS` 用的 `.watch-video--evidence-overlay-container` / `*maturity*` 一个都不再命中。BUG-2170 的开播时间门只管开播窗，管不到逐句 seek 后重弹的提示。
2. **内置播放器换集后隐藏态丢失。** 队列换集走 `loadUrl` 整页重载，上一份文档的 chrome 隐藏 `<style>` 随之消失；Dart 只在开跑前挂过一次，`onLoadStop` 只重挂了字幕隐藏。

## 修复

- `fushi/assets/web_video/web_video_glue.js`：集中 `NETFLIX_ADVISORY_SELECTORS`（advisories 容器 + `[class*=]` 哈希兜底 + 旧 evidence 回滚兜底）；Netflix 页 document-start 常驻 `display:none` 隐藏（每份文档重新注入，整页换集不丢）；`HIDE_CHROME_CSS` 复用同一组。
- `web_video_fushi_page.dart`：`onLoadStop` 按 `_mineRunning` 重挂 chrome 隐藏；`_navigateForMining` 画面就绪后开录前再挂一次（页面侧按 style id 幂等）。
- `tools/browser-extension/content.js`（+ assets 镜像，`sync_browser_extension` 同步）：常驻清单与录制期 hideStyle 补 advisories 两条；版本横幅 v47 → v48。

## 测试

- 新守卫 `fushi/test/mining/netflix_bug2260_advisory_overlay_guard_test.dart`（8 条：扩展两镜像常驻/录制作用域、glue 常驻 display:none + chrome 清单复用、Dart onLoadStop / 换集重挂）。
- `netflix_bug685_seek_gate_guard_test.dart` / `netflix_mining_robustness_guard_test.dart` 版本断言随 v48 更新。

## 验证

- `node --test`（tools/browser-extension）490 绿。
- 定向 `flutter test`（mining 下 5 个 Netflix 守卫 + 镜像全量守卫）71 绿，exit 0。
- `flutter analyze` 零问题。
- glue 在 node vm 里跑：netflix 主机 document-start 挂上 `#fushi-web-video-hide-advisory`，youtube 不挂。
- **未做**真机制卡复测（探针里视频未推进，seek 后是否重弹没量到；常驻隐藏不依赖这点）。

https://claude.ai/code/session_01Q53C5GFSCYq7GaqPtaQeVs
