### PR TITLE
fix(manga): macOS Aidoku 章节列表恒为空——桌面 runtime 丢弃 send_partial_result（BUG-2262）

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -373,7 +373,7 @@ jobs:
             fi
           done < <(find "$runtime_dir" -type f)
           chmod +x tool/mihon/verify_desktop_runtime.sh
-          tool/mihon/verify_desktop_runtime.sh "$runtime_dir"
+          tool/mihon/verify_desktop_runtime.sh "$runtime_dir" "$app_dir/Contents/MacOS/fushi"
           codesign --force --deep --sign - --timestamp=none "$app_dir"
           codesign --verify --deep --strict --verbose=2 "$app_dir"
       # BUG-1922：与 release-desktop.yml 的 macos job 成对存在。这条 debug job 是

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1113,7 +1113,7 @@ jobs:
             fi
           done < <(find "$runtime_dir" -type f)
           chmod +x tool/mihon/verify_desktop_runtime.sh
-          tool/mihon/verify_desktop_runtime.sh "$runtime_dir"
+          tool/mihon/verify_desktop_runtime.sh "$runtime_dir" "$app_dir/Contents/MacOS/fushi"
           codesign --force --deep --sign - --timestamp=none "$app_dir"
           codesign --verify --deep --strict --verbose=2 "$app_dir"
       # BUG-1922：这一步以前根本不存在。tool/aidoku/build_macos_runtime.sh 只被本地

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2116 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2263](bugs/BUG-2263-macos-mihon-chapters-not-loading.md) | 🚧 | 🚧 | macOS Mihon 章节列表加载不出来（未复现） |
+| [BUG-2262](bugs/BUG-2262-macos-aidoku-partial-result-chapters-dropped.md) | ✅ | ✅ | macOS Aidoku 章节列表恒为空：桌面 runtime 丢弃 send_partial_result 回传的章节 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2262-macos-aidoku-partial-result-chapters-dropped.md
+++ b/docs/bugs/BUG-2262-macos-aidoku-partial-result-chapters-dropped.md
@@ -1,0 +1,18 @@
+## BUG-2262 · macOS Aidoku 章节列表恒为空：桌面 runtime 丢弃 send_partial_result 回传的章节
+- **报告**：2026-09-08（用户：mac 上漫画的 Mihon 和 Aidoku 都没有章节加载出来）
+- **真实性**：✅ 真 bug（Aidoku 半边）。根因 `native/aidoku_runtime/src/main.rs:149`（`imports::generate_imports` 的 import object 被原样使用），对照 `native/aidoku_runtime/src/embedded.rs:860-874`（iOS 自己实现了同一个 import）与 `embedded.rs:2228-2240`（iOS 的合并）。
+
+  **链路**：`MangaSeriesPage._refreshFromSource`（`fushi/lib/src/media/manga/library/manga_series_page.dart`）→ `AidokuLibraryAdapter.refresh`（`fushi/lib/src/media/manga/library/online_manga_runtime_adapter.dart`）→ `chaptersOf(details)`（同文件，只读 `details['chapters']`）→ `DesktopAidokuRuntime.getDetails`（`fushi/lib/src/media/manga/aidoku/aidoku_runtime.dart`）→ 子进程 `fushi-aidoku-runtime details` → `AidokuRuntime::details()` 调 wasm 的 `get_manga_update(manga, 1, 1)`。
+
+  **根因**：aidoku-rs 的源**不在 `get_manga_update` 的返回值里**给章节列表——它把章节通过 host import `env.send_partial_result` 单独推出来（搜索的补充条目同理）。桌面 runner 直接用了上游 `aidoku-test-runner` 生成的 import object，而上游把这个 import 注册成**显式空实现**：
+
+  > `crates/test-runner/src/imports/env.rs:22`（rev `1a6bb691`）
+  > `pub fn send_partial_result(_env: FunctionEnvMut<WasmEnv>, _value: i32) {`
+  > `    // leaving this function unimplemented for now since the test runner doesn't use partial results`
+
+  于是整份章节列表被丢进黑洞。返回值里 `chapters` 是 `None`，`chaptersOf()` 直接返回空列表，**不抛异常**；`_refreshFromSource` 只在抛异常时才置 `_refreshError`，所以 UI 既不弹 toast 也不挂错误横幅——用户看到的就是「搜索正常、点进作品页章节永远是空的、什么错都不报」。
+
+  iOS 从来没有这个 bug：`embedded.rs` 用 wasmi 自己搭 linker，实现了 `send_partial_result` 并在 `details()` / `search()` 里合并 partial。这是一条**只在 macOS 成立**的 iOS/桌面不对等。
+- **[x] ① 已修复** — `native/aidoku_runtime/src/main.rs`：新增 `PartialResults` env + `host_send_partial_result`，在 `AidokuRuntime::load()` 里用 `import_object.define("env", "send_partial_result", ...)` 覆盖上游的空实现（wasmer 的 `define` 是替换语义，与既有的 `std.abort` / `std.print` 覆盖同形）；`details()` 按 `embedded.rs` 同一口径把 partial 里非空的 `chapters` 合并进结果，`search()` 按 `key` 去重合并 partial 条目。线格式（小端 u32 总长 + 8 字节头 + postcard 负载）抽成可单测的 `partial_result_payload_length()`。
+- **[x] ② 已加自动化测试** — `fushi/test/build/aidoku_partial_result_parity_guard_test.dart`（6 条）：钉「`embedded.rs` 与 `main.rs` 对 partial result 的处理必须对等」这条不变式——两侧都得有 `send_partial_result` 实现、都得合并章节、都得按 key 去重合并搜索条目，外加桌面侧的 take 语义、头长度解析、以及 Dart 消费口仍是 `details['chapters']`。已做变异验证：把 `result.chapters = partial.chapters;` 改坏后该测试立刻红。另加 Rust 单测 `decodes_a_partial_result_payload_length` / `rejects_a_partial_result_shorter_than_its_header`。
+- **备注**：提交者本机 cargo 不可用，Rust 侧编译由 PR 的 macOS job 兜底——`build-multiplatform.yml` 的 macos job 会跑 `tool/aidoku/build_macos_runtime.sh`，里面就是 `cargo build --locked --release`。仓库目前**没有任何 `cargo test` / `cargo fmt` / `cargo clippy` 门**，所以新增的两条 Rust 单测不会被 CI 执行（守卫那 6 条会）。**尚未在真 Mac 上复测原始失败路径**（提交者是 Windows），按 CLAUDE.md 验证纪律，合入后需在 Mac 上用任一 Aidoku 源验证作品页章节列表非空再关掉这条。Mihon 半边另见 [BUG-2263](BUG-2263-macos-mihon-chapters-not-loading.md)。

--- a/docs/bugs/BUG-2263-macos-mihon-chapters-not-loading.md
+++ b/docs/bugs/BUG-2263-macos-mihon-chapters-not-loading.md
@@ -1,0 +1,19 @@
+## BUG-2263 · macOS Mihon 章节列表加载不出来（未复现）
+- **报告**：2026-09-08（用户：mac 上漫画的 Mihon 和 Aidoku 都没有章节加载出来）
+- **真实性**：❌ 未复现（提交者本机 Windows，无法在 macOS 上跑原始失败路径）。**沿真实代码路径逐跳查完，没有发现任何 macOS 专有的章节缺陷**——与同批报告的 Aidoku 半边（[BUG-2262](BUG-2262-macos-aidoku-partial-result-chapters-dropped.md)，已定案已修）不同，Mihon 这条链是平台无关的。
+
+  **已排除（逐条带证据）**：
+  - 平台门：`fushi/lib/src/media/manga/mihon/mihon_runtime_factory.dart` 明确把 macOS 与 Windows 同等对待，走同一个 `DesktopMihonRuntime`。
+  - 资源路径：`fushi/lib/src/media/manga/mihon/desktop_mihon_runtime.dart` 的 `_defaultResourceDirectory()`（macOS 走 `Contents/Resources/mihon_bridge`）与 `_javaExecutablePath()`（按 `Abi.current()` 选 `runtime-macos-arm64` / `runtime-macos-x64`）拼装正确，与 `tool/mihon/build_desktop_runtime.sh` 的产物命名一致。
+  - 章节调用链：`mihon_bridge_runtime.dart` 的 `getChapters` → `invokeBridge(..., 'getChapterList', ...)` 是 Android 与桌面**共用**的，没有平台分支；sidecar 侧 `MihonInvoker.invokeGetChapterList` 用 `getMangaUpdate(fetchDetails = false, fetchChapters = true).chapters`，而 `Source.getMangaUpdate` 的默认实现在源没迁移到 1.6 API 时正确回退到 `getChapterList(manga)`。
+  - entitlements：`fushi/macos/Runner/Release.entitlements` 与 `DebugProfile.entitlements` 均已去沙盒且保留 `network.client` / `network.server`，回环连接与子进程监听不受限；两份无 debug/release 分叉。
+  - 打包：两条 macOS job 都装 `mihon_bridge` 并跑 verify；发布 job 还给 JVM 单独授 `allow-jit` / `allow-unsigned-executable-memory` / `disable-library-validation`。
+  - 空章节保护：`online_manga_library_service.dart` 在源返回空列表而库里原有章节时主动抛 `runtimeFailure`，不会静默清空。
+
+  **仍未排除、需要用户机器上的证据才能定案**：
+  1. `<fushi.app>/Contents/Resources/mihon_bridge/` 是否真的有 `m-extension-server.jar` 与 `runtime-macos-<abi>/bin/java`。**Xcode 工程里零接线**（`fushi/macos/Runner.xcodeproj/project.pbxproj` 无任何 mihon/aidoku build phase），两个 runtime 只由 CI 的 post-build 步骤和 `script/build_and_run.sh` 注入——所以任何直接 `flutter build macos` / `flutter run -d macos` 产出的 app 里两个 runtime**都是空的**，Mihon 与 Aidoku 会同时死。这与用户「两个都没章节」的描述高度吻合，是当前最可能的单一解释。
+  2. `<数据根>/mihon/logs/sidecar.log`（`desktop_mihon_runtime.dart` 的 `_SidecarLogSink`）：sidecar 起来了的话，`getChapterList` 的完整 Java 栈一定在里面。
+  3. Intel Mac 的话，见下面已补的架构门。
+- **[ ] ① 未修复** — 无确证根因，不做投机修改。本轮只补了一条**可验证的** macOS 专有缺口（不宣称它就是用户的症状）：`tool/mihon/verify_desktop_runtime.sh` 原本只按 `uname -m` 冒烟宿主架构的 `java`，而 CI runner 恒是 Apple Silicon——交叉 jlink（arm64 宿主 + x64 jmods）出来的 `runtime-macos-x64` 从来没被核对过一次，一旦它实际是 arm64，Intel Mac 上会被内核以 EBADARCH 拒掉，表现为**整条 Mihon 链（源列表/搜索/详情/章节/看图）全废而 CI 全绿**。这与 Aidoku 侧 BUG-1668 / BUG-1922 同形，那边早已有 `tool/aidoku/verify_macos_runtime.sh` 的架构覆盖门，Mihon 侧一直缺。现按同一形状补上：verify 接受可选的 app 本体参数，逐个核对「app 能跑的每个架构都有对应的 JVM 镜像、且那个镜像真的是该架构」，两条 macOS job 都把 `$app_dir/Contents/MacOS/fushi` 喂进去。
+- **[ ] ② 未加自动化测试** — 症状本身没有可落地的测试层（无根因）。已补的架构门有守卫：`fushi/test/build/macos_mihon_bundle_guard_test.dart` 新增 3 条（verify 脚本必须有 `lipo -archs "$app_executable"` 与可诊断的 EBADARCH 失败原因；构建脚本默认 `FUSHI_MIHON_ARCHS:-all`；两条 workflow 都必须把 app 本体传给 verify）。
+- **备注**：下次拿到用户证据（上面的 1/2/3 任一）后再定案。取证顺序：先 `ls "<fushi.app>/Contents/Resources/mihon_bridge/"`，若为空或缺 `runtime-macos-<abi>/bin/java` 即可直接结案为「app 不是 CI 产物」；否则读 sidecar.log。

--- a/fushi/test/build/aidoku_partial_result_parity_guard_test.dart
+++ b/fushi/test/build/aidoku_partial_result_parity_guard_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-2262：macOS 上 Aidoku 作品页的章节列表恒为空，且不报任何错。
+///
+/// aidoku-rs 的源不是在 `get_manga_update` 的返回值里给章节列表的——它把章节
+/// 通过 `env.send_partial_result` 单独推出来（搜索的补充条目同理）。iOS 那侧
+/// （`embedded.rs`）自己实现了这个 import 并在拿到最终结果后合并 partial；
+/// 桌面那侧（`main.rs`）直接用了上游 `aidoku-test-runner` 的 import object，
+/// 而上游把 `send_partial_result` 注册成**显式空实现**（源码注释原话：
+/// "leaving this function unimplemented for now since the test runner doesn't
+/// use partial results"）。于是整份章节列表被丢进黑洞：搜索正常、详情正常、
+/// 章节恒为空，`chaptersOf()` 拿到 null 就静静返回空列表，UI 连错误横幅都不挂。
+///
+/// 这组守卫钉的不变式是：**两个 runtime 对 partial result 的处理必须对等**。
+/// 只在 iOS 侧加一种 partial 用法、桌面侧忘了跟，就是这个 bug 的复发形态，
+/// 所以每条断言都成对检查 `embedded.rs` 与 `main.rs`。
+void main() {
+  String readCode(String path) {
+    final File file = File(path);
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: 'expected file at ${file.absolute.path}',
+    );
+    // 掩注释再折叠空白：本文件里每条 needle 都同时出现在解释性注释中，不掩就
+    // 会拿注释假绿；折叠空白是为了不被 rustfmt 的换行位置绑死。
+    return compactCode(maskComments(file.readAsStringSync()));
+  }
+
+  late final String desktop = readCode('../native/aidoku_runtime/src/main.rs');
+  late final String embedded = readCode(
+    '../native/aidoku_runtime/src/embedded.rs',
+  );
+
+  test('桌面 runtime 自己实现 env.send_partial_result，不吃上游的空实现', () {
+    expect(
+      desktop,
+      contains('import_object.define("env","send_partial_result",'),
+      reason: 'imports::generate_imports() 给的是上游的 no-op。不覆盖它，'
+          '源推出来的章节列表就整份丢失（BUG-2262）。',
+    );
+    expect(
+      desktop,
+      contains('fnhost_send_partial_result('),
+      reason: '覆盖必须指向真正读 wasm 内存的 host 函数，不能又是个空壳。',
+    );
+    expect(
+      embedded,
+      contains('"send_partial_result",'),
+      reason: 'iOS 侧一直实现着它；这条掉了说明两侧一起塌了。',
+    );
+  });
+
+  test('两侧都把 partial 里的章节合并进 details 结果', () {
+    for (final MapEntry<String, String> runtime in <String, String>{
+      'main.rs': desktop,
+      'embedded.rs': embedded,
+    }.entries) {
+      expect(
+        runtime.value,
+        contains('result.chapters=partial.chapters;'),
+        reason: '${runtime.key} 没有合并 partial 章节。get_manga_update 的返回值里'
+            'chapters 往往是 None，不合并就等于作品页永远没有章节。',
+      );
+      expect(
+        runtime.value,
+        contains('postcard::from_bytes::<Manga>(&bytes)'),
+        reason: '${runtime.key} 必须按 Manga 解码 partial 负载。',
+      );
+    }
+  });
+
+  test('两侧都把 partial 里的补充条目合并进搜索结果', () {
+    for (final MapEntry<String, String> runtime in <String, String>{
+      'main.rs': desktop,
+      'embedded.rs': embedded,
+    }.entries) {
+      expect(
+        runtime.value,
+        contains('result.entries.push(partial);'),
+        reason: '${runtime.key} 丢掉了以 partial 形式补发的搜索条目。',
+      );
+      expect(
+        runtime.value,
+        contains('!result.entries.iter().any(|manga|manga.key==partial.key)'),
+        reason: '${runtime.key} 合并搜索条目时必须按 key 去重，否则会出现重复卡片。',
+      );
+    }
+  });
+
+  test('桌面 runtime 每次调用后清空 partial 缓冲，不跨调用串味', () {
+    expect(
+      desktop,
+      contains('fntake_partials(&mutself)->Vec<Vec<u8>>'),
+      reason: '取用必须是「取走」语义。',
+    );
+    expect(
+      desktop,
+      contains(
+        'std::mem::take(&mutself.partials.as_mut(&mutself.store).buffers)',
+      ),
+      reason: '留着不清，下一次调用会把上一次的章节当成自己的结果——'
+          '一个进程一条命令时看不出来，但 runtime 是可复用的。',
+    );
+  });
+
+  test('partial 负载长度按 8 字节头解析，短于头的一律丢弃', () {
+    expect(
+      desktop,
+      contains('fnpartial_result_payload_length(header:[u8;4])->Option<usize>'),
+      reason: '线格式由 aidoku-rs 定死，解析必须是可单测的独立函数。',
+    );
+    expect(
+      desktop,
+      contains('iflength<8{'),
+      reason: '头本身占 8 字节，小于 8 的长度不是合法 partial。',
+    );
+  });
+
+  test('Dart 侧仍然只从 details 的 chapters 键里取章节', () {
+    final String adapter = readCode(
+      'lib/src/media/manga/library/online_manga_runtime_adapter.dart',
+    );
+
+    expect(
+      adapter,
+      contains("details['chapters']"),
+      reason: 'Rust 侧的合并结果就是喂给这里的。消费口一旦改名，上面所有断言就'
+          '变成在守一份没人读的数据。',
+    );
+  });
+}

--- a/fushi/test/build/macos_mihon_bundle_guard_test.dart
+++ b/fushi/test/build/macos_mihon_bundle_guard_test.dart
@@ -30,4 +30,54 @@ void main() {
     expect(script, contains('shasum -a 256 --check'));
     expect(script, contains('--continue-at -'));
   });
+
+  test('Mihon runtime 默认出全架构，不是 runner 的 host 架构', () {
+    final String script =
+        File('../tool/mihon/build_desktop_runtime.sh').readAsStringSync();
+
+    expect(
+      script,
+      contains(r'${FUSHI_MIHON_ARCHS:-all}'),
+      reason: '发布包必须两个架构都出。降级成 host 会让 Intel Mac 上整条 Mihon 链'
+          '直接没有 JVM 镜像可用。',
+    );
+  });
+
+  test('verify 脚本用 app 本体核对 JVM 镜像的架构覆盖', () {
+    final String script =
+        File('../tool/mihon/verify_desktop_runtime.sh').readAsStringSync();
+
+    expect(
+      script,
+      contains(r'lipo -archs "$app_executable"'),
+      reason: '脚本原本只按 uname -m 冒烟宿主架构的 java，而 runner 恒是 Apple '
+          'Silicon——交叉 jlink 出来的 x64 镜像一次都没被核对过。',
+    );
+    expect(
+      script,
+      contains('runtime-macos-x64/bin/java'),
+      reason: 'Dart 侧按 Abi.current() 选目录，两个目录都要能被这道门核到。',
+    );
+    expect(
+      script,
+      contains('EBADARCH'),
+      reason: '架构不匹配时必须给出可诊断的失败原因，而不是一句泛泛的 verify failed。',
+    );
+  });
+
+  test('两条 macOS job 都把 app 本体喂给 Mihon 的架构门', () {
+    for (final String path in <String>[
+      '../.github/workflows/release-desktop.yml',
+      '../.github/workflows/build-multiplatform.yml',
+    ]) {
+      final String workflow = File(path).readAsStringSync();
+
+      expect(
+        workflow,
+        contains(r'tool/mihon/verify_desktop_runtime.sh "$runtime_dir" '
+            r'"$app_dir/Contents/MacOS/fushi"'),
+        reason: '$path 不传 app 本体，verify 里的架构覆盖门就整段被跳过。',
+      );
+    }
+  });
 }

--- a/native/aidoku_runtime/src/main.rs
+++ b/native/aidoku_runtime/src/main.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use wasmer::{Function, FunctionEnv, FunctionEnvMut, Instance, Module, Store, TypedFunction};
+use wasmer::{Function, FunctionEnv, FunctionEnvMut, Instance, Memory, Module, Store, TypedFunction};
 use zip::ZipArchive;
 
 const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
@@ -116,8 +116,69 @@ fn validate_manifest(manifest: &Value) -> Result<()> {
 struct AidokuRuntime {
     store: Store,
     environment: FunctionEnv<WasmEnv>,
+    partials: FunctionEnv<PartialResults>,
     instance: Instance,
     module: Module,
+}
+
+/// Buffers handed over by the source through `env.send_partial_result`.
+///
+/// aidoku-rs sources stream the expensive half of `get_manga_update` — the
+/// chapter list — out through this import instead of putting it in the value
+/// they finally return; the same goes for extra search entries. The upstream
+/// MIT test runner registers the import as an explicit no-op ("leaving this
+/// function unimplemented for now since the test runner doesn't use partial
+/// results"), so inheriting its import object drops every chapter list on the
+/// floor. That is exactly what macOS did: search worked, the series page came
+/// back with zero chapters, and nothing failed loudly enough to show an error
+/// (BUG-2262). iOS never had the bug because `embedded.rs` implements the
+/// import itself; this type restores parity for the desktop runner.
+#[derive(Default)]
+struct PartialResults {
+    memory: Option<Memory>,
+    buffers: Vec<Vec<u8>>,
+}
+
+/// Payload length of a partial-result buffer, or `None` when the header does
+/// not describe one.
+///
+/// Wire shape is fixed by aidoku-rs and mirrored from `embedded.rs`: a
+/// little-endian `u32` total length at the pointer, four bytes the host does
+/// not need, then `length - 8` bytes of postcard payload at `pointer + 8`.
+fn partial_result_payload_length(header: [u8; 4]) -> Option<usize> {
+    let length = u32::from_le_bytes(header);
+    if length < 8 {
+        return None;
+    }
+    Some((length - 8) as usize)
+}
+
+/// Host side of `env.send_partial_result`.
+///
+/// Every failure path is a silent `return` on purpose: a malformed partial is
+/// an optimisation that did not land, never a reason to fail the whole call —
+/// the source still returns its real result afterwards.
+fn host_send_partial_result(mut environment: FunctionEnvMut<PartialResults>, pointer: i32) {
+    if pointer < 0 {
+        return;
+    }
+    let (data, store) = environment.data_and_store_mut();
+    let Some(memory) = data.memory.clone() else {
+        return;
+    };
+    let view = memory.view(&store);
+    let mut header = [0u8; 4];
+    if view.read(pointer as u64, &mut header).is_err() {
+        return;
+    }
+    let Some(payload_length) = partial_result_payload_length(header) else {
+        return;
+    };
+    let mut payload = vec![0u8; payload_length];
+    if view.read(pointer as u64 + 8, &mut payload).is_err() {
+        return;
+    }
+    data.buffers.push(payload);
 }
 
 fn host_std_abort(mut environment: FunctionEnvMut<WasmEnv>) {
@@ -146,7 +207,16 @@ impl AidokuRuntime {
         let mut store = Store::default();
         let module = Module::new(&store, wasm).context("failed to compile Aidoku WebAssembly")?;
         let environment = FunctionEnv::new(&mut store, WasmEnv::new());
+        let partials = FunctionEnv::new(&mut store, PartialResults::default());
         let mut import_object = imports::generate_imports(&mut store, &environment);
+        // Overrides the upstream no-op so partial results actually reach us;
+        // see `PartialResults` for why dropping them empties every chapter
+        // list (BUG-2262).
+        import_object.define(
+            "env",
+            "send_partial_result",
+            Function::new_typed_with_env(&mut store, &partials, host_send_partial_result),
+        );
         // aidoku-rs' panic handler imports these from `std`, while the current
         // MIT test runner only registers the normal logging functions in
         // `env`. Supplying both namespaces matches the source ABI.
@@ -167,6 +237,7 @@ impl AidokuRuntime {
             .get_memory("memory")
             .context("Aidoku source does not export memory")?
             .clone();
+        partials.as_mut(&mut store).memory = Some(memory.clone());
         environment.as_mut(&mut store).memory = Some(memory);
 
         let start: TypedFunction<(), ()> = instance
@@ -180,9 +251,16 @@ impl AidokuRuntime {
         Ok(Self {
             store,
             environment,
+            partials,
             instance,
             module,
         })
+    }
+
+    /// Drains everything the source pushed through `env.send_partial_result`
+    /// since the last call.
+    fn take_partials(&mut self) -> Vec<Vec<u8>> {
+        std::mem::take(&mut self.partials.as_mut(&mut self.store).buffers)
     }
 
     fn capabilities(&self) -> Value {
@@ -305,7 +383,16 @@ impl AidokuRuntime {
             .store
             .remove(filters_descriptor);
 
-        self.take_result(result_pointer)
+        let mut result: SearchPageResult = self.take_result(result_pointer)?;
+        for bytes in self.take_partials() {
+            let Ok(partial) = postcard::from_bytes::<Manga>(&bytes) else {
+                continue;
+            };
+            if !result.entries.iter().any(|manga| manga.key == partial.key) {
+                result.entries.push(partial);
+            }
+        }
+        Ok(result)
     }
 
     fn list(&mut self, listing: &Listing, page: i32) -> Result<SearchPageResult> {
@@ -352,7 +439,24 @@ impl AidokuRuntime {
             .as_mut(&mut self.store)
             .store
             .remove(manga_descriptor);
-        self.take_result(result_pointer)
+        let mut result: Manga = self.take_result(result_pointer)?;
+        // The chapter list normally arrives as a partial result, not in the
+        // returned value — without this merge `result.chapters` stays `None`
+        // and the series page renders an empty, error-free chapter list
+        // (BUG-2262). Last non-empty partial wins, same as `embedded.rs`.
+        for bytes in self.take_partials() {
+            let Ok(partial) = postcard::from_bytes::<Manga>(&bytes) else {
+                continue;
+            };
+            if partial
+                .chapters
+                .as_ref()
+                .is_some_and(|value| !value.is_empty())
+            {
+                result.chapters = partial.chapters;
+            }
+        }
+        Ok(result)
     }
 
     fn pages(&mut self, manga: &Manga, chapter: &Chapter) -> Result<Vec<HostPage>> {
@@ -548,6 +652,21 @@ mod tests {
         );
         let error = AixPackage::open(file.path()).expect_err("reject empty name");
         assert!(error.to_string().contains("info.name"));
+    }
+
+    #[test]
+    fn decodes_a_partial_result_payload_length() {
+        // 8-byte header + 3 payload bytes.
+        assert_eq!(partial_result_payload_length(11u32.to_le_bytes()), Some(3));
+        // Header only: a partial with no payload is still well formed.
+        assert_eq!(partial_result_payload_length(8u32.to_le_bytes()), Some(0));
+    }
+
+    #[test]
+    fn rejects_a_partial_result_shorter_than_its_header() {
+        for length in [0u32, 1, 7] {
+            assert_eq!(partial_result_payload_length(length.to_le_bytes()), None);
+        }
     }
 
     #[test]

--- a/tool/mihon/verify_desktop_runtime.sh
+++ b/tool/mihon/verify_desktop_runtime.sh
@@ -1,17 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "usage: $0 RUNTIME_DIRECTORY" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 RUNTIME_DIRECTORY [APP_EXECUTABLE]" >&2
   exit 64
 fi
 
 runtime_directory="$(cd "$1" && pwd)"
+app_executable="${2:-}"
 case "$(uname -m)" in
   arm64) java="$runtime_directory/runtime-macos-arm64/bin/java" ;;
   x86_64) java="$runtime_directory/runtime-macos-x64/bin/java" ;;
   *) echo "unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
 esac
+
+# 下面那段冒烟只证明**这台 runner 的架构**能跑它，而 runner 恒是 Apple Silicon。
+# `DesktopMihonRuntime._javaExecutablePath()` 按 `Abi.current()` 在
+# runtime-macos-arm64 / runtime-macos-x64 之间选目录，所以真正的不变式是：app
+# 本体能以哪些架构运行，就必须有哪个架构的 JVM 镜像、且那个镜像真的是该架构。
+# 交叉 jlink（arm64 宿主 + x64 jmods）出错时产物看着齐全、名字也对，只有到
+# Intel Mac 上才被内核以 EBADARCH 拒掉——表现是整条 Mihon 链（源列表、搜索、
+# 详情、章节、看图）全废，而 CI 全绿。Aidoku 侧的同形门见
+# tool/aidoku/verify_macos_runtime.sh（BUG-1668 / BUG-1922）。
+if [[ -n "$app_executable" ]]; then
+  if [[ ! -x "$app_executable" ]]; then
+    echo "app executable not found for the Mihon runtime architecture gate: $app_executable" >&2
+    exit 1
+  fi
+  app_archs="$(lipo -archs "$app_executable")"
+  echo "app archs: $app_archs"
+  for want in $app_archs; do
+    case "$want" in
+      arm64) want_java="$runtime_directory/runtime-macos-arm64/bin/java" ;;
+      x86_64) want_java="$runtime_directory/runtime-macos-x64/bin/java" ;;
+      *)
+        echo "unsupported app architecture for the Mihon runtime gate: $want" >&2
+        exit 1
+        ;;
+    esac
+    if [[ ! -x "$want_java" ]]; then
+      echo "Mihon runtime 缺 $want 的 JVM 镜像（缺 $want_java）。该架构的 Mac 上 sidecar 起不来，漫画 Mihon 源整条链全部失效。" >&2
+      exit 1
+    fi
+    want_java_archs="$(lipo -archs "$want_java")"
+    echo "mihon $want java archs: $want_java_archs"
+    case " $want_java_archs " in
+      *" $want "*) ;;
+      *)
+        echo "Mihon 的 $want JVM 镜像实际是 $want_java_archs（交叉 jlink 出错）。该架构的 Mac 上会被内核以 EBADARCH 拒掉。" >&2
+        exit 1
+        ;;
+    esac
+  done
+fi
 server="$runtime_directory/m-extension-server.jar"
 for required in "$java" "$server" "$runtime_directory/checksums.json" \
   "$runtime_directory/LICENSE-M-Extension-Server.txt" \


### PR DESCRIPTION
## 症状

用户报：macOS 上漫画的 Aidoku 源，作品页章节列表永远是空的——**搜索正常、详情正常、章节恒为空，而且不报任何错**（连错误横幅都不挂）。

## 根因（BUG-2262）

aidoku-rs 的源**不在 `get_manga_update` 的返回值里**给章节列表——它把章节通过 host import `env.send_partial_result` 单独推出来（搜索的补充条目同理）。

桌面 runner（`native/aidoku_runtime/src/main.rs`）直接用了上游 `aidoku-test-runner` 生成的 import object，而上游把这个 import 注册成**显式空实现**：

> `crates/test-runner/src/imports/env.rs:22`（rev `1a6bb691`）
> ```rust
> pub fn send_partial_result(_env: FunctionEnvMut<WasmEnv>, _value: i32) {
>     // leaving this function unimplemented for now since the test runner doesn't use partial results
> ```

于是整份章节列表被丢进黑洞。返回值里 `chapters` 是 `None`，`chaptersOf()` 直接返回空列表且**不抛异常**；`MangaSeriesPage._refreshFromSource` 只在抛异常时才置 `_refreshError`，所以 UI 静默无声。

iOS 从来没有这个 bug：`embedded.rs` 用 wasmi 自己搭 linker，实现了 `send_partial_result` 并在 `details()` / `search()` 里合并 partial。**这是一条只在 macOS 成立的 iOS/桌面不对等。**

## 改动

**修复**（`native/aidoku_runtime/src/main.rs`）
- 新增 `PartialResults` env + `host_send_partial_result`，在 `AidokuRuntime::load()` 里用 `import_object.define("env", "send_partial_result", ...)` 覆盖上游的空实现（wasmer 的 `define` 是替换语义，与既有的 `std.abort` / `std.print` 覆盖同形）。
- `details()` 合并 partial 里非空的 `chapters`，`search()` 按 `key` 去重合并 partial 条目——口径与 `embedded.rs` 逐字对齐。
- 线格式（小端 u32 总长 + 8 字节头 + postcard 负载）抽成可单测的 `partial_result_payload_length()`。

**守卫**（`fushi/test/build/aidoku_partial_result_parity_guard_test.dart`，6 条）
钉「`embedded.rs` 与 `main.rs` 对 partial result 的处理必须对等」这条不变式——只在 iOS 侧加一种 partial 用法而桌面侧忘了跟，就是本 bug 的复发形态。**已做变异验证**：把 `result.chapters = partial.chapters;` 改坏后该测试立刻红。

**顺带：Mihon 侧同形但一直缺失的架构硬门**（BUG-2263，症状未复现）
`tool/mihon/verify_desktop_runtime.sh` 原本只按 `uname -m` 冒烟宿主架构的 `java`，而 CI runner 恒是 Apple Silicon——交叉 jlink（arm64 宿主 + x64 jmods）出来的 `runtime-macos-x64` **从来没被核对过一次**。它若实际是 arm64，Intel Mac 上整条 Mihon 链（源列表/搜索/详情/章节/看图）会被内核以 EBADARCH 拒掉而 CI 全绿。这与 Aidoku 侧 BUG-1668 / BUG-1922 同形，那边早有 `tool/aidoku/verify_macos_runtime.sh` 的架构覆盖门，Mihon 侧一直缺。现按同一形状补上，两条 macOS job 都把 `$app_dir/Contents/MacOS/fushi` 喂进去。

## 关于 Mihon 那半边（BUG-2263，标为未复现）

用户同时报了 Mihon 也没章节，但**沿真实代码路径逐跳查完，没有发现任何 macOS 专有的章节缺陷**，因此不做投机修改。已排除：平台门、资源路径拼装、章节调用链（`getChapterList` 是 Android/桌面共用，无平台分支）、sidecar 的 `getMangaUpdate(fetchChapters = true)` 及其默认回退、entitlements、CI 打包与签名、空章节保护。

最可能的单一解释记录在 BUG-2263 里待取证：**Xcode 工程里两个 runtime 零接线**，只由 CI 的 post-build 步骤和 `script/build_and_run.sh` 注入——所以任何直接 `flutter build macos` / `flutter run -d macos` 产出的 app 里 Mihon 与 Aidoku 的 runtime 都是空的，会同时死。

## 验证

- `flutter analyze` → `No issues found!`，退出码 0。
- 相关守卫 24 条全绿，退出码 0（新增 6 条 + Mihon 门 3 条 + 既有 Aidoku 打包守卫、bug 文档结构守卫、source_guard 采用守卫）。
- 「目录枚举型守卫」整批 362 tests，与仓库文档基线一致。

## 已知局限

- 提交者本机 Windows 且 cargo 不可用，**Rust 侧编译由本 PR 的 macOS job 兜底**（`tool/aidoku/build_macos_runtime.sh` 里就是 `cargo build --locked --release`）。
- 本仓**没有任何 `cargo test` / `cargo fmt` / `cargo clippy` 门**，所以新增的两条 Rust 单测不会被 CI 执行（那 6 条 Dart 守卫会）。
- **尚未在真 Mac 上复测原始失败路径**，已在 BUG-2262 备注里登记待补：合入后需在 Mac 上用任一 Aidoku 源验证作品页章节列表非空。

https://claude.ai/code/session_0147RsVXcoJmUjdykvG7uXfd
