### PR TITLE
feat(reader): 阅读统计浮层改纯文字左标签右数值，手动计时开关升成底栏级整宽按钮

### DIFF
--- a/fushi/lib/src/reader/reader_statistics_dialog.dart
+++ b/fushi/lib/src/reader/reader_statistics_dialog.dart
@@ -4,6 +4,16 @@
 /// `loadStatFacts` 切片，统计域 v92 纪律：展示只从 `StatFacts` 派生）/ 预计读完
 /// （本章 / 全书剩余字数 ÷ 速度）。账本只在 `StudyClock` 一本，本层不持有任何会话
 /// 累计副本——会话读数是每秒采样的函数（同底部状态行）。
+///
+/// 排版是**纯文字行**：一块一列，每行左标签、右数值（[_StatRows]）。此前是等宽三
+/// 格 + 竖分隔线的横排卡片，格宽 = 卡宽 / 3 与文字长度无关——手机窄屏上「速度」
+/// 那格的 `12345 / h`、时长那格的 `1:23:45` 稳定被省略成「…」，统计浮层最该看的
+/// 数字反而看不全。纵向排一行给数值整条行宽，任何语言的标签和任何位数的数值都不
+/// 再互相挤。
+///
+/// 手动计时开关是浮层底部的整宽按钮（[_TrackingToggleButton]），与底栏按钮同级
+/// （高度走 `density.controlHeight`）：它此前是「本次会话」小标题旁 18px 的紧凑
+/// IconButton，触摸目标远小于 48dp 的可点击下限，手机上难点中。
 library;
 
 import 'dart:async';
@@ -215,40 +225,16 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
             ],
           ),
           Padding(
-            padding: EdgeInsets.only(right: tokens.spacing.gap),
+            // 标题行的关闭键贴着 gap 的右边距，正文行不跟着贴——补到与左边一样的
+            // page，纯文字行的右侧数值才与左侧标签对称。
+            padding: EdgeInsets.only(
+              right: tokens.spacing.page - tokens.spacing.gap,
+            ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    ReaderSideSheetSectionLabel(t.reader_stats_session),
-                    const SizedBox(width: 4),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 12),
-                      child: IconButton(
-                        key: const ValueKey<String>(
-                          'fushi_reader_stats_tracking_toggle',
-                        ),
-                        visualDensity: VisualDensity.compact,
-                        iconSize: 18,
-                        tooltip: paused ? t.play : t.pause,
-                        icon: Icon(
-                          paused
-                              ? Icons.play_arrow_rounded
-                              : Icons.pause_rounded,
-                          color: paused
-                              ? theme.colorScheme.primary
-                              : theme.colorScheme.onSurfaceVariant,
-                        ),
-                        onPressed: () {
-                          widget.onToggleTracking();
-                          setState(() {});
-                        },
-                      ),
-                    ),
-                  ],
-                ),
-                _StatCard(
+                ReaderSideSheetSectionLabel(t.reader_stats_session),
+                _StatRows(
                   cells: _metricCells(
                     session.chars,
                     session.durationMs,
@@ -258,7 +244,7 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
                 ReaderSideSheetSectionLabel(
                   '${t.stat_today} · ${t.reader_stats_this_book}',
                 ),
-                _StatCard(
+                _StatRows(
                   cells: _metricCells(
                     book.todayChars,
                     book.todayMs,
@@ -268,11 +254,11 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
                 ReaderSideSheetSectionLabel(
                   '${t.stat_all_time} · ${t.reader_stats_this_book}',
                 ),
-                _StatCard(
+                _StatRows(
                   cells: _metricCells(book.allChars, book.allMs, live: false),
                 ),
                 ReaderSideSheetSectionLabel(t.reader_stats_time_to_finish),
-                _StatCard(
+                _StatRows(
                   cells: <_StatCell>[
                     _StatCell(
                       label: t.reader_stats_finish_chapter,
@@ -285,6 +271,14 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
                       value: bookMs == null ? '—' : formatStatClock(bookMs),
                     ),
                   ],
+                ),
+                SizedBox(height: tokens.spacing.page),
+                _TrackingToggleButton(
+                  paused: paused,
+                  onPressed: () {
+                    widget.onToggleTracking();
+                    setState(() {});
+                  },
                 ),
               ],
             ),
@@ -316,9 +310,13 @@ class _StatCell {
   final String? unit;
 }
 
-/// 一行等宽格子：上小标签、下大数字（等宽数字）。格子间竖分隔线。
-class _StatCard extends StatelessWidget {
-  const _StatCard({required this.cells});
+/// 一块统计：每行左标签、右数值（等宽数字），行间横分隔线。
+///
+/// 纵向排而不是横排等宽格子——横排时格宽恒为卡宽 / 3，与文字实际长度无关，窄屏
+/// 上数值只能省略成「…」；纵排把整条行宽让给数值，标签按剩余宽度收缩，数值永不
+/// 被截断（[Text] 不加 `overflow`，宽度由它自己的内在尺寸决定）。
+class _StatRows extends StatelessWidget {
+  const _StatRows({required this.cells});
 
   final List<_StatCell> cells;
 
@@ -326,10 +324,10 @@ class _StatCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final TextStyle labelStyle = theme.textTheme.labelMedium!.copyWith(
+    final TextStyle labelStyle = theme.textTheme.bodyMedium!.copyWith(
       color: theme.colorScheme.onSurfaceVariant,
     );
-    final TextStyle valueStyle = theme.textTheme.headlineSmall!.copyWith(
+    final TextStyle valueStyle = theme.textTheme.titleMedium!.copyWith(
       fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
       color: theme.colorScheme.onSurface,
     );
@@ -342,51 +340,86 @@ class _StatCard extends StatelessWidget {
         borderRadius: tokens.radii.cardRadius,
         border: Border.all(color: theme.colorScheme.outlineVariant),
       ),
-      child: IntrinsicHeight(
-        child: Row(
-          children: <Widget>[
-            for (int i = 0; i < cells.length; i++) ...<Widget>[
-              if (i > 0)
-                VerticalDivider(
-                  width: 1,
-                  thickness: 1,
-                  color: theme.colorScheme.outlineVariant,
-                ),
-              Expanded(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: tokens.spacing.gap * 1.5,
-                    vertical: tokens.spacing.gap,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Text(cells[i].label, style: labelStyle, maxLines: 1),
-                      const SizedBox(height: 4),
-                      Text.rich(
-                        TextSpan(
-                          text: cells[i].value,
-                          style: valueStyle,
-                          children: <InlineSpan>[
-                            if (cells[i].unit != null)
-                              TextSpan(
-                                text: ' ${cells[i].unit}',
-                                style: unitStyle,
-                              ),
-                          ],
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ),
-                ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          for (int i = 0; i < cells.length; i++) ...<Widget>[
+            if (i > 0)
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: theme.colorScheme.outlineVariant,
               ),
-            ],
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.gap * 1.5,
+                vertical: tokens.spacing.gap,
+              ),
+              child: Row(
+                children: <Widget>[
+                  // 标签是唯一可收缩的一侧：长标签折行 / 收窄，数值照常整数显示。
+                  Expanded(child: Text(cells[i].label, style: labelStyle)),
+                  SizedBox(width: tokens.spacing.gap * 1.5),
+                  Text.rich(
+                    TextSpan(
+                      text: cells[i].value,
+                      style: valueStyle,
+                      children: <InlineSpan>[
+                        if (cells[i].unit != null)
+                          TextSpan(text: ' ${cells[i].unit}', style: unitStyle),
+                      ],
+                    ),
+                    textAlign: TextAlign.end,
+                  ),
+                ],
+              ),
+            ),
           ],
-        ),
+        ],
       ),
+    );
+  }
+}
+
+/// 浮层底部的手动计时开关：整宽、底栏级高度（`density.controlHeight`）的按钮。
+///
+/// 暂停中用实心 [FilledButton]（计时停着是需要用户注意的非常态），计时中用
+/// tonal 变体。文案沿用旧 tooltip 的 `t.play` / `t.pause`——这两个 key 在 17 种
+/// 语言都有真翻译，新造一对「暂停计时 / 继续计时」只会在 15 种语言上回落成英文。
+/// key 沿用旧的紧凑 IconButton 那一个，桌面端快捷键集成测试按它断言浮层里有计时
+/// 开关。
+class _TrackingToggleButton extends StatelessWidget {
+  const _TrackingToggleButton({required this.paused, required this.onPressed});
+
+  final bool paused;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final Widget icon = Icon(
+      paused ? Icons.play_arrow_rounded : Icons.pause_rounded,
+    );
+    final Widget label = Text(paused ? t.play : t.pause);
+    const ValueKey<String> key = ValueKey<String>(
+      'fushi_reader_stats_tracking_toggle',
+    );
+    return SizedBox(
+      width: double.infinity,
+      height: tokens.density.controlHeight,
+      child: paused
+          ? FilledButton.icon(
+              key: key,
+              onPressed: onPressed,
+              icon: icon,
+              label: label,
+            )
+          : FilledButton.tonalIcon(
+              key: key,
+              onPressed: onPressed,
+              icon: icon,
+              label: label,
+            ),
     );
   }
 }

--- a/fushi/test/reader/reader_statistics_dialog_test.dart
+++ b/fushi/test/reader/reader_statistics_dialog_test.dart
@@ -1,9 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderParagraph;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/pages/implementations/stat_trends.dart'
     show kMinCphSampleMs;
 import 'package:fushi/src/reader/reader_statistics_dialog.dart';
 import 'package:fushi/src/reader/reader_status_footer.dart';
 import 'package:fushi/src/stats/stat_facts.dart';
+import 'package:fushi_audio/fushi_audio.dart' show StudySessionTotals;
 import 'package:fushi_core/fushi_core.dart'
     show FushiDatabase, kActivityMediaBook;
 
@@ -142,5 +146,111 @@ void main() {
       ),
       '10 / 100  10.00%',
     );
+  });
+
+  group('浮层排版（窄屏不截断 + 计时开关是底栏级按钮）', () {
+    /// 320dp 是仓库里最窄的在售机型宽度（见 FushiDialogFrame 的 BUG-1184 注释），
+    /// 数值取到「五位字数 + 五位速度 + 带小时位的时钟」这种最长形态。
+    const StudySessionTotals session = (
+      durationMs: 12345678,
+      chars: 98765,
+      active: true,
+    );
+
+    Future<void> pumpDialog(
+      WidgetTester tester, {
+      required bool paused,
+      VoidCallback? onToggle,
+    }) async {
+      tester.view.physicalSize = const Size(320, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ReaderStatisticsDialog(
+                sessionTotals: () => session,
+                loadBookTotals: () async => (
+                  todayChars: 87654,
+                  todayMs: 23456789,
+                  allChars: 987654,
+                  allMs: 123456789,
+                ),
+                remainingChapterChars: 12345,
+                remainingBookChars: 654321,
+                trackingPaused: () => paused,
+                onToggleTracking: onToggle ?? () {},
+                tick: const Duration(days: 1),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // 计时 ticker 是 Timer.periodic：不卸载会留 pending timer 把测试判红。
+    Future<void> disposeDialog(WidgetTester tester) =>
+        tester.pumpWidget(const SizedBox.shrink());
+
+    testWidgets('320dp 窄屏上标签在左、数值在右，且没有一格被挤到溢出', (WidgetTester tester) async {
+      await pumpDialog(tester, paused: false);
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: '纯文字行不得在最窄机型上撑出 RenderFlex overflow',
+      );
+
+      // 「速度」这一行是旧三格排版最先被省略成「…」的那格（标签 + 数值 + 单位）。
+      final Finder speedLabel = find.text(t.stat_metric_speed).first;
+      final Finder speedRow = find
+          .ancestor(of: speedLabel, matching: find.byType(Row))
+          .first;
+      final Rect rowRect = tester.getRect(speedRow);
+      final Rect labelRect = tester.getRect(speedLabel);
+      final Finder speedValue = find
+          .descendant(of: speedRow, matching: find.byType(Text))
+          .last;
+      final Rect valueRect = tester.getRect(speedValue);
+
+      expect(labelRect.left, lessThan(valueRect.left), reason: '左标签右数值');
+      expect(
+        valueRect.right,
+        closeTo(rowRect.right, 0.5),
+        reason: '数值贴行右缘（右对齐）',
+      );
+      final RenderParagraph value = tester.renderObject<RenderParagraph>(
+        speedValue,
+      );
+      expect(value.didExceedMaxLines, isFalse, reason: '数值整条行宽可用，不再被省略成「…」');
+      await disposeDialog(tester);
+    });
+
+    testWidgets('计时开关是整宽、底栏级高度的按钮，不是紧凑小图标', (WidgetTester tester) async {
+      int toggled = 0;
+      await pumpDialog(tester, paused: false, onToggle: () => toggled++);
+      final Finder toggle = find.byKey(
+        const ValueKey<String>('fushi_reader_stats_tracking_toggle'),
+      );
+      final Size size = tester.getSize(toggle);
+      expect(
+        size.height,
+        greaterThanOrEqualTo(48),
+        reason: '触摸目标不得低于 48dp（旧的紧凑 IconButton 只有 40）',
+      );
+      expect(size.width, greaterThan(200), reason: '整宽按钮，与底栏按钮同一级别');
+      expect(find.text(t.pause), findsOneWidget);
+      await tester.tap(toggle);
+      expect(toggled, 1);
+      await disposeDialog(tester);
+    });
+
+    testWidgets('暂停中按钮切成「播放」文案 + 播放图标', (WidgetTester tester) async {
+      await pumpDialog(tester, paused: true);
+      expect(find.text(t.play), findsOneWidget);
+      expect(find.text(t.pause), findsNothing);
+      await disposeDialog(tester);
+    });
   });
 }


### PR DESCRIPTION
## 问题

移动端窄屏上阅读统计浮层显示不全。三块统计卡是「等宽三格 + 竖分隔线」的横排，格宽恒为卡宽 ÷ 3、与文字实际长度无关：手机上「速度」那格的 `12345 / h`、时长那格的 `1:23:45` 稳定被省略成「…」，浮层里最该看的数字反而看不全。

另外「本次会话」小标题旁的手动计时开关是 18px、`visualDensity.compact` 的 IconButton，触摸目标约 40dp，低于 48dp 可点击下限，手机上难点中。

## 改动

1. **统计块改纯文字行**：一块一列，每行左标签、右数值，行间横分隔线（`_StatCard` → `_StatRows`）。标签是唯一可收缩的一侧（`Expanded`），数值按自身内在宽度占位，任何语言的标签和任何位数的数值都不再互相挤。内容区右边距从 `gap` 补到 `page`，与左边对称。
2. **计时开关升成底栏级按钮**：移到浮层底部做成整宽按钮，高度走 `density.controlHeight`（48），与底栏按钮同级；暂停中用实心 `FilledButton`（停表是需要注意的非常态），计时中用 tonal 变体。文案沿用旧 tooltip 的 `t.play` / `t.pause`（17 种语言都有真翻译，不新造 key），`ValueKey` 也沿用旧的那一个——桌面端快捷键集成测试按它断言浮层里有计时开关。

## 验证

- 新增 3 条守卫测试：320dp 窄屏 + 最长数值形态下不得 RenderFlex overflow、数值贴行右缘、开关高度 ≥ 48dp 且整宽、暂停态切成播放文案。
- `flutter test test/reader/reader_statistics_dialog_test.dart` 11/11 通过；`flutter analyze` 改动文件零问题。

https://claude.ai/code/session_01XS6yvHU8rUYb5ntvUGcy1j
