### PR TITLE
fix(audio): 修复 Android 发音库引用缓存导致更新后失声

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-2265](bugs/BUG-2265-android-audio-saf-cache-reference.md) | 🚧 | 🚧 | 安卓查词发音库把 SAF 缓存副本当成原文件引用 |
+| [BUG-2265](bugs/BUG-2265-android-audio-saf-cache-reference.md) | ✅ | ✅ | 安卓查词发音库把 SAF 缓存副本当成原文件引用 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2111 条。点号进各自文件。
+> 共 2112 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2265](bugs/BUG-2265-android-audio-saf-cache-reference.md) | 🚧 | 🚧 | 安卓查词发音库把 SAF 缓存副本当成原文件引用 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
+++ b/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
@@ -9,7 +9,25 @@
   3. `fushi/lib/src/settings/settings_schema_lookup.dart:862` 按该标记允许引用；`fushi/lib/src/models/local_audio_manager.dart:226` 在引用模式直接保存传入路径，未复制到持久库目录。
   4. `fushi/lib/src/models/local_audio_manager.dart:337`：启动时文件缺失则跳过绑定，设置仍保留已开启条目。缓存清理后可出现本地发音消失。
 - **与 BUG-1667 的关系**：此前只防住未授权时 file_picker 的缓存回退；已有全文件权限的原生 SAF 本身也会回退到缓存，该分支漏判。现有 `fushi/test/tools/local_audio_import_real_path_guard_test.dart` 只检查源码存在 `isRealPath: false`，未覆盖该跨语言返回契约。
-- **[ ] ① 根因修复** — 本轮仅调查。应让原生选择结果明确携带真实文件/临时副本出处，临时副本必须转为持久副本；已保存缓存路径在文件尚存时迁移，文件缺失时明确引导重新选择原 DB。
-- **[ ] ② 自动化测试** — 待补原生 SAF 回退缓存的行为测试、持久化后清理缓存仍可查询的回归测试。不能仅用源码字符串守卫证明契约正确。
+- **[x] ① 根因修复** — 本分支修复提交（见 Git 历史）：
+  - Android SAF 文件结果改为 `{path, isRealPath}`；目录契约保持字符串。Dart 严格解码，过滤扩展名也保留出处，临时副本由既有导入路径复制到持久库。
+  - 主入口与弹窗入口绑定前迁移本机实际临时目录下的旧库；复制成功后以短事务 CAS 同步替换两份偏好路径，保留顺序、开关、子来源和名称。配置在复制期间变化则保留新配置。原文件不删除，失败记录诊断并保留恢复入口。
+  - 迁移和孤儿清理共用进程内队列与跨进程文件锁；清理在锁内读取最新持久配置，防止删除正在迁移或刚提交的库。文件名保留数字形状并加入进程 ID，隔离主进程与 popup 的同毫秒命名。
+  - 缺失库显示本地化提示和「重新选择发音库」，恢复时复制持久副本并保留原行顺序/开关/名称/子来源；取消或选择失败不替换。
+  - Dart 与 Android native 绑定保留缺失库的序号槽位；空配置也清除旧绑定，防止后续正常库错位及 warm popup 使用已移除库。
+- **[x] ② 自动化测试** —
+  - `fushi/test/media/import/saf_file_provenance_test.dart`：真实/缓存返回、扩展过滤、取消、损坏契约及原生接线。
+  - `fushi/test/models/local_audio_cache_reference_migration_test.dart`：真实 SQLite 迁移、缓存清除、幂等、失败回滚、并发配置修改与迁移/清理互斥。
+  - `fushi/test/models/local_audio_binding_slots_test.dart`：缺失首库不挤序号、关闭与移除后清空旧绑定、原生槽位契约。
+  - `fushi/test/pages/audio_sources_missing_file_test.dart`：缺失提示、重选成功/取消/失败、异步期间排序与开关变化。
+  - `fushi/integration_test/local_audio_cache_recovery_itest.dart`：Android 实际查询、BLOB 字节比对、WAV 启播、清源缓存后重载及旧引用迁移（执行结果见验证记录）。
 - **临时恢复**：重新选择原始 android_english.db，关闭引用原文件（不复制）选项，复制入应用持久库目录。沿原设置重新导入可能只重造缓存并再次复发。此建议尚未在报告用户设备执行验证。
-- **验证边界**：已读取两张原图、追踪 Java → Dart 选择器 → 本地库导入 → 重启绑定，并经独立只读复核；未运行 Android 真机/E2E，未修改运行时代码。
+- **验证边界**：已读取两张原图并沿 Java → Dart → 导入 → 重启绑定复核。最终自动化、构建及设备结果见下方；未取得报告用户设备日志，不能断言更新动作清除了缓存。
+
+### 本轮验证记录
+- 首轮定向 86 条通过。
+- 扩展定向覆盖 243 条：242 条通过，一条既有 Windows 测试清理因后台索引占用文件失败；补齐清理等待后，该文件 18 条重跑全部通过。未运行本地全量套件。
+- 全量 `flutter analyze --no-pub`：零问题。
+- `dart tool/bug.dart check`：号唯一、索引同步、无跨工作区撞号。
+- Android `:app:assembleRelease`：因缺少本地 `android/key.properties` 被发布签名门阻止，未绕过签名。
+- Android 平台测试首次零用例启动失败：Flutter 在未生成 APK 时不识别当前 launcher activity-alias；继续先构建 debug APK，再执行平台测试。最终结果待补。

--- a/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
+++ b/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
@@ -1,0 +1,15 @@
+## BUG-2265 · 安卓查词发音库把 SAF 缓存副本当成原文件引用
+
+- **报告**：2026-09-08，用户转述 Android 有声书页面查词单词无声，昨晚正常，更新后显示「暂无发音」。有声书正文播放不是本次故障。
+- **真实性**：真 bug，截图与真实代码路径相符；未取得用户设备文件存在性、日志与更新前后版本，不能断言更新动作删除了缓存。
+- **截图证据**：单词 disgust 查词显示「暂无发音」；管理音频来源中 android_english.db 开启，但持久引用路径为 `/data/user/0/app.fushi.reader/cache/saf_pick/android_english.db`。
+- **根因**：
+  1. `fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java:371`：SAF 无法解析原路径时回退 `copyUriToCache`，仍将裸字符串返回 Dart。`:1373` 明确写入 `getCacheDir()/saf_pick`。
+  2. `fushi/lib/src/media/import/real_path_directory_picker.dart:182` 与 `:192`：SAF 分支无条件标记 `isRealPath: true`，丢失临时缓存出处。
+  3. `fushi/lib/src/settings/settings_schema_lookup.dart:862` 按该标记允许引用；`fushi/lib/src/models/local_audio_manager.dart:226` 在引用模式直接保存传入路径，未复制到持久库目录。
+  4. `fushi/lib/src/models/local_audio_manager.dart:337`：启动时文件缺失则跳过绑定，设置仍保留已开启条目。缓存清理后可出现本地发音消失。
+- **与 BUG-1667 的关系**：此前只防住未授权时 file_picker 的缓存回退；已有全文件权限的原生 SAF 本身也会回退到缓存，该分支漏判。现有 `fushi/test/tools/local_audio_import_real_path_guard_test.dart` 只检查源码存在 `isRealPath: false`，未覆盖该跨语言返回契约。
+- **[ ] ① 根因修复** — 本轮仅调查。应让原生选择结果明确携带真实文件/临时副本出处，临时副本必须转为持久副本；已保存缓存路径在文件尚存时迁移，文件缺失时明确引导重新选择原 DB。
+- **[ ] ② 自动化测试** — 待补原生 SAF 回退缓存的行为测试、持久化后清理缓存仍可查询的回归测试。不能仅用源码字符串守卫证明契约正确。
+- **临时恢复**：重新选择原始 android_english.db，关闭引用原文件（不复制）选项，复制入应用持久库目录。沿原设置重新导入可能只重造缓存并再次复发。此建议尚未在报告用户设备执行验证。
+- **验证边界**：已读取两张原图、追踪 Java → Dart 选择器 → 本地库导入 → 重启绑定，并经独立只读复核；未运行 Android 真机/E2E，未修改运行时代码。

--- a/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
+++ b/docs/bugs/BUG-2265-android-audio-saf-cache-reference.md
@@ -30,4 +30,10 @@
 - 全量 `flutter analyze --no-pub`：零问题。
 - `dart tool/bug.dart check`：号唯一、索引同步、无跨工作区撞号。
 - Android `:app:assembleRelease`：因缺少本地 `android/key.properties` 被发布签名门阻止，未绕过签名。
-- Android 平台测试首次零用例启动失败：Flutter 在未生成 APK 时不识别当前 launcher activity-alias；继续先构建 debug APK，再执行平台测试。最终结果待补。
+- Android 平台测试首次零用例启动失败：Flutter 在未生成 APK 时不识别当前 launcher activity-alias；继续先构建 debug APK，再执行平台测试。后续构建与运行结果见下。
+- Android 调试 APK 构建通过（包含本轮 Java/Dart 修复）。依赖下载最初失败后，从相同上游下载 SQLite / PDFium 并供原构建 hook 使用（SQLite SHA-256 校验通过）；未修改依赖或绕过签名。
+- 最后新增的正常配置迁移快路径：相关迁移/绑定 12 条重跑通过，全量 analyze 再次零问题（78.5s）。
+
+- Android API 34 x86_64 隔离模拟器：`flutter test integration_test/local_audio_cache_recovery_itest.dart -d emulator-5584 --no-pub` **1 条通过**（实际执行，11s）；真实 native 查询、提取字节一致、WAV 启播、清源缓存后重载和旧缓存迁移均通过。API 36 旧模拟器因 SurfaceFlinger 图形服务断言和包管理服务故障未能执行；未把零用例安装失败当作测试通过。
+- 尚未覆盖：报告用户原始文件 provider 的真实 SAF 选择 UI、用户手机升级全链路和扬声器录音验收。平台测试验证启播返回值，不声称人耳已确认声音。
+- 修复提交：`0dbc59ceab`；正常配置迁移快路径：`fa189d1b19`。

--- a/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
@@ -364,17 +364,28 @@ public class MainActivity extends AudioServiceActivity {
             final boolean isTree = requestCode == SAF_PICK_REAL_DIR_REQUEST;
             ioExecutor.execute(() -> {
                 String resolved = resolveSafRealPath(pickedUri, isTree);
-                // Files: if no real path (true cloud DocumentsProvider), copy to
-                // cache so the pick still works — matches the no-permission
-                // file_picker escape hatch (dangles on cache clear, but rare).
+                // BUG-2265: provenance comes from resolution, never from the
+                // provider name or the returned path's spelling. A cache copy
+                // must be consumed/copied by the importer, never referenced.
+                final boolean isRealPath = resolved != null;
+                // Files: unresolved providers remain usable via a cache copy.
                 // Folders: no fallback (dart:io cannot read a cloud tree anyway).
                 if (resolved == null && !isTree) {
                     resolved = copyUriToCache(pickedUri);
                 }
-                final String realPath = resolved;
+                final Object pickedResult;
+                if (isTree || resolved == null) {
+                    // Keep the directory channel's existing String contract.
+                    pickedResult = resolved;
+                } else {
+                    Map<String, Object> fileResult = new java.util.HashMap<>();
+                    fileResult.put("path", resolved);
+                    fileResult.put("isRealPath", isRealPath);
+                    pickedResult = fileResult;
+                }
                 // null = user picked a folder we cannot map, or a copy failure.
                 new Handler(Looper.getMainLooper()).post(() ->
-                    safResult.success(realPath));
+                    safResult.success(pickedResult));
             });
             return;
         }
@@ -1363,7 +1374,8 @@ public class MainActivity extends AudioServiceActivity {
     // Last-resort copy of a picked file content URI into app cache, returning the
     // cache path. Used only when the URI has no real filesystem path (true cloud
     // DocumentsProvider) — same escape hatch as the no-permission file_picker
-    // path (dangles on cache clear, but the pick still works).
+    // path. The caller labels this as isRealPath=false so importers copy it into
+    // owned storage instead of persisting a reference to this temporary file.
     private String copyUriToCache(Uri uri) {
         try {
             String name = queryDisplayName(uri);

--- a/fushi/android/app/src/main/java/app/fushi/reader/TtsChannelHandler.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/TtsChannelHandler.java
@@ -304,7 +304,16 @@ public class TtsChannelHandler {
             synchronized (dbLock) {
                 closeAllAudioDbsLocked();
 
+                final List<String> indexTargets = new ArrayList<>();
                 for (String dbPath : paths) {
+                    // BUG-2265: Dart queries by configured enabled-source index.
+                    // Missing/broken databases must keep their slot; compacting
+                    // the list would query a different source at the same index.
+                    final int slot = localAudioDbs.size();
+                    localAudioDbs.add(null);
+                    localAudioDbPaths.add(dbPath);
+                    List<String> order = orderByPath.get(dbPath);
+                    localAudioDbOrders.add(order != null ? order : new ArrayList<>());
                     if (dbPath == null || dbPath.isEmpty()) continue;
                     try {
                         File dbFile = new File(dbPath);
@@ -334,18 +343,14 @@ public class TtsChannelHandler {
                                     | SQLiteDatabase.NO_LOCALIZED_COLLATORS);
                             db.enableWriteAheadLogging();
                         }
-                        localAudioDbPaths.add(dbPath);
-                        localAudioDbs.add(db);
-                        // 开库成功后再记 order，保证与 localAudioDbs 的 index 对齐。
-                        List<String> order = orderByPath.get(dbPath);
-                        localAudioDbOrders.add(order != null ? order : new ArrayList<>());
+                        localAudioDbs.set(slot, db);
+                        indexTargets.add(dbPath);
                     } catch (Exception e) {
                         android.util.Log.e("hibiki-audio",
                             "Failed to open DB: " + dbPath, e);
                     }
                 }
 
-                final List<String> indexTargets = new ArrayList<>(localAudioDbPaths);
                 indexFuture = ioExecutor.submit(() -> {
                     for (String path : indexTargets) {
                         ensureQueryIndexes(path);

--- a/fushi/integration_test/local_audio_cache_recovery_itest.dart
+++ b/fushi/integration_test/local_audio_cache_recovery_itest.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/models/local_audio_manager.dart';
+import 'package:fushi/src/utils/misc/tts_channel.dart';
+import 'package:fushi/utils.dart' show UpdateChecker;
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import 'helpers/library_fixture.dart' show readyAppModel;
+import 'support/test_app_launcher.dart';
+
+/// Android 平台链路验收：真实 SQLite、MethodChannel 查询/提取、MediaPlayer 启播。
+/// 不操作 SAF UI，也不把启播成功当作扬声器输出已被人耳或录音验证。
+Uint8List _toneWav() {
+  const int rate = 16000;
+  const int samples = rate ~/ 4;
+  final ByteData bytes = ByteData(44 + samples * 2);
+  void ascii(int offset, String value) {
+    for (int i = 0; i < value.length; i++) {
+      bytes.setUint8(offset + i, value.codeUnitAt(i));
+    }
+  }
+
+  ascii(0, 'RIFF');
+  bytes.setUint32(4, bytes.lengthInBytes - 8, Endian.little);
+  ascii(8, 'WAVEfmt ');
+  bytes.setUint32(16, 16, Endian.little);
+  bytes.setUint16(20, 1, Endian.little);
+  bytes.setUint16(22, 1, Endian.little);
+  bytes.setUint32(24, rate, Endian.little);
+  bytes.setUint32(28, rate * 2, Endian.little);
+  bytes.setUint16(32, 2, Endian.little);
+  bytes.setUint16(34, 16, Endian.little);
+  ascii(36, 'data');
+  bytes.setUint32(40, samples * 2, Endian.little);
+  for (int i = 0; i < samples; i++) {
+    bytes.setInt16(44 + i * 2,
+        (4000 * math.sin(2 * math.pi * 440 * i / rate)).round(), Endian.little);
+  }
+  return bytes.buffer.asUint8List();
+}
+
+void _writeAudioDb(File file, String term, Uint8List wav) {
+  final sqlite.Database db = sqlite.sqlite3.open(file.path);
+  try {
+    db.execute('CREATE TABLE entries '
+        '(expression TEXT, reading TEXT, file TEXT, source TEXT)');
+    db.execute('CREATE TABLE android (file TEXT, source TEXT, data BLOB)');
+    db.execute('INSERT INTO entries VALUES (?, ?, ?, ?)',
+        <Object?>[term, '', '$term.wav', 'cache-recovery-itest']);
+    db.execute('INSERT INTO android VALUES (?, ?, ?)',
+        <Object?>['$term.wav', 'cache-recovery-itest', wav]);
+  } finally {
+    db.dispose();
+  }
+}
+
+Future<void> _verifyNativeAudio(
+    String term, Uint8List wav, Set<String> extractedFiles) async {
+  final TtsChannel channel = TtsChannel.instance;
+  final Map<String, dynamic>? result = await channel.queryLocalAudio(term, '');
+  expect(result, isNotNull, reason: 'Android native query must find fixture');
+  final String? extracted = await channel.extractLocalAudio(
+    result!['file'] as String,
+    result['source'] as String,
+    dbIndex: (result['dbIndex'] as num).toInt(),
+  );
+  expect(extracted, isNotNull);
+  extractedFiles.add(extracted!);
+  expect(await File(extracted).readAsBytes(), orderedEquals(wav));
+  expect(await channel.playFile(extracted), isTrue,
+      reason: 'Real Android MediaPlayer must prepare and start valid WAV');
+  await channel.stop();
+  // 下一轮必须重新从库读取 BLOB，不能靠之前提取的文件证明恢复成功。
+  await File(extracted).delete();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  testWidgets(
+      'Android local audio survives cache removal and migrates old refs',
+      (WidgetTester tester) async {
+    expect(Platform.isAndroid, isTrue,
+        reason: 'Run this platform verification only on an Android emulator');
+    final bool previousAutoCheck = UpdateChecker.disableAutoCheckForTesting;
+    UpdateChecker.disableAutoCheckForTesting = true;
+    await launchFushiTestApp();
+    for (int i = 0;
+        i < 120 && find.byType(MaterialApp).evaluate().isEmpty;
+        i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    final AppModel appModel = await readyAppModel(tester);
+    final LocalAudioManager manager = LocalAudioManager(
+      prefsRepo: appModel.prefsRepo,
+      databaseDirectory: appModel.databaseDirectory,
+    );
+    final Map<String, String> snapshot = appModel.prefsRepo.prefsSnapshot;
+    const List<String> changedKeys = <String>[
+      'local_audio_dbs',
+      'local_audio_db_path',
+      'local_audio_db_display_name',
+      'audio_source_configs',
+      'audio_sources',
+    ];
+    final Directory fixture = await appModel.temporaryDirectory
+        .createTemp('local_audio_cache_recovery_itest_');
+    final Set<String> generatedDbs = <String>{};
+    final Set<String> extractedFiles = <String>{};
+    final Uint8List wav = _toneWav();
+    final String suffix = DateTime.now().microsecondsSinceEpoch.toString();
+    try {
+      // 本测试会触发生产 pruneOrphans，故仅允许干净的模拟器音频库配置。
+      expect(appModel.localAudioDbs, isEmpty,
+          reason:
+              'Use an isolated emulator with no user local audio databases');
+      final File source = File(path.join(fixture.path, 'copied.db'));
+      final String copyTerm = 'cachecopy$suffix';
+      _writeAudioDb(source, copyTerm, wav);
+      final LocalAudioDbEntry imported = await appModel.importLocalAudioDbFile(
+          source.path,
+          displayName: 'cache-copy-itest-$suffix',
+          reference: false);
+      generatedDbs.add(imported.path);
+      expect(path.isWithin(appModel.databaseDirectory.path, imported.path),
+          isTrue);
+      await appModel.setAudioSourceConfigs(<AudioSourceConfig>[
+        AudioSourceConfig.localAudio(
+            label: imported.displayName, path: imported.path, enabled: true),
+      ]);
+      await _verifyNativeAudio(copyTerm, wav, extractedFiles);
+      await source.delete();
+      await appModel.prefsRepo.loadFromDb();
+      await manager.bindForNativeHandler();
+      await _verifyNativeAudio(copyTerm, wav, extractedFiles);
+
+      final File legacy = File(path.join(fixture.path, 'legacy.db'));
+      final String legacyTerm = 'cachelegacy$suffix';
+      _writeAudioDb(legacy, legacyTerm, wav);
+      final LocalAudioDbEntry legacyEntry = LocalAudioDbEntry(
+          path: legacy.path,
+          displayName: 'cache-legacy-itest-$suffix',
+          enabled: true,
+          sources: const <LocalAudioSourcePref>[
+            LocalAudioSourcePref(name: 'cache-recovery-itest'),
+          ]);
+      // 直接播种旧版本持久化形状；不能用新导入函数提前消除旧缓存引用。
+      await appModel.prefsRepo.setPrefs(<String, dynamic>{
+        'local_audio_dbs': jsonEncode(<Map<String, dynamic>>[
+          imported.toJson(),
+          legacyEntry.toJson(),
+        ]),
+        'audio_source_configs': <Map<String, dynamic>>[
+          AudioSourceConfig.localAudio(
+                  label: imported.displayName,
+                  path: imported.path,
+                  enabled: true)
+              .toJson(),
+          AudioSourceConfig.localAudio(
+                  label: legacyEntry.displayName,
+                  path: legacy.path,
+                  enabled: true)
+              .toJson(),
+        ],
+      });
+      await manager.migrateTemporaryReferences(appModel.temporaryDirectory);
+      final LocalAudioDbEntry migrated = manager.entries.last;
+      generatedDbs.add(migrated.path);
+      expect(migrated.path, isNot(legacy.path));
+      expect(migrated.sources, legacyEntry.sources);
+      expect(
+          appModel.audioSourceConfigs
+              .where((AudioSourceConfig source) =>
+                  source.kind == AudioSourceKind.localAudio)
+              .last
+              .path,
+          migrated.path);
+      expect(await legacy.exists(), isTrue);
+      await legacy.delete();
+      await appModel.prefsRepo.loadFromDb();
+      await manager.migrateTemporaryReferences(appModel.temporaryDirectory);
+      expect(manager.entries.last.path, migrated.path);
+      await manager.bindForNativeHandler();
+      await _verifyNativeAudio(legacyTerm, wav, extractedFiles);
+    } finally {
+      await TtsChannel.instance.stop();
+      await TtsChannel.instance.setLocalAudioDbs(const <LocalAudioDbConfig>[]);
+      await appModel.database.setPrefs(<String, String>{
+        for (final String key in changedKeys)
+          if (snapshot.containsKey(key)) key: snapshot[key]!,
+      });
+      for (final String key in changedKeys) {
+        if (!snapshot.containsKey(key)) await appModel.database.deletePref(key);
+      }
+      await appModel.prefsRepo.loadFromDb();
+      await manager.bindForNativeHandler();
+      for (final String filename in generatedDbs) {
+        if (path.isWithin(appModel.databaseDirectory.path, filename)) {
+          await LocalAudioManager.deleteFiles(filename);
+        }
+      }
+      for (final String filename in extractedFiles) {
+        if (await File(filename).exists()) await File(filename).delete();
+      }
+      if (await fixture.exists()) await fixture.delete(recursive: true);
+      UpdateChecker.disableAutoCheckForTesting = previousAutoCheck;
+    }
+  }, timeout: const Timeout(Duration(minutes: 4)));
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 75446 (4438 per locale)
+/// Strings: 75480 (4440 per locale)
 ///
-/// Built on 2026-09-07 at 11:03 UTC
+/// Built on 2026-09-08 at 05:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4460,7 +4460,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get book_language_description =>
       'Decides which font renders this book\'s text. Automatic uses the language declared in the EPUB.';
   String get local_audio_reference_unavailable =>
-      'Can\'t reference the original file without all-files access; a copy was imported instead.';
+      'The selected file is a temporary copy. Importing a persistent copy instead.';
   String get video_collection_scrape => 'Scrape info & cover';
   String get update_testflight_open => 'Open TestFlight';
   String get update_app_store_open => 'Open App Store';
@@ -6144,6 +6144,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'AniList is rate-limiting this app right now. Wait a moment and retry.';
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  String get local_audio_file_unavailable =>
+      'Audio database unavailable. Select the original DB file again.';
+  String get local_audio_file_reselect => 'Select audio database again';
 }
 
 // Path: <root>
@@ -13729,7 +13732,7 @@ class _StringsAr extends _StringsEn {
       'تحدد الخط المستخدم لعرض نص هذا الكتاب. التلقائي يستخدم اللغة المُعلنة في EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'لا يمكن الإشارة إلى الملف الأصلي بدون إذن الوصول لجميع الملفات؛ تم استيراد نسخة بدلاً من ذلك.';
+      'الملف المحدد نسخة مؤقتة. يجري استيراد نسخة دائمة بدلاً منها.';
   @override
   String get video_collection_scrape => 'كشط المعلومات والغلاف';
   @override
@@ -16555,6 +16558,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'قاعدة بيانات الصوت غير متاحة. حدد ملف DB الأصلي مرة أخرى.';
+  @override
+  String get local_audio_file_reselect => 'تحديد قاعدة بيانات الصوت مرة أخرى';
 }
 
 // Path: <root>
@@ -24314,7 +24322,7 @@ class _StringsDe extends _StringsEn {
       'Bestimmt, welche Schriftart den Text dieses Buches rendert. Automatisch verwendet die im EPUB deklarierte Sprache.';
   @override
   String get local_audio_reference_unavailable =>
-      'Ohne Zugriff auf alle Dateien kann die Originaldatei nicht referenziert werden; stattdessen wurde eine Kopie importiert.';
+      'Die ausgewählte Datei ist eine temporäre Kopie. Stattdessen wird eine dauerhafte Kopie importiert.';
   @override
   String get video_collection_scrape => 'Info & Cover scrapen';
   @override
@@ -27193,6 +27201,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Audiodatenbank nicht verfügbar. Wähle die ursprüngliche DB-Datei erneut aus.';
+  @override
+  String get local_audio_file_reselect => 'Audiodatenbank erneut auswählen';
 }
 
 // Path: <root>
@@ -34985,7 +34998,7 @@ class _StringsEs extends _StringsEn {
       'Decide qué fuente renderiza el texto de este libro. Automático usa el idioma declarado en el EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'No se puede referenciar el archivo original sin acceso a todos los archivos; se importó una copia en su lugar.';
+      'El archivo seleccionado es una copia temporal. Se importará una copia permanente en su lugar.';
   @override
   String get video_collection_scrape => 'Obtener info y portada';
   @override
@@ -37884,6 +37897,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'La base de datos de audio no está disponible. Selecciona de nuevo el archivo DB original.';
+  @override
+  String get local_audio_file_reselect =>
+      'Seleccionar de nuevo la base de datos de audio';
 }
 
 // Path: <root>
@@ -45701,7 +45720,7 @@ class _StringsFr extends _StringsEn {
       'Détermine quelle police affiche le texte de ce livre. Automatique utilise la langue déclarée dans l\'EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Impossible de référencer le fichier original sans l\'accès complet aux fichiers ; une copie a été importée à la place.';
+      'Le fichier sélectionné est une copie temporaire. Une copie permanente sera importée à la place.';
   @override
   String get video_collection_scrape => 'Récupérer infos et couverture';
   @override
@@ -48609,6 +48628,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Base de données audio indisponible. Sélectionnez à nouveau le fichier DB d’origine.';
+  @override
+  String get local_audio_file_reselect =>
+      'Sélectionner à nouveau la base de données audio';
 }
 
 // Path: <root>
@@ -56293,7 +56318,7 @@ class _StringsId extends _StringsEn {
       'Menentukan font mana yang merender teks buku ini. Otomatis menggunakan bahasa yang dideklarasikan dalam EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Tidak bisa mereferensikan file asli tanpa akses semua file; salinan diimpor sebagai gantinya.';
+      'File yang dipilih adalah salinan sementara. Salinan permanen akan diimpor sebagai gantinya.';
   @override
   String get video_collection_scrape => 'Scrape info & sampul';
   @override
@@ -59137,6 +59162,11 @@ class _StringsId extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Basis data audio tidak tersedia. Pilih kembali file DB asli.';
+  @override
+  String get local_audio_file_reselect => 'Pilih kembali basis data audio';
 }
 
 // Path: <root>
@@ -66881,7 +66911,7 @@ class _StringsIt extends _StringsEn {
       'Decide quale font renderizza il testo di questo libro. Automatico usa la lingua dichiarata nell\'EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Impossibile riferirsi al file originale senza accesso a tutti i file; una copia è stata importata invece.';
+      'Il file selezionato è una copia temporanea. Verrà importata una copia permanente al suo posto.';
   @override
   String get video_collection_scrape => 'Scrape info e copertina';
   @override
@@ -69756,6 +69786,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Database audio non disponibile. Seleziona di nuovo il file DB originale.';
+  @override
+  String get local_audio_file_reselect =>
+      'Seleziona di nuovo il database audio';
 }
 
 // Path: <root>
@@ -77037,7 +77073,7 @@ class _StringsJa extends _StringsEn {
       'この本のテキストを表示するフォントを決定します。自動の場合、EPUBで宣言された言語を使用します。';
   @override
   String get local_audio_reference_unavailable =>
-      'すべてのファイルへのアクセスがないため元のファイルを参照できません。代わりにコピーがインポートされました。';
+      '選択したファイルは一時コピーです。代わりに永続的なコピーとしてインポートします。';
   @override
   String get video_collection_scrape => '情報と封面を取得';
   @override
@@ -79755,6 +79791,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      '音声データベースを利用できません。元の DB ファイルを選択し直してください。';
+  @override
+  String get local_audio_file_reselect => '音声データベースを選択し直す';
 }
 
 // Path: <root>
@@ -87046,7 +87087,7 @@ class _StringsKo extends _StringsEn {
       '이 책의 텍스트를 렌더링할 글꼴을 결정합니다. 자동은 EPUB에 선언된 언어를 사용합니다.';
   @override
   String get local_audio_reference_unavailable =>
-      '모든 파일 접근 권한 없이는 원본 파일을 참조할 수 없어 사본이 대신 가져와졌습니다.';
+      '선택한 파일은 임시 사본입니다. 대신 영구적으로 저장되는 사본을 가져옵니다.';
   @override
   String get video_collection_scrape => '정보 및 표지 스크랩';
   @override
@@ -89764,6 +89805,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      '음성 데이터베이스를 사용할 수 없습니다. 원본 DB 파일을 다시 선택하세요.';
+  @override
+  String get local_audio_file_reselect => '음성 데이터베이스 다시 선택';
 }
 
 // Path: <root>
@@ -97474,7 +97520,7 @@ class _StringsNl extends _StringsEn {
       'Bepaalt welk lettertype de tekst van dit boek weergeeft. Automatisch gebruikt de taal die in de EPUB is gedeclareerd.';
   @override
   String get local_audio_reference_unavailable =>
-      'Kan het originele bestand niet refereren zonder volledige bestandstoegang; er is in plaats daarvan een kopie geïmporteerd.';
+      'Het geselecteerde bestand is een tijdelijke kopie. Er wordt in plaats daarvan een permanente kopie geïmporteerd.';
   @override
   String get video_collection_scrape => 'Info & omslag scrapen';
   @override
@@ -100341,6 +100387,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Audiodatabase niet beschikbaar. Selecteer het oorspronkelijke DB-bestand opnieuw.';
+  @override
+  String get local_audio_file_reselect => 'Audiodatabase opnieuw selecteren';
 }
 
 // Path: <root>
@@ -108089,7 +108140,7 @@ class _StringsPtBr extends _StringsEn {
       'Define qual fonte renderiza o texto deste livro. Automático usa o idioma declarado no EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Não é possível referenciar o arquivo original sem acesso a todos os arquivos; uma cópia foi importada.';
+      'O arquivo selecionado é uma cópia temporária. Uma cópia permanente será importada em seu lugar.';
   @override
   String get video_collection_scrape => 'Buscar info e capa';
   @override
@@ -110970,6 +111021,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Banco de dados de áudio indisponível. Selecione o arquivo DB original novamente.';
+  @override
+  String get local_audio_file_reselect =>
+      'Selecionar o banco de dados de áudio novamente';
 }
 
 // Path: <root>
@@ -118697,7 +118754,7 @@ class _StringsRu extends _StringsEn {
       'Определяет, какой шрифт используется для отображения текста книги. «Автоматически» использует язык, указанный в EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Невозможно сослаться на исходный файл без полного доступа к файлам; вместо этого импортирована копия.';
+      'Выбранный файл — временная копия. Вместо неё будет импортирована постоянная копия.';
   @override
   String get video_collection_scrape => 'Получить информацию и обложку';
   @override
@@ -121577,6 +121634,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'База аудиоданных недоступна. Выберите исходный файл DB ещё раз.';
+  @override
+  String get local_audio_file_reselect => 'Выбрать базу аудиоданных заново';
 }
 
 // Path: <root>
@@ -129152,7 +129214,7 @@ class _StringsTh extends _StringsEn {
       'กำหนดฟอนต์ที่ใช้แสดงข้อความหนังสือ อัตโนมัติจะใช้ภาษาที่ระบุใน EPUB';
   @override
   String get local_audio_reference_unavailable =>
-      'ไม่สามารถอ้างอิงไฟล์ต้นฉบับได้หากไม่มีสิทธิ์เข้าถึงไฟล์ทั้งหมด จึงนำเข้าเป็นสำเนาแทน';
+      'ไฟล์ที่เลือกเป็นสำเนาชั่วคราว ระบบจะนำเข้าสำเนาที่จัดเก็บถาวรแทน';
   @override
   String get video_collection_scrape => 'สแกนข้อมูลและปก';
   @override
@@ -131982,6 +132044,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'ไม่สามารถใช้ฐานข้อมูลเสียงได้ โปรดเลือกไฟล์ DB ต้นฉบับอีกครั้ง';
+  @override
+  String get local_audio_file_reselect => 'เลือกฐานข้อมูลเสียงอีกครั้ง';
 }
 
 // Path: <root>
@@ -139649,7 +139716,7 @@ class _StringsTr extends _StringsEn {
       'Bu kitabın metnini hangi yazı tipinin oluşturacağını belirler. Otomatik, EPUB\'da beyan edilen dili kullanır.';
   @override
   String get local_audio_reference_unavailable =>
-      'Tüm dosyalara erişim olmadan orijinal dosyaya başvurulamıyor; bunun yerine bir kopya içe aktarıldı.';
+      'Seçilen dosya geçici bir kopyadır. Bunun yerine kalıcı bir kopya içe aktarılıyor.';
   @override
   String get video_collection_scrape => 'Bilgi ve kapak tara';
   @override
@@ -142505,6 +142572,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Ses veritabanı kullanılamıyor. Orijinal DB dosyasını yeniden seçin.';
+  @override
+  String get local_audio_file_reselect => 'Ses veritabanını yeniden seç';
 }
 
 // Path: <root>
@@ -150150,7 +150222,7 @@ class _StringsVi extends _StringsEn {
       'Quyết định phông chữ nào hiển thị văn bản của cuốn sách này. Tự động sử dụng ngôn ngữ được khai báo trong EPUB.';
   @override
   String get local_audio_reference_unavailable =>
-      'Không thể tham chiếu tệp gốc mà không có quyền truy cập tất cả tệp; đã nhập một bản sao thay thế.';
+      'Tệp đã chọn là bản sao tạm thời. Hệ thống sẽ nhập một bản sao được lưu trữ lâu dài thay thế.';
   @override
   String get video_collection_scrape => 'Quét thông tin & bìa';
   @override
@@ -152999,6 +153071,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get local_audio_file_unavailable =>
+      'Không thể sử dụng cơ sở dữ liệu âm thanh. Vui lòng chọn lại tệp DB gốc.';
+  @override
+  String get local_audio_file_reselect => 'Chọn lại cơ sở dữ liệu âm thanh';
 }
 
 // Path: <root>
@@ -160058,8 +160135,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get book_language_description => '决定这本书的正文用哪种字体渲染。自动 = 用 EPUB 里声明的语言。';
   @override
-  String get local_audio_reference_unavailable =>
-      '没有「所有文件访问权限」无法引用原文件，已改为导入副本。';
+  String get local_audio_reference_unavailable => '所选文件是临时副本，已改为导入持久副本。';
   @override
   String get video_collection_scrape => '刮削资料与封面';
   @override
@@ -162634,6 +162710,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+  @override
+  String get local_audio_file_unavailable => '发音库文件不可用，请重新选择原始 DB 文件。';
+  @override
+  String get local_audio_file_reselect => '重新选择发音库';
 }
 
 // Path: <root>
@@ -169699,8 +169779,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_language_description => '決定這本書的正文用哪種字體渲染。自動 = 用 EPUB 裡聲明的語言。';
   @override
-  String get local_audio_reference_unavailable =>
-      '沒有「所有檔案訪問權限」無法引用原檔案，已改為導入副本。';
+  String get local_audio_reference_unavailable => '所選檔案是暫存副本，已改為匯入永久副本。';
   @override
   String get video_collection_scrape => '刮削資料與封面';
   @override
@@ -172322,6 +172401,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+  @override
+  String get local_audio_file_unavailable => '發音庫檔案無法使用，請重新選擇原始 DB 檔案。';
+  @override
+  String get local_audio_file_reselect => '重新選擇發音庫';
 }
 
 /// Flat map(s) containing all translations.
@@ -179084,7 +179167,7 @@ extension on _StringsEn {
       case 'book_language_description':
         return 'Decides which font renders this book\'s text. Automatic uses the language declared in the EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Can\'t reference the original file without all-files access; a copy was imported instead.';
+        return 'The selected file is a temporary copy. Importing a persistent copy instead.';
       case 'video_collection_scrape':
         return 'Scrape info & cover';
       case 'update_testflight_open':
@@ -181441,6 +181524,10 @@ extension on _StringsEn {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Audio database unavailable. Select the original DB file again.';
+      case 'local_audio_file_reselect':
+        return 'Select audio database again';
       default:
         return null;
     }
@@ -188199,7 +188286,7 @@ extension on _StringsAr {
       case 'book_language_description':
         return 'تحدد الخط المستخدم لعرض نص هذا الكتاب. التلقائي يستخدم اللغة المُعلنة في EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'لا يمكن الإشارة إلى الملف الأصلي بدون إذن الوصول لجميع الملفات؛ تم استيراد نسخة بدلاً من ذلك.';
+        return 'الملف المحدد نسخة مؤقتة. يجري استيراد نسخة دائمة بدلاً منها.';
       case 'video_collection_scrape':
         return 'كشط المعلومات والغلاف';
       case 'update_testflight_open':
@@ -190555,6 +190642,10 @@ extension on _StringsAr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'قاعدة بيانات الصوت غير متاحة. حدد ملف DB الأصلي مرة أخرى.';
+      case 'local_audio_file_reselect':
+        return 'تحديد قاعدة بيانات الصوت مرة أخرى';
       default:
         return null;
     }
@@ -197349,7 +197440,7 @@ extension on _StringsDe {
       case 'book_language_description':
         return 'Bestimmt, welche Schriftart den Text dieses Buches rendert. Automatisch verwendet die im EPUB deklarierte Sprache.';
       case 'local_audio_reference_unavailable':
-        return 'Ohne Zugriff auf alle Dateien kann die Originaldatei nicht referenziert werden; stattdessen wurde eine Kopie importiert.';
+        return 'Die ausgewählte Datei ist eine temporäre Kopie. Stattdessen wird eine dauerhafte Kopie importiert.';
       case 'video_collection_scrape':
         return 'Info & Cover scrapen';
       case 'update_testflight_open':
@@ -199714,6 +199805,10 @@ extension on _StringsDe {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Audiodatenbank nicht verfügbar. Wähle die ursprüngliche DB-Datei erneut aus.';
+      case 'local_audio_file_reselect':
+        return 'Audiodatenbank erneut auswählen';
       default:
         return null;
     }
@@ -206502,7 +206597,7 @@ extension on _StringsEs {
       case 'book_language_description':
         return 'Decide qué fuente renderiza el texto de este libro. Automático usa el idioma declarado en el EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'No se puede referenciar el archivo original sin acceso a todos los archivos; se importó una copia en su lugar.';
+        return 'El archivo seleccionado es una copia temporal. Se importará una copia permanente en su lugar.';
       case 'video_collection_scrape':
         return 'Obtener info y portada';
       case 'update_testflight_open':
@@ -208864,6 +208959,10 @@ extension on _StringsEs {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'La base de datos de audio no está disponible. Selecciona de nuevo el archivo DB original.';
+      case 'local_audio_file_reselect':
+        return 'Seleccionar de nuevo la base de datos de audio';
       default:
         return null;
     }
@@ -215660,7 +215759,7 @@ extension on _StringsFr {
       case 'book_language_description':
         return 'Détermine quelle police affiche le texte de ce livre. Automatique utilise la langue déclarée dans l\'EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Impossible de référencer le fichier original sans l\'accès complet aux fichiers ; une copie a été importée à la place.';
+        return 'Le fichier sélectionné est une copie temporaire. Une copie permanente sera importée à la place.';
       case 'video_collection_scrape':
         return 'Récupérer infos et couverture';
       case 'update_testflight_open':
@@ -218023,6 +218122,10 @@ extension on _StringsFr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Base de données audio indisponible. Sélectionnez à nouveau le fichier DB d’origine.';
+      case 'local_audio_file_reselect':
+        return 'Sélectionner à nouveau la base de données audio';
       default:
         return null;
     }
@@ -224796,7 +224899,7 @@ extension on _StringsId {
       case 'book_language_description':
         return 'Menentukan font mana yang merender teks buku ini. Otomatis menggunakan bahasa yang dideklarasikan dalam EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Tidak bisa mereferensikan file asli tanpa akses semua file; salinan diimpor sebagai gantinya.';
+        return 'File yang dipilih adalah salinan sementara. Salinan permanen akan diimpor sebagai gantinya.';
       case 'video_collection_scrape':
         return 'Scrape info & sampul';
       case 'update_testflight_open':
@@ -227153,6 +227256,10 @@ extension on _StringsId {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Basis data audio tidak tersedia. Pilih kembali file DB asli.';
+      case 'local_audio_file_reselect':
+        return 'Pilih kembali basis data audio';
       default:
         return null;
     }
@@ -233944,7 +234051,7 @@ extension on _StringsIt {
       case 'book_language_description':
         return 'Decide quale font renderizza il testo di questo libro. Automatico usa la lingua dichiarata nell\'EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Impossibile riferirsi al file originale senza accesso a tutti i file; una copia è stata importata invece.';
+        return 'Il file selezionato è una copia temporanea. Verrà importata una copia permanente al suo posto.';
       case 'video_collection_scrape':
         return 'Scrape info e copertina';
       case 'update_testflight_open':
@@ -236305,6 +236412,10 @@ extension on _StringsIt {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Database audio non disponibile. Seleziona di nuovo il file DB originale.';
+      case 'local_audio_file_reselect':
+        return 'Seleziona di nuovo il database audio';
       default:
         return null;
     }
@@ -243035,7 +243146,7 @@ extension on _StringsJa {
       case 'book_language_description':
         return 'この本のテキストを表示するフォントを決定します。自動の場合、EPUBで宣言された言語を使用します。';
       case 'local_audio_reference_unavailable':
-        return 'すべてのファイルへのアクセスがないため元のファイルを参照できません。代わりにコピーがインポートされました。';
+        return '選択したファイルは一時コピーです。代わりに永続的なコピーとしてインポートします。';
       case 'video_collection_scrape':
         return '情報と封面を取得';
       case 'update_testflight_open':
@@ -245384,6 +245495,10 @@ extension on _StringsJa {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return '音声データベースを利用できません。元の DB ファイルを選択し直してください。';
+      case 'local_audio_file_reselect':
+        return '音声データベースを選択し直す';
       default:
         return null;
     }
@@ -252116,7 +252231,7 @@ extension on _StringsKo {
       case 'book_language_description':
         return '이 책의 텍스트를 렌더링할 글꼴을 결정합니다. 자동은 EPUB에 선언된 언어를 사용합니다.';
       case 'local_audio_reference_unavailable':
-        return '모든 파일 접근 권한 없이는 원본 파일을 참조할 수 없어 사본이 대신 가져와졌습니다.';
+        return '선택한 파일은 임시 사본입니다. 대신 영구적으로 저장되는 사본을 가져옵니다.';
       case 'video_collection_scrape':
         return '정보 및 표지 스크랩';
       case 'update_testflight_open':
@@ -254467,6 +254582,10 @@ extension on _StringsKo {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return '음성 데이터베이스를 사용할 수 없습니다. 원본 DB 파일을 다시 선택하세요.';
+      case 'local_audio_file_reselect':
+        return '음성 데이터베이스 다시 선택';
       default:
         return null;
     }
@@ -261251,7 +261370,7 @@ extension on _StringsNl {
       case 'book_language_description':
         return 'Bepaalt welk lettertype de tekst van dit boek weergeeft. Automatisch gebruikt de taal die in de EPUB is gedeclareerd.';
       case 'local_audio_reference_unavailable':
-        return 'Kan het originele bestand niet refereren zonder volledige bestandstoegang; er is in plaats daarvan een kopie geïmporteerd.';
+        return 'Het geselecteerde bestand is een tijdelijke kopie. Er wordt in plaats daarvan een permanente kopie geïmporteerd.';
       case 'video_collection_scrape':
         return 'Info & omslag scrapen';
       case 'update_testflight_open':
@@ -263612,6 +263731,10 @@ extension on _StringsNl {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Audiodatabase niet beschikbaar. Selecteer het oorspronkelijke DB-bestand opnieuw.';
+      case 'local_audio_file_reselect':
+        return 'Audiodatabase opnieuw selecteren';
       default:
         return null;
     }
@@ -270392,7 +270515,7 @@ extension on _StringsPtBr {
       case 'book_language_description':
         return 'Define qual fonte renderiza o texto deste livro. Automático usa o idioma declarado no EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Não é possível referenciar o arquivo original sem acesso a todos os arquivos; uma cópia foi importada.';
+        return 'O arquivo selecionado é uma cópia temporária. Uma cópia permanente será importada em seu lugar.';
       case 'video_collection_scrape':
         return 'Buscar info e capa';
       case 'update_testflight_open':
@@ -272752,6 +272875,10 @@ extension on _StringsPtBr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Banco de dados de áudio indisponível. Selecione o arquivo DB original novamente.';
+      case 'local_audio_file_reselect':
+        return 'Selecionar o banco de dados de áudio novamente';
       default:
         return null;
     }
@@ -279539,7 +279666,7 @@ extension on _StringsRu {
       case 'book_language_description':
         return 'Определяет, какой шрифт используется для отображения текста книги. «Автоматически» использует язык, указанный в EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Невозможно сослаться на исходный файл без полного доступа к файлам; вместо этого импортирована копия.';
+        return 'Выбранный файл — временная копия. Вместо неё будет импортирована постоянная копия.';
       case 'video_collection_scrape':
         return 'Получить информацию и обложку';
       case 'update_testflight_open':
@@ -281899,6 +282026,10 @@ extension on _StringsRu {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'База аудиоданных недоступна. Выберите исходный файл DB ещё раз.';
+      case 'local_audio_file_reselect':
+        return 'Выбрать базу аудиоданных заново';
       default:
         return null;
     }
@@ -288662,7 +288793,7 @@ extension on _StringsTh {
       case 'book_language_description':
         return 'กำหนดฟอนต์ที่ใช้แสดงข้อความหนังสือ อัตโนมัติจะใช้ภาษาที่ระบุใน EPUB';
       case 'local_audio_reference_unavailable':
-        return 'ไม่สามารถอ้างอิงไฟล์ต้นฉบับได้หากไม่มีสิทธิ์เข้าถึงไฟล์ทั้งหมด จึงนำเข้าเป็นสำเนาแทน';
+        return 'ไฟล์ที่เลือกเป็นสำเนาชั่วคราว ระบบจะนำเข้าสำเนาที่จัดเก็บถาวรแทน';
       case 'video_collection_scrape':
         return 'สแกนข้อมูลและปก';
       case 'update_testflight_open':
@@ -291018,6 +291149,10 @@ extension on _StringsTh {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'ไม่สามารถใช้ฐานข้อมูลเสียงได้ โปรดเลือกไฟล์ DB ต้นฉบับอีกครั้ง';
+      case 'local_audio_file_reselect':
+        return 'เลือกฐานข้อมูลเสียงอีกครั้ง';
       default:
         return null;
     }
@@ -297795,7 +297930,7 @@ extension on _StringsTr {
       case 'book_language_description':
         return 'Bu kitabın metnini hangi yazı tipinin oluşturacağını belirler. Otomatik, EPUB\'da beyan edilen dili kullanır.';
       case 'local_audio_reference_unavailable':
-        return 'Tüm dosyalara erişim olmadan orijinal dosyaya başvurulamıyor; bunun yerine bir kopya içe aktarıldı.';
+        return 'Seçilen dosya geçici bir kopyadır. Bunun yerine kalıcı bir kopya içe aktarılıyor.';
       case 'video_collection_scrape':
         return 'Bilgi ve kapak tara';
       case 'update_testflight_open':
@@ -300152,6 +300287,10 @@ extension on _StringsTr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Ses veritabanı kullanılamıyor. Orijinal DB dosyasını yeniden seçin.';
+      case 'local_audio_file_reselect':
+        return 'Ses veritabanını yeniden seç';
       default:
         return null;
     }
@@ -306923,7 +307062,7 @@ extension on _StringsVi {
       case 'book_language_description':
         return 'Quyết định phông chữ nào hiển thị văn bản của cuốn sách này. Tự động sử dụng ngôn ngữ được khai báo trong EPUB.';
       case 'local_audio_reference_unavailable':
-        return 'Không thể tham chiếu tệp gốc mà không có quyền truy cập tất cả tệp; đã nhập một bản sao thay thế.';
+        return 'Tệp đã chọn là bản sao tạm thời. Hệ thống sẽ nhập một bản sao được lưu trữ lâu dài thay thế.';
       case 'video_collection_scrape':
         return 'Quét thông tin & bìa';
       case 'update_testflight_open':
@@ -309280,6 +309419,10 @@ extension on _StringsVi {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'local_audio_file_unavailable':
+        return 'Không thể sử dụng cơ sở dữ liệu âm thanh. Vui lòng chọn lại tệp DB gốc.';
+      case 'local_audio_file_reselect':
+        return 'Chọn lại cơ sở dữ liệu âm thanh';
       default:
         return null;
     }
@@ -315991,7 +316134,7 @@ extension on _StringsZhCn {
       case 'book_language_description':
         return '决定这本书的正文用哪种字体渲染。自动 = 用 EPUB 里声明的语言。';
       case 'local_audio_reference_unavailable':
-        return '没有「所有文件访问权限」无法引用原文件，已改为导入副本。';
+        return '所选文件是临时副本，已改为导入持久副本。';
       case 'video_collection_scrape':
         return '刮削资料与封面';
       case 'update_testflight_open':
@@ -318329,6 +318472,10 @@ extension on _StringsZhCn {
         return 'AniList 正在对本应用限流。稍等一会儿再重试。';
       case 'video_anilist_error_unreachable':
         return '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+      case 'local_audio_file_unavailable':
+        return '发音库文件不可用，请重新选择原始 DB 文件。';
+      case 'local_audio_file_reselect':
+        return '重新选择发音库';
       default:
         return null;
     }
@@ -325041,7 +325188,7 @@ extension on _StringsZhHk {
       case 'book_language_description':
         return '決定這本書的正文用哪種字體渲染。自動 = 用 EPUB 裡聲明的語言。';
       case 'local_audio_reference_unavailable':
-        return '沒有「所有檔案訪問權限」無法引用原檔案，已改為導入副本。';
+        return '所選檔案是暫存副本，已改為匯入永久副本。';
       case 'video_collection_scrape':
         return '刮削資料與封面';
       case 'update_testflight_open':
@@ -327386,6 +327533,10 @@ extension on _StringsZhHk {
         return 'AniList 正在對本應用限流。稍等一會兒再重試。';
       case 'video_anilist_error_unreachable':
         return '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+      case 'local_audio_file_unavailable':
+        return '發音庫檔案無法使用，請重新選擇原始 DB 檔案。';
+      case 'local_audio_file_reselect':
+        return '重新選擇發音庫';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automatic",
   "book_language_action": "Content language",
   "book_language_description": "Decides which font renders this book's text. Automatic uses the language declared in the EPUB.",
-  "local_audio_reference_unavailable": "Can't reference the original file without all-files access; a copy was imported instead.",
+  "local_audio_reference_unavailable": "The selected file is a temporary copy. Importing a persistent copy instead.",
   "video_collection_scrape": "Scrape info & cover",
   "update_testflight_open": "Open TestFlight",
   "update_app_store_open": "Open App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Leave blank to use the bundled app API key.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Audio database unavailable. Select the original DB file again.",
+  "local_audio_file_reselect": "Select audio database again"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "تلقائي",
   "book_language_action": "لغة المحتوى",
   "book_language_description": "تحدد الخط المستخدم لعرض نص هذا الكتاب. التلقائي يستخدم اللغة المُعلنة في EPUB.",
-  "local_audio_reference_unavailable": "لا يمكن الإشارة إلى الملف الأصلي بدون إذن الوصول لجميع الملفات؛ تم استيراد نسخة بدلاً من ذلك.",
+  "local_audio_reference_unavailable": "الملف المحدد نسخة مؤقتة. يجري استيراد نسخة دائمة بدلاً منها.",
   "video_collection_scrape": "كشط المعلومات والغلاف",
   "update_testflight_open": "فتح TestFlight",
   "update_app_store_open": "فتح App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "اتركه فارغًا لاستخدام مفتاح API المضمّن في التطبيق.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "قاعدة بيانات الصوت غير متاحة. حدد ملف DB الأصلي مرة أخرى.",
+  "local_audio_file_reselect": "تحديد قاعدة بيانات الصوت مرة أخرى"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automatisch",
   "book_language_action": "Inhaltssprache",
   "book_language_description": "Bestimmt, welche Schriftart den Text dieses Buches rendert. Automatisch verwendet die im EPUB deklarierte Sprache.",
-  "local_audio_reference_unavailable": "Ohne Zugriff auf alle Dateien kann die Originaldatei nicht referenziert werden; stattdessen wurde eine Kopie importiert.",
+  "local_audio_reference_unavailable": "Die ausgewählte Datei ist eine temporäre Kopie. Stattdessen wird eine dauerhafte Kopie importiert.",
   "video_collection_scrape": "Info & Cover scrapen",
   "update_testflight_open": "TestFlight öffnen",
   "update_app_store_open": "App Store öffnen",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Leer lassen, um den enthaltenen API-Schlüssel der App zu verwenden.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Audiodatenbank nicht verfügbar. Wähle die ursprüngliche DB-Datei erneut aus.",
+  "local_audio_file_reselect": "Audiodatenbank erneut auswählen"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automático",
   "book_language_action": "Idioma del contenido",
   "book_language_description": "Decide qué fuente renderiza el texto de este libro. Automático usa el idioma declarado en el EPUB.",
-  "local_audio_reference_unavailable": "No se puede referenciar el archivo original sin acceso a todos los archivos; se importó una copia en su lugar.",
+  "local_audio_reference_unavailable": "El archivo seleccionado es una copia temporal. Se importará una copia permanente en su lugar.",
   "video_collection_scrape": "Obtener info y portada",
   "update_testflight_open": "Abrir TestFlight",
   "update_app_store_open": "Abrir App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Déjalo vacío para usar la clave API incluida en la aplicación.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "La base de datos de audio no está disponible. Selecciona de nuevo el archivo DB original.",
+  "local_audio_file_reselect": "Seleccionar de nuevo la base de datos de audio"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automatique",
   "book_language_action": "Langue du contenu",
   "book_language_description": "Détermine quelle police affiche le texte de ce livre. Automatique utilise la langue déclarée dans l'EPUB.",
-  "local_audio_reference_unavailable": "Impossible de référencer le fichier original sans l'accès complet aux fichiers ; une copie a été importée à la place.",
+  "local_audio_reference_unavailable": "Le fichier sélectionné est une copie temporaire. Une copie permanente sera importée à la place.",
   "video_collection_scrape": "Récupérer infos et couverture",
   "update_testflight_open": "Ouvrir TestFlight",
   "update_app_store_open": "Ouvrir l'App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Laissez vide pour utiliser la clé API incluse dans l’application.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Base de données audio indisponible. Sélectionnez à nouveau le fichier DB d’origine.",
+  "local_audio_file_reselect": "Sélectionner à nouveau la base de données audio"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Otomatis",
   "book_language_action": "Bahasa konten",
   "book_language_description": "Menentukan font mana yang merender teks buku ini. Otomatis menggunakan bahasa yang dideklarasikan dalam EPUB.",
-  "local_audio_reference_unavailable": "Tidak bisa mereferensikan file asli tanpa akses semua file; salinan diimpor sebagai gantinya.",
+  "local_audio_reference_unavailable": "File yang dipilih adalah salinan sementara. Salinan permanen akan diimpor sebagai gantinya.",
   "video_collection_scrape": "Scrape info & sampul",
   "update_testflight_open": "Buka TestFlight",
   "update_app_store_open": "Buka App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Biarkan kosong untuk menggunakan kunci API bawaan aplikasi.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Basis data audio tidak tersedia. Pilih kembali file DB asli.",
+  "local_audio_file_reselect": "Pilih kembali basis data audio"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automatico",
   "book_language_action": "Lingua del contenuto",
   "book_language_description": "Decide quale font renderizza il testo di questo libro. Automatico usa la lingua dichiarata nell'EPUB.",
-  "local_audio_reference_unavailable": "Impossibile riferirsi al file originale senza accesso a tutti i file; una copia è stata importata invece.",
+  "local_audio_reference_unavailable": "Il file selezionato è una copia temporanea. Verrà importata una copia permanente al suo posto.",
   "video_collection_scrape": "Scrape info e copertina",
   "update_testflight_open": "Apri TestFlight",
   "update_app_store_open": "Apri App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Lascia vuoto per usare la chiave API inclusa nell’app.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Database audio non disponibile. Seleziona di nuovo il file DB originale.",
+  "local_audio_file_reselect": "Seleziona di nuovo il database audio"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "自動",
   "book_language_action": "コンテンツ言語",
   "book_language_description": "この本のテキストを表示するフォントを決定します。自動の場合、EPUBで宣言された言語を使用します。",
-  "local_audio_reference_unavailable": "すべてのファイルへのアクセスがないため元のファイルを参照できません。代わりにコピーがインポートされました。",
+  "local_audio_reference_unavailable": "選択したファイルは一時コピーです。代わりに永続的なコピーとしてインポートします。",
   "video_collection_scrape": "情報と封面を取得",
   "update_testflight_open": "TestFlightを開く",
   "update_app_store_open": "App Storeを開く",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "空欄の場合、アプリ内蔵の API キーを使用します。",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "音声データベースを利用できません。元の DB ファイルを選択し直してください。",
+  "local_audio_file_reselect": "音声データベースを選択し直す"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "자동",
   "book_language_action": "콘텐츠 언어",
   "book_language_description": "이 책의 텍스트를 렌더링할 글꼴을 결정합니다. 자동은 EPUB에 선언된 언어를 사용합니다.",
-  "local_audio_reference_unavailable": "모든 파일 접근 권한 없이는 원본 파일을 참조할 수 없어 사본이 대신 가져와졌습니다.",
+  "local_audio_reference_unavailable": "선택한 파일은 임시 사본입니다. 대신 영구적으로 저장되는 사본을 가져옵니다.",
   "video_collection_scrape": "정보 및 표지 스크랩",
   "update_testflight_open": "TestFlight 열기",
   "update_app_store_open": "App Store 열기",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "비워 두면 앱에 내장된 API 키를 사용합니다.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "음성 데이터베이스를 사용할 수 없습니다. 원본 DB 파일을 다시 선택하세요.",
+  "local_audio_file_reselect": "음성 데이터베이스 다시 선택"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automatisch",
   "book_language_action": "Inhoudstaal",
   "book_language_description": "Bepaalt welk lettertype de tekst van dit boek weergeeft. Automatisch gebruikt de taal die in de EPUB is gedeclareerd.",
-  "local_audio_reference_unavailable": "Kan het originele bestand niet refereren zonder volledige bestandstoegang; er is in plaats daarvan een kopie geïmporteerd.",
+  "local_audio_reference_unavailable": "Het geselecteerde bestand is een tijdelijke kopie. Er wordt in plaats daarvan een permanente kopie geïmporteerd.",
   "video_collection_scrape": "Info & omslag scrapen",
   "update_testflight_open": "TestFlight openen",
   "update_app_store_open": "App Store openen",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Laat leeg om de meegeleverde API-sleutel van de app te gebruiken.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Audiodatabase niet beschikbaar. Selecteer het oorspronkelijke DB-bestand opnieuw.",
+  "local_audio_file_reselect": "Audiodatabase opnieuw selecteren"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Automático",
   "book_language_action": "Idioma do conteúdo",
   "book_language_description": "Define qual fonte renderiza o texto deste livro. Automático usa o idioma declarado no EPUB.",
-  "local_audio_reference_unavailable": "Não é possível referenciar o arquivo original sem acesso a todos os arquivos; uma cópia foi importada.",
+  "local_audio_reference_unavailable": "O arquivo selecionado é uma cópia temporária. Uma cópia permanente será importada em seu lugar.",
   "video_collection_scrape": "Buscar info e capa",
   "update_testflight_open": "Abrir TestFlight",
   "update_app_store_open": "Abrir App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Deixe vazio para usar a chave API incluída no aplicativo.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Banco de dados de áudio indisponível. Selecione o arquivo DB original novamente.",
+  "local_audio_file_reselect": "Selecionar o banco de dados de áudio novamente"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Автоматически",
   "book_language_action": "Язык содержимого",
   "book_language_description": "Определяет, какой шрифт используется для отображения текста книги. «Автоматически» использует язык, указанный в EPUB.",
-  "local_audio_reference_unavailable": "Невозможно сослаться на исходный файл без полного доступа к файлам; вместо этого импортирована копия.",
+  "local_audio_reference_unavailable": "Выбранный файл — временная копия. Вместо неё будет импортирована постоянная копия.",
   "video_collection_scrape": "Получить информацию и обложку",
   "update_testflight_open": "Открыть TestFlight",
   "update_app_store_open": "Открыть App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Оставьте пустым, чтобы использовать встроенный ключ API приложения.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "База аудиоданных недоступна. Выберите исходный файл DB ещё раз.",
+  "local_audio_file_reselect": "Выбрать базу аудиоданных заново"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "อัตโนมัติ",
   "book_language_action": "ภาษาเนื้อหา",
   "book_language_description": "กำหนดฟอนต์ที่ใช้แสดงข้อความหนังสือ อัตโนมัติจะใช้ภาษาที่ระบุใน EPUB",
-  "local_audio_reference_unavailable": "ไม่สามารถอ้างอิงไฟล์ต้นฉบับได้หากไม่มีสิทธิ์เข้าถึงไฟล์ทั้งหมด จึงนำเข้าเป็นสำเนาแทน",
+  "local_audio_reference_unavailable": "ไฟล์ที่เลือกเป็นสำเนาชั่วคราว ระบบจะนำเข้าสำเนาที่จัดเก็บถาวรแทน",
   "video_collection_scrape": "สแกนข้อมูลและปก",
   "update_testflight_open": "เปิด TestFlight",
   "update_app_store_open": "เปิด App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "เว้นว่างไว้เพื่อใช้คีย์ API ที่มีอยู่ในแอป",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "ไม่สามารถใช้ฐานข้อมูลเสียงได้ โปรดเลือกไฟล์ DB ต้นฉบับอีกครั้ง",
+  "local_audio_file_reselect": "เลือกฐานข้อมูลเสียงอีกครั้ง"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Otomatik",
   "book_language_action": "İçerik dili",
   "book_language_description": "Bu kitabın metnini hangi yazı tipinin oluşturacağını belirler. Otomatik, EPUB'da beyan edilen dili kullanır.",
-  "local_audio_reference_unavailable": "Tüm dosyalara erişim olmadan orijinal dosyaya başvurulamıyor; bunun yerine bir kopya içe aktarıldı.",
+  "local_audio_reference_unavailable": "Seçilen dosya geçici bir kopyadır. Bunun yerine kalıcı bir kopya içe aktarılıyor.",
   "video_collection_scrape": "Bilgi ve kapak tara",
   "update_testflight_open": "TestFlight'ı aç",
   "update_app_store_open": "App Store'u aç",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Uygulamayla gelen API anahtarını kullanmak için boş bırakın.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Ses veritabanı kullanılamıyor. Orijinal DB dosyasını yeniden seçin.",
+  "local_audio_file_reselect": "Ses veritabanını yeniden seç"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "Tự động",
   "book_language_action": "Ngôn ngữ nội dung",
   "book_language_description": "Quyết định phông chữ nào hiển thị văn bản của cuốn sách này. Tự động sử dụng ngôn ngữ được khai báo trong EPUB.",
-  "local_audio_reference_unavailable": "Không thể tham chiếu tệp gốc mà không có quyền truy cập tất cả tệp; đã nhập một bản sao thay thế.",
+  "local_audio_reference_unavailable": "Tệp đã chọn là bản sao tạm thời. Hệ thống sẽ nhập một bản sao được lưu trữ lâu dài thay thế.",
   "video_collection_scrape": "Quét thông tin & bìa",
   "update_testflight_open": "Mở TestFlight",
   "update_app_store_open": "Mở App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "Để trống để dùng khóa API tích hợp trong ứng dụng.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "local_audio_file_unavailable": "Không thể sử dụng cơ sở dữ liệu âm thanh. Vui lòng chọn lại tệp DB gốc.",
+  "local_audio_file_reselect": "Chọn lại cơ sở dữ liệu âm thanh"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "自动",
   "book_language_action": "内容语言",
   "book_language_description": "决定这本书的正文用哪种字体渲染。自动 = 用 EPUB 里声明的语言。",
-  "local_audio_reference_unavailable": "没有「所有文件访问权限」无法引用原文件，已改为导入副本。",
+  "local_audio_reference_unavailable": "所选文件是临时副本，已改为导入持久副本。",
   "video_collection_scrape": "刮削资料与封面",
   "update_testflight_open": "打开 TestFlight",
   "update_app_store_open": "打开 App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "留空使用应用内置 API 密钥。",
   "video_anilist_error_api_disabled": "AniList 官方因服务器稳定性问题暂时停用了公开 API。这不是你的网络或代理的问题——请求已经打到 AniList 并被它当面拒绝了。请稍后再试。",
   "video_anilist_error_rate_limited": "AniList 正在对本应用限流。稍等一会儿再重试。",
-  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。"
+  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。",
+  "local_audio_file_unavailable": "发音库文件不可用，请重新选择原始 DB 文件。",
+  "local_audio_file_reselect": "重新选择发音库"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3287,7 +3287,7 @@
   "dict_language_auto": "自動",
   "book_language_action": "內容語言",
   "book_language_description": "決定這本書的正文用哪種字體渲染。自動 = 用 EPUB 裡聲明的語言。",
-  "local_audio_reference_unavailable": "沒有「所有檔案訪問權限」無法引用原檔案，已改為導入副本。",
+  "local_audio_reference_unavailable": "所選檔案是暫存副本，已改為匯入永久副本。",
   "video_collection_scrape": "刮削資料與封面",
   "update_testflight_open": "打開 TestFlight",
   "update_app_store_open": "打開 App Store",
@@ -4436,5 +4436,7 @@
   "video_opensubtitles_app_key_hint": "留空以使用應用程式內置的 API 金鑰。",
   "video_anilist_error_api_disabled": "AniList 官方因伺服器穩定性問題暫時停用了公開 API。這不是你的網絡或代理的問題——請求已經打到 AniList 並被它當面拒絕了。請稍後再試。",
   "video_anilist_error_rate_limited": "AniList 正在對本應用限流。稍等一會兒再重試。",
-  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。"
+  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。",
+  "local_audio_file_unavailable": "發音庫檔案無法使用，請重新選擇原始 DB 檔案。",
+  "local_audio_file_reselect": "重新選擇發音庫"
 }

--- a/fushi/lib/src/media/import/real_path_directory_picker.dart
+++ b/fushi/lib/src/media/import/real_path_directory_picker.dart
@@ -78,7 +78,9 @@ Future<String?> pickRealDirectoryPath({
 /// 授予 `MANAGE_EXTERNAL_STORAGE`（全文件访问）后，`dart:io` 可全盘读真实路径，
 /// 于是安卓改为：先确保权限 → 调**系统原生 SAF** 文件选择器
 /// （`ACTION_OPEN_DOCUMENT`，原生 handler 见 MainActivity 的 `pickRealFile`）→
-/// 原生把 document URI 解析回真实绝对路径 → 返回真实绝对路径，不产生任何副本。
+/// 原生把 document URI 解析回真实绝对路径；无法解析的 provider 则复制到缓存。
+/// 需要长期持有文件的调用方必须用 [pickRealFilePathDetailed] 检查出处，缓存要复制
+/// 进应用持久存储；本入口只丢弃出处，不承诺返回路径可长期引用。
 ///
 /// **降级逃生口**：安卓未授予全文件访问时，回退到 `FilePicker.pickFiles()`（仍复制到
 /// cache，但功能可用）——不硬性要求授权。**桌面 / iOS 维持 `pickFiles()`**（它们本就
@@ -135,10 +137,10 @@ class PickedFilePath {
   final String path;
 
   /// true = 用户原始位置的真实路径，可被长期引用（桌面 / iOS 的 `pickFiles()`、
-  /// 安卓授予全文件访问后的 SAF 解析）。
+  /// 安卓 SAF 成功解析到原始位置）。全文件访问权限不保证 provider 能解析真实路径。
   ///
-  /// false = file_picker 在安卓复制出来的 **app cache 临时副本**
-  /// （`FileUtils.openFileStream` 把整份文件同步拷进 `getCacheDir()/file_picker/`）。
+  /// false = 安卓 SAF 或 file_picker 复制出来的 **app cache 临时副本**
+  /// （SAF 用 `getCacheDir()/saf_pick/`，file_picker 用 `getCacheDir()/file_picker/`）。
   /// 清缓存即失效，**只能立刻复制消费，不能作为长期引用落库**。
   final bool isRealPath;
 }
@@ -175,21 +177,19 @@ Future<PickedFilePath?> pickRealFilePathDetailed({
     );
   }
 
-  // 原生 SAF 文件选择器 → 原生解析真实绝对路径（不复制到 cache）。
-  final String? realPath = await _pickRealPathViaSaf('pickRealFile');
-  if (realPath == null) return null; // 取消 / 云盘虚拟 provider（同旧浏览器不可达）
+  // 原生同时返回路径与出处；权限只控制能否尝试解析，不能证明没有发生缓存复制。
+  final PickedFilePath? picked = await _pickFileViaSaf();
+  if (picked == null) return null;
   if (allowedExtensions == null || allowedExtensions.isEmpty) {
-    return PickedFilePath(path: realPath, isRealPath: true);
+    return picked;
   }
   // 带扩展名过滤：原生 SAF 不做扩展名限制，在 Dart 端按集合校验并提示。
   final List<String> accepted = _filterPickedFilesByExtension(
     context: context.mounted ? context : null,
-    paths: <String>[realPath],
+    paths: <String>[picked.path],
     allowedExtensions: _normalizeExtensions(allowedExtensions),
   );
-  return accepted.isEmpty
-      ? null
-      : PickedFilePath(path: accepted.first, isRealPath: true);
+  return accepted.isEmpty ? null : picked;
 }
 
 /// [pickRealFilePathDetailed] 的 file_picker 回退分支（桌面 / iOS，以及安卓未授予
@@ -217,8 +217,7 @@ Future<PickedFilePath?> _detailedFallback({
 }
 
 /// 调原生 SAF 选择器并返回真实绝对路径；null = 用户取消，或云盘/虚拟 provider
-/// 无法映射真实路径。[method] 为 `'pickRealDirectory'`（目录）或 `'pickRealFile'`
-/// （文件），对应 MainActivity 的 SAF channel handler。
+/// 无法映射真实路径。仅用于目录；文件走带出处的 [_pickFileViaSaf]。
 Future<String?> _pickRealPathViaSaf(String method) async {
   try {
     return await FushiChannels.saf.invokeMethod<String>(method);
@@ -227,6 +226,30 @@ Future<String?> _pickRealPathViaSaf(String method) async {
   } on MissingPluginException {
     return null;
   }
+}
+
+/// BUG-2265：文件 channel 必须显式交回出处。未知/缺失出处不能默认为可引用，
+/// 也不能按路径里是否出现 cache 猜测；契约损坏按「选了但无可用路径」报告失败。
+Future<PickedFilePath?> _pickFileViaSaf() async {
+  final Object? result;
+  try {
+    result = await FushiChannels.saf.invokeMethod<Object?>('pickRealFile');
+  } on PlatformException {
+    return null;
+  } on MissingPluginException {
+    return null;
+  }
+  if (result == null) return null;
+  if (result is! Map<Object?, Object?> ||
+      result['path'] is! String ||
+      (result['path'] as String).trim().isEmpty ||
+      result['isRealPath'] is! bool) {
+    throw const PickedFileWithoutPathException(count: 1);
+  }
+  return PickedFilePath(
+    path: result['path'] as String,
+    isRealPath: result['isRealPath'] as bool,
+  );
 }
 
 /// 「选一个文件、走系统文件选择器（安卓 SAF / iOS Files / 桌面原生），返回其路径」。
@@ -413,8 +436,9 @@ Future<_RawPickResult> _fallbackPickRaw({
   required bool allowMultiple,
   Set<String>? allowedExtensions,
 }) async {
-  final Set<String> normalizedExtensions =
-      _normalizeExtensions(allowedExtensions);
+  final Set<String> normalizedExtensions = _normalizeExtensions(
+    allowedExtensions,
+  );
   // 移动端一律「先 `FileType.any` 打开选择器、再在 Dart 端按扩展名校验」。两个平台
   // 的原生过滤各有一条**静默丢弃扩展名**的路径，把过滤交给它们的结果不是「少过滤
   // 一点」，而是用户**选不中自己的文件**：

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2694,7 +2694,7 @@ class AppModel with ChangeNotifier {
         JapaneseLanguage.instance.initialise(),
         injectAssetLicenses(),
         _seedBuiltInTags(),
-        _localAudioManager.bindForNativeHandler(clearMissingPath: true),
+        _prepareLocalAudioForPlayback(),
       ]);
 
       debugPrint(
@@ -2929,7 +2929,7 @@ class AppModel with ChangeNotifier {
       // mutated a preference / switched profile since the last lookup; a cheap
       // single-row DB version read gates it.
       await refreshPrefCacheIfChanged();
-      await _localAudioManager.bindForNativeHandler();
+      await _prepareLocalAudioForPlayback();
       return;
     }
     try {
@@ -3006,7 +3006,7 @@ class AppModel with ChangeNotifier {
         exportDirectory: _exportDirectory,
         alternateExportDirectory: _alternateExportDirectory,
       );
-      await _localAudioManager.bindForNativeHandler();
+      await _prepareLocalAudioForPlayback();
 
       populateLanguages();
       populateLocales();
@@ -7314,7 +7314,7 @@ class AppModel with ChangeNotifier {
   /// 持久化交给后续 [setAudioSourceConfigs]。
   ///
   /// [reference]=true（仅桌面）时跳过复制、直接引用用户原路径（BUG-483），不在
-  /// AppData 留副本；移动端缓存临时副本不可引用，故 UI 只在桌面暴露此开关，默认 false。
+  /// AppData 留副本；临时副本不可引用，调用方按选择结果的实际出处决定。
   Future<LocalAudioDbEntry> importLocalAudioDbFile(
     String sourcePath, {
     required String displayName,
@@ -7325,6 +7325,23 @@ class AppModel with ChangeNotifier {
 
   Future<void> setLocalAudioDbs(List<LocalAudioDbEntry> dbs) =>
       _localAudioManager.setEntries(dbs);
+
+  /// 修复旧版本保存的临时缓存引用后再绑定，主入口与弹窗入口共用。
+  Future<void> _prepareLocalAudioForPlayback() async {
+    try {
+      await _localAudioManager.migrateTemporaryReferences(temporaryDirectory);
+    } catch (error, stack) {
+      // 迁移事务失败已恢复旧配置；发音库故障不能阻止用户打开书籍和诊断页。
+      ErrorLogService.instance.log('AppModel.migrateLocalAudio', error, stack);
+    }
+    await _localAudioManager.bindForNativeHandler();
+  }
+
+  Future<bool> isLocalAudioDbAvailable(String storedPath) async {
+    final String resolved = LocalAudioManager.resolveInternalPath(
+        storedPath, databaseDirectory.path);
+    return File(resolved).exists();
+  }
 
   /// 枚举一个本地音频库内的全部子来源名（用于「编辑来源」对话框）。
   Future<List<String>> listLocalAudioSources(String path) =>

--- a/fushi/lib/src/models/local_audio_manager.dart
+++ b/fushi/lib/src/models/local_audio_manager.dart
@@ -211,6 +211,13 @@ class LocalAudioManager {
   /// native 绑定前等待完成；不能用路径中的 `cache` 字样猜测用户文件归属。
   /// 缺失或不可复制的文件保留原配置供重新选择；不会删除源文件或推送 native。
   Future<void> migrateTemporaryReferences(Directory temporaryDirectory) async {
+    final String temporaryRoot = path.canonicalize(temporaryDirectory.path);
+    if (!entries.any((LocalAudioDbEntry entry) =>
+        entry.path.isNotEmpty &&
+        path.isWithin(temporaryRoot, path.canonicalize(entry.path)))) {
+      // 正常配置的 warm popup 不应为了已完成的迁移重新读整张偏好表。
+      return;
+    }
     await _withMigrationLock(() async {
       await _prefsRepo.loadFromDb();
       await _migrateTemporaryReferencesLocked(temporaryDirectory);

--- a/fushi/lib/src/models/local_audio_manager.dart
+++ b/fushi/lib/src/models/local_audio_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -7,6 +8,7 @@ import 'package:path/path.dart' as path;
 import 'package:fushi/src/models/local_audio_source_pref.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/utils/misc/local_audio_db.dart';
+import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi/src/utils/misc/tts_channel.dart';
 
 /// 选中的文件不是一个可用的本地音频源库（不是 Yomitan「本地音频服务器」SQLite，
@@ -52,12 +54,13 @@ class LocalAudioDbEntry {
   final List<LocalAudioSourcePref> sources;
 
   LocalAudioDbEntry copyWith({
+    String? path,
     String? displayName,
     bool? enabled,
     List<LocalAudioSourcePref>? sources,
   }) =>
       LocalAudioDbEntry(
-        path: path,
+        path: path ?? this.path,
         displayName: displayName ?? this.displayName,
         enabled: enabled ?? this.enabled,
         sources: sources ?? this.sources,
@@ -89,8 +92,46 @@ class LocalAudioManager {
   /// 让每次导入的内部文件名唯一（仍是单段数字，匹配 [pruneOrphans] 的命名正则）。
   static int _lastImportStamp = 0;
 
+  // 文件锁覆盖主进程/:popup；进程内文件锁不一定互斥独立句柄，另按目录串行。
+  static final Map<String, Future<void>> _migrationQueues =
+      <String, Future<void>>{};
+
+  Future<void> _withMigrationLock(Future<void> Function() action) async {
+    final String directory = path.canonicalize(_databaseDirectory.absolute.path);
+    final String key = Platform.isWindows ? directory.toLowerCase() : directory;
+    final Future<void> previous = _migrationQueues[key] ?? Future<void>.value();
+    final Completer<void> released = Completer<void>();
+    _migrationQueues[key] = released.future;
+    await previous;
+    try {
+      if (!await _databaseDirectory.exists()) return;
+      final RandomAccessFile lock = await File(
+        path.join(directory, 'local_audio_migration.lock'),
+      ).open(mode: FileMode.append);
+      bool acquired = false;
+      try {
+        await lock.lock(FileLock.blockingExclusive);
+        acquired = true;
+        await action();
+      } finally {
+        try {
+          if (acquired) await lock.unlock();
+        } finally {
+          await lock.close();
+        }
+      }
+      // 锁文件永久保留：删掉会使等待者与新进程锁住不同 inode。
+    } finally {
+      released.complete();
+      if (identical(_migrationQueues[key], released.future)) {
+        _migrationQueues.remove(key);
+      }
+    }
+  }
+
   /// 内部副本命名（[importFile] 生成、[pruneOrphans] 回收的形状）：
-  /// `local_audio_<毫秒时间戳>.db`。是判定「可跨机按文件名归一」的唯一真值。
+  /// `local_audio_<数字标识>.db`（兼容旧时间戳；新文件附加进程 ID）。
+  /// 是判定「可跨机按文件名归一」的唯一真值。
   static final RegExp _internalCopyNamePattern =
       RegExp(r'^local_audio_\d+\.db$');
 
@@ -166,6 +207,100 @@ class LocalAudioManager {
         .setLocalAudioDbs(dbs.where((e) => e.enabled).map(_configFor).toList());
   }
 
+  /// 把旧版本误存的临时引用收进持久库。调用方传本机实际临时目录，并在
+  /// native 绑定前等待完成；不能用路径中的 `cache` 字样猜测用户文件归属。
+  /// 缺失或不可复制的文件保留原配置供重新选择；不会删除源文件或推送 native。
+  Future<void> migrateTemporaryReferences(Directory temporaryDirectory) async {
+    await _withMigrationLock(() async {
+      await _prefsRepo.loadFromDb();
+      await _migrateTemporaryReferencesLocked(temporaryDirectory);
+    });
+  }
+
+  Future<void> _migrateTemporaryReferencesLocked(
+      Directory temporaryDirectory) async {
+    final Map<String, String> snapshot = _prefsRepo.prefsSnapshot;
+    final Map<String, String?> expectedRaw = <String, String?>{
+      for (final String key in <String>[
+        'local_audio_dbs',
+        'local_audio_db_path',
+        'local_audio_db_display_name',
+        'audio_source_configs',
+      ])
+        key: snapshot[key],
+    };
+    final dynamic storedSources = _prefsRepo.getPref(
+      'audio_source_configs',
+      defaultValue: null,
+    );
+    final String temporaryRoot = path.canonicalize(temporaryDirectory.path);
+    final List<LocalAudioDbEntry> current = entries;
+    final Map<String, String> replacements = <String, String>{};
+    for (final LocalAudioDbEntry entry in current) {
+      if (entry.path.isEmpty ||
+          !path.isWithin(temporaryRoot, path.canonicalize(entry.path)) ||
+          replacements.containsKey(entry.path)) {
+        continue;
+      }
+      try {
+        final LocalAudioDbEntry copied = await importFile(
+          entry.path,
+          displayName: entry.displayName,
+        );
+        replacements[entry.path] = copied.path;
+      } catch (error, stack) {
+        ErrorLogService.instance.log(
+          'LocalAudioManager.migrateTemporaryReferences',
+          error,
+          stack,
+        );
+      }
+    }
+    if (replacements.isEmpty) return;
+
+    final Map<String, dynamic> updates = <String, dynamic>{
+      'local_audio_dbs': jsonEncode(
+        current
+            .map(
+              (LocalAudioDbEntry entry) =>
+                  entry.copyWith(path: replacements[entry.path]).toJson(),
+            )
+            .toList(),
+      ),
+      'local_audio_db_path': '',
+      'local_audio_db_display_name': '',
+    };
+    // 修改存储列表本身，避免 getter 补默认来源、过滤未知字段或改变顺序。
+    if (storedSources is List) {
+      updates['audio_source_configs'] = storedSources.map((dynamic source) {
+        if (source is! Map || source['kind'] != 'localAudio') return source;
+        final String? replacement = replacements[source['path']];
+        if (replacement == null) return source;
+        return <String, dynamic>{
+          ...Map<String, dynamic>.from(source),
+          'path': replacement,
+        };
+      }).toList();
+    }
+    try {
+      // 两份路径必须同一事务提交，避免进程退出时一份仍引用缓存。
+      await _prefsRepo.compareAndSetPrefs(
+        expectedRaw: expectedRaw,
+        updates: updates,
+      );
+    } catch (error, stack) {
+      ErrorLogService.instance.log(
+        'LocalAudioManager.migrateTemporaryReferences.persist',
+        error,
+        stack,
+      );
+      // 回读回滚后的 DB，避免本进程继续绑定复制期间已过期的配置。
+      // 已复制的文件留给既有 pruneOrphans 回收，原文件始终保留。
+      await _prefsRepo.loadFromDb();
+      rethrow;
+    }
+  }
+
   /// 只改某个库的子来源偏好（优先级序 + 逐源启用），立即持久化并重推 native。
   Future<void> setSourcesFor(
       String path, List<LocalAudioSourcePref> prefs) async {
@@ -235,7 +370,9 @@ class LocalAudioManager {
     int stamp = DateTime.now().millisecondsSinceEpoch;
     if (stamp <= _lastImportStamp) stamp = _lastImportStamp + 1;
     _lastImportStamp = stamp;
-    final String internalName = 'local_audio_$stamp.db';
+    // Android 主进程与 :popup 可同毫秒复制；数字段附加 pid 隔离两者，
+    // 仍满足既有内部副本识别/孤儿清理的 local_audio_\d+.db 契约。
+    final String internalName = 'local_audio_$stamp$pid.db';
     final String internalPath =
         path.join(_databaseDirectory.path, internalName);
     try {
@@ -261,6 +398,18 @@ class LocalAudioManager {
   /// （只动 `local_audio_*.db` 及其 -wal/-shm 旁文件，绝不碰其它文件，如主库 hibiki.db）。
   /// 用于回收"拷贝了但从未持久化"的孤儿文件。
   Future<void> pruneOrphans(Iterable<String> keepPaths) async {
+    final List<String> requestedKeep = List<String>.of(keepPaths);
+    await _withMigrationLock(() async {
+      // 等待迁移提交后重新读取；调用者传进来的 keep 列表可能还指向旧缓存。
+      await _prefsRepo.loadFromDb();
+      await _pruneOrphansLocked(<String>[
+        ...requestedKeep,
+        ...entries.map((LocalAudioDbEntry entry) => entry.path),
+      ]);
+    });
+  }
+
+  Future<void> _pruneOrphansLocked(Iterable<String> keepPaths) async {
     // 规范化引用路径，避免 Windows 反斜杠 / 正斜杠 + 大小写差异导致误删被引用文件。
     // 归一后再规范化：跨机导入后 keepPaths 里内部副本仍带**源机**绝对前缀，
     // 若不归一，本机已落地的同名副本会被判为孤儿误删（TODO-1171 数据丢失）。
@@ -324,26 +473,25 @@ class LocalAudioManager {
     await setEntries(dbs);
   }
 
-  Future<void> bindForNativeHandler({bool clearMissingPath = false}) async {
+  Future<void> bindForNativeHandler() async {
     final dbs = entries;
-    if (dbs.isEmpty) return;
 
-    final validConfigs = <LocalAudioDbConfig>[];
+    final configs = <LocalAudioDbConfig>[];
     for (final entry in dbs) {
       if (!entry.enabled) continue;
       // 存在性判定认归一后的本机路径（内部副本按文件名重挂），而非可能来自别机
       // 的存储 path——否则跨机导入的同名库虽已落地却被判缺失静默跳过（TODO-1171）。
       final String resolved =
           resolveInternalPath(entry.path, _databaseDirectory.path);
-      if (await File(resolved).exists()) {
-        validConfigs.add(_configFor(entry));
-      } else {
-        debugPrint('[fushi-audio] DB missing, skipping: $resolved'
+      if (!await File(resolved).exists()) {
+        debugPrint('[fushi-audio] DB missing, retaining source slot: $resolved'
             '${resolved == entry.path ? '' : ' (stored: ${entry.path})'}');
       }
+      // BUG-2265: resolver 的 dbIndex 按启用来源计数，缺失项也必须占位；
+      // 否则前一个缓存库失效会把后面的正常库错配到其它来源。
+      configs.add(_configFor(entry));
     }
-    if (validConfigs.isNotEmpty) {
-      await TtsChannel.instance.setLocalAudioDbs(validConfigs);
-    }
+    // warm popup 也会重绑定。全关闭/全删除时必须清空旧句柄，不能保留上次状态。
+    await TtsChannel.instance.setLocalAudioDbs(configs);
   }
 }

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -182,6 +182,30 @@ class PreferencesRepository extends ChangeNotifier {
     await _db.setPrefs(encoded);
   }
 
+  /// 只在持久化原值仍匹配快照时提交更新。耗时迁移在事务外准备文件，
+  /// 此处仅短事务比较/写入，避免覆盖其它进程或用户期间的新配置。
+  /// [expectedRaw] 使用 [prefsSnapshot] 的原始编码值；null 表示 key 不存在。
+  Future<bool> compareAndSetPrefs({
+    required Map<String, String?> expectedRaw,
+    required Map<String, dynamic> updates,
+  }) async {
+    final Map<String, String> encoded = <String, String>{
+      for (final MapEntry<String, dynamic> entry in updates.entries)
+        entry.key: PrefCodec.encode(entry.value),
+    };
+    final bool applied = await _db.transaction(() async {
+      final Map<String, String> persisted = await _db.getAllPrefs();
+      for (final MapEntry<String, String?> entry in expectedRaw.entries) {
+        if (persisted[entry.key] != entry.value) return false;
+      }
+      await _db.setPrefs(encoded);
+      return true;
+    });
+    // 冲突时也刷新本进程，后续绑定必须使用赢家配置；提交前不改缓存。
+    await loadFromDb();
+    return applied;
+  }
+
   /// The prefs-version value currently held in this process's in-memory cache,
   /// as last populated by [loadFromDb]/[refreshFromDb] (0 when never loaded).
   /// Cheap synchronous read; NOT a cross-process check and NOT advanced by this

--- a/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -18,11 +20,13 @@ class AudioSourcesDialog extends StatefulWidget {
     required this.onSave,
     this.onPickLocalDb,
     this.onEditLocalSources,
+    this.isLocalDbAvailable,
+    this.onReplaceLocalDb,
     super.key,
   });
 
   final List<AudioSourceConfig> sources;
-  final void Function(List<AudioSourceConfig>) onSave;
+  final FutureOr<void> Function(List<AudioSourceConfig>) onSave;
 
   /// 选文件并导入为一个 localAudio 源（未持久化）；返回 null 表示用户取消。
   ///
@@ -33,6 +37,9 @@ class AudioSourcesDialog extends StatefulWidget {
 
   /// 打开某个本地音频库的「子来源顺序 + 逐源启用」编辑器（按库路径）。
   final Future<void> Function(String path)? onEditLocalSources;
+
+  final Future<bool> Function(String path)? isLocalDbAvailable;
+  final Future<AudioSourceConfig?> Function(String path)? onReplaceLocalDb;
 
   /// 自定义远端音频 URL 合法性：必须是 http(s) 链接，且至少含一个
   /// `{term}` / `{reading}` 占位符（否则播放时无法代入查词参数）。
@@ -87,6 +94,8 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
   /// 写到**别人**那行上。[AudioSourceConfig] 是 `@immutable` 且实现了 `==`，提交时用
   /// `indexOf` 现场定位即可；该行被删掉则 `indexOf` 返回 -1，编辑态在删除处即时清空。
   AudioSourceConfig? _editingSource;
+
+  final Map<String, Future<bool>> _localAvailability = <String, Future<bool>>{};
 
   @override
   void initState() {
@@ -236,6 +245,39 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
   }
 
   Widget _buildSourceRow(FushiDesignTokens tokens, int index) {
+    final AudioSourceConfig source = _sources[index];
+    final String? dbPath = source.path;
+    if (source.kind != AudioSourceKind.localAudio ||
+        dbPath == null ||
+        widget.isLocalDbAvailable == null) {
+      return _buildSourceRowContent(tokens, index);
+    }
+    return FutureBuilder<bool>(
+      future: _localAvailability.putIfAbsent(
+          dbPath, () => widget.isLocalDbAvailable!(dbPath)),
+      builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+        final bool unavailable = snapshot.hasError || snapshot.data == false;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            _buildSourceRowContent(tokens, index),
+            if (unavailable) ...<Widget>[
+              Text(t.local_audio_file_unavailable,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error)),
+              if (widget.onReplaceLocalDb != null)
+                TextButton.icon(
+                  onPressed: _importing ? null : () => _replaceLocalDb(dbPath),
+                  icon: const Icon(Icons.file_open_outlined),
+                  label: Text(t.local_audio_file_reselect),
+                ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildSourceRowContent(FushiDesignTokens tokens, int index) {
     final AudioSourceConfig source = _sources[index];
     final bool isHibiki = source.kind == AudioSourceKind.fushiRemote;
     final bool isLocal = source.kind == AudioSourceKind.localAudio;
@@ -476,7 +518,8 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
         // 导入即落盘：拷贝本地库是离散动作，当场持久化才让「导入成功」名副其实，
         // 且此后即便不经任何关闭路径退出（甚至杀进程）也不丢（BUG-053）；dispose
         // 的兜底保存仍覆盖此后的排序/开关/URL 等批量编辑。
-        widget.onSave(_sources);
+        await widget.onSave(List<AudioSourceConfig>.of(_sources));
+        if (!mounted) return;
         _showSnack(t.local_audio_imported);
       }
       // added == null 表示用户取消选择，不弹反馈。
@@ -488,6 +531,36 @@ class _AudioSourcesDialogState extends State<AudioSourcesDialog> {
       if (mounted) {
         // BUG-779：无效文件（zip / 备份 zip / 空库）给专属可读文案，不把裸异常字符串
         // 甩给用户；其它真·失败（权限 / 磁盘 / 平台）仍带异常摘要便于复述。
+        _showSnack(e is InvalidLocalAudioDbException
+            ? t.local_audio_invalid_db
+            : t.local_audio_import_failed_detail(reason: '$e'));
+      }
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  Future<void> _replaceLocalDb(String oldPath) async {
+    setState(() => _importing = true);
+    try {
+      final AudioSourceConfig? replacement =
+          await widget.onReplaceLocalDb!(oldPath);
+      if (!mounted || replacement == null) return;
+      // 选择器打开期间允许排序/切换；按路径重新定位，保留用户最新的开关状态。
+      final int index = _sources.indexWhere((AudioSourceConfig source) =>
+          source.kind == AudioSourceKind.localAudio && source.path == oldPath);
+      if (index < 0) return;
+      setState(() {
+        _sources[index] = _sources[index].copyWith(path: replacement.path);
+        _localAvailability.remove(oldPath);
+      });
+      await widget.onSave(List<AudioSourceConfig>.of(_sources));
+      if (!mounted) return;
+      _showSnack(t.local_audio_imported);
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('AudioSourcesDialog.replaceLocalDb', e, stack);
+      if (mounted) {
         _showSnack(e is InvalidLocalAudioDbException
             ? t.local_audio_invalid_db
             : t.local_audio_import_failed_detail(reason: '$e'));

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -97,7 +97,7 @@ Future<void> _terminatePortOwnerAndRetry(
   // 占用进程已结束（或本就已退出）：重试开启。进程退出后 OS 释放端口可能有极短
   // 延迟，端口仍占时再等一拍重试一次，仍失败按端口冲突报出。
   await appModel.setYomitanApiServerEnabled(true);
-  for (int attempt = 0; ; attempt++) {
+  for (int attempt = 0;; attempt++) {
     try {
       await appModel.startYomitanApiServer();
       break;
@@ -814,6 +814,60 @@ Future<void> showAudioSourcesManagerDialog({
   required AppModel appModel,
   VoidCallback? onLocalSourcesEdited,
 }) {
+  final Map<String, List<LocalAudioSourcePref>> replacementPrefs =
+      <String, List<LocalAudioSourcePref>>{};
+  Future<AudioSourceConfig?> pickLocalDb(bool reference) async {
+    // BUG-1667：本地音频库曾是全 app 唯一还在用裸 `FilePicker.pickFiles()`
+    // 的大文件导入入口，偏偏承载体积最大的文件（Yomitan 本地音频服务器的
+    // android.db 常见 1~6 GB）。安卓上 file_picker 会先把整份文件同步复制进
+    // app cache 再返回缓存路径，随后 `importFile` 又复制一份进库目录 →
+    // 峰值需要 **2 倍库体积的内部存储**，6 GB 的库要 12 GB，且全程只有一个
+    // 转圈、无进度无取消，多数手机直接失败或看起来永久卡死 = 「安卓上用
+    // android.db 配本地音频怎么都跑不通」。视频/书/有声书/漫画/字幕/制卡音频
+    // 早已统一走 [pickRealFilePathDetailed]（安卓 SAF 解析真实路径、零复制），
+    // 这条是最后的漏网。
+    final PickedFilePath? picked;
+    try {
+      picked = await pickRealFilePathDetailed(
+        context: context,
+        appModel: appModel,
+      );
+    } on PickedFileWithoutPathException catch (e) {
+      // BUG-446：平台交回了条目却没给可用 path（只回 bytes）**不是取消**，
+      // 是失败。记完整诊断（含条目数）后显式抛出，交给上层弹可见反馈——
+      // 静默返回会让用户以为自己没选中，真因全丢。
+      ErrorLogService.instance.log(
+        'AudioSourcesDialog.pickLocalDb',
+        'unexpected file selection: count=${e.count}, pathNull=true',
+      );
+      throw Exception(
+        'picked audio db has no file path (platform '
+        'returned bytes without a path)',
+      );
+    }
+    // 用户取消选择：返回 null，正常无声返回（不是失败）。
+    if (picked == null) return null;
+    // 引用只在**事实上拿到用户真实路径**时才成立（BUG-1667）。安卓未授予
+    // 全文件访问时降级回 file_picker，拿到的是 app cache 临时副本——引用它
+    // 等于引用一个清缓存就消失的文件，必须落回复制，并告诉用户为什么。
+    final bool canReference = picked.isRealPath;
+    if (reference && !canReference && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.local_audio_reference_unavailable)),
+      );
+    }
+    final LocalAudioDbEntry entry = await appModel.importLocalAudioDbFile(
+      picked.path,
+      displayName: p.basename(picked.path),
+      reference: reference && canReference,
+    );
+    return AudioSourceConfig.localAudio(
+      label: entry.displayName,
+      path: entry.path,
+      enabled: true,
+    );
+  }
+
   return showAppDialog(
     context: context,
     builder: (_) => AudioSourcesDialog(
@@ -823,58 +877,18 @@ Future<void> showAudioSourcesManagerDialog({
       // 列表编辑式 UX 无单条删除确认时机，故不在源端逐条弹选择。
       onSave: (List<AudioSourceConfig> next) => appModel.setAudioSourceConfigs(
         next,
+        sourcesByPath: replacementPrefs,
         scope: DeleteScope.syncEverywhere,
       ),
-      onPickLocalDb: (bool reference) async {
-        // BUG-1667：本地音频库曾是全 app 唯一还在用裸 `FilePicker.pickFiles()`
-        // 的大文件导入入口，偏偏承载体积最大的文件（Yomitan 本地音频服务器的
-        // android.db 常见 1~6 GB）。安卓上 file_picker 会先把整份文件同步复制进
-        // app cache 再返回缓存路径，随后 `importFile` 又复制一份进库目录 →
-        // 峰值需要 **2 倍库体积的内部存储**，6 GB 的库要 12 GB，且全程只有一个
-        // 转圈、无进度无取消，多数手机直接失败或看起来永久卡死 = 「安卓上用
-        // android.db 配本地音频怎么都跑不通」。视频/书/有声书/漫画/字幕/制卡音频
-        // 早已统一走 [pickRealFilePathDetailed]（安卓 SAF 解析真实路径、零复制），
-        // 这条是最后的漏网。
-        final PickedFilePath? picked;
-        try {
-          picked = await pickRealFilePathDetailed(
-            context: context,
-            appModel: appModel,
-          );
-        } on PickedFileWithoutPathException catch (e) {
-          // BUG-446：平台交回了条目却没给可用 path（只回 bytes）**不是取消**，
-          // 是失败。记完整诊断（含条目数）后显式抛出，交给上层弹可见反馈——
-          // 静默返回会让用户以为自己没选中，真因全丢。
-          ErrorLogService.instance.log(
-            'AudioSourcesDialog.pickLocalDb',
-            'unexpected file selection: count=${e.count}, pathNull=true',
-          );
-          throw Exception(
-            'picked audio db has no file path (platform '
-            'returned bytes without a path)',
-          );
+      isLocalDbAvailable: appModel.isLocalAudioDbAvailable,
+      onPickLocalDb: pickLocalDb,
+      onReplaceLocalDb: (String oldPath) async {
+        final AudioSourceConfig? replacement = await pickLocalDb(false);
+        if (replacement != null) {
+          replacementPrefs[replacement.path!] =
+              appModel.sourcePrefsForLocalDb(oldPath);
         }
-        // 用户取消选择：返回 null，正常无声返回（不是失败）。
-        if (picked == null) return null;
-        // 引用只在**事实上拿到用户真实路径**时才成立（BUG-1667）。安卓未授予
-        // 全文件访问时降级回 file_picker，拿到的是 app cache 临时副本——引用它
-        // 等于引用一个清缓存就消失的文件，必须落回复制，并告诉用户为什么。
-        final bool canReference = picked.isRealPath;
-        if (reference && !canReference && context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(t.local_audio_reference_unavailable)),
-          );
-        }
-        final LocalAudioDbEntry entry = await appModel.importLocalAudioDbFile(
-          picked.path,
-          displayName: p.basename(picked.path),
-          reference: reference && canReference,
-        );
-        return AudioSourceConfig.localAudio(
-          label: entry.displayName,
-          path: entry.path,
-          enabled: true,
-        );
+        return replacement;
       },
       onEditLocalSources: (String path) async {
         await showAppDialog(

--- a/fushi/test/media/import/saf_file_provenance_test.dart
+++ b/fushi/test/media/import/saf_file_provenance_test.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/import/real_path_directory_picker.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/utils/misc/channel_constants.dart';
+
+import '../../helpers/test_platform_services.dart';
+
+/// Exercise the public picker through the real codec/channel boundary, including
+/// extension filtering: neither Android permission nor filtering grants a cache
+/// copy permission to be retained as an original file (BUG-2265).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<T> withPicker<T>(
+    WidgetTester tester,
+    Object? response,
+    Future<T> Function(BuildContext context, AppModel model) body,
+  ) async {
+    final AppModel model = AppModel(testPlatformServices());
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(FushiChannels.saf, (MethodCall call) async {
+      expect(call.method, anyOf('pickRealFile', 'pickRealDirectory'));
+      return response;
+    });
+    try {
+      late BuildContext context;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext value) {
+              context = value;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      return await body(context, model);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(FushiChannels.saf, null);
+      model.dispose();
+    }
+  }
+
+  for (final bool real in <bool>[true, false]) {
+    for (final Set<String>? extensions in <Set<String>?>[
+      null,
+      <String>{},
+      <String>{'.DB'},
+    ]) {
+      testWidgets('SAF preserves isRealPath=$real with filter $extensions', (
+        WidgetTester tester,
+      ) async {
+        // Deliberately use a neutral name: provenance must not be path guessing.
+        const String path = '/storage/provider/android_english.db';
+        final PickedFilePath? picked = await withPicker(
+          tester,
+          <String, Object>{'path': path, 'isRealPath': real},
+          (BuildContext context, AppModel model) => pickRealFilePathDetailed(
+            context: context,
+            appModel: model,
+            allowedExtensions: extensions,
+          ),
+        );
+        expect(picked?.path, path);
+        expect(picked?.isRealPath, real);
+      });
+    }
+  }
+
+  testWidgets('SAF cancellation stays null', (WidgetTester tester) async {
+    expect(
+      await withPicker(
+        tester,
+        null,
+        (BuildContext context, AppModel model) =>
+            pickRealFilePathDetailed(context: context, appModel: model),
+      ),
+      isNull,
+    );
+  });
+
+  for (final Object malformed in <Object>[
+    '/cache/saf_pick/old-contract.db',
+    <String, Object>{'path': '/storage/audio.db'},
+    <String, Object>{'path': '/storage/audio.db', 'isRealPath': 'true'},
+    <String, Object>{'path': '', 'isRealPath': true},
+    <String, Object>{'path': '   ', 'isRealPath': false},
+    <String, Object>{'path': 12, 'isRealPath': false},
+    <String, Object>{'isRealPath': true},
+  ]) {
+    testWidgets('malformed SAF result is failure: $malformed', (
+      WidgetTester tester,
+    ) async {
+      await withPicker(tester, malformed, (
+        BuildContext context,
+        AppModel model,
+      ) async {
+        await expectLater(
+          pickRealFilePathDetailed(context: context, appModel: model),
+          throwsA(isA<PickedFileWithoutPathException>()),
+        );
+        expect(
+          await pickRealFilePath(context: context, appModel: model),
+          isNull,
+        );
+      });
+    });
+  }
+
+  testWidgets('extension rejection does not accept a cache result', (
+    WidgetTester tester,
+  ) async {
+    await withPicker(
+      tester,
+      <String, Object>{'path': '/provider/book.epub', 'isRealPath': false},
+      (BuildContext context, AppModel model) async {
+        // The filter must remain functional even if the calling page disappears
+        // while the native picker is open; no toast can be shown in this case.
+        await tester.pumpWidget(const SizedBox.shrink());
+        expect(
+          await pickRealFilePathDetailed(
+            context: context,
+            appModel: model,
+            allowedExtensions: <String>{'db'},
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+
+  testWidgets('directory channel keeps its String response', (
+    WidgetTester tester,
+  ) async {
+    expect(
+      await withPicker(
+        tester,
+        '/storage/books',
+        (BuildContext context, AppModel model) =>
+            pickRealDirectoryPath(context: context, appModel: model),
+      ),
+      '/storage/books',
+    );
+  });
+
+  test('native file channel captures provenance before copying to cache', () {
+    final String source = File(
+      'android/app/src/main/java/app/fushi/reader/MainActivity.java',
+    ).readAsStringSync();
+    final int resolve = source.indexOf(
+      'String resolved = resolveSafRealPath(pickedUri, isTree);',
+    );
+    expect(resolve, isNonNegative);
+    final String result = source.substring(
+      resolve,
+      source.indexOf('safResult.success(pickedResult)', resolve),
+    );
+    expect(result, contains('final boolean isRealPath = resolved != null;'));
+    expect(
+      result.indexOf('final boolean isRealPath'),
+      lessThan(result.indexOf('resolved = copyUriToCache(pickedUri)')),
+    );
+    expect(result, contains('if (isTree || resolved == null)'));
+    expect(result, contains('fileResult.put("path", resolved)'));
+    expect(result, contains('fileResult.put("isRealPath", isRealPath)'));
+  });
+}

--- a/fushi/test/models/local_audio_binding_slots_test.dart
+++ b/fushi/test/models/local_audio_binding_slots_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/local_audio_manager.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/utils/misc/local_audio_db.dart';
+import 'package:fushi/src/utils/misc/tts_channel.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as path;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+void main() {
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late Directory root;
+  late String present;
+  late LocalAudioManager manager;
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    root = Directory.systemTemp.createTempSync('local_audio_binding_');
+    present = path.join(root.path, 'present.db');
+    final sqlite.Database audio = sqlite.sqlite3.open(present);
+    audio.execute('CREATE TABLE entries '
+        '(expression TEXT, reading TEXT, file TEXT, source TEXT)');
+    audio.execute('CREATE TABLE android (file TEXT, source TEXT, data BLOB)');
+    audio.execute("INSERT INTO entries VALUES ('cat', '', 'cat.mp3', 'valid')");
+    audio.execute("INSERT INTO android VALUES ('cat.mp3', 'valid', X'010203')");
+    audio.dispose();
+    manager = LocalAudioManager(prefsRepo: prefs, databaseDirectory: root);
+  });
+
+  tearDown(() async {
+    await LocalAudioDb.waitForPendingIndexing(present);
+    await TtsChannel.instance.setLocalAudioDbs(<LocalAudioDbConfig>[]);
+    prefs.dispose();
+    await db.close();
+    root.deleteSync(recursive: true);
+  });
+
+  Future<void> bind(List<LocalAudioDbEntry> entries) async {
+    await prefs.setPref('local_audio_dbs',
+        jsonEncode(entries.map((LocalAudioDbEntry e) => e.toJson()).toList()));
+    await manager.bindForNativeHandler();
+  }
+
+  test('missing first enabled DB retains its index before a working DB',
+      () async {
+    await bind(<LocalAudioDbEntry>[
+      LocalAudioDbEntry(
+        path: path.join(root.path, 'missing.db'),
+        displayName: 'missing',
+        enabled: true,
+      ),
+      LocalAudioDbEntry(path: present, displayName: 'valid', enabled: true),
+    ]);
+    expect(await TtsChannel.instance.queryLocalAudio('cat', '', dbIndex: 0),
+        isNull);
+    final Map<String, dynamic>? found =
+        await TtsChannel.instance.queryLocalAudio('cat', '', dbIndex: 1);
+    expect(found?['source'], 'valid');
+    expect(found?['dbIndex'], 1);
+  });
+
+  test('disabled sources do not consume enabled-source indices', () async {
+    await bind(<LocalAudioDbEntry>[
+      LocalAudioDbEntry(
+          path: path.join(root.path, 'disabled.db'), displayName: 'off'),
+      LocalAudioDbEntry(path: present, displayName: 'valid', enabled: true),
+    ]);
+    expect(
+        (await TtsChannel.instance
+            .queryLocalAudio('cat', '', dbIndex: 0))?['source'],
+        'valid');
+  });
+
+  for (final bool removed in <bool>[true, false]) {
+    test('warm rebind clears previous DB when removed=$removed', () async {
+      await bind(<LocalAudioDbEntry>[
+        LocalAudioDbEntry(path: present, displayName: 'valid', enabled: true),
+      ]);
+      expect(await TtsChannel.instance.queryLocalAudio('cat', ''), isNotNull);
+      await bind(<LocalAudioDbEntry>[
+        if (!removed) LocalAudioDbEntry(path: present, displayName: 'off'),
+      ]);
+      expect(await TtsChannel.instance.queryLocalAudio('cat', ''), isNull);
+    });
+  }
+
+  test('native binding allocates slots before failure and consumes null safely',
+      () {
+    final String java = File(
+      'android/app/src/main/java/app/fushi/reader/TtsChannelHandler.java',
+    ).readAsStringSync();
+    final int start = java.indexOf('for (String dbPath : paths)');
+    expect(start, isNonNegative);
+    final String loop =
+        java.substring(start, java.indexOf('indexFuture =', start));
+    expect(loop.indexOf('localAudioDbs.add(null)'),
+        lessThan(loop.indexOf('if (dbPath == null')));
+    expect(loop, contains('localAudioDbs.set(slot, db)'));
+    expect(loop, isNot(contains('localAudioDbs.add(db)')));
+    expect(loop, contains('indexTargets.add(dbPath)'));
+    final String query = java.substring(
+      java.indexOf('private void handleQueryLocalAudio('),
+      java.indexOf('private static String[] pickByOrder('),
+    );
+    expect(query, contains('if (db == null || !db.isOpen()) continue'));
+    final String extract = java.substring(
+      java.indexOf('private void handleExtractLocalAudio('),
+      java.indexOf('private static String localAudioCacheKey('),
+    );
+    expect(extract, contains('if (db == null || !db.isOpen())'));
+    final String close =
+        java.substring(java.indexOf('private void closeAllAudioDbsLocked()'));
+    expect(close, contains('if (db != null && db.isOpen())'));
+  });
+}

--- a/fushi/test/models/local_audio_cache_reference_migration_test.dart
+++ b/fushi/test/models/local_audio_cache_reference_migration_test.dart
@@ -1,0 +1,348 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/local_audio_manager.dart';
+import 'package:fushi/src/models/local_audio_source_pref.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as path;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+void _writeAudioDb(String filename) {
+  File(filename).parent.createSync(recursive: true);
+  final sqlite.Database db = sqlite.sqlite3.open(filename);
+  db.execute(
+    'CREATE TABLE entries '
+    '(expression TEXT, reading TEXT, file TEXT, source TEXT)',
+  );
+  db.execute('CREATE TABLE android (file TEXT, source TEXT, data BLOB)');
+  db.execute("INSERT INTO entries VALUES ('cat', '', 'cat.mp3', 'forvo')");
+  db.execute("INSERT INTO android VALUES ('cat.mp3', 'forvo', X'010203')");
+  db.dispose();
+}
+
+/// 在真实文件复制完成与路径提交之间插入另一个设置写入者。
+class _ConcurrentEditAudioManager extends LocalAudioManager {
+  _ConcurrentEditAudioManager({
+    required super.prefsRepo,
+    required super.databaseDirectory,
+    required this.onCopied,
+  });
+
+  final Future<void> Function(String copiedPath) onCopied;
+
+  @override
+  Future<LocalAudioDbEntry> importFile(
+    String sourcePath, {
+    required String displayName,
+    bool reference = false,
+  }) async {
+    final LocalAudioDbEntry copied = await super.importFile(
+      sourcePath,
+      displayName: displayName,
+      reference: reference,
+    );
+    await onCopied(copied.path);
+    return copied;
+  }
+}
+
+void main() {
+  late FushiDatabase db;
+  late PreferencesRepository prefs;
+  late Directory root;
+  late Directory temporary;
+  late Directory store;
+  late LocalAudioManager manager;
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    root = Directory.systemTemp.createTempSync('local_audio_migration_');
+    temporary = Directory(path.join(root.path, 'cache'))..createSync();
+    store = Directory(path.join(root.path, 'database'))..createSync();
+    manager = LocalAudioManager(prefsRepo: prefs, databaseDirectory: store);
+  });
+
+  tearDown(() async {
+    prefs.dispose();
+    await db.close();
+    root.deleteSync(recursive: true);
+  });
+
+  Future<void> saveEntries(List<LocalAudioDbEntry> entries) async {
+    await prefs.setPref(
+      'local_audio_dbs',
+      jsonEncode(entries.map((LocalAudioDbEntry e) => e.toJson()).toList()),
+    );
+    await prefs.setPref('audio_source_configs', <Map<String, dynamic>>[
+      <String, dynamic>{
+        'kind': 'remoteAudio',
+        'url': 'https://example.org/audio',
+        'enabled': true,
+      },
+      for (final LocalAudioDbEntry e in entries)
+        <String, dynamic>{
+          'kind': 'localAudio',
+          'path': e.path,
+          'label': e.displayName,
+          'enabled': e.enabled,
+        },
+    ]);
+  }
+
+  test(
+    'moves cached DB while preserving both lists and survives cache removal',
+    () async {
+      final String cached = path.join(temporary.path, 'saf_pick', 'english.db');
+      _writeAudioDb(cached);
+      final List<int> original = File(cached).readAsBytesSync();
+      final String external = path.join(root.path, 'cache-user', 'external.db');
+      _writeAudioDb(external);
+      await saveEntries(<LocalAudioDbEntry>[
+        LocalAudioDbEntry(
+          path: external,
+          displayName: 'external',
+          enabled: true,
+        ),
+        LocalAudioDbEntry(
+          path: cached,
+          displayName: 'English',
+          sources: const <LocalAudioSourcePref>[
+            LocalAudioSourcePref(name: 'forvo', enabled: false),
+            LocalAudioSourcePref(name: 'other'),
+          ],
+        ),
+      ]);
+      final dynamic beforeSources = prefs.getPref('audio_source_configs');
+      await manager.migrateTemporaryReferences(temporary);
+
+      final List<LocalAudioDbEntry> migrated = manager.entries;
+      expect(migrated.first.path, external);
+      expect(migrated.last.displayName, 'English');
+      expect(migrated.last.enabled, isFalse);
+      expect(migrated.last.sources, const <LocalAudioSourcePref>[
+        LocalAudioSourcePref(name: 'forvo', enabled: false),
+        LocalAudioSourcePref(name: 'other'),
+      ]);
+      expect(path.isWithin(store.path, migrated.last.path), isTrue);
+      expect(LocalAudioManager.isInternalCopyName(migrated.last.path), isTrue);
+      final List<dynamic> expectedSources = List<dynamic>.from(
+        beforeSources as List,
+      );
+      expectedSources[2] = <String, dynamic>{
+        ...Map<String, dynamic>.from(expectedSources[2] as Map),
+        'path': migrated.last.path,
+      };
+      expect(prefs.getPref('audio_source_configs'), expectedSources);
+      expect(File(cached).existsSync(), isTrue);
+      temporary.deleteSync(recursive: true);
+      expect(File(migrated.last.path).readAsBytesSync(), original);
+      await prefs.loadFromDb();
+      await manager.migrateTemporaryReferences(temporary);
+      expect(manager.entries.last.path, migrated.last.path);
+      expect(store.listSync().whereType<File>().where(
+          (File file) => LocalAudioManager.isInternalCopyName(file.path)),
+          hasLength(1));
+    },
+  );
+
+  test(
+    'missing and invalid cached files preserve original configuration',
+    () async {
+      final String missing = path.join(
+        temporary.path,
+        'saf_pick',
+        'missing.db',
+      );
+      final String invalid = path.join(temporary.path, 'invalid.db');
+      File(invalid).writeAsStringSync('not sqlite');
+      await saveEntries(<LocalAudioDbEntry>[
+        LocalAudioDbEntry(path: missing, displayName: 'missing', enabled: true),
+        LocalAudioDbEntry(path: invalid, displayName: 'invalid'),
+      ]);
+      await prefs.loadFromDb();
+      final Map<String, String> before = prefs.prefsSnapshot;
+      await manager.migrateTemporaryReferences(temporary);
+      expect(prefs.prefsSnapshot, before);
+      expect(store.listSync().whereType<File>().where(
+          (File file) => LocalAudioManager.isInternalCopyName(file.path)), isEmpty);
+      expect(File(invalid).readAsStringSync(), 'not sqlite');
+    },
+  );
+
+  test('copy failure preserves preferences and source', () async {
+    final String cached = path.join(temporary.path, 'saf_pick', 'english.db');
+    _writeAudioDb(cached);
+    await saveEntries(<LocalAudioDbEntry>[
+      LocalAudioDbEntry(path: cached, displayName: 'English', enabled: true),
+    ]);
+    final Map<String, String> before = prefs.prefsSnapshot;
+    store.deleteSync();
+    File(store.path).writeAsStringSync('destination is a file');
+    await manager.migrateTemporaryReferences(temporary);
+    expect(prefs.prefsSnapshot, before);
+    expect(File(cached).existsSync(), isTrue);
+  });
+
+  test(
+    'second preference failure rolls back both DB paths and in-memory cache',
+    () async {
+      final String cached = path.join(temporary.path, 'saf_pick', 'english.db');
+      _writeAudioDb(cached);
+      await saveEntries(<LocalAudioDbEntry>[
+        LocalAudioDbEntry(path: cached, displayName: 'English', enabled: true),
+      ]);
+      final String beforeEntries = prefs.getPref('local_audio_dbs') as String;
+      final dynamic beforeSources = prefs.getPref('audio_source_configs');
+      await db.customStatement(
+        "CREATE TRIGGER reject_audio_migration BEFORE UPDATE ON preferences WHEN NEW.key = 'audio_source_configs' BEGIN SELECT RAISE(ABORT, 'test migration failure'); END",
+      );
+      await expectLater(
+        manager.migrateTemporaryReferences(temporary),
+        throwsA(isA<Exception>()),
+      );
+      expect(prefs.getPref('local_audio_dbs'), beforeEntries);
+      expect(prefs.getPref('audio_source_configs'), beforeSources);
+      await prefs.loadFromDb();
+      expect(prefs.getPref('local_audio_dbs'), beforeEntries);
+      expect(prefs.getPref('audio_source_configs'), beforeSources);
+      expect(File(cached).existsSync(), isTrue);
+    },
+  );
+
+  test('CAS rejects stale persisted values and refreshes the losing cache',
+      () async {
+    await prefs.setPref('local_audio_dbs', 'old');
+    final Map<String, String> before = prefs.prefsSnapshot;
+    final PreferencesRepository otherProcess = PreferencesRepository(db);
+    addTearDown(otherProcess.dispose);
+    await otherProcess.loadFromDb();
+    await otherProcess.setPrefs(<String, dynamic>{
+      'local_audio_dbs': 'user replacement',
+      'audio_source_configs': <String>['new priority'],
+    });
+
+    final bool applied = await prefs.compareAndSetPrefs(
+      expectedRaw: <String, String?>{
+        'local_audio_dbs': before['local_audio_dbs'],
+        'audio_source_configs': before['audio_source_configs'],
+      },
+      updates: <String, dynamic>{
+        'local_audio_dbs': 'migration replacement',
+        'audio_source_configs': <String>['old priority'],
+      },
+    );
+    expect(applied, isFalse);
+    expect(prefs.getPref('local_audio_dbs'), 'user replacement');
+    expect(prefs.getPref('audio_source_configs'), <String>['new priority']);
+    await otherProcess.loadFromDb();
+    expect(otherProcess.getPref('local_audio_dbs'), 'user replacement');
+  });
+
+  test('configuration edited during copying wins over migration snapshot',
+      () async {
+    final String cached = path.join(temporary.path, 'saf_pick', 'english.db');
+    _writeAudioDb(cached);
+    await saveEntries(<LocalAudioDbEntry>[
+      LocalAudioDbEntry(path: cached, displayName: 'English', enabled: true),
+    ]);
+    final PreferencesRepository otherProcess = PreferencesRepository(db);
+    addTearDown(otherProcess.dispose);
+    await otherProcess.loadFromDb();
+    String? copiedPath;
+    final String latestEntries = jsonEncode(<Map<String, dynamic>>[
+      LocalAudioDbEntry(path: cached, displayName: 'User renamed').toJson(),
+    ]);
+    final List<Map<String, dynamic>> latestSources = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'kind': 'localAudio',
+        'path': cached,
+        'label': 'User renamed',
+        'enabled': false,
+      },
+    ];
+    final LocalAudioManager concurrentManager = _ConcurrentEditAudioManager(
+      prefsRepo: prefs,
+      databaseDirectory: store,
+      onCopied: (String copied) async {
+        copiedPath = copied;
+        await otherProcess.setPrefs(<String, dynamic>{
+          'local_audio_dbs': latestEntries,
+          'audio_source_configs': latestSources,
+        });
+      },
+    );
+    await concurrentManager.migrateTemporaryReferences(temporary);
+
+    expect(prefs.getPref('local_audio_dbs'), latestEntries);
+    expect(prefs.getPref('audio_source_configs'), latestSources);
+    expect(concurrentManager.entries.single.path, cached);
+    expect(concurrentManager.entries.single.enabled, isFalse);
+    expect(File(cached).existsSync(), isTrue);
+    expect(copiedPath, isNotNull);
+    expect(File(copiedPath!).existsSync(), isTrue);
+    // CAS 失败只留下可回收副本，不重试并覆盖用户刚保存的配置。
+    expect(store.listSync().whereType<File>().where(
+        (File file) => LocalAudioManager.isInternalCopyName(file.path)),
+        hasLength(1));
+    await manager.pruneOrphans(concurrentManager.entries.map(
+      (LocalAudioDbEntry entry) => entry.path,
+    ));
+    expect(File(copiedPath!).existsSync(), isFalse);
+    expect(File(cached).existsSync(), isTrue);
+    await prefs.loadFromDb();
+    expect(prefs.getPref('local_audio_dbs'), latestEntries);
+    expect(prefs.getPref('audio_source_configs'), latestSources);
+  });
+
+  test('prune waits for migration and protects its newly committed copy',
+      () async {
+    final String cached = path.join(temporary.path, 'saf_pick', 'english.db');
+    _writeAudioDb(cached);
+    await saveEntries(<LocalAudioDbEntry>[
+      LocalAudioDbEntry(path: cached, displayName: 'English', enabled: true),
+    ]);
+    final Completer<String> copied = Completer<String>();
+    final Completer<void> resumeMigration = Completer<void>();
+    final LocalAudioManager migrating = _ConcurrentEditAudioManager(
+      prefsRepo: prefs,
+      databaseDirectory: store,
+      onCopied: (String copiedPath) async {
+        copied.complete(copiedPath);
+        await resumeMigration.future;
+      },
+    );
+    final PreferencesRepository pruningPrefs = PreferencesRepository(db);
+    addTearDown(pruningPrefs.dispose);
+    await pruningPrefs.loadFromDb();
+    final LocalAudioManager pruning = LocalAudioManager(
+      prefsRepo: pruningPrefs,
+      databaseDirectory: store,
+    );
+    final Future<void> migration = migrating.migrateTemporaryReferences(temporary);
+    final String newPath = await copied.future;
+    bool pruneFinished = false;
+    // 模拟另一个管理器以迁移前的旧列表请求清理。
+    final Future<void> prune = pruning.pruneOrphans(<String>[cached]).then((_) {
+      pruneFinished = true;
+    });
+    await Future<void>.delayed(Duration.zero);
+    expect(pruneFinished, isFalse);
+    expect(File(newPath).existsSync(), isTrue);
+    resumeMigration.complete();
+    await Future.wait(<Future<void>>[migration, prune]);
+
+    expect(pruneFinished, isTrue);
+    expect(pruning.entries.single.path, newPath);
+    expect(File(newPath).existsSync(), isTrue);
+    expect(File(newPath).readAsBytesSync(), File(cached).readAsBytesSync());
+    expect(File(path.join(store.path, 'local_audio_migration.lock')).existsSync(),
+        isTrue);
+  });
+}

--- a/fushi/test/models/local_audio_manager_test.dart
+++ b/fushi/test/models/local_audio_manager_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:fushi/src/utils/misc/local_audio_db.dart' show LocalAudioDb;
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -283,6 +285,8 @@ void main() {
 
     expect(manager.entries, isEmpty); // 条目已移除
     expect(original.existsSync(), isTrue); // 但用户原文件绝不被删
+    // 绑定时的后台索引探测仍可持有外部文件；测试清理必须等待其结束。
+    await LocalAudioDb.waitForPendingIndexing(original.path);
     await ext.delete(recursive: true);
   });
 

--- a/fushi/test/pages/audio_sources_missing_file_test.dart
+++ b/fushi/test/pages/audio_sources_missing_file_test.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/pages/implementations/dictionary_settings_dialog_page.dart';
+import 'package:fushi/utils.dart';
+
+Widget _host(Widget child) => TranslationProvider(
+      child: MaterialApp(
+        theme: ThemeData(useMaterial3: true, platform: TargetPlatform.windows),
+        home: Scaffold(body: child),
+      ),
+    );
+
+AudioSourceConfig _local(String path, {bool enabled = false}) =>
+    AudioSourceConfig.localAudio(
+      label: 'Saved pronunciation name',
+      path: path,
+      enabled: enabled,
+    );
+
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  testWidgets('missing database exposes an executable file reselect action',
+      (WidgetTester tester) async {
+    final List<String> pickedPaths = <String>[];
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[_local('/cache/gone.db')],
+      onSave: (_) {},
+      isLocalDbAvailable: (_) async => false,
+      onReplaceLocalDb: (String path) async {
+        pickedPaths.add(path);
+        return null;
+      },
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.local_audio_file_unavailable), findsOneWidget);
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pumpAndSettle();
+    expect(pickedPaths, <String>['/cache/gone.db']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('healthy database has no missing-file warning or recovery action',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[_local('/support/audio.db')],
+      onSave: (_) {},
+      isLocalDbAvailable: (_) async => true,
+      onReplaceLocalDb: (_) async => null,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Saved pronunciation name'), findsOneWidget);
+    expect(find.text(t.local_audio_file_unavailable), findsNothing);
+    expect(find.text(t.local_audio_file_reselect), findsNothing);
+  });
+
+  testWidgets(
+      'replacement saves the new path with existing priority and settings',
+      (WidgetTester tester) async {
+    final List<List<AudioSourceConfig>> saves = <List<AudioSourceConfig>>[];
+    final AudioSourceConfig remote = AudioSourceConfig.remoteAudio(
+      url: 'https://example.com/audio?term={term}',
+      label: 'Remote source',
+    );
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[remote, _local('/cache/gone.db')],
+      onSave: (List<AudioSourceConfig> sources) =>
+          saves.add(List<AudioSourceConfig>.of(sources)),
+      isLocalDbAvailable: (String path) async => path == '/support/new.db',
+      onReplaceLocalDb: (_) async => AudioSourceConfig.localAudio(
+        label: 'New file name',
+        path: '/support/new.db',
+        enabled: true,
+      ),
+    )));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pumpAndSettle();
+
+    expect(saves, hasLength(1));
+    expect(saves.single.first.url, remote.url);
+    expect(saves.single.last.path, '/support/new.db');
+    expect(saves.single.last.label, 'Saved pronunciation name');
+    expect(saves.single.last.enabled, isFalse);
+    expect(find.text('/cache/gone.db'), findsNothing);
+    expect(find.text('/support/new.db'), findsOneWidget);
+    expect(find.text(t.local_audio_file_unavailable), findsNothing);
+  });
+
+  testWidgets(
+      'cancelled replacement keeps the old source and does not save early',
+      (WidgetTester tester) async {
+    final List<List<AudioSourceConfig>> saves = <List<AudioSourceConfig>>[];
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[_local('/cache/gone.db', enabled: true)],
+      onSave: (List<AudioSourceConfig> sources) =>
+          saves.add(List<AudioSourceConfig>.of(sources)),
+      isLocalDbAvailable: (_) async => false,
+      onReplaceLocalDb: (_) async => null,
+    )));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pumpAndSettle();
+
+    expect(saves, isEmpty);
+    expect(find.text('/cache/gone.db'), findsOneWidget);
+    expect(find.text(t.local_audio_file_unavailable), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(saves.single.single.path, '/cache/gone.db');
+    expect(saves.single.single.enabled, isTrue);
+  });
+
+  testWidgets(
+      'failed replacement retains the source and permits another attempt',
+      (WidgetTester tester) async {
+    final List<List<AudioSourceConfig>> saves = <List<AudioSourceConfig>>[];
+    int attempts = 0;
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[_local('/cache/gone.db')],
+      onSave: (List<AudioSourceConfig> sources) =>
+          saves.add(List<AudioSourceConfig>.of(sources)),
+      isLocalDbAvailable: (_) async => false,
+      onReplaceLocalDb: (_) async {
+        attempts++;
+        throw StateError('fixture import failure');
+      },
+    )));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pumpAndSettle();
+
+    expect(saves, isEmpty);
+    expect(find.text('/cache/gone.db'), findsOneWidget);
+    expect(find.textContaining('fixture import failure'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pumpAndSettle();
+    expect(attempts, 2);
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(saves.single.single.path, '/cache/gone.db');
+  });
+
+  testWidgets('pending replacement follows its source after reorder and toggle',
+      (WidgetTester tester) async {
+    final Completer<AudioSourceConfig?> replacement =
+        Completer<AudioSourceConfig?>();
+    final List<List<AudioSourceConfig>> saves = <List<AudioSourceConfig>>[];
+    await tester.pumpWidget(_host(AudioSourcesDialog(
+      sources: <AudioSourceConfig>[
+        _local('/cache/gone.db'),
+        AudioSourceConfig.localAudio(
+          label: 'Healthy second source',
+          path: '/support/healthy.db',
+        ),
+      ],
+      onSave: (List<AudioSourceConfig> sources) =>
+          saves.add(List<AudioSourceConfig>.of(sources)),
+      isLocalDbAvailable: (String path) async => path != '/cache/gone.db',
+      onReplaceLocalDb: (_) => replacement.future,
+    )));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.local_audio_file_reselect));
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.keyboard_arrow_up).last);
+    await tester.pump();
+    await tester.tap(find.byType(Switch).last);
+    await tester.pump();
+    replacement.complete(AudioSourceConfig.localAudio(
+      label: 'Replacement filename',
+      path: '/support/new.db',
+    ));
+    await tester.pumpAndSettle();
+
+    expect(saves, hasLength(1));
+    expect(saves.single.map((AudioSourceConfig source) => source.path),
+        <String>['/support/healthy.db', '/support/new.db']);
+    expect(saves.single.first.label, 'Healthy second source');
+    expect(saves.single.first.enabled, isFalse);
+    expect(saves.single.last.label, 'Saved pronunciation name');
+    expect(saves.single.last.enabled, isTrue);
+    expect(find.text(t.local_audio_file_unavailable), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Android 用户的英语发音库被长期引用到 cache/saf_pick，缓存清理后即使音源开关仍开也会提示“暂无发音”。本改动从 SAF 原生返回中保留文件出处，临时副本复制到持久库；旧缓存仍在时自动迁移，已丢失时提供保留原行设置的重新选择入口。

迁移以短事务比较原值再提交，保留并发更新；迁移与孤儿清理共用文件锁。缺失库保留 native 索引槽位，空列表清理旧绑定，避免影响后续正常音源。17 语言文案同步更新，正常配置的 warm popup 跳过已完成迁移。

验证：
- 定向覆盖 243 条；一条旧 Windows 清理用例补齐后台索引等待后，所属 18 条重跑通过。迁移快路径追加后相关 12 条再验通过。
- 全量 flutter analyze 零问题；BUG-2265 索引、编号和跨工作区检查通过。
- Android debug APK 构建通过。
- Android API 34 x86_64 平台集成 1 条通过：真实查询、提取字节比对、WAV 启播、清源缓存后重载、旧缓存迁移后重载。

验证边界：release 构建缺少本地 key.properties 被签名门拦截，未绕过签名。本地全量套件未运行，交 CI。原 API 36 模拟器系统图形/包管理服务故障导致零用例，换新隔离 API 34 后完成平台验证。未覆盖用户原始 provider 的真实 SAF 选择 UI、手机升级全链路或扬声器录音。
