### PR TITLE
fix(download): 修复 CoreAudio 下载失败误报及诊断日志缺失

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2111 条。点号进各自文件。
+> 共 2112 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2267](bugs/BUG-2267-coreaudio-download-errors.md) | ✅ | ✅ | CoreAudio下载失败被误报为qBittorrent推送失败 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/bugs/BUG-2267-coreaudio-download-errors.md
+++ b/docs/bugs/BUG-2267-coreaudio-download-errors.md
@@ -1,0 +1,6 @@
+## BUG-2267 · CoreAudio下载失败被误报为qBittorrent推送失败
+- **报告**：2026-09-08（用户截图：CoreAudio「若い読者のための哲学史」下载失败，设置选择内置引擎）
+- **真实性**：✅ 错误误报为真 bug。`fushi/lib/src/pages/implementations/media_discovery_page.dart:398` 将资源解析异常统一转成推送失败；`fushi/lib/src/pages/implementations/download_actions.dart:163` 吞掉入队异常；同文件 `genericPushMessage` 原来固定使用 qBittorrent 失败文案，成功又一律承诺自动入库。实际后端仍通过 `currentVideoDownloadBackendTarget()` 读取配置，截图不能证明选择错误。
+- **[x] ① 已修复** — 本文件同提交：区分解析与入队阶段，种子数据无效、单卷匹配失败和资源获取失败分别提供恢复提示；捕获点记录原始异常与堆栈；通用成功提示改为「已加入下载」，失败不再归咎 qBittorrent。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/discovery_torrent_failure_test.dart` 覆盖异常分类、成功语义、阶段及日志调用。该文件与 downloads_center_contract_guard、media_discovery_page、core_audio_discovery_source 共 19 条定向测试通过（退出码 0）。
+- **备注**：原始下载失败尚未复现，未宣称修复下载传输。真实目录 `B0BX4ZWYGL` / Nyaa `2006488` 的 616676 字节种子经生产解析器及 matcher 测试通过（1/1）；唯一选中 index 10，588859527 字节，与目录文件名、KiB 大小吻合。没有下载整本音频，也未做用户设备 E2E。等待用户原始日志；本机网络验证不代表用户网络状态。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 75446 (4438 per locale)
+/// Strings: 75514 (4442 per locale)
 ///
-/// Built on 2026-09-07 at 11:03 UTC
+/// Built on 2026-09-08 at 06:42 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6144,6 +6144,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'AniList is rate-limiting this app right now. Wait a moment and retry.';
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -16555,6 +16563,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -27193,6 +27213,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -37884,6 +37916,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -48609,6 +48653,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -59137,6 +59193,18 @@ class _StringsId extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -69756,6 +69824,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -79755,6 +79835,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -89764,6 +89856,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -100341,6 +100445,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -110970,6 +111086,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -121577,6 +121705,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -131982,6 +132122,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -142505,6 +142657,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -152999,6 +153163,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 // Path: <root>
@@ -162634,6 +162810,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+  @override
+  String get download_request_failed => '无法创建下载。请检查下载设置和任务列表后重试。';
+  @override
+  String get download_resource_resolve_failed => '无法获取下载资源。请检查网络和代理设置后重试。';
+  @override
+  String get download_torrent_invalid => '来源返回的种子数据无效。请稍后重试或更换来源。';
+  @override
+  String get download_torrent_selection_failed => '无法在种子中唯一匹配这本书。请刷新目录或更换来源。';
 }
 
 // Path: <root>
@@ -172322,6 +172506,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+  @override
+  String get download_request_failed =>
+      'Could not create the download. Check the download settings and task list, then try again.';
+  @override
+  String get download_resource_resolve_failed =>
+      'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+  @override
+  String get download_torrent_invalid =>
+      'The source returned invalid torrent data. Retry later or choose another source.';
+  @override
+  String get download_torrent_selection_failed =>
+      'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
 }
 
 /// Flat map(s) containing all translations.
@@ -181441,6 +181637,14 @@ extension on _StringsEn {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -190555,6 +190759,14 @@ extension on _StringsAr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -199714,6 +199926,14 @@ extension on _StringsDe {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -208864,6 +209084,14 @@ extension on _StringsEs {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -218023,6 +218251,14 @@ extension on _StringsFr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -227153,6 +227389,14 @@ extension on _StringsId {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -236305,6 +236549,14 @@ extension on _StringsIt {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -245384,6 +245636,14 @@ extension on _StringsJa {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -254467,6 +254727,14 @@ extension on _StringsKo {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -263612,6 +263880,14 @@ extension on _StringsNl {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -272752,6 +273028,14 @@ extension on _StringsPtBr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -281899,6 +282183,14 @@ extension on _StringsRu {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -291018,6 +291310,14 @@ extension on _StringsTh {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -300152,6 +300452,14 @@ extension on _StringsTr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -309280,6 +309588,14 @@ extension on _StringsVi {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }
@@ -318329,6 +318645,14 @@ extension on _StringsZhCn {
         return 'AniList 正在对本应用限流。稍等一会儿再重试。';
       case 'video_anilist_error_unreachable':
         return '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+      case 'download_request_failed':
+        return '无法创建下载。请检查下载设置和任务列表后重试。';
+      case 'download_resource_resolve_failed':
+        return '无法获取下载资源。请检查网络和代理设置后重试。';
+      case 'download_torrent_invalid':
+        return '来源返回的种子数据无效。请稍后重试或更换来源。';
+      case 'download_torrent_selection_failed':
+        return '无法在种子中唯一匹配这本书。请刷新目录或更换来源。';
       default:
         return null;
     }
@@ -327386,6 +327710,14 @@ extension on _StringsZhHk {
         return 'AniList 正在對本應用限流。稍等一會兒再重試。';
       case 'video_anilist_error_unreachable':
         return '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+      case 'download_request_failed':
+        return 'Could not create the download. Check the download settings and task list, then try again.';
+      case 'download_resource_resolve_failed':
+        return 'Could not fetch the download resource. Check the network and proxy settings, then try again.';
+      case 'download_torrent_invalid':
+        return 'The source returned invalid torrent data. Retry later or choose another source.';
+      case 'download_torrent_selection_failed':
+        return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Leave blank to use the bundled app API key.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "اتركه فارغًا لاستخدام مفتاح API المضمّن في التطبيق.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Leer lassen, um den enthaltenen API-Schlüssel der App zu verwenden.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Déjalo vacío para usar la clave API incluida en la aplicación.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Laissez vide pour utiliser la clé API incluse dans l’application.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Biarkan kosong untuk menggunakan kunci API bawaan aplikasi.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Lascia vuoto per usare la chiave API inclusa nell’app.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "空欄の場合、アプリ内蔵の API キーを使用します。",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "비워 두면 앱에 내장된 API 키를 사용합니다.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Laat leeg om de meegeleverde API-sleutel van de app te gebruiken.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Deixe vazio para usar a chave API incluída no aplicativo.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Оставьте пустым, чтобы использовать встроенный ключ API приложения.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "เว้นว่างไว้เพื่อใช้คีย์ API ที่มีอยู่ในแอป",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Uygulamayla gelen API anahtarını kullanmak için boş bırakın.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "Để trống để dùng khóa API tích hợp trong ứng dụng.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "留空使用应用内置 API 密钥。",
   "video_anilist_error_api_disabled": "AniList 官方因服务器稳定性问题暂时停用了公开 API。这不是你的网络或代理的问题——请求已经打到 AniList 并被它当面拒绝了。请稍后再试。",
   "video_anilist_error_rate_limited": "AniList 正在对本应用限流。稍等一会儿再重试。",
-  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。"
+  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。",
+  "download_request_failed": "无法创建下载。请检查下载设置和任务列表后重试。",
+  "download_resource_resolve_failed": "无法获取下载资源。请检查网络和代理设置后重试。",
+  "download_torrent_invalid": "来源返回的种子数据无效。请稍后重试或更换来源。",
+  "download_torrent_selection_failed": "无法在种子中唯一匹配这本书。请刷新目录或更换来源。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4436,5 +4436,9 @@
   "video_opensubtitles_app_key_hint": "留空以使用應用程式內置的 API 金鑰。",
   "video_anilist_error_api_disabled": "AniList 官方因伺服器穩定性問題暫時停用了公開 API。這不是你的網絡或代理的問題——請求已經打到 AniList 並被它當面拒絕了。請稍後再試。",
   "video_anilist_error_rate_limited": "AniList 正在對本應用限流。稍等一會兒再重試。",
-  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。"
+  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。",
+  "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
+  "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
+  "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
 }

--- a/fushi/lib/src/pages/implementations/download_actions.dart
+++ b/fushi/lib/src/pages/implementations/download_actions.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:flutter/material.dart';
 
 import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/sources/core_audio_discovery_source.dart';
 import 'package:fushi/src/media/torrent/anime_download_config.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
 import 'package:fushi/src/media/torrent/magnet_utils.dart';
@@ -159,7 +160,8 @@ Future<GenericPushOutcome> enqueueSelectedDiscoveryTorrent({
       ),
     );
     return GenericPushOutcome.ok;
-  } on Object {
+  } on Object catch (error, stack) {
+    ErrorLogService.instance.log('DiscoveryTorrent.enqueue', error, stack);
     return GenericPushOutcome.pushFailed;
   }
 }
@@ -168,7 +170,7 @@ Future<GenericPushOutcome> enqueueSelectedDiscoveryTorrent({
 String genericPushMessage(GenericPushOutcome outcome) {
   switch (outcome) {
     case GenericPushOutcome.ok:
-      return t.anime_download_pushed;
+      return t.discovery_download_queued;
     case GenericPushOutcome.invalidMagnet:
       return t.anime_download_magnet_invalid;
     case GenericPushOutcome.storeUnavailable:
@@ -176,6 +178,15 @@ String genericPushMessage(GenericPushOutcome outcome) {
     case GenericPushOutcome.notReady:
       return t.download_backend_not_configured;
     case GenericPushOutcome.pushFailed:
-      return t.anime_download_push_failed;
+      return t.download_request_failed;
   }
+}
+
+/// 解析尚未触及下载后端；按数据边界提示恢复动作，避免误导用户修改 qB 设置。
+String discoveryTorrentResolveFailureMessage(Object error) {
+  if (error is CoreAudioFileMatchException) {
+    return t.download_torrent_selection_failed;
+  }
+  if (error is FormatException) return t.download_torrent_invalid;
+  return t.download_resource_resolve_failed;
 }

--- a/fushi/lib/src/pages/implementations/media_discovery_page.dart
+++ b/fushi/lib/src/pages/implementations/media_discovery_page.dart
@@ -349,12 +349,14 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
         final String resolvingKey = '${item.sourceId}\u0000${item.id}';
         if (!_resolvingTorrentIds.add(resolvingKey)) return;
         if (mounted) setState(() {});
+        bool resolving = true;
         try {
           final MediaDiscoverySource? source =
               appModel.mediaDiscoveryService.sourceById(item.sourceId);
           if (source == null) return;
           final DiscoveryPayload payload =
               item.payload ?? await source.resolvePayload(item);
+          resolving = false;
           if (!mounted) return;
           final GenericPushOutcome outcome;
           if (payload is DiscoveryTorrentPayload) {
@@ -393,10 +395,17 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
                 ? ToastSeverity.success
                 : ToastSeverity.error,
           );
-        } on Object {
+        } on Object catch (error, stack) {
+          ErrorLogService.instance.log(
+            'DiscoveryTorrent.${resolving ? 'resolve' : 'enqueue'}.${item.sourceId}',
+            error,
+            stack,
+          );
           if (mounted) {
             FushiToast.show(
-              msg: genericPushMessage(GenericPushOutcome.pushFailed),
+              msg: resolving
+                  ? discoveryTorrentResolveFailureMessage(error)
+                  : genericPushMessage(GenericPushOutcome.pushFailed),
               severity: ToastSeverity.error,
             );
           }

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1247
+version: 2.3.0+1248
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/pages/discovery_torrent_failure_test.dart
+++ b/fushi/test/pages/discovery_torrent_failure_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/discovery/sources/core_audio_discovery_source.dart';
+import 'package:fushi/src/media/torrent/torrent_metainfo.dart';
+import 'package:fushi/src/pages/implementations/download_actions.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final AppLocale originalLocale = LocaleSettings.currentLocale;
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+  tearDown(() => LocaleSettings.setLocale(originalLocale));
+
+  test(
+    'resource fetch failures explain network recovery before backend use',
+    () {
+      for (final Object error in <Object>[
+        http.ClientException('HTTP 503', Uri.parse('https://source.test/file')),
+        TimeoutException('request timed out'),
+      ]) {
+        final String message = discoveryTorrentResolveFailureMessage(error);
+        expect(message, t.download_resource_resolve_failed);
+        expect(message, isNot(contains('qBittorrent')));
+        expect(message, isNot(contains('source.test')));
+      }
+    },
+  );
+
+  test(
+    'invalid metainfo and ambiguous volume selection have distinct recovery',
+    () {
+      final String invalid = discoveryTorrentResolveFailureMessage(
+        TorrentMetainfoException(
+          TorrentMetainfoErrorCode.invalidBencode,
+          'unexpected HTML response',
+        ),
+      );
+      final String selection = discoveryTorrentResolveFailureMessage(
+        const CoreAudioFileMatchException(
+          'Multiple torrent files match volume',
+        ),
+      );
+      expect(invalid, t.download_torrent_invalid);
+      expect(selection, t.download_torrent_selection_failed);
+      expect(selection, isNot(invalid));
+      expect(invalid, isNot(contains('unexpected HTML')));
+    },
+  );
+
+  test(
+    'queued success does not promise automatic import or name a backend',
+    () {
+      expect(
+        genericPushMessage(GenericPushOutcome.ok),
+        t.discovery_download_queued,
+      );
+      expect(genericPushMessage(GenericPushOutcome.ok), isNot(contains('入库')));
+      expect(
+        genericPushMessage(GenericPushOutcome.ok),
+        isNot(contains('qBittorrent')),
+      );
+      expect(
+        genericPushMessage(GenericPushOutcome.pushFailed),
+        t.download_request_failed,
+      );
+      expect(
+        genericPushMessage(GenericPushOutcome.pushFailed),
+        isNot(contains('qBittorrent')),
+      );
+    },
+  );
+
+  test('production download catches preserve stage and original diagnostics',
+      () {
+    final String page = File(
+      'lib/src/pages/implementations/media_discovery_page.dart',
+    ).readAsStringSync();
+    final String download = page.substring(
+      page.indexOf('Future<void> _download('),
+    );
+    expect(download, contains('bool resolving = true;'));
+    expect(
+      download.indexOf('resolving = false;'),
+      greaterThan(download.indexOf('await source.resolvePayload(item)')),
+    );
+    expect(download, contains('on Object catch (error, stack)'));
+    expect(download, contains("resolving ? 'resolve' : 'enqueue'"));
+    expect(
+      download,
+      matches(
+        RegExp(r'ErrorLogService\.instance\.log\([\s\S]*?error,\s*stack,'),
+      ),
+    );
+    expect(download, contains('discoveryTorrentResolveFailureMessage(error)'));
+
+    final String actions = File(
+      'lib/src/pages/implementations/download_actions.dart',
+    ).readAsStringSync();
+    final String enqueue = actions.substring(
+      actions.indexOf(
+        'Future<GenericPushOutcome> enqueueSelectedDiscoveryTorrent',
+      ),
+      actions.indexOf('String genericPushMessage'),
+    );
+    expect(enqueue, contains('on Object catch (error, stack)'));
+    expect(
+      enqueue,
+      contains(
+        "ErrorLogService.instance.log('DiscoveryTorrent.enqueue', error, stack)",
+      ),
+    );
+  });
+}


### PR DESCRIPTION
修复发现页下载错误的误报：CoreAudio 获取种子、解析与选卷失败原先一律显示「推送到 qBittorrent 失败」，且原始异常被吞掉。现在按失败阶段提供恢复提示，并记录异常和堆栈；任务创建成功显示「已加入下载」，不再对仅下载有声书承诺自动入库。

验证：19 条定向 Flutter 测试通过；真实 CoreAudio 目录与 Nyaa 种子经生产解析器和 matcher 验证 1/1 通过，精确选中目标音频 index 10；BUG 编号检查及 diff check 通过。版本 2.3.0+1248。

范围说明：未发现下载引擎选择错误；原始设备上的下载失败尚未复现，需要原始日志继续定位。本 PR 修复已确认的错误分类、误导文案与诊断信息缺失。未下载整本音频，未做用户设备 E2E 或安装包构建；全量测试交 CI。

全量 flutter analyze --no-pub 通过（No issues found）。提交：5a1d68c17f。

已核对用户补充的错误日志：其中没有 CoreAudio/发现页下载异常记录，其他音频源与更新检查错误不能作为本次下载根因。原始下载失败继续保持未复现，需含本 PR 诊断修复的版本重新触发并导出日志。
