### PR TITLE
feat(macos): 顶栏与 Windows 同壳（去交通灯）+ Retina 视频按物理像素渲染（BUG-2258）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2115 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2258](bugs/BUG-2258-macos-video-retina-blur.md) | ✅ | ✅ | mac 视频在 Retina 上发虚：media_kit 按视频原生分辨率建纹理，放大交给 Flutter 双线性 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2258-macos-video-retina-blur.md
+++ b/docs/bugs/BUG-2258-macos-video-retina-blur.md
@@ -1,0 +1,30 @@
+## BUG-2258 · mac 视频在 Retina 上发虚：media_kit 按视频原生分辨率建纹理，放大交给 Flutter 双线性
+- **报告**：2026-09-08（用户：「mac视频的retina也要适配」→ 追问后确认症状是**发虚**，并指定「参考 iina 的处理方式」）
+- **真实性**：✅ 真 bug（结构性，非偶发）。根因链：
+  - `third_party/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift:180-196`
+    （`videoSize`）——未显式 `setSize` 时纹理尺寸恒等于 mpv 报的 `dw/dh`，即**视频原生
+    分辨率**，与显示器 backing scale 无关。
+  - `third_party/media_kit_video/lib/src/video/video_texture.dart:410-436`——`Texture` 被放进
+    `SizedBox(rect.width, rect.height)`（逻辑像素）再由 `FittedBox` 缩放，缩放器是
+    `filterQuality`，默认 `FilterQuality.low`（双线性）。
+  - 于是 Retina（DPR 2）下 1080p 片源在 1440×810pt 的框里，实际要铺 2880×1620 **物理**像素，
+    每帧都是「1920 宽的图被双线性拉到 2880」→ 整片发虚；mpv 自己的缩放器与用户着色器
+    （`fushi/lib/src/media/video/video_shader_manager.dart`）完全用不上，因为缩放根本不在
+    mpv 里发生。
+  - IINA 的做法是让 mpv 直接渲染到 backing store 尺寸（`convertToBacking`），缩放全部在 mpv
+    内完成——这正是「参考 iina」要对齐的点。
+- **[x] ① 已修复** — 新增 `fushi/lib/src/media/video/video_backing_render_size.dart`：量出 `Video`
+  控件框的物理像素尺寸，按**片源宽高比**算出画面真正要占的物理像素，经
+  `VideoController.setSize` 交给 mpv（防抖 180ms、±5% 内不动、4K 像素上限、仅 macOS）。
+  窗口侧与全屏路由两条 `Video` 都接
+  （`fushi/lib/src/pages/implementations/video_fushi/layout.part.dart`、`.../fullscreen.part.dart`）。
+  按片源比例而不是框的比例下发是必须的：mpv 会在给定尺寸内保持比例并自行补黑边，比例不等
+  时黑边会被烤进纹理，Flutter 侧的 `cover` / `fill` 会连黑边一起裁 / 拉。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_backing_render_size_test.dart`：
+  数值契约钉在纯函数 `resolveVideoBackingRenderSize` 上（Retina contain / cover / fill 取边、
+  比例守恒、缩小也下发、像素上限、退化输入不下发），接线钉源码（两条 Video 都接、输入取原生
+  解码尺寸而非 `controller.rect`、macOS 门控 + 防抖）。真实渲染要 macOS + NSWindow + 平台通道，
+  headless `flutter test` 一样都没有，故最强可落地层就是这两组。
+- **备注**：真机复测未做（本机是 Windows，无 Mac）——按仓库口径这条属
+  `implemented_unverified`，Retina 观感改善需在 Mac 上回原始路径确认。同批改动还包含
+  「macOS 改用与 Windows 同款自绘 MD3 顶栏、隐藏交通灯」，二者共处一条分支但互相独立。

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -38,7 +38,7 @@ import 'package:fushi/src/utils/misc/present_watchdog.dart';
 import 'package:fushi/src/utils/misc/shortcut_icon_sync.dart';
 import 'package:fushi/src/utils/misc/wgc_capture_log.dart';
 import 'package:fushi/src/utils/window_caption_channel.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/src/utils/adaptive/fushi_macos_theme.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/shortcuts/global_navigation.dart';
@@ -237,16 +237,27 @@ void main([List<String> args = const <String>[]]) {
     }
     if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
       await windowManager.ensureInitialized();
-      if (Platform.isWindows) {
+      if (Platform.isWindows || Platform.isMacOS) {
         // window_manager's Windows plugin implements setTitleBarStyle as a
         // string assignment + SetWindowPos and always reports success, so there
-        // is no failure mode to fall back from here. The app frame is therefore
-        // unconditional on Windows once the plugin is initialised.
+        // is no failure mode to fall back from here (the macOS plugin likewise
+        // just flips NSWindow properties). The app frame is therefore
+        // unconditional on both hosts once the plugin is initialised.
+        //
+        // macOS 走同一条路（用户拍板：两端同一个 MD3 顶栏）：`hidden` 在 macOS
+        // 上是 `titleVisibility=.hidden` + `titlebarAppearsTransparent` +
+        // `fullSizeContentView`，`windowButtonVisibility: false` 则把红黄绿三个
+        // 交通灯 `standardWindowButton(_).isHidden = true`。于是 macOS 不再有
+        // 系统交通灯，最小化/缩放/关闭全部由 [FushiDesktopTitleBar] 的 MD3 按钮
+        // 提供（AppKit 仍然自己拥有窗口四边的 resize 边框，不需要 app 代劳）。
+        // 这也一并根除了「交通灯浮在 Flutter 内容左上角」派生的一整串让位补丁
+        // （BUG-869 的 SafeArea 保留带、BUG-973 视频页临时隐藏、BUG-1343 阅读器
+        // 自绘拖拽带）。
         await windowManager.setTitleBarStyle(
           TitleBarStyle.hidden,
           windowButtonVisibility: false,
         );
-        FushiWindowsTitleBar.markEnabled();
+        FushiDesktopTitleBar.markEnabled();
       }
       // BUG-1619：主窗前台真值的唯一来源，必须在 window_manager 初始化之后、
       // 任何页面挂载之前起来——焦点闸门与焦点控制器都读它。
@@ -1983,8 +1994,11 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                         scale: uiScale,
                         child: navigation,
                       );
-                      if (Platform.isWindows &&
-                          FushiWindowsTitleBar.isEnabled) {
+                      // 自绘顶栏的唯一门控就是这条启动闩（Windows / macOS 由
+                      // `main()` 置位）：不再叠一层 `Platform.isWindows`，否则
+                      // macOS 明明已经隐藏了系统标题栏与交通灯，却拿不到替代顶栏
+                      // ——窗口既没有标题也没有最小化/关闭按钮。
+                      if (FushiDesktopTitleBar.isEnabled) {
                         navigation = ValueListenableBuilder<bool>(
                           // The home rail is only on screen while the home
                           // shell is the top route; opening a media item
@@ -1999,7 +2013,7 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
                             final bool railVisible = !mediaOpen &&
                                 windowSizeClassForWidth(viewport.width) !=
                                     WindowSizeClass.compact;
-                            return FushiWindowsTitleBar(
+                            return FushiDesktopTitleBar(
                               // The native-sized frame sits outside app UI
                               // zoom; align its title with the visually scaled
                               // home rail. Breakpoint and rail width both come

--- a/fushi/lib/src/media/video/video_backing_render_size.dart
+++ b/fushi/lib/src/media/video/video_backing_render_size.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+import 'package:media_kit_video/media_kit_video.dart' show VideoController;
+
+/// macOS Retina 下「按物理像素渲染视频」（IINA 同款做法）。
+///
+/// 症状（用户报告：mac 视频发虚）：media_kit 在 darwin 上把纹理**固定建成视频原生
+/// 分辨率**（`VideoOutput.videoSize` 读 mpv 的 `dw/dh`），`Video` 再把这张图交给
+/// Flutter 按 `FilterQuality.low`（双线性）缩放到控件框。Retina 屏上控件框的物理
+/// 像素是逻辑尺寸的 2 倍：1080p 片源在 1440×810pt 的框里实际要铺 2880×1620 物理
+/// 像素，于是每帧都是「1920 宽的图被双线性拉到 2880」——整片发虚，而且 mpv 的缩放
+/// 器与用户着色器（`VideoShaderManager`）全都用不上，因为缩放根本不在 mpv 里发生。
+///
+/// IINA 的做法是让 mpv 直接渲染到 backing store 尺寸（`convertToBacking`），缩放由
+/// mpv 完成。本组件是同一思路在 media_kit 上的落点：量出 `Video` 控件框的物理像素
+/// 尺寸，按视频原生宽高比算出「画面真正要占的物理像素」，用
+/// [VideoController.setSize] 把它交给 mpv。按视频宽高比下发（而不是直接把框的尺寸
+/// 丢过去）是必须的：mpv 会在给定尺寸里保持比例、自己补黑边，比例一旦不等于片源，
+/// 黑边会被烤进纹理，Flutter 侧的 `cover` / `fill` 就会连黑边一起裁 / 拉。
+///
+/// 为什么只在 macOS：Windows 走 ANGLE 共享纹理 + HDR 直通宿主窗（另一条链路，改渲染
+/// 尺寸会牵动 `HdrHostRectReporter` 的矩形契约），移动端拿不到同等收益却要为软件渲染
+/// 多付 CPU。本次用户要的就是 mac 端。
+///
+/// 尺寸变化必经防抖：拖窗口会连发几十帧不同尺寸，每帧重建纹理就是卡顿。
+class VideoBackingRenderSize extends StatefulWidget {
+  const VideoBackingRenderSize({
+    required this.controller,
+    required this.videoSize,
+    required this.fit,
+    required this.child,
+    super.key,
+  });
+
+  /// 目标控制器：算出来的物理尺寸下发到它。
+  final VideoController controller;
+
+  /// 视频**原生**解码尺寸（`player.state.width/height`）。
+  ///
+  /// 必须是原生尺寸而不是 `controller.rect`：后者正是本组件写进去的值，拿它当输入
+  /// 会自激（下发 → rect 变 → 重算 → 再下发）。
+  final Size? videoSize;
+
+  /// 画面在框内的贴合方式（用户偏好 `VideoFitMode` 换算而来）。
+  final BoxFit fit;
+
+  final Widget child;
+
+  @override
+  State<VideoBackingRenderSize> createState() => _VideoBackingRenderSizeState();
+}
+
+class _VideoBackingRenderSizeState extends State<VideoBackingRenderSize> {
+  static const Duration _debounce = Duration(milliseconds: 180);
+
+  Timer? _timer;
+  Size? _applied;
+  Size? _pending;
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _schedule(Size? target) {
+    if (target == _pending) return;
+    _pending = target;
+    _timer?.cancel();
+    _timer = Timer(_debounce, _apply);
+  }
+
+  void _apply() {
+    final Size? target = _pending;
+    if (!mounted || target == _applied) return;
+    _applied = target;
+    // 失败静默：渲染尺寸是纯画质优化，平台通道不可用时保持 media_kit 默认（视频原生
+    // 尺寸），绝不因此让播放链路抛错。
+    unawaited(
+      widget.controller
+          .setSize(width: target?.width.round(), height: target?.height.round())
+          .catchError((Object e) {
+        debugPrint('[Fushi] video backing render size skipped: $e');
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!Platform.isMacOS) return widget.child;
+    final double dpr = MediaQuery.devicePixelRatioOf(context);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        _schedule(
+          resolveVideoBackingRenderSize(
+            boxLogicalSize: constraints.biggest,
+            devicePixelRatio: dpr,
+            videoNativeSize: widget.videoSize,
+            fit: widget.fit,
+          ),
+        );
+        return widget.child;
+      },
+    );
+  }
+}
+
+/// 把 mpv 报上来的原生宽高（`player.state.width/height`）收成 [Size]；任一维缺失或
+/// 非正（首帧解出画之前就是这样）返回 null，调用方据此保持 media_kit 默认尺寸。
+Size? videoNativeSizeOf(int? width, int? height) {
+  if (width == null || height == null || width <= 0 || height <= 0) return null;
+  return Size(width.toDouble(), height.toDouble());
+}
+
+/// 单帧最多渲染多少像素（4K）。darwin 走的是软件渲染路径（`TextureSW`），每帧成本
+/// 与像素数线性相关，5K/6K 显示器全屏放大会把 CPU 吃满，所以设上限；超过就按上限
+/// 等比收，画质仍好过「原生尺寸再被 Flutter 拉大」。
+const double kVideoBackingRenderMaxPixels = 3840 * 2160;
+
+/// 与视频原生尺寸差多少才值得改（±5%）。窗口拖一点点就重建纹理不划算。
+const double kVideoBackingRenderMinDelta = 0.05;
+
+/// 算出 mpv 应当渲染的物理像素尺寸；返回 null = 用 media_kit 默认（视频原生尺寸）。
+///
+/// 纯函数，行为单测直接钉它——真实渲染要 macOS + NSWindow + 平台通道，headless
+/// `flutter test` 一样都没有。
+Size? resolveVideoBackingRenderSize({
+  required Size boxLogicalSize,
+  required double devicePixelRatio,
+  required Size? videoNativeSize,
+  required BoxFit fit,
+  double maxPixels = kVideoBackingRenderMaxPixels,
+}) {
+  final Size? video = videoNativeSize;
+  if (video == null || video.width <= 0 || video.height <= 0) return null;
+  if (devicePixelRatio <= 0) return null;
+  if (!boxLogicalSize.width.isFinite || !boxLogicalSize.height.isFinite) {
+    return null;
+  }
+  final double boxW = boxLogicalSize.width * devicePixelRatio;
+  final double boxH = boxLogicalSize.height * devicePixelRatio;
+  if (boxW <= 1 || boxH <= 1) return null;
+
+  // 画面在框里的实际占用比例。contain 取 min（内接，两侧可能留黑边）；cover / fill
+  // 取 max：cover 裁掉超出部分、fill 由 Flutter 拉伸，两者都需要「至少铺满框」那一档
+  // 像素，取 min 会让被放大的那一维欠采样。
+  final double scaleW = boxW / video.width;
+  final double scaleH = boxH / video.height;
+  final double scale = switch (fit) {
+    BoxFit.contain ||
+    BoxFit.scaleDown ||
+    BoxFit.none =>
+      math.min(scaleW, scaleH),
+    _ => math.max(scaleW, scaleH),
+  };
+  if (scale <= 0) return null;
+  // 与原生尺寸几乎一致就别改：保持 media_kit 默认路径（也避免换片瞬间来回抖）。
+  if ((scale - 1).abs() < kVideoBackingRenderMinDelta) return null;
+
+  double width = video.width * scale;
+  double height = video.height * scale;
+  final double pixels = width * height;
+  if (pixels > maxPixels) {
+    final double clamp = math.sqrt(maxPixels / pixels);
+    width *= clamp;
+    height *= clamp;
+    // 收到上限后若又落回原生尺寸附近，就别下发了。
+    if ((width / video.width - 1).abs() < kVideoBackingRenderMinDelta) {
+      return null;
+    }
+  }
+  // 取偶数：奇数宽高在 YUV 半采样色度平面上要多一次补齐拷贝。
+  return Size(
+    math.max(2, (width / 2).round() * 2).toDouble(),
+    math.max(2, (height / 2).round() * 2).toDouble(),
+  );
+}

--- a/fushi/lib/src/media/video/video_display_claim.dart
+++ b/fushi/lib/src/media/video/video_display_claim.dart
@@ -2,11 +2,13 @@ import 'package:meta/meta.dart';
 
 /// 视频页对**进程级显示态**的所有权登记表（BUG-2105）。
 ///
-/// 视频页在 `initState` 里认领三件全局显示态（都是进程唯一、没有「谁设的谁看得见」
+/// 视频页在 `initState` 里认领这些全局显示态（都是进程唯一、没有「谁设的谁看得见」
 /// 的作用域）：
 ///   * 移动端横屏锁（`SystemChrome.setPreferredOrientations`）；
-///   * 移动端系统栏可见性回调（`SystemChrome.setSystemUIChangeCallback`，全局单槽）；
-///   * macOS 交通灯隐藏（`setMacOSTrafficLightsHidden`）。
+///   * 移动端系统栏可见性回调（`SystemChrome.setSystemUIChangeCallback`，全局单槽）。
+///
+/// （原先还有第三件「macOS 交通灯隐藏」。macOS 改用自绘 MD3 顶栏后交通灯是启动即
+/// 永久隐藏，没有还原动作，也就不再需要登记所有权。）
 ///
 /// 原先这三件在 `dispose` 里**无条件**还原。换集（`_switchEpisode` 的窗口模式分支）
 /// 用 `pushReplacement`，而 Flutter 语义下**旧路由的 `dispose` 晚于新路由的
@@ -15,7 +17,7 @@ import 'package:meta/meta.dart';
 /// 被置空。移动端开着「自动旋转锁定」时，方向集一旦含 `portraitUp` 就退回用户锁定
 /// 的竖屏，观感就是「换集后掉出全屏播放」。
 ///
-/// 根治形状与仓内 `FushiWindowsTitleBar._contentFullscreenOwners` 一致：**按所有者
+/// 根治形状与仓内 `FushiDesktopTitleBar._contentFullscreenOwners` 一致：**按所有者
 /// 记账，只有最后一个持有者离开才还原**。换集期间集合短暂同时含新旧两页，旧页释放
 /// 时集合非空 → 不还原；正常退页时集合空 → 还原。
 ///

--- a/fushi/lib/src/media/video/video_hdr_output.dart
+++ b/fushi/lib/src/media/video/video_hdr_output.dart
@@ -49,7 +49,7 @@ const String kVideoHdrOutputPref = 'video_hdr_output';
 ///
 /// 视频洞要一路透到 DWM，**每一层**盖在视频矩形上的祖先都得不画底色——视频页自己的
 /// Scaffold 由 `VideoPlayerController.hdrHostActive` 管，但 Windows 自绘标题栏外壳
-/// （`FushiWindowsTitleBar` 的 `ColoredBox(surface)`）包着整个 Navigator、拿不到页面级
+/// （`FushiDesktopTitleBar` 的 `ColoredBox(surface)`）包着整个 Navigator、拿不到页面级
 /// 控制器，只能听这个全局位。同一时刻只有一个播放器，所以单个进程级 notifier 够用；
 /// 由 `VideoPlayerController` 在进入 / 退出 / dispose 时写，其它地方只读。
 final ValueNotifier<bool> hdrHostActiveGlobal = ValueNotifier<bool>(false);

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -277,7 +277,7 @@ double resolveAutoFitPopupHeight({
 /// mixin 家族（video / 首页词典 / texthooker / 网页视频）把查词浮层插进根 Overlay，
 /// 再用 [FushiAppUiScaleNeutralizer] 中和回净缩放 1；选区矩形则来自被点字符的
 /// `localToGlobal`。两者只有在根 Overlay 原点与屏幕原点重合时才同系。Windows 上
-/// `FushiWindowsTitleBar` 把整个导航器（含根 Overlay）压在一条 32 逻辑像素的自绘
+/// `FushiDesktopTitleBar` 把整个导航器（含根 Overlay）压在一条 32 逻辑像素的自绘
 /// 标题栏之下（main.dart），根 Overlay 原点就比屏幕原点低一个标题栏：浮层按
 /// 「屏幕 rect」摆到 Overlay 坐标里，整栈集体下移 32px，贴在被查词上方的弹窗底边
 /// 正好压进词里。中和层的原点与根 Overlay 原点重合（FittedBox 左上对齐、净缩放 1），

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -19,7 +19,7 @@ import 'package:fushi/src/anki/anki_media_dedup_dialogs.dart';
 import 'package:fushi/src/onboarding/recommended_pack_download_mini_bar.dart';
 import 'package:fushi/src/onboarding/recommended_pack_tutorial_prompt.dart';
 import 'package:fushi/src/onboarding/recommended_pack_tutorial_state.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/src/utils/components/nav_rail_brand_button.dart';
 import 'package:fushi/src/utils/misc/build_version.dart';
 import 'package:fushi/src/pages/implementations/download_backend_setup_dialog.dart';
@@ -1207,12 +1207,13 @@ class _HomePageState extends BasePageState<HomePage>
   }
 
   Widget _buildDesktopLayout(WindowSizeClass sizeClass) {
-    // Windows 自绘标题栏（[FushiWindowsTitleBar.isEnabled]）已经把当前 tab 名画在
-    // 应用顶栏上，主导航 rail 始终可见，再叠一层「隐藏 rail + 页头返回箭头」的全屏
-    // 设置就成了没有来源的第二条返回出口。**只有 Windows 走这个新路径**：macOS
-    // （交通灯预留 BUG-869）、Linux、横屏 Android 平板都保持原分支，它们的顶栏没有
-    // tab 名、也没有 rail 常驻的保证。
-    if (_visibleTab == HomeTab.settings && !FushiWindowsTitleBar.isEnabled) {
+    // 自绘标题栏（[FushiDesktopTitleBar.isEnabled]，Windows + macOS）已经把当前
+    // tab 名画在应用顶栏上，主导航 rail 始终可见，再叠一层「隐藏 rail + 页头返回
+    // 箭头」的全屏设置就成了没有来源的第二条返回出口。macOS 现在与 Windows 同壳，
+    // 设置页因此也是「rail 常驻 + 二栏 list-detail」（用户拍板：两端一致）。
+    // Linux、横屏 Android 平板仍走原分支：它们的顶栏没有 tab 名、也没有 rail 常驻
+    // 的保证。
+    if (_visibleTab == HomeTab.settings && !FushiDesktopTitleBar.isEnabled) {
       // 设置标签（全部设计系统）：隐藏 3 图标侧栏，全屏二栏（内部
       // MaterialSupportingPaneLayout），左上返回箭头切回来源 tab（参考 Mihon
       // 宽屏设置）。Cupertino 桌面也走这里——叶子控件保持 Cupertino 皮肤，但外壳
@@ -1222,12 +1223,11 @@ class _HomePageState extends BasePageState<HomePage>
       return Scaffold(
         resizeToAvoidBottomInset: false,
         body: SafeArea(
-          // macOS 透明标题栏 + full-size content view 下，交通灯不计入
-          // MediaQuery.padding，返回箭头会被压在按钮下方。预留标题栏高度作为
-          // SafeArea 下限，让顶部内容整体让位（BUG-869）。其它平台 top=0 无影响。
-          minimum: EdgeInsets.only(
-            top: Platform.isMacOS ? kMacTitleBarHeight : 0,
-          ),
+          // 这里曾按 BUG-869 预留一条 macOS 标题栏高度：透明标题栏 +
+          // full-size content view 下交通灯不计入 MediaQuery.padding，会压住返回
+          // 箭头。macOS 改用自绘顶栏后交通灯已被隐藏（`main()` 的
+          // `windowButtonVisibility: false`），且这条分支在 macOS 上根本不再命中
+          // （[FushiDesktopTitleBar.isEnabled] 恒真），预留带随之删除。
           child: FocusTraversalGroup(
             child: _buildSettingsTabContent(showBackButton: true),
           ),
@@ -1257,12 +1257,10 @@ class _HomePageState extends BasePageState<HomePage>
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: SafeArea(
-        // macOS 交通灯保留带：透明标题栏 + full-size content view 下交通灯不计入
-        // SafeArea，导航 rail 顶部会被红黄绿按钮压住。预留标题栏高度作为下限，
-        // 把整行内容下移一条标题栏（BUG-869）。其它平台 top=0，零影响。
-        minimum: EdgeInsets.only(
-          top: Platform.isMacOS ? kMacTitleBarHeight : 0,
-        ),
+        // 这里曾是 macOS 交通灯保留带（BUG-869）：透明标题栏 + full-size content
+        // view 下交通灯不计入 SafeArea，会压住导航 rail 顶部。macOS 现在与 Windows
+        // 一样自绘顶栏、交通灯在 `main()` 里被隐藏，rail 本来就落在顶栏之下，
+        // 再留一条 28pt 就是纯空白。
         // Two traversal groups so Tab / Shift+Tab walk each region as one block
         // in visual order (whole rail, then whole content) instead of zig-zagging
         // between the rail and the content pane row-by-row.

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -2089,7 +2089,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
     }
     final Color fg = _themeTextColor();
     return Positioned(
-      top: _stableTopInset + _macosWindowTitlebarInset,
+      top: _stableTopInset,
       left: MediaQuery.viewPaddingOf(context).left,
       right: MediaQuery.viewPaddingOf(context).right,
       // 焦点排除在 ReaderDesktopHeader 内部（纯指针面，TODO-700 不变式）；底栏的
@@ -2356,7 +2356,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
       return const SizedBox.shrink();
     }
     return Positioned(
-      top: _stableTopInset + _macosWindowTitlebarInset,
+      top: _stableTopInset,
       left: 0,
       right: 0,
       height: kReaderHoverRevealStripHeight,
@@ -2482,7 +2482,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
               );
 
     return Positioned(
-      top: _stableTopInset + _macosWindowTitlebarInset,
+      top: _stableTopInset,
       left: 16,
       right: 16,
       child: Align(

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -20,7 +20,6 @@ import 'package:fushi/src/models/theme_notifier.dart'
     show SurfaceRoles, ThemeNotifier, deriveSurfaceRolesFrom;
 import 'package:fushi/src/models/content_font_chain.dart';
 import 'package:fushi/src/utils/adaptive/adaptive_widgets.dart';
-import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/epub/epub_book.dart';
 import 'package:fushi/src/epub/epub_parser.dart';
@@ -92,7 +91,6 @@ import 'package:fushi/src/webview/webview_death_guard.dart';
 import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/media/audiobook/floating_lyric_channel.dart';
 import 'package:fushi/src/media/audiobook/pointer_seek.dart';
-import 'package:fushi/src/platform/macos_fullscreen_state.dart';
 import 'package:fushi/src/platform/selection_external_actions.dart';
 import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
@@ -109,7 +107,6 @@ import 'package:fushi/src/utils/misc/fushi_share.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
-import 'package:window_manager/window_manager.dart';
 import 'package:fushi/src/utils/misc/platform_utils.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_icon_button.dart';
@@ -2023,25 +2020,12 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   bool get _anyChromeFloating =>
       (_topProgressFloating && !_statusFooterEnabled) || _bottomBarFloating;
 
-  /// BUG-1343：macOS 的 NSWindow 全局启用了透明标题栏 + full-size content，而默认 MD3 根壳
-  /// 不挂 MacosWindow/ToolBar。阅读器需自行保留一条可拖拽标题栏，否则原生 WebView
-  /// 吞满顶边后窗口没有稳定抓手。其它平台严格为 0。
-  ///
-  /// BUG-1744：原生全屏下这条带子必须归零。全屏时既没有标题栏也没有交通灯，窗口
-  /// 也不能被拖动——留着它就是一条纯浪费的不透明横带（用户报的「顶部横带」），
-  /// 还连带把正文整体下压 28pt。这里是单一真相源：[_readerTopOffset] /
-  /// [popupTopReserve] / `independentDocumentInsets` / 顶部进度条全部读它。
-  double get _macosWindowTitlebarInset =>
-      Platform.isMacOS && !_macosFullscreen ? kMacTitleBarHeight : 0;
-
-  /// macOS 原生全屏态。非 macOS 恒为 false。
-  bool _macosFullscreen = false;
-
+  // BUG-1343 / BUG-1744 的 macOS 顶部拖拽带（`_macosWindowTitlebarInset` + 一条
+  // 28pt 的 DragToMoveArea）已随「macOS 改用自绘 MD3 顶栏」整块删除：交通灯在
+  // `main()` 里被隐藏，[FushiDesktopTitleBar] 在整个 Navigator 之上提供稳定抓手，
+  // 阅读器不再需要自己让位或自绘拖拽带——留着就是顶栏下面又压一条 28pt 空白。
   double get _readerTopOffset =>
-      _stableTopInset +
-      _macosWindowTitlebarInset +
-      _topProgressReserve +
-      _desktopHeaderReserve;
+      _stableTopInset + _topProgressReserve + _desktopHeaderReserve;
 
   double get _readerBottomReserve =>
       _bottomChromeReserve + _statusFooterReserve + _stableBottomInset;
@@ -2053,7 +2037,7 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
       _bottomChromeReserve > 0 ? _readerBottomReserve : 0;
 
   @override
-  double get popupTopReserve => _stableTopInset + _macosWindowTitlebarInset;
+  double get popupTopReserve => _stableTopInset;
 
   @override
   bool get popupVerticalWriting =>
@@ -2085,14 +2069,6 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     _exitFlushCallback = ExitFlushRegistry.instance.register(
       _flushAllForProcessExit,
     );
-    // BUG-1744：macOS 全屏进出必须重算顶部让位并把新 inset 回喂给 WebView。
-    // didChangeDependencies 只比较 viewPadding，而桌面全屏切换通常不改
-    // viewPadding（两边都是 0），所以那条路径永远不会触发。
-    _macosFullscreen = MacosFullscreenState.instance.isFullscreen.value;
-    MacosFullscreenState.instance.isFullscreen.addListener(
-      _onMacosFullscreenChanged,
-    );
-    unawaited(MacosFullscreenState.instance.ensureRegistered());
     // The inset reading-content focus ring only paints in traditional
     // (keyboard/gamepad) highlight mode; rebuild it when the mode flips so it
     // appears/disappears with the input device, not only on focus changes.
@@ -2686,9 +2662,6 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     // Complete it as failed now (and clear its precise-locate request) instead
     // of leaving the callback alive until the 10-second timeout.
     _failNavigation();
-    MacosFullscreenState.instance.isFullscreen.removeListener(
-      _onMacosFullscreenChanged,
-    );
     assert(() {
       // TODO-2603：页面走了就释放钩子所有权，下一个阅读器才能装（无条件清，与旧行为
       // 逐字一致——钩子本来就是无条件清的，这里只多清一个所有者字段）。
@@ -3014,19 +2987,6 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     _armResizeRepaginateDebounce();
   }
 
-  /// BUG-1744：全屏翻转 → 重算 [_macosWindowTitlebarInset] → 回喂 WebView 几何。
-  ///
-  /// 只 setState 是不够的：JS 侧的 `--chrome-top-inset` 由 [_applyChromeInsets]
-  /// 单独推送，不跟着 Flutter 重建走。漏了它，正文 padding-top 会停在旧的 28px
-  /// 上（全屏后顶部仍留一条空白带，正是要修的症状）。
-  void _onMacosFullscreenChanged() {
-    if (!mounted) return;
-    final bool next = MacosFullscreenState.instance.isFullscreen.value;
-    if (next == _macosFullscreen) return;
-    setState(() => _macosFullscreen = next);
-    unawaited(_applyChromeInsets());
-  }
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -3215,30 +3175,10 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
                             ),
                           ),
                         ),
-                      // BUG-1744：全屏时窗口不可拖动、也没有交通灯要让位——这条
-                      // 不透明带在全屏下纯粹是一条顶部横带，必须整体不挂。
-                      if (Platform.isMacOS && !_macosFullscreen)
-                        Positioned(
-                          top: 0,
-                          left: 0,
-                          right: 0,
-                          height: kMacTitleBarHeight,
-                          // BUG-1692：本 Stack 里排在 WebView **之后**的每一块 Flutter
-                          // 内容都必须自带 RepaintBoundary，否则它们会合并进页面级
-                          // RepaintBoundary 那一张 cull rect = 整窗的 PictureLayer，
-                          // macOS engine 据此把整窗加进 FlutterMutatorView 的
-                          // _hitTestIgnoreRegion，WebView 整块收不到任何鼠标事件。
-                          child: RepaintBoundary(
-                            child: DragToMoveArea(
-                              child: ColoredBox(
-                                key: const ValueKey<String>(
-                                  'fushi_reader_window_drag_area',
-                                ),
-                                color: bgColor,
-                              ),
-                            ),
-                          ),
-                        ),
+                      // 这里曾挂 macOS 专用的 28pt 拖拽带（BUG-1343，全屏下不挂
+                      // 见 BUG-1744）。macOS 改用自绘 MD3 顶栏后，窗口抓手由
+                      // [FushiDesktopTitleBar] 的 DragToMoveArea 提供、交通灯也已
+                      // 隐藏，阅读器再挂一条只会在顶栏下面多压一条不透明带。
                       _buildTopProgressBar(),
                       // 桌面端顶边悬停热区（收起时才存在）+ 顶部工具栏（ッツ 形态）：与底栏
                       // 同一显隐状态机，排在词典弹层之前。
@@ -3281,11 +3221,9 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     // _showChrome / _hasEverLoaded 切换会触发 _rebuild 重建本树。
     final EdgeInsets independentDocumentPadding = independentDocumentInsets(
       lyricsMode: _lyricsMode,
-      spreadDocumentLoaded: _spreadDocumentLoaded,
       // 底栏占位条件与 _buildBottomChrome / popupBottomReserve 一致。
       chromeOccupiesLayout: _hasEverLoaded && _showChrome,
       bottomReserve: _readerBottomReserve,
-      titlebarInset: _macosWindowTitlebarInset,
     );
     if (independentDocumentPadding == EdgeInsets.zero) return webView;
     return Padding(padding: independentDocumentPadding, child: webView);

--- a/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/fullscreen.part.dart
@@ -123,7 +123,7 @@ extension _VideoFullscreen on _VideoFushiPageState {
     if (!widget.initialFullscreen || isMobilePlatform) return;
     _ownsHandedOverNativeFullscreen = true;
     if (Platform.isWindows) {
-      FushiWindowsTitleBar.setContentFullscreen(owner: this, enabled: true);
+      FushiDesktopTitleBar.setContentFullscreen(owner: this, enabled: true);
     }
   }
 
@@ -257,11 +257,22 @@ extension _VideoFullscreen on _VideoFushiPageState {
                           if (playerController == null) return fullscreenVideo;
                           return _videoWithSubtitlePanel(
                             playerController,
-                            // HDR 直通：全屏路由的 Video 同样上报矩形（与窗口侧
-                            // [_buildVideoBody] 一致，宿主窗跟着全屏画面走）。
-                            HdrHostRectReporter(
-                              onRect: playerController.reportHdrHostRect,
-                              child: fullscreenVideo,
+                            // macOS Retina：全屏是「片源被放得最大」的场景，按物理
+                            // 像素渲染的收益也最大（与窗口侧 [_buildVideoBody] 同一
+                            // 组件、同一 fit 偏好）。非 macOS 恒透传。
+                            VideoBackingRenderSize(
+                              controller: controllerValue,
+                              videoSize: videoNativeSizeOf(
+                                playerController.videoWidth,
+                                playerController.videoHeight,
+                              ),
+                              fit: videoFitModeToBoxFit(_videoFitMode),
+                              // HDR 直通：全屏路由的 Video 同样上报矩形（与窗口侧
+                              // [_buildVideoBody] 一致，宿主窗跟着全屏画面走）。
+                              child: HdrHostRectReporter(
+                                onRect: playerController.reportHdrHostRect,
+                                child: fullscreenVideo,
+                              ),
                             ),
                           );
                         },
@@ -379,7 +390,7 @@ extension _VideoFullscreen on _VideoFushiPageState {
       if (Platform.isWindows) {
         // Hide the app frame before the native transition so no title-bar
         // frame remains above the fullscreen surface.
-        FushiWindowsTitleBar.setContentFullscreen(
+        FushiDesktopTitleBar.setContentFullscreen(
           owner: this,
           enabled: true,
         );
@@ -423,7 +434,7 @@ extension _VideoFullscreen on _VideoFushiPageState {
         // 时 runner 已同步还原窗口矩形，再亮出 app frame——早亮会在退出过程上
         // 闪一下标题栏。
         await WindowCaptionChannel.setFullscreen(false);
-        FushiWindowsTitleBar.setContentFullscreen(
+        FushiDesktopTitleBar.setContentFullscreen(
           owner: this,
           enabled: false,
         );

--- a/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/layout.part.dart
@@ -86,11 +86,21 @@ extension _VideoLayout on _VideoFushiPageState {
       // Row[Expanded(Video), 面板列]，画面真挤窄、不被遮（见 [_videoWithSubtitlePanel]）。
       child: _videoWithSubtitlePanel(
         controller,
-        // HDR 直通：把 Video 的物理像素矩形喂给 runner 宿主窗（非 HDR 时只是记着，
-        // 进入直通那一刻就有正确矩形可用）。
-        HdrHostRectReporter(
-          onRect: controller.reportHdrHostRect,
-          child: Video(
+        // macOS Retina：让 mpv 直接渲染到画面实际占用的物理像素（IINA 同款做法），
+        // 否则 1080p 片源在 Retina 上永远是「原生纹理被 Flutter 双线性拉大」= 发虚。
+        // 非 macOS 恒透传（见 [VideoBackingRenderSize]）。
+        VideoBackingRenderSize(
+          controller: videoController,
+          videoSize: videoNativeSizeOf(
+            controller.videoWidth,
+            controller.videoHeight,
+          ),
+          fit: videoFitModeToBoxFit(_videoFitMode),
+          // HDR 直通：把 Video 的物理像素矩形喂给 runner 宿主窗（非 HDR 时只是记着，
+          // 进入直通那一刻就有正确矩形可用）。
+          child: HdrHostRectReporter(
+            onRect: controller.reportHdrHostRect,
+            child: Video(
           controller: videoController,
           // 用本页持有的 FocusNode 替换 Video 内置的匿名节点，以便覆盖层（对话框 /
           // bottom sheet / 文件选择器）关闭后能主动把键盘焦点还给它，恢复空格等内置
@@ -138,6 +148,7 @@ extension _VideoLayout on _VideoFushiPageState {
           onEnterFullscreen: _enterVideoNativeFullscreen,
           onExitFullscreen: _exitVideoNativeFullscreen,
         ),
+          ),
         ),
       ),
     );

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -31,7 +31,7 @@ import 'package:fushi/src/media/tracking/media_tracking_service.dart'
     show kMediaTrackingEnabled;
 import 'package:fushi/src/pages/implementations/video_loading_overlay.dart';
 import 'package:fushi/src/utils/misc/lookup_dismiss_barrier.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 // 只取语义枚举与调色板：视频页的通知一律走左上角 _showOsd，不得用 FushiToast
 // （BUG-931 有守卫），故刻意不 import 整套 toast API。
 import 'package:fushi/src/utils/misc/toast_severity.dart';
@@ -85,6 +85,7 @@ import 'package:fushi/src/media/video/video_controls_focus_gate.dart';
 import 'package:fushi/src/media/video/video_controls_theme_pair.dart';
 import 'package:fushi/src/media/video/video_danmaku_model.dart';
 import 'package:fushi/src/media/video/video_danmaku_overlay.dart';
+import 'package:fushi/src/media/video/video_backing_render_size.dart';
 import 'package:fushi/src/media/video/video_danmaku_source.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
@@ -2011,11 +2012,12 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     VideoDisplayClaim.claim(this);
     // TODO-099: 进入视频页强制横屏（移动端），退出 [dispose] 还原；桌面 no-op。
     unawaited(_lockLandscapeForVideo());
-    // BUG-973: 进入视频页隐藏 macOS 系统交通灯（左上角三个圆点），退出 [dispose] 恢复。
-    // 交通灯浮在透明标题栏 + 全尺寸内容视图之上，会遮住视频顶栏返回按钮 / 左上角 OSD
-    // 提示（用户报告）。仅 macOS 有交通灯；Windows / Linux / 移动端恒 no-op。用户仍可
-    // Esc / 顶栏返回按钮 / Cmd+Q / 进原生全屏退出，不损失退出口。
-    unawaited(setMacOSTrafficLightsHidden(true));
+    // BUG-973 的「进页隐藏 / 退页恢复 macOS 交通灯」已删除：macOS 改用自绘 MD3 顶栏
+    // 后，`main()` 启动时就把三个圆点永久隐藏了（`windowButtonVisibility: false`），
+    // 视频页再隐藏一次是重复，退页恢复更会把它们放回来（正是 BUG-973 的症状）。
+    // 唯一仍需重申的时机是「退出原生全屏」——AppKit 重建标题栏视图会复位
+    // `isHidden`，那条重申留在 [_exitVideoNativeFullscreen] 与
+    // [FushiDesktopTitleBar] 的全屏监听里。
     // TODO-158/BUG-219: 进入视频页显式持有「沉浸隐藏系统栏」所有权（移动端）。原先
     // 只靠 [AppModel.openMedia] 在打开媒体时一次性设 immersiveSticky（书 / 视频共用
     // 入口），从不重申 → 后台返回 / 通知栏交互 / 全屏路由后系统栏残留。退出由
@@ -3830,7 +3832,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       WindowsImeSpaceChannel.clearHandler(this);
       // Abnormal route teardown must never leave the app frame hidden. The
       // normal fullscreen exit releases this owner only after HWND restoration.
-      FushiWindowsTitleBar.setContentFullscreen(
+      FushiDesktopTitleBar.setContentFullscreen(
         owner: this,
         enabled: false,
       );
@@ -6758,8 +6760,9 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
     }
     // TODO-099: 还原屏幕方向允许态（移动端），不把其他页锁死在横屏；桌面 no-op。
     unawaited(_restoreOrientationOnExit());
-    // BUG-973: 恢复 macOS 系统交通灯（与 initState 的隐藏对称）；非 macOS 恒 no-op。
-    unawaited(setMacOSTrafficLightsHidden(false));
+    // 这里曾与 initState 对称地恢复 macOS 交通灯（BUG-973）。交通灯现在是全局
+    // 永久隐藏（`main()` 的 `windowButtonVisibility: false`），退视频页恢复它们
+    // 等于让三个系统圆点重新压在自绘顶栏上，故整条删除。
   }
 
   Future<void> _setLockWindowAspectRatio(bool value) async {

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -60,7 +60,7 @@ import 'package:fushi/src/sync/fushi_library_host_service.dart'
 import 'package:fushi/src/utils/adaptive/adaptive_widgets.dart'
     show adaptivePageRoute;
 import 'package:fushi/src/utils/app_ui_scale.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi/src/utils/misc/lookup_dismiss_barrier.dart';
 import 'package:fushi/src/utils/overlay_entry_lifecycle.dart';
@@ -503,7 +503,7 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
       _popupOverlayEntry = null;
     }
     if (_fullscreen && Platform.isWindows) {
-      FushiWindowsTitleBar.setContentFullscreen(owner: this, enabled: false);
+      FushiDesktopTitleBar.setContentFullscreen(owner: this, enabled: false);
     }
     _controller.removeListener(_onControllerChanged);
     _controller.dispose();
@@ -1563,7 +1563,7 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
     final bool enter = !_fullscreen;
     setState(() => _fullscreen = enter);
     if (Platform.isWindows) {
-      FushiWindowsTitleBar.setContentFullscreen(owner: this, enabled: enter);
+      FushiDesktopTitleBar.setContentFullscreen(owner: this, enabled: enter);
     }
     try {
       if (enter) {

--- a/fushi/lib/src/platform/desktop/macos_traffic_lights.dart
+++ b/fushi/lib/src/platform/desktop/macos_traffic_lights.dart
@@ -7,9 +7,13 @@ import 'package:macos_ui/macos_ui.dart' show WindowManipulator;
 ///
 /// macOS 壳启动时开了透明标题栏 + 全尺寸内容视图（`main.dart` 的
 /// `makeTitlebarTransparent` + `enableFullSizeContentView`），Flutter 内容一直画到
-/// 窗口左上角，系统交通灯浮在其上。视频页把「退出 / 返回」按钮和左上角 OSD 提示画在
-/// 同一位置会被交通灯遮住（BUG-973 用户报告）。视频页全程隐藏交通灯即根除遮挡——
-/// 用户仍可用 Esc / 顶栏返回按钮 / Cmd+Q / 进原生全屏退出，不损失任何退出口。
+/// 窗口左上角，系统交通灯浮在其上（BUG-973：视频页的返回按钮 / 左上角 OSD 被遮）。
+///
+/// 现在交通灯是**启动即永久隐藏**：`main()` 用
+/// `setTitleBarStyle(hidden, windowButtonVisibility: false)` 一次性关掉它们，窗口
+/// 控制改由自绘的 [FushiDesktopTitleBar] MD3 顶栏提供。所以本函数只剩一个用途——
+/// **重申隐藏**（见下面的时序告警）；`hidden: false` 分支只作为对称 API 保留，
+/// 生产路径不再调用它（调了就等于把三个系统圆点放回顶栏之上）。
 ///
 /// 底层是 `NSWindow.standardWindowButton(_).isHidden`（见 macos_window_utils 的
 /// `MainFlutterWindowManipulator`），一个持久属性。只有 macOS 有交通灯，其它平台
@@ -17,8 +21,10 @@ import 'package:macos_ui/macos_ui.dart' show WindowManipulator;
 /// 吞掉，绝不因窗口按钮操作崩溃调用方。
 ///
 /// ⚠️ 时序：AppKit 的 `toggleFullScreen` 进出原生全屏会重建标题栏视图、可能把
-/// `isHidden` 复位。故不能「隐藏一次」了事——退出原生全屏后需重新调用本函数断言隐藏
-/// （视频页在 `_exitVideoNativeFullscreen` 处理）。
+/// `isHidden` 复位。故不能「隐藏一次」了事——退出原生全屏后需重新调用本函数断言隐藏。
+/// 两个重申点：[FushiDesktopTitleBar] 监听 `MacosFullscreenState`（覆盖快捷键 /
+/// 菜单 / 手势等**全部**入口），视频页在 `_exitVideoNativeFullscreen` 里另有一次
+/// （media_kit 自己的退全屏路径，不经 app 的全屏开关）。
 Future<void> setMacOSTrafficLightsHidden(bool hidden) async {
   if (!Platform.isMacOS) {
     return;

--- a/fushi/lib/src/reader/reader_chrome_floating.dart
+++ b/fushi/lib/src/reader/reader_chrome_floating.dart
@@ -104,20 +104,22 @@ double bottomChromeReserve({
 ///    （`_hasEverLoaded && _showChrome`，与 [bottomChromeReserve] 同一门控），
 ///    [bottomReserve] 已含悬浮态恒 0 的语义（悬浮不占正文位置）。
 ///    spread 不需要底部留白：它没有文档级滚动条，底栏叠在整页图上是既有可接受形态。
-///  * **顶部**（BUG-1343）：macOS 顶部 DragToMoveArea 叠在 WebView 之上，独立文档若不
-///    缩进，首行歌词 / 整页图会落到拖拽区下面且无法交互。[titlebarInset] 在非 macOS 恒 0。
+///  * **顶部**：曾有一笔 `titlebarInset`（BUG-1343：macOS 阅读器自绘的 28pt
+///    DragToMoveArea 叠在 WebView 之上，独立文档不缩进就会把首行歌词 / 整页图压到
+///    拖拽区下面）。macOS 改用自绘 MD3 顶栏（`FushiDesktopTitleBar`，在整个
+///    Navigator 之上）后那条带子已删除，页内不再有任何叠在 WebView 上的顶部 chrome
+///    需要独立文档让位，这笔留白随之取消。
 ///
 /// 返回 [EdgeInsets.zero] 表示「无需任何留白」，调用方据此跳过 `Padding` 包装。
+/// 顶部那笔取消后，spread 与「完全没有独立文档」在留白上已不可区分（两者都是
+/// 零），所以 `spreadDocumentLoaded` 也一并从签名里去掉——留一个不影响任何返回值的
+/// 必填参数只会让调用方以为它还有作用。
 EdgeInsets independentDocumentInsets({
   required bool lyricsMode,
-  required bool spreadDocumentLoaded,
   required bool chromeOccupiesLayout,
   required double bottomReserve,
-  required double titlebarInset,
 }) {
-  final bool independentDocument = lyricsMode || spreadDocumentLoaded;
   return EdgeInsets.only(
-    top: independentDocument ? titlebarInset : 0,
     bottom: lyricsMode && chromeOccupiesLayout ? bottomReserve : 0,
   );
 }

--- a/fushi/lib/src/settings/settings_home_page.dart
+++ b/fushi/lib/src/settings/settings_home_page.dart
@@ -10,7 +10,7 @@ import 'package:fushi/src/settings/settings_detail_page.dart';
 import 'package:fushi/src/settings/settings_renderer.dart';
 import 'package:fushi/src/settings/settings_schema.dart';
 import 'package:fushi/src/settings/settings_search.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/utils.dart';
 
 class SettingsHomePage extends BasePage {
@@ -54,8 +54,9 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     // 主从：详情内容直接在本页渲染，走不到 [SettingsDetailPage] 那份订阅
     // （BUG-2165）。不听这一条，开着设置页时下载开始/下完/暂停，「推荐包」那一行
     // 的出现与消失就只能靠 AppModel 顺带 notify 撞上，变成偶发刷新。
-    appModelNoUpdate.recommendedPackDownloadController.stage
-        .addListener(_onLogChanged);
+    appModelNoUpdate.recommendedPackDownloadController.stage.addListener(
+      _onLogChanged,
+    );
   }
 
   @override
@@ -64,8 +65,9 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     ErrorLogService.instance.removeListener(_onLogChanged);
     DebugLogService.instance.removeListener(_onLogChanged);
     GalIngameLookupController.instance.admission.removeListener(_onLogChanged);
-    appModelNoUpdate.recommendedPackDownloadController.stage
-        .removeListener(_onLogChanged);
+    appModelNoUpdate.recommendedPackDownloadController.stage.removeListener(
+      _onLogChanged,
+    );
     super.dispose();
   }
 
@@ -259,9 +261,10 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     if (!widget.embedded) {
       return content;
     }
-    // Windows 主窗口已经由应用壳层提供当前 tab 标题；设置仍是普通 home tab，
-    // 左侧主导航始终可见，因此无需再画第二条「返回 + 设置」页头。
-    if (FushiWindowsTitleBar.isEnabled) {
+    // 自绘顶栏的桌面主窗口（Windows / macOS）已经由应用壳层提供当前 tab 标题；
+    // 设置仍是普通 home tab，左侧主导航始终可见，因此无需再画第二条
+    // 「返回 + 设置」页头。
+    if (FushiDesktopTitleBar.isEnabled) {
       return content;
     }
     // Cupertino 手机（compact 走底栏导航、onBack 为空、无需返回出口）保持原生

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -16,7 +16,7 @@ import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show
         arrowFocusMoveDirection,
@@ -525,7 +525,7 @@ Future<bool?> readDesktopWindowFullscreen() async {
       // WindowCaptionChannel.setFullscreen 的文档）；window_manager 在 Windows
       // 上不再进入全屏、其 isFullScreen 恒 false，状态只能问 runner。
       final bool fullscreen = await WindowCaptionChannel.isFullscreen();
-      FushiWindowsTitleBar.setWindowManagerFullscreen(fullscreen);
+      FushiDesktopTitleBar.setWindowManagerFullscreen(fullscreen);
       return fullscreen;
     }
     if (Platform.isLinux) {
@@ -572,16 +572,16 @@ Future<bool?> setDesktopWindowFullscreen(bool fullscreen) async {
       // not emit leave-full-screen when a fullscreen window returns to its
       // previous maximized state, so WindowListener alone can remain stuck.
       final bool previousChromeState =
-          FushiWindowsTitleBar.isWindowManagerFullscreen;
+          FushiDesktopTitleBar.isWindowManagerFullscreen;
       // Claim the hidden-caption state before the native flip so the app frame
       // never paints over the fullscreen surface for a frame.
       if (fullscreen) {
-        FushiWindowsTitleBar.setWindowManagerFullscreen(true);
+        FushiDesktopTitleBar.setWindowManagerFullscreen(true);
       }
       // One resolve, one write: the chrome owner is derived from the single
       // authoritative value below instead of being poked at every step.
       final bool? applied = await _resolveWindowsFullscreen(fullscreen);
-      FushiWindowsTitleBar.setWindowManagerFullscreen(
+      FushiDesktopTitleBar.setWindowManagerFullscreen(
         applied ?? previousChromeState,
       );
       return applied;

--- a/fushi/lib/src/utils/components/fushi_desktop_title_bar.dart
+++ b/fushi/lib/src/utils/components/fushi_desktop_title_bar.dart
@@ -1,40 +1,54 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/video/video_hdr_output.dart'
     show hdrHostActiveGlobal;
+import 'package:fushi/src/platform/desktop/macos_traffic_lights.dart';
+import 'package:fushi/src/platform/macos_fullscreen_state.dart';
 import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:window_manager/window_manager.dart';
 
-/// App-themed Windows frame used after the native caption is hidden.
+/// App-themed desktop frame used after the native caption is hidden.
 ///
-/// The frame keeps resizing, dragging, double-click maximize/restore and the
-/// existing intercepted close lifecycle, while avoiding Win32 caption chrome.
-class FushiWindowsTitleBar extends StatefulWidget {
-  const FushiWindowsTitleBar({
+/// Windows and macOS both run it: `main()` hides the platform caption
+/// ([TitleBarStyle.hidden]; on macOS that also hides the three traffic-light
+/// buttons) and this widget draws the MD3 replacement — one title bar, one look,
+/// on both hosts.
+///
+/// The frame keeps dragging, maximize/restore and the existing intercepted
+/// close lifecycle, while avoiding Win32 caption chrome / AppKit titlebar
+/// chrome. Resize is where the two hosts differ: Windows needs the app to
+/// forward edge drags (`DragToResizeArea` → `startResizing`, which
+/// `window_manager` only implements on Windows/Linux), while AppKit keeps
+/// owning the window's own resize border under a full-size content view — so
+/// macOS mounts no resize edges at all (see [_resizeEdges]).
+class FushiDesktopTitleBar extends StatefulWidget {
+  const FushiDesktopTitleBar({
     required this.title,
     required this.child,
     this.leadingInset = 0,
     super.key,
   });
 
-  /// Keep the app frame as compact as the native Windows caption it replaces.
+  /// Keep the app frame as compact as the native caption it replaces.
   /// This is intentionally outside [FushiAppUiScale], so the window controls do
   /// not grow with content zoom.
   static const double height = 32;
 
   static bool _isEnabled = false;
 
-  /// True once the app shell has installed its own Windows frame
+  /// True once the app shell has installed its own desktop frame
   /// ([TitleBarStyle.hidden] + this widget). Widgets below the app frame read
   /// it to avoid rendering a second, redundant page header, and `HomePage`
   /// reads it to decide whether the settings tab still needs its own
   /// full-screen shell with a back arrow.
   ///
-  /// Deliberately a startup latch and **not** a `Platform.isWindows` expression:
-  /// widget tests never run `main()`, so a platform-derived value would make the
-  /// Windows dev host and the Linux CI host take different layout branches for
-  /// the very same test.
+  /// Deliberately a startup latch and **not** a
+  /// `Platform.isWindows || Platform.isMacOS` expression: widget tests never run
+  /// `main()`, so a platform-derived value would make the Windows/macOS dev host
+  /// and the Linux CI host take different layout branches for the very same
+  /// test.
   static bool get isEnabled => _isEnabled;
 
   /// Latched exactly once from `main()` after the hidden title bar is applied.
@@ -51,8 +65,9 @@ class FushiWindowsTitleBar extends StatefulWidget {
   /// while another fullscreen surface is still active.
   static final Set<Object> _contentFullscreenOwners = <Object>{};
   static final Object _windowManagerFullscreenOwner = Object();
-  static final ValueNotifier<bool> _contentFullscreen =
-      ValueNotifier<bool>(false);
+  static final ValueNotifier<bool> _contentFullscreen = ValueNotifier<bool>(
+    false,
+  );
 
   static void setContentFullscreen({
     required Object owner,
@@ -87,18 +102,49 @@ class FushiWindowsTitleBar extends StatefulWidget {
   final double leadingInset;
 
   @override
-  State<FushiWindowsTitleBar> createState() => _FushiWindowsTitleBarState();
+  State<FushiDesktopTitleBar> createState() => _FushiDesktopTitleBarState();
 }
 
-class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
+class _FushiDesktopTitleBarState extends State<FushiDesktopTitleBar>
     with WindowListener {
   bool _isMaximized = false;
+
+  /// macOS 原生全屏的 chrome 所有者（与 window_manager 那个所有者并列，互不覆盖）。
+  final Object _macosNativeFullscreenOwner = Object();
 
   @override
   void initState() {
     super.initState();
     windowManager.addListener(this);
+    if (Platform.isMacOS) {
+      // macOS 上 window_manager 的 [WindowListener] 收不到全屏通知：
+      // macos_window_utils 持有 NSWindow.delegate 并把它的 delegate 覆盖掉。
+      // [MacosFullscreenState] 挂的是 NSWindowDelegate，AppKit 在**所有**入口
+      // （快捷键 / 「显示」菜单 / 系统全屏手势）上都发，是唯一能覆盖全部路径的信号。
+      MacosFullscreenState.instance.isFullscreen.addListener(
+        _onMacosFullscreenChanged,
+      );
+      unawaited(MacosFullscreenState.instance.ensureRegistered());
+      _onMacosFullscreenChanged();
+    }
     unawaited(_readInitialWindowState());
+  }
+
+  /// macOS 原生全屏时收起自绘顶栏（全屏下窗口既不能拖也不能缩放，留着就是一条
+  /// 纯浪费的横带），退出全屏再把它挂回来。
+  ///
+  /// 顺带重申交通灯隐藏：`toggleFullScreen` 会重建标题栏视图，可能把
+  /// `standardWindowButton.isHidden` 复位——复位后三个圆点会浮在 Flutter 内容
+  /// 左上角，正好压住自绘顶栏的标题（BUG-973 同一根因）。
+  void _onMacosFullscreenChanged() {
+    final bool fullscreen = MacosFullscreenState.instance.isFullscreen.value;
+    FushiDesktopTitleBar.setContentFullscreen(
+      owner: _macosNativeFullscreenOwner,
+      enabled: fullscreen,
+    );
+    if (!fullscreen) {
+      unawaited(setMacOSTrafficLightsHidden(true));
+    }
   }
 
   Future<void> _readInitialWindowState() async {
@@ -108,7 +154,7 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
         windowManager.isFullScreen(),
       ]);
       if (!mounted) return;
-      FushiWindowsTitleBar.setWindowManagerFullscreen(state[1]);
+      FushiDesktopTitleBar.setWindowManagerFullscreen(state[1]);
       setState(() {
         _isMaximized = state[0];
       });
@@ -120,6 +166,15 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
   @override
   void dispose() {
     windowManager.removeListener(this);
+    if (Platform.isMacOS) {
+      MacosFullscreenState.instance.isFullscreen.removeListener(
+        _onMacosFullscreenChanged,
+      );
+      FushiDesktopTitleBar.setContentFullscreen(
+        owner: _macosNativeFullscreenOwner,
+        enabled: false,
+      );
+    }
     super.dispose();
   }
 
@@ -135,12 +190,12 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
 
   @override
   void onWindowEnterFullScreen() {
-    FushiWindowsTitleBar.setWindowManagerFullscreen(true);
+    FushiDesktopTitleBar.setWindowManagerFullscreen(true);
   }
 
   @override
   void onWindowLeaveFullScreen() {
-    FushiWindowsTitleBar.setWindowManagerFullscreen(false);
+    FushiDesktopTitleBar.setWindowManagerFullscreen(false);
   }
 
   void _minimize() {
@@ -177,7 +232,7 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     return ValueListenableBuilder<bool>(
-      valueListenable: FushiWindowsTitleBar._contentFullscreen,
+      valueListenable: FushiDesktopTitleBar._contentFullscreen,
       builder: (BuildContext context, bool contentFullscreen, Widget? child) {
         final bool hideFrame = contentFullscreen;
         // HDR 直通（video_hdr_output.dart）：这层 surface 底色盖着整个 Navigator，宿主
@@ -199,7 +254,7 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
             children: <Widget>[
               if (!hideFrame)
                 Container(
-                  height: FushiWindowsTitleBar.height,
+                  height: FushiDesktopTitleBar.height,
                   // The caption row keeps its own surface fill: only the page
                   // area below may go transparent for HDR passthrough.
                   color: colors.surface,
@@ -257,10 +312,7 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
                 ),
               Expanded(
                 child: LayoutBuilder(
-                  builder: (
-                    BuildContext context,
-                    BoxConstraints constraints,
-                  ) {
+                  builder: (BuildContext context, BoxConstraints constraints) {
                     // The title bar consumes real layout height. Rebase the
                     // Navigator's MediaQuery to the remaining viewport so
                     // native WebViews paginate against their actual surface,
@@ -292,17 +344,28 @@ class _FushiWindowsTitleBarState extends State<FushiWindowsTitleBar>
         // every edge a bare `Container()` with no gesture target, which is
         // exactly the zero-hit-area semantics the removed branch had.
         return DragToResizeArea(
-          enableResizeEdges: (hideFrame || _isMaximized)
-              ? const <ResizeEdge>[]
-              : const <ResizeEdge>[
-                  ResizeEdge.topLeft,
-                  ResizeEdge.top,
-                  ResizeEdge.topRight,
-                ],
+          enableResizeEdges: _resizeEdges(hideFrame: hideFrame),
           child: frame,
         );
       },
     );
+  }
+
+  /// 哪些边由 app 自己转发拖拽给原生「开始改变窗口大小」。
+  ///
+  /// macOS 恒为空表：`window_manager` 的 macOS 插件根本没有 `startResizing`
+  /// （只有 Windows/Linux 实现），挂上去点一下就是 `MissingPluginException`；
+  /// 而 AppKit 在 full-size content view 下仍然自己拥有窗口四边的 resize 边框，
+  /// 本来就不需要 app 代劳。Windows 侧维持原状：全屏无命中区、最大化时禁用，
+  /// 其余只接管顶边三段（左右下三边由 runner 的非客户区命中测试处理）。
+  List<ResizeEdge> _resizeEdges({required bool hideFrame}) {
+    if (Platform.isMacOS) return const <ResizeEdge>[];
+    if (hideFrame || _isMaximized) return const <ResizeEdge>[];
+    return const <ResizeEdge>[
+      ResizeEdge.topLeft,
+      ResizeEdge.top,
+      ResizeEdge.topRight,
+    ];
   }
 }
 

--- a/fushi/test/build/hdr_video_host_guard_test.dart
+++ b/fushi/test/build/hdr_video_host_guard_test.dart
@@ -75,11 +75,11 @@ void main() {
     // 真机复现：外壳的 ColoredBox(surface) 包着整个 Navigator，视频洞下面就是它；
     // 一旦让整层透明，标题行也透了（能看到别的窗口）。两条都要咬住。
     final String bar = _read(
-      '${_fushiDir()}/lib/src/utils/components/fushi_windows_title_bar.dart',
+      '${_fushiDir()}/lib/src/utils/components/fushi_desktop_title_bar.dart',
     );
     expect(bar, contains('valueListenable: hdrHostActiveGlobal'));
     expect(bar, contains('hdrHost ? Colors.transparent : colors.surface'));
-    final int caption = bar.indexOf('height: FushiWindowsTitleBar.height,');
+    final int caption = bar.indexOf('height: FushiDesktopTitleBar.height,');
     expect(caption, greaterThan(0));
     final String captionBlock = bar.substring(caption, caption + 400);
     expect(captionBlock, contains('color: colors.surface,'));

--- a/fushi/test/build/win_fullscreen_flash_guard_test.dart
+++ b/fushi/test/build/win_fullscreen_flash_guard_test.dart
@@ -236,7 +236,7 @@ void main() {
         readAt,
       );
       final int readChromeAt = navDart.indexOf(
-        'FushiWindowsTitleBar.setWindowManagerFullscreen(fullscreen)',
+        'FushiDesktopTitleBar.setWindowManagerFullscreen(fullscreen)',
         readAt,
       );
       expect(readWinAt, isNonNegative);

--- a/fushi/test/desktop/desktop_title_bar_macos_frame_guard_test.dart
+++ b/fushi/test/desktop/desktop_title_bar_macos_frame_guard_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// macOS 顶栏改造的源码守卫：用户拍板「mac 端去掉交通灯，改成跟 Windows 一样的原生
+/// MD3 顶栏」。真机行为门全在 `dart:io` 的 `Platform.isMacOS` 与 NSWindow 平台通道上
+/// （`flutter test` 里两者都不存在，Linux CI 更没有 AppKit），所以按仓库
+/// `*_guard_test` 惯例钉源码级不变式。
+void main() {
+  // 一律扫**掩掉注释后**的源码：这些不变式的注释本身就会写「windowButtonVisibility:
+  // false」「_macosWindowTitlebarInset」等字样，不掩会把说明文字当成实现命中。
+  final String main = maskComments(File('lib/main.dart').readAsStringSync());
+  final String titleBar = maskComments(
+    File(
+      'lib/src/utils/components/fushi_desktop_title_bar.dart',
+    ).readAsStringSync(),
+  );
+
+  test('macOS 与 Windows 走同一条「隐藏系统标题栏 + 自绘顶栏」路径', () {
+    final int gate = main.indexOf('Platform.isWindows || Platform.isMacOS');
+    expect(gate, greaterThanOrEqualTo(0));
+    final int style = main.indexOf('TitleBarStyle.hidden', gate);
+    final int buttons = main.indexOf('windowButtonVisibility: false', gate);
+    final int latch = main.indexOf('FushiDesktopTitleBar.markEnabled()', gate);
+    expect(style, greaterThan(gate));
+    expect(buttons, greaterThan(style));
+    expect(
+      latch,
+      greaterThan(buttons),
+      reason: '闩必须在真正隐藏原生标题栏之后置位，否则会先画一帧「两条标题栏」',
+    );
+  });
+
+  test('顶栏挂载只由启动闩决定，不再叠 Platform.isWindows', () {
+    expect(
+      RegExp(
+        r'Platform\.isWindows\s*&&\s*FushiDesktopTitleBar\.isEnabled',
+      ).hasMatch(main.replaceAll(RegExp(r'\s+'), ' ')),
+      isFalse,
+      reason: 'macOS 已经隐藏了系统标题栏与交通灯；再用 Platform.isWindows 门控挂载 '
+          '= macOS 窗口既没有标题也没有最小化/关闭按钮。',
+    );
+    expect(
+      main.contains('if (FushiDesktopTitleBar.isEnabled) {'),
+      isTrue,
+      reason: '自绘顶栏的唯一门控是启动闩（Windows / macOS 由 main() 置位）。',
+    );
+  });
+
+  test('macOS 不挂 DragToResizeArea 的命中区（window_manager 没有 startResizing）', () {
+    // window_manager 的 macOS 插件方法表里根本没有 `startResizing`（只有
+    // Windows/Linux 实现），挂上去拖一下就是 MissingPluginException；而 AppKit 在
+    // full-size content view 下仍自己拥有窗口四边的 resize 边框，本来就不需要代劳。
+    expect(
+      titleBar.contains('if (Platform.isMacOS) return const <ResizeEdge>[];'),
+      isTrue,
+      reason: 'macOS 必须返回空边表，把 resize 完全留给 AppKit。',
+    );
+  });
+
+  test('macOS 原生全屏由 NSWindowDelegate 真相源驱动顶栏显隐', () {
+    // window_manager 的 WindowListener 在 macOS 上收不到全屏通知（macos_window_utils
+    // 占着 NSWindow.delegate），只靠它顶栏会在全屏里留成一条横带。
+    expect(titleBar.contains('MacosFullscreenState.instance'), isTrue);
+    expect(titleBar.contains('ensureRegistered()'), isTrue);
+    expect(
+      titleBar.contains('setMacOSTrafficLightsHidden(true)'),
+      isTrue,
+      reason: 'AppKit 退全屏会复位 standardWindowButton.isHidden，必须重申隐藏。',
+    );
+  });
+}

--- a/fushi/test/desktop/fushi_desktop_title_bar_subtree_identity_test.dart
+++ b/fushi/test/desktop/fushi_desktop_title_bar_subtree_identity_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:fushi/src/utils/components/fushi_windows_title_bar.dart';
+import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:window_manager/window_manager.dart';
 
-/// [FushiWindowsTitleBar] 把整棵 app 子树（`FushiAppUiScale` → 全局快捷键 Focus 节点
+/// [FushiDesktopTitleBar] 把整棵 app 子树（`FushiAppUiScale` → 全局快捷键 Focus 节点
 /// → `FushiFocusRoot` 焦点控制器 → Navigator）挂在自己下面。这些层里除 Navigator 外
 /// 都没有 key，所以**它们的 Element 身份完全由本组件 build 出的 widget 树形状决定**。
 ///
@@ -42,7 +42,7 @@ void main() {
 
   tearDown(() {
     // 静态 owner 集合是进程级的，用例之间必须归零，否则会污染后续用例。
-    FushiWindowsTitleBar.setContentFullscreen(owner: owner, enabled: false);
+    FushiDesktopTitleBar.setContentFullscreen(owner: owner, enabled: false);
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(const MethodChannel('window_manager'), null);
   });
@@ -50,8 +50,10 @@ void main() {
   testWidgets('进出全屏不重建标题栏下方子树，焦点保持原位', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home:
-            FushiWindowsTitleBar(title: Text('Fushi'), child: _SubtreeProbe()),
+        home: FushiDesktopTitleBar(
+          title: Text('Fushi'),
+          child: _SubtreeProbe(),
+        ),
       ),
     );
     await tester.pump();
@@ -64,12 +66,14 @@ void main() {
     expect(before.node.hasFocus, isTrue, reason: '前置条件：焦点先落在子树里');
 
     // 进全屏。
-    FushiWindowsTitleBar.setContentFullscreen(owner: owner, enabled: true);
+    FushiDesktopTitleBar.setContentFullscreen(owner: owner, enabled: true);
     await tester.pump();
 
     expect(
       identical(
-          tester.state<_SubtreeProbeState>(find.byType(_SubtreeProbe)), before),
+        tester.state<_SubtreeProbeState>(find.byType(_SubtreeProbe)),
+        before,
+      ),
       isTrue,
       reason: '进全屏时标题栏下方子树被重建了——全局快捷键 Focus 节点与焦点控制器'
           '（都没有 key）会一起销毁重建，焦点必然丢失。',
@@ -77,12 +81,14 @@ void main() {
     expect(before.node.hasFocus, isTrue, reason: '进全屏后焦点必须仍在原处');
 
     // 出全屏。
-    FushiWindowsTitleBar.setContentFullscreen(owner: owner, enabled: false);
+    FushiDesktopTitleBar.setContentFullscreen(owner: owner, enabled: false);
     await tester.pump();
 
     expect(
       identical(
-          tester.state<_SubtreeProbeState>(find.byType(_SubtreeProbe)), before),
+        tester.state<_SubtreeProbeState>(find.byType(_SubtreeProbe)),
+        before,
+      ),
       isTrue,
       reason: '出全屏时标题栏下方子树被重建了（同上）。',
     );
@@ -92,8 +98,10 @@ void main() {
   testWidgets('全屏态下 resize 边框零命中区，widget 类型不变', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
-        home:
-            FushiWindowsTitleBar(title: Text('Fushi'), child: _SubtreeProbe()),
+        home: FushiDesktopTitleBar(
+          title: Text('Fushi'),
+          child: _SubtreeProbe(),
+        ),
       ),
     );
     await tester.pump();
@@ -106,7 +114,7 @@ void main() {
       const <ResizeEdge>[
         ResizeEdge.topLeft,
         ResizeEdge.top,
-        ResizeEdge.topRight
+        ResizeEdge.topRight,
       ],
       reason: 'window_manager 的 TitleBarStyle.hidden 只吃掉顶边，顶边三个 resize '
           '把手必须由 Flutter 侧补。',
@@ -114,7 +122,7 @@ void main() {
     // 顶栏可见。
     expect(find.byIcon(Icons.close_rounded), findsOneWidget);
 
-    FushiWindowsTitleBar.setContentFullscreen(owner: owner, enabled: true);
+    FushiDesktopTitleBar.setContentFullscreen(owner: owner, enabled: true);
     await tester.pump();
 
     expect(
@@ -122,11 +130,7 @@ void main() {
       findsOneWidget,
       reason: '全屏态必须仍是 DragToResizeArea——换成别的 widget 类型会让整棵子树重建。',
     );
-    expect(
-      area().enableResizeEdges,
-      isEmpty,
-      reason: '全屏时不得留任何 resize 命中区。',
-    );
+    expect(area().enableResizeEdges, isEmpty, reason: '全屏时不得留任何 resize 命中区。');
     // 顶栏隐藏。
     expect(find.byIcon(Icons.close_rounded), findsNothing);
   });

--- a/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
+++ b/fushi/test/macos/macos_shell_fullscreen_sidebar_test.dart
@@ -131,107 +131,60 @@ void main() {
             'pagination geometry so fullscreen re-layout uses the live inset.');
   });
 
-  test('BUG-1343 windowed macOS reader exposes a draggable titlebar strip', () {
-    // 默认 auto=MD3 时根部不会挂 MacosWindow/ToolBar，但 NSWindow 仍是透明标题栏 +
-    // full-size content。Reader 必须自己提供稳定可抓区，不能让 WebView 吞满顶边。
-    expect(reader, contains('package:window_manager/window_manager.dart'));
-    expect(reader, contains('DragToMoveArea('));
-    expect(reader, contains("'fushi_reader_window_drag_area'"));
-    expect(reader, contains('kMacTitleBarHeight'));
-    expect(reader, contains('_macosWindowTitlebarInset'));
-    expect(reader, contains('_readerTopOffset =>'));
-    // BUG-1381：这两条原本钉的是 `_lyricsMode || _spreadDocumentLoaded` 和局部变量名
-    // `top: independentDocumentTopInset` 两个**实现拼写**——与它们同一方法体里那条
-    // `EdgeInsets.only(bottom: _readerBottomReserve)` 守卫同属 B 类「要求型」锚点，
-    // `_buildBody` 一重构就凭空变红（行为分毫未变）。独立文档缩进多少现由纯函数
-    // `independentDocumentInsets` 承载，「歌词/spread 缩进标题栏高、正文不缩进」的数值
-    // 契约由 test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart 的行为
-    // 断言钉死；这里只钉一件本文件该管的事：reader 页确实把标题栏高喂进了那个真相源。
-    final String buildBody = methodBody(reader, '  Widget _buildBody()');
-    expect(
-      containsIdentifierCall(buildBody, 'independentDocumentInsets'),
-      isTrue,
-      reason: '不注入正文引擎的歌词/spread 文档也必须避开顶部拖拽区，'
-          '缩进量走单一真相源 independentDocumentInsets',
-    );
-    expect(
-      containsCodeLine(buildBody, 'titlebarInset: _macosWindowTitlebarInset'),
-      isTrue,
-      reason: '独立文档由 Flutter 侧真实缩进标题栏高，不能只改正文 CSS inset',
-    );
-    expect(
-      readerChrome,
-      contains('_stableTopInset + _macosWindowTitlebarInset'),
-      reason: '顶部进度 pill 必须落在 drag strip 下方，不能盖住拖动区或交通灯',
-    );
+  test('macOS 阅读器不再自绘标题栏拖拽带（BUG-1343 / BUG-1744 的形态已作废）', () {
+    // macOS 改用应用级自绘 MD3 顶栏（FushiDesktopTitleBar，包在整个 Navigator 之上）
+    // 后：交通灯在 main() 里被永久隐藏，窗口抓手由顶栏的 DragToMoveArea 提供。
+    // 阅读器再留 BUG-1343 那条 28pt 拖拽带 + 同高让位，就是在顶栏底下又压一条
+    // 不透明带 + 一条空白——所以整块必须消失，而不是「改成条件更严的分支」。
+    // 掩掉注释：删除说明本身会提到这些名字，不掩就等于自己命中自己。
+    final String readerCode = maskComments(reader);
+    for (final String gone in <String>[
+      '_macosWindowTitlebarInset',
+      'fushi_reader_window_drag_area',
+      'kMacTitleBarHeight',
+      'DragToMoveArea(',
+    ]) {
+      expect(readerCode, isNot(contains(gone)),
+          reason: '阅读器残留 macOS 顶部拖拽带痕迹（$gone）= 顶栏下面多一条带/空白');
+    }
+    expect(maskComments(readerChrome),
+        isNot(contains('_macosWindowTitlebarInset')),
+        reason: '顶部进度 pill 不该再为已删除的拖拽带让位');
   });
 
-  // BUG-1744：用户报的「阅读器顶部横带」。BUG-1343 引入的 28pt 拖拽带唯一条件是
-  // Platform.isMacOS——进原生全屏后既没有标题栏也没有交通灯、窗口也拖不动，这条
-  // 不透明带和它同高的正文让位却仍在，就是那条横带。
-  test('BUG-1744 fullscreen drops the titlebar strip and its content inset',
-      () {
-    // 让位量必须由全屏态门控（单一真相源：_readerTopOffset / popupTopReserve /
-    // independentDocumentInsets / 顶部进度 pill 全部读它）。
-    expect(
-      reader,
-      contains(
-          'Platform.isMacOS && !_macosFullscreen ? kMacTitleBarHeight : 0'),
-      reason: '_macosWindowTitlebarInset 未按全屏态门控 → 全屏下正文仍被下压 28pt',
-    );
-    // 带子本身也必须整体不挂，只归零 inset 会留下一条盖住正文的不透明条。
-    // （DragToMoveArea 挂在 build() 的 Stack 里，不在 _buildBody()。）
-    final String pageBuild =
-        methodBody(reader, '  Widget build(BuildContext context)');
-    expect(
-      containsCodeLine(pageBuild, 'if (Platform.isMacOS && !_macosFullscreen)'),
-      isTrue,
-      reason: '全屏下仍挂 DragToMoveArea 的 ColoredBox = 一条纯浪费的顶部横带',
-    );
-    expect(
-      containsCodeLine(pageBuild, 'DragToMoveArea('),
-      isTrue,
-      reason: '守卫取错了窗口（DragToMoveArea 应在同一个 build 方法体内）',
-    );
-    // 状态来源必须是能覆盖**全部**入口的 NSWindowDelegate：绿灯按钮和「显示」
-    // 菜单都不经过 app 自己的 F11 快捷键，只记快捷键状态会漏掉最常用的两条路。
-    expect(
-      reader,
-      contains('MacosFullscreenState.instance'),
-      reason: '全屏态必须取自单一真相源 MacosFullscreenState',
-    );
-    expect(
-      fullscreenState,
-      contains('windowDidEnterFullScreen'),
-      reason: 'NSWindowDelegate 是唯一能覆盖绿灯/菜单/快捷键全部入口的信号',
-    );
-    expect(
-      fullscreenState,
-      contains('windowDidExitFullScreen'),
-      reason: '只监听进入不监听退出，退出全屏后横带不会回来',
-    );
-    // 光 setState 不够：JS 的 --chrome-top-inset 由 _applyChromeInsets 单独推送，
-    // 漏了它正文 padding-top 会停在旧的 28px 上（横带原样还在）。
-    final String onChange =
-        methodBody(reader, '  void _onMacosFullscreenChanged()');
-    expect(containsCodeLine(onChange, '_applyChromeInsets'), isTrue,
-        reason: '全屏翻转后必须把新 inset 回喂 WebView，否则 CSS 侧仍留 28px 空白');
-    expect(containsCodeLine(onChange, 'setState'), isTrue);
-    // 监听器必须摘掉，否则页面走了还在被全局 notifier 持有。
-    // 判据钉「dispose 里确实把这个回调摘掉了」，不钉排版：dart format 的 tall
-    // style 会把 `.removeListener(_onMacosFullscreenChanged)` 拆行并补尾逗号，
-    // 裸 contains 于是凭空变红（行为分毫未变）。改成结构判据——取回调标识符所在
-    // 的**最内层调用**，问它是不是 removeListener；顺带把窗口收进 dispose 体内，
-    // 比原来的全文件 contains 更严（写在别处的 removeListener 不再算数）。
-    final String disposeBody = methodBody(reader, '  void dispose() {');
-    final int callbackAt =
-        maskComments(disposeBody).indexOf('_onMacosFullscreenChanged');
-    expect(callbackAt, isNonNegative,
+  test('窗口抓手与 macOS 全屏信号都归自绘顶栏所有', () {
+    final String titleBar = maskComments(File(
+      'lib/src/utils/components/fushi_desktop_title_bar.dart',
+    ).readAsStringSync());
+    final String mainCode = maskComments(main);
+
+    // ① macOS 与 Windows 走同一条「隐藏系统标题栏 + 自绘顶栏」路径，且交通灯必须
+    //    在同一次调用里关掉（windowButtonVisibility: false），否则三个圆点会浮在
+    //    自绘顶栏的标题上（BUG-973 的根因）。
+    expect(mainCode, contains('Platform.isWindows || Platform.isMacOS'));
+    expect(mainCode, contains('windowButtonVisibility: false'));
+    expect(mainCode, contains('FushiDesktopTitleBar.markEnabled()'),
+        reason: '不置位启动闩 = 隐藏了系统标题栏却不挂替代顶栏（无标题无按钮）');
+
+    // ② 窗口抓手：顶栏自己提供 DragToMoveArea。
+    expect(titleBar, contains('DragToMoveArea('));
+
+    // ③ macOS 原生全屏必须由 NSWindowDelegate 真相源驱动：window_manager 的
+    //    WindowListener 在 macOS 上收不到全屏通知（macos_window_utils 占着
+    //    NSWindow.delegate），只靠它顶栏会在全屏里留成一条横带。
+    expect(titleBar, contains('MacosFullscreenState.instance'),
+        reason: '全屏态必须取自单一真相源 MacosFullscreenState');
+    expect(titleBar, contains('setContentFullscreen('),
+        reason: '全屏时必须按所有者收起自绘顶栏');
+    expect(titleBar, contains('removeListener('),
         reason: 'dispose 未摘监听 = 泄漏 + 已 dispose 的 State 上 setState');
-    expect(
-      enclosingCall(disposeBody, callbackAt).name,
-      endsWith('removeListener'),
-      reason: '回调必须是 removeListener 的实参，不能只是被顺手提到',
-    );
+    // ④ AppKit 退全屏会重建标题栏视图、复位 standardWindowButton.isHidden，
+    //    退出时必须重申隐藏，否则交通灯回到自绘顶栏之上。
+    expect(titleBar, contains('setMacOSTrafficLightsHidden(true)'),
+        reason: '退出原生全屏后不重申隐藏 → 交通灯复现并压住自绘顶栏');
+    expect(fullscreenState, contains('windowDidEnterFullScreen'),
+        reason: 'NSWindowDelegate 是唯一能覆盖绿灯/菜单/快捷键全部入口的信号');
+    expect(fullscreenState, contains('windowDidExitFullScreen'),
+        reason: '只监听进入不监听退出，退出全屏后顶栏不会回来');
   });
 }

--- a/fushi/test/media/video/video_backing_render_size_test.dart
+++ b/fushi/test/media/video/video_backing_render_size_test.dart
@@ -1,0 +1,207 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/video_backing_render_size.dart';
+
+import '../../helpers/source_guard.dart';
+
+/// 用户报告「mac 视频发虚」，指定按 IINA 的做法修。
+///
+/// 根因：media_kit 在 darwin 上把纹理固定建成**视频原生分辨率**，缩放由 Flutter 用
+/// `FilterQuality.low`（双线性）做。Retina 屏的物理像素是逻辑尺寸的 2 倍，于是
+/// 1080p 片源在 1440×810pt 的框里每帧都被从 1920 拉到 2880 物理像素——发虚，且 mpv
+/// 的缩放器 / 用户着色器完全用不上（缩放不在 mpv 里发生）。IINA 让 mpv 直接渲染到
+/// backing store 尺寸；本仓的落点是 `VideoBackingRenderSize` + `setSize`。
+///
+/// 真实渲染要 macOS + NSWindow + 平台通道，headless 一样都没有，所以数值契约落在纯
+/// 函数上（下面第一组），接线落在源码守卫上（第二组）。
+void main() {
+  const Size hd = Size(1920, 1080);
+
+  group('resolveVideoBackingRenderSize（渲染尺寸契约）', () {
+    test('Retina contain：按画面实际占用的物理像素渲染（IINA 同款）', () {
+      // 1440×810pt 的框、DPR 2 ⇒ 2880×1620 物理像素；片源比例与框一致 ⇒ 满铺。
+      final Size? size = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(1440, 810),
+        devicePixelRatio: 2,
+        videoNativeSize: hd,
+        fit: BoxFit.contain,
+      );
+      expect(size, const Size(2880, 1620));
+    });
+
+    test('比例不等的框：contain 取内接边，绝不按框的比例拉伸', () {
+      // 2000×1000pt @DPR2 = 4000×2000 物理；16:9 片源内接后由高度决定 ⇒ ×2000/1080。
+      final Size? size = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(2000, 1000),
+        devicePixelRatio: 2,
+        videoNativeSize: hd,
+        fit: BoxFit.contain,
+        maxPixels: double.infinity,
+      );
+      expect(size, isNotNull);
+      // 必须保持片源宽高比：mpv 会在给定尺寸里自己保持比例并补黑边，比例一旦不对，
+      // 黑边就被烤进纹理，Flutter 侧的 cover / fill 会连黑边一起裁 / 拉。
+      expect(size!.width / size.height, closeTo(hd.width / hd.height, 0.01));
+      expect(size.height, closeTo(2000, 2));
+    });
+
+    test('cover / fill 取外接边（欠采样的那一维才是被放大的那一维）', () {
+      final Size? cover = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(2000, 1000),
+        devicePixelRatio: 2,
+        videoNativeSize: hd,
+        fit: BoxFit.cover,
+        maxPixels: double.infinity,
+      );
+      expect(cover, isNotNull);
+      expect(cover!.width, closeTo(4000, 2));
+      expect(cover.width / cover.height, closeTo(hd.width / hd.height, 0.01));
+
+      final Size? fill = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(2000, 1000),
+        devicePixelRatio: 2,
+        videoNativeSize: hd,
+        fit: BoxFit.fill,
+        maxPixels: double.infinity,
+      );
+      expect(fill, cover, reason: 'fill 由 Flutter 拉伸，像素量需求与 cover 同档');
+    });
+
+    test('非 Retina 且尺寸接近原生：不下发（保持 media_kit 默认路径）', () {
+      expect(
+        resolveVideoBackingRenderSize(
+          boxLogicalSize: const Size(1920, 1080),
+          devicePixelRatio: 1,
+          videoNativeSize: hd,
+          fit: BoxFit.contain,
+        ),
+        isNull,
+      );
+      // ±5% 以内同样不动（拖窗口一点点就重建纹理不划算）。
+      expect(
+        resolveVideoBackingRenderSize(
+          boxLogicalSize: const Size(1960, 1102),
+          devicePixelRatio: 1,
+          videoNativeSize: hd,
+          fit: BoxFit.contain,
+        ),
+        isNull,
+      );
+    });
+
+    test('缩小也要下发：4K 片源塞进小窗口，交给 mpv 降采样', () {
+      final Size? size = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(640, 360),
+        devicePixelRatio: 2,
+        videoNativeSize: const Size(3840, 2160),
+        fit: BoxFit.contain,
+      );
+      expect(size, const Size(1280, 720));
+    });
+
+    test('像素上限：软件渲染路径不能被 6K 全屏放大吃满 CPU', () {
+      final Size? size = resolveVideoBackingRenderSize(
+        boxLogicalSize: const Size(3008, 1692),
+        devicePixelRatio: 2,
+        videoNativeSize: hd,
+        fit: BoxFit.contain,
+      );
+      expect(size, isNotNull);
+      expect(
+        size!.width * size.height,
+        lessThanOrEqualTo(kVideoBackingRenderMaxPixels),
+      );
+      expect(size.width / size.height, closeTo(hd.width / hd.height, 0.01));
+    });
+
+    test('首帧出画前 / 退化输入：一律不下发', () {
+      expect(
+        resolveVideoBackingRenderSize(
+          boxLogicalSize: const Size(1440, 810),
+          devicePixelRatio: 2,
+          videoNativeSize: null,
+          fit: BoxFit.contain,
+        ),
+        isNull,
+      );
+      expect(
+        resolveVideoBackingRenderSize(
+          boxLogicalSize: Size.infinite,
+          devicePixelRatio: 2,
+          videoNativeSize: hd,
+          fit: BoxFit.contain,
+        ),
+        isNull,
+        reason: '无界约束（infinite）算出来的尺寸没有意义',
+      );
+      expect(
+        resolveVideoBackingRenderSize(
+          boxLogicalSize: Size.zero,
+          devicePixelRatio: 2,
+          videoNativeSize: hd,
+          fit: BoxFit.contain,
+        ),
+        isNull,
+      );
+    });
+
+    test('videoNativeSizeOf：只认解出画的正尺寸', () {
+      expect(videoNativeSizeOf(1920, 1080), const Size(1920, 1080));
+      expect(videoNativeSizeOf(null, 1080), isNull);
+      expect(videoNativeSizeOf(1920, null), isNull);
+      expect(videoNativeSizeOf(0, 0), isNull);
+    });
+  });
+
+  group('接线', () {
+    final String helper = maskComments(
+      File(
+        'lib/src/media/video/video_backing_render_size.dart',
+      ).readAsStringSync(),
+    );
+    final String layout = maskComments(
+      File(
+        'lib/src/pages/implementations/video_fushi/layout.part.dart',
+      ).readAsStringSync(),
+    );
+    final String fullscreen = maskComments(
+      File(
+        'lib/src/pages/implementations/video_fushi/fullscreen.part.dart',
+      ).readAsStringSync(),
+    );
+
+    test('窗口与全屏两条 Video 都接上（全屏才是放得最大的那条）', () {
+      expect(layout, contains('VideoBackingRenderSize('));
+      expect(fullscreen, contains('VideoBackingRenderSize('));
+    });
+
+    test('尺寸输入取原生解码尺寸，不取 controller.rect（否则自激）', () {
+      expect(helper, contains('videoNativeSizeOf('));
+      expect(
+        helper,
+        isNot(contains('controller.rect')),
+        reason: 'rect 正是本组件写进去的值，拿它当输入会「下发→rect 变→再下发」',
+      );
+      for (final String source in <String>[layout, fullscreen]) {
+        expect(source, contains('videoNativeSizeOf('));
+        expect(
+          source,
+          contains('videoFitModeToBoxFit(_videoFitMode)'),
+          reason: '渲染尺寸必须跟随用户的画面比例偏好，否则 cover 下欠采样',
+        );
+      }
+    });
+
+    test('只在 macOS 生效，且尺寸变化经防抖', () {
+      expect(
+        helper,
+        contains('Platform.isMacOS'),
+        reason: 'Windows 走 ANGLE + HDR 宿主窗另一条链路，不在本次范围',
+      );
+      expect(helper, contains('Timer('), reason: '拖窗口会连发几十帧不同尺寸，不防抖就是每帧重建纹理');
+      expect(helper, contains('setSize('));
+    });
+  });
+}

--- a/fushi/test/media/video/video_lifecycle_static_test.dart
+++ b/fushi/test/media/video/video_lifecycle_static_test.dart
@@ -434,9 +434,10 @@ void main() {
           reason: 'initState 必须经 VideoDisplayClaim.claim 登记本页持有进程级显示态');
       // 登记必须早于设置动作：先登记再设，换集期间新旧两页同时在册，旧页释放时才
       // 看得到「还有人持有」。
+      // macOS 交通灯已不在此列：改用自绘 MD3 顶栏后它们是启动即永久隐藏，
+      // 视频页不再认领、也不再还原（见 macos_video_trafficlight_hide_guard_test）。
       for (final String action in <String>[
         '_lockLandscapeForVideo()',
-        'setMacOSTrafficLightsHidden(true)',
         '_registerSystemBarsVisibilityCallback()',
       ]) {
         final int at = b.indexOf(action);
@@ -461,7 +462,6 @@ void main() {
       for (final String unconditional in <String>[
         '_restoreOrientationOnExit()',
         'setSystemUIChangeCallback(null)',
-        'setMacOSTrafficLightsHidden(false)',
       ]) {
         expect(b.contains(unconditional), isFalse,
             reason: 'dispose 不得直接调 $unconditional（须经 VideoDisplayClaim 记账门控）');
@@ -484,7 +484,6 @@ void main() {
       for (final String restore in <String>[
         'setSystemUIChangeCallback(null)',
         '_restoreOrientationOnExit()',
-        'setMacOSTrafficLightsHidden(false)',
       ]) {
         final int at = b.indexOf(restore);
         expect(at, greaterThanOrEqualTo(0),

--- a/fushi/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
+++ b/fushi/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
@@ -28,21 +28,16 @@ import 'reader_fushi_page_source_corpus.dart';
 void main() {
   group('independentDocumentInsets（独立 HTML 文档留白契约）', () {
     const double reserve = 72;
-    const double titlebar = 28;
 
     EdgeInsets insets({
       required bool lyricsMode,
-      bool spreadDocumentLoaded = false,
       required bool chromeOccupiesLayout,
       double bottomReserve = reserve,
-      double titlebarInset = 0,
     }) {
       return independentDocumentInsets(
         lyricsMode: lyricsMode,
-        spreadDocumentLoaded: spreadDocumentLoaded,
         chromeOccupiesLayout: chromeOccupiesLayout,
         bottomReserve: bottomReserve,
-        titlebarInset: titlebarInset,
       );
     }
 
@@ -75,45 +70,19 @@ void main() {
       expect(insets(lyricsMode: true, chromeOccupiesLayout: false).bottom, 0);
     });
 
-    test('正文模式不留底部（正文走 setChromeInsets，重复留白会挖掉一条空白）', () {
+    test('正文 / spread 模式不留底部（正文走 setChromeInsets，重复留白会挖掉一条空白）', () {
       expect(insets(lyricsMode: false, chromeOccupiesLayout: true).bottom, 0);
-      expect(
-        insets(
-          lyricsMode: false,
-          spreadDocumentLoaded: true,
-          chromeOccupiesLayout: true,
-        ).bottom,
-        0,
-        reason: 'spread 没有文档级滚动条，不需要也不应吃底栏预留',
-      );
+      // spread 整页图也是独立文档，但它没有文档级滚动条，不需要也不应吃底栏预留
+      // ——判据只认 lyricsMode，所以 spread 与「没有独立文档」在这里同为 0。
     });
 
-    test('BUG-1343：歌词 / spread 顶部缩进标题栏高，正文不缩进', () {
-      expect(
-        insets(
-          lyricsMode: true,
-          chromeOccupiesLayout: true,
-          titlebarInset: titlebar,
-        ).top,
-        titlebar,
-      );
-      expect(
-        insets(
-          lyricsMode: false,
-          spreadDocumentLoaded: true,
-          chromeOccupiesLayout: false,
-          titlebarInset: titlebar,
-        ).top,
-        titlebar,
-      );
-      expect(
-        insets(
-          lyricsMode: false,
-          chromeOccupiesLayout: true,
-          titlebarInset: titlebar,
-        ).top,
-        0,
-      );
+    test('顶部恒不留白（macOS 拖拽带随自绘顶栏一并删除）', () {
+      // BUG-1343 曾让独立文档顶部缩进 macOS 阅读器自绘的 28pt 拖拽带。macOS 改用
+      // 应用级 MD3 顶栏（FushiDesktopTitleBar，在整个 Navigator 之上）后，页内不再
+      // 有任何叠在 WebView 上的顶部 chrome，这笔留白必须消失，否则歌词/整页图会在
+      // 顶栏下面再空一条。
+      expect(insets(lyricsMode: true, chromeOccupiesLayout: true).top, 0);
+      expect(insets(lyricsMode: false, chromeOccupiesLayout: false).top, 0);
     });
 
     test('两笔留白都为 0 时返回 EdgeInsets.zero（调用方据此跳过 Padding）', () {

--- a/fushi/test/pages/video_fullscreen_switch_flatten_guard_test.dart
+++ b/fushi/test/pages/video_fullscreen_switch_flatten_guard_test.dart
@@ -256,7 +256,7 @@ void main() {
     );
     expect(
       fullscreenSrc.contains(
-        'FushiWindowsTitleBar.setContentFullscreen(owner: this, enabled: true)',
+        'FushiDesktopTitleBar.setContentFullscreen(owner: this, enabled: true)',
       ),
       isTrue,
       reason: '认领时 Windows 必须立刻持有标题栏 owner，否则旧页 dispose 后标题栏闪出',

--- a/fushi/test/pages/video_lookup_popup_overlay_test.dart
+++ b/fushi/test/pages/video_lookup_popup_overlay_test.dart
@@ -215,7 +215,7 @@ void main() {
     tester.view.physicalSize = physical;
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
-    // main.dart：Windows 上 FushiWindowsTitleBar 把 FushiAppUiScale(导航器) 放在一条
+    // main.dart：Windows 上 FushiDesktopTitleBar 把 FushiAppUiScale(导航器) 放在一条
     // 32px、不随界面缩放的标题栏之下——根 Overlay 原点比屏幕原点低 32px。
     const double titleBar = 32;
 

--- a/fushi/test/pages/video_orientation_fullscreen_guard_test.dart
+++ b/fushi/test/pages/video_orientation_fullscreen_guard_test.dart
@@ -111,7 +111,7 @@ void main() {
         reason: '进全屏桌面分支必须转调 defaultEnterNativeFullscreen (保留桌面真全屏)',
       );
       expect(
-        enterBody.contains('FushiWindowsTitleBar.setContentFullscreen') &&
+        enterBody.contains('FushiDesktopTitleBar.setContentFullscreen') &&
             enterBody.contains('owner: this') &&
             enterBody.contains('enabled: true'),
         isTrue,

--- a/fushi/test/reader/reader_chrome_floating_test.dart
+++ b/fushi/test/reader/reader_chrome_floating_test.dart
@@ -203,15 +203,17 @@ void main() {
         '  double get _readerTopOffset =>',
         '  double get _readerBottomReserve =>',
       );
+      // macOS 那条 28pt 自绘拖拽带（BUG-1343）随「macOS 改用应用级 MD3 顶栏」
+      // 删除，顶部预留不再含 _macosWindowTitlebarInset；派生 getter 本身仍是
+      // 唯一真相源（关掉进度 / 桌面顶栏挤压都靠它回收空白）。
       for (final String term in <String>[
         '_stableTopInset',
-        '_macosWindowTitlebarInset',
         '_topProgressReserve',
         '_desktopHeaderReserve',
       ]) {
         expect(topOffset.contains(term), isTrue,
-            reason: '顶部预留必须经派生 getter（关进度回收空白 / 桌面顶栏挤压），'
-                '并避开 macOS 拖拽区：缺 $term');
+            reason: '顶部预留必须经派生 getter（关进度回收空白 / 桌面顶栏挤压）：'
+                '缺 $term');
       }
       expect(
         src.contains('_readerBottomReserve =>\n'

--- a/fushi/test/reader/reader_status_footer_test.dart
+++ b/fushi/test/reader/reader_status_footer_test.dart
@@ -240,7 +240,9 @@ void main() {
       final String anyFloating = _slice(
         src,
         '  bool get _anyChromeFloating =>',
-        '  /// BUG-1343',
+        // 结束锚点用结构（下一个 getter 定义），不用某条注释：BUG-1343 那段
+        // macOS 拖拽带的文档注释已随该功能删除。
+        '  double get _readerTopOffset =>',
       );
       expect(
         anyFloating.contains('(_topProgressFloating && !_statusFooterEnabled)'),

--- a/fushi/test/tools/bug_1692_platform_view_overlay_guard_test.dart
+++ b/fushi/test/tools/bug_1692_platform_view_overlay_guard_test.dart
@@ -134,17 +134,24 @@ void main() {
       );
     });
 
-    test('阅读器 macOS 标题栏拖拽区必须自带 RepaintBoundary', () {
+    test('阅读器页内已无 macOS 专用拖拽区（该形态随自绘顶栏一并删除）', () {
+      // 这条原本守「阅读器自绘的 28pt macOS 标题栏拖拽区必须自带 RepaintBoundary」。
+      // macOS 改用应用级 MD3 顶栏（FushiDesktopTitleBar，包在整个 Navigator 之上、
+      // 不在阅读器页的 Stack 里）后，那条带子整块删除：窗口抓手由顶栏的
+      // DragToMoveArea 提供，交通灯也在 main() 里被永久隐藏。
+      //
+      // 判据因此反过来——页内不得再出现这个拖拽区。它若复活而没带
+      // RepaintBoundary，就会并进页面级 cull rect = 整窗的 PictureLayer，macOS
+      // engine 据此把整窗加进 FlutterMutatorView 的 _hitTestIgnoreRegion，正文
+      // WebView 整块收不到鼠标事件（BUG-1692 的原始症状）。
       final String page = File(
         'lib/src/pages/implementations/reader_fushi_page.dart',
       ).readAsStringSync();
-      final int at = page.indexOf('fushi_reader_window_drag_area');
-      expect(at, greaterThan(-1), reason: '拖拽区 key 改了，守卫需同步更新');
-      final String before = page.substring((at - 600).clamp(0, at), at);
       expect(
-        before.contains('RepaintBoundary'),
-        isTrue,
-        reason: 'macOS 标题栏拖拽区画在阅读器 WebView 之后，同上（BUG-1692）',
+        page.contains('fushi_reader_window_drag_area'),
+        isFalse,
+        reason: '阅读器页内又出现 macOS 拖拽区 = 自绘顶栏之下再压一条不透明带；'
+            '若确要恢复，必须同时恢复它的 RepaintBoundary 与本守卫的正向判据',
       );
     });
   });

--- a/fushi/test/tools/macos_trafficlight_inset_guard_test.dart
+++ b/fushi/test/tools/macos_trafficlight_inset_guard_test.dart
@@ -2,64 +2,68 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Guards the BUG-869 fix: on macOS the app enables a transparent titlebar +
-/// full-size content view unconditionally (`main.dart`, required by macos_ui's
-/// ToolBar). Flutter content then extends under the red/yellow/green traffic
-/// light buttons, and macOS does NOT report those as `MediaQuery.padding.top`,
-/// so a plain `SafeArea` lets the traffic lights sit on top of the Material
-/// desktop shell's nav rail / back button.
+/// BUG-869 的**当前形态**守卫。
 ///
-/// The fix reserves the titlebar height (`kMacTitleBarHeight`) as the minimum
-/// top inset in both `_buildDesktopLayout` branches (settings full-screen +
-/// normal rail+content). A source guard is the strongest feasible landing
-/// layer here: the branch is gated on `dart:io`'s `Platform.isMacOS`, which
-/// (unlike `debugDefaultTargetPlatformOverride`) can't be faked in a widget
-/// test on the Linux CI host, so we can't drive the real macOS layout there.
+/// 旧形态：macOS 无条件开透明标题栏 + full-size content view，Flutter 内容画到窗口
+/// 左上角，交通灯浮在其上且不计入 `MediaQuery.padding.top`，于是桌面壳两条分支都用
+/// `SafeArea.minimum` 预留一条 `kMacTitleBarHeight`，把 rail / 返回箭头整体下压。
+///
+/// 现在 macOS 与 Windows 同壳：`main()` 用
+/// `setTitleBarStyle(hidden, windowButtonVisibility: false)` 隐藏系统标题栏**和**三个
+/// 交通灯，再由 `FushiDesktopTitleBar` 画 MD3 顶栏。顶栏吃掉真实布局高度，rail 与返回
+/// 箭头本来就落在它下面——再留 28pt 就是一条纯空白。所以不变式反过来了：桌面壳里不能
+/// 再出现那条 macOS 专用的 SafeArea 预留带。
+///
+/// 源码守卫仍是最强可落地层：分支门在 `dart:io` 的 `Platform.isMacOS` 上，
+/// `debugDefaultTargetPlatformOverride` 伪装不了，Linux CI 上跑不出真 macOS 布局。
 void main() {
-  test('kMacTitleBarHeight is a positive titlebar reserve (BUG-869)', () {
-    final String source = File('lib/src/utils/adaptive/adaptive_platform.dart')
-        .readAsStringSync();
-    final RegExp decl =
-        RegExp(r'const\s+double\s+kMacTitleBarHeight\s*=\s*([0-9.]+)\s*;');
-    final Match? m = decl.firstMatch(source);
-    expect(m, isNotNull,
-        reason: 'kMacTitleBarHeight must be defined in adaptive_platform.dart '
-            'so both desktop shells reserve the same macOS traffic-light band.');
-    final double value = double.parse(m!.group(1)!);
-    // Traffic lights are 12pt discs at roughly y=[6,18]; the reserve must
-    // comfortably clear them. 20pt is a conservative lower bound.
-    expect(value, greaterThanOrEqualTo(20.0),
-        reason: 'kMacTitleBarHeight must be tall enough to clear the traffic '
-            'lights (they sit within the standard ~28pt titlebar).');
-  });
-
-  test(
-      'both _buildDesktopLayout SafeAreas reserve the macOS titlebar (BUG-869)',
-      () {
-    final String source =
-        File('lib/src/pages/implementations/home_page.dart').readAsStringSync();
+  test('桌面壳不再为交通灯预留 SafeArea 顶部带（BUG-869 的旧形态）', () {
+    final String source = File(
+      'lib/src/pages/implementations/home_page.dart',
+    ).readAsStringSync();
 
     final int start = source.indexOf('Widget _buildDesktopLayout(');
-    expect(start, greaterThanOrEqualTo(0),
-        reason: '_buildDesktopLayout must exist in home_page.dart.');
-    // Bound the scan to the method body (up to the next top-level `Widget `
-    // member) so we only inspect this one method's two Scaffolds.
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: '_buildDesktopLayout must exist in home_page.dart.',
+    );
     final int next = source.indexOf('\n  Widget ', start + 1);
     final String body =
         next > start ? source.substring(start, next) : source.substring(start);
 
-    // The macOS traffic-light reserve, applied via SafeArea.minimum. Both the
-    // settings full-screen branch and the rail+content branch must carry it,
-    // so require the pattern to appear at least twice.
-    final RegExp inset = RegExp(
-      r'minimum:\s*EdgeInsets\.only\(\s*top:\s*Platform\.isMacOS\s*\?\s*'
-      r'kMacTitleBarHeight\s*:\s*0',
+    expect(
+      RegExp(
+        r'minimum:\s*EdgeInsets\.only\(\s*top:\s*Platform\.isMacOS',
+      ).hasMatch(body),
+      isFalse,
+      reason: 'macOS 已无交通灯（main() 的 windowButtonVisibility: false），自绘顶栏又'
+          '真占布局高度；再留 kMacTitleBarHeight 会在顶栏下面多出一条空白。',
     );
-    final int occurrences = inset.allMatches(body).length;
-    expect(occurrences, greaterThanOrEqualTo(2),
-        reason: 'Both _buildDesktopLayout Scaffolds (settings full-screen and '
-            'rail+content) must reserve kMacTitleBarHeight as the SafeArea '
-            'minimum top inset on macOS, or the traffic lights overlap the nav '
-            'rail / back button again (BUG-869).');
+    expect(
+      body.contains('kMacTitleBarHeight'),
+      isFalse,
+      reason: '桌面壳不该再引用交通灯预留高。',
+    );
+  });
+
+  test('macOS 的窗口控制来自自绘顶栏，而不是系统交通灯（BUG-869 根因消除）', () {
+    final String main = File('lib/main.dart').readAsStringSync();
+    final int block = main.indexOf('Platform.isWindows || Platform.isMacOS');
+    expect(
+      block,
+      greaterThanOrEqualTo(0),
+      reason: 'macOS 必须与 Windows 走同一条自绘顶栏路径。',
+    );
+    expect(
+      main.contains('TitleBarStyle.hidden'),
+      isTrue,
+      reason: '不隐藏系统标题栏 = 自绘顶栏之上再叠一条原生标题栏。',
+    );
+    expect(
+      main.contains('windowButtonVisibility: false'),
+      isTrue,
+      reason: '交通灯必须在同一次调用里关掉，否则它们会浮在自绘顶栏的标题上。',
+    );
   });
 }

--- a/fushi/test/video/macos_video_trafficlight_hide_guard_test.dart
+++ b/fushi/test/video/macos_video_trafficlight_hide_guard_test.dart
@@ -2,31 +2,27 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Guards the BUG-973 fix: on macOS the app enables a transparent titlebar +
-/// full-size content view (`main.dart`), so the red/yellow/green traffic light
-/// buttons float over the top-left of the Flutter content. The video page draws
-/// its exit/back button (top bar `topLeft` slot) and left-corner OSD toasts in
-/// that same region, and macOS does NOT report the traffic lights as
-/// `MediaQuery.padding`, so they overlap. Unlike the home shell (BUG-869, which
-/// reserves `kMacTitleBarHeight` via `SafeArea.minimum`), the video page is a
-/// full-page route that owns its own chrome, so the fix hides the traffic
-/// lights for the whole video session and restores them on exit.
+import '../helpers/source_guard.dart';
+
+/// BUG-973 的**当前形态**守卫：macOS 上交通灯（红黄绿三个圆点）压住视频页返回按钮 /
+/// 左上角 OSD 的根因，已经不是「视频页忘了隐藏」，而是「窗口上还有交通灯」。
 ///
-/// A source guard is the strongest feasible landing layer: the behaviour is
-/// gated on `dart:io`'s `Platform.isMacOS` (which, unlike
-/// `debugDefaultTargetPlatformOverride`, can't be faked in a widget test on the
-/// Linux/Windows CI host) and drives native `NSWindow.standardWindowButton`
-/// visibility through a method channel, neither of which exists under
-/// `flutter test`. So we pin the wiring instead: the helper must gate on macOS
-/// and toggle all three buttons, and the video lifecycle must hide on enter /
-/// restore on exit / re-assert after leaving native fullscreen.
+/// macOS 改用自绘 MD3 顶栏（[FushiDesktopTitleBar]）后，`main()` 用
+/// `setTitleBarStyle(hidden, windowButtonVisibility: false)` 在启动时就把三个按钮
+/// 永久关掉，窗口控制全部由顶栏的 MD3 按钮提供。于是：
+///  * 视频页不该再「进页隐藏 / 退页恢复」——恢复恰恰把 BUG-973 的症状放回来；
+///  * 唯一仍需重申隐藏的时机是**退出原生全屏**（AppKit 的 `toggleFullScreen` 重建
+///    标题栏视图时会复位 `standardWindowButton.isHidden`）。
+///
+/// 源码守卫是最强可落地层：行为门在 `dart:io` 的 `Platform.isMacOS` 与
+/// `NSWindow.standardWindowButton` 平台通道上，`flutter test` 下两者都不存在。
 void main() {
   test(
       'setMacOSTrafficLightsHidden gates on macOS and toggles all three '
       'traffic-light buttons (BUG-973)', () {
-    final String source =
-        File('lib/src/platform/desktop/macos_traffic_lights.dart')
-            .readAsStringSync();
+    final String source = File(
+      'lib/src/platform/desktop/macos_traffic_lights.dart',
+    ).readAsStringSync();
 
     expect(
       RegExp(r'if\s*\(\s*!\s*Platform\.isMacOS\s*\)').hasMatch(source),
@@ -52,69 +48,67 @@ void main() {
     }
   });
 
-  test(
-      'video page hides traffic lights on enter and restores on exit '
-      '(BUG-973)', () {
-    final String source =
-        File('lib/src/pages/implementations/video_fushi_page.dart')
-            .readAsStringSync();
-
-    final int initState = source.indexOf('void initState()');
-    final int dispose = source.indexOf('void dispose()');
-    expect(initState, greaterThanOrEqualTo(0));
-    expect(dispose, greaterThan(initState),
-        reason:
-            'dispose() is expected to follow initState() in the state class.');
-
-    final String initBody = source.substring(initState, dispose);
+  test('交通灯由启动时一次性隐藏，视频页不再进出页开关它（BUG-973）', () {
+    final String main = File('lib/main.dart').readAsStringSync();
     expect(
-      initBody.contains('setMacOSTrafficLightsHidden(true)'),
+      main.contains('windowButtonVisibility: false'),
       isTrue,
-      reason:
-          'initState must hide the macOS traffic lights when the video page '
-          'mounts, or the exit button / OSD stay under them (BUG-973).',
+      reason: 'main() 必须在装自绘顶栏的同一次 setTitleBarStyle 里关掉交通灯，'
+          '否则三个系统圆点会浮在自绘顶栏的标题上。',
     );
 
-    // Bound dispose to the next member so we do not accidentally read a later
-    // method. dispose() is large; scan a generous window from its start.
-    final String disposeBody = source.substring(dispose);
+    // 掩掉注释：删除说明里会写到这个调用名，不掩就等于自己命中自己。
+    final String video = maskComments(
+      File(
+        'lib/src/pages/implementations/video_fushi_page.dart',
+      ).readAsStringSync(),
+    );
     expect(
-      disposeBody.contains('setMacOSTrafficLightsHidden(false)'),
-      isTrue,
-      reason: 'dispose must restore the traffic lights on exit (symmetry with '
-          'the initState hide), so the home shell gets them back (BUG-973).',
+      video.contains('setMacOSTrafficLightsHidden(false)'),
+      isFalse,
+      reason: '退出视频页恢复交通灯 = 把 BUG-973 的遮挡放回来（窗口已无系统标题栏，'
+          '三个圆点会直接压在自绘顶栏上）。',
     );
   });
 
-  test('exiting native fullscreen re-asserts the traffic-light hide (BUG-973)',
-      () {
-    final String source = File(
-      'lib/src/pages/implementations/video_fushi/fullscreen.part.dart',
-    ).readAsStringSync();
+  test(
+    'exiting native fullscreen re-asserts the traffic-light hide (BUG-973)',
+    () {
+      final String source = File(
+        'lib/src/pages/implementations/video_fushi/fullscreen.part.dart',
+      ).readAsStringSync();
 
-    // 锚定**定义**而非裸符号：BUG-2043 后同文件里更早处有一个调用点
-    // （_releaseHandedOverNativeFullscreen），裸 indexOf 会先命中它、扫错方法体。
-    final int exitFs =
-        source.indexOf('Future<void> _exitVideoNativeFullscreen()');
-    expect(exitFs, greaterThanOrEqualTo(0));
-    // Scan the method body: from its declaration to the next method.
-    final int nextMethod = source.indexOf('\n  Future<', exitFs + 1);
-    final int nextAny = source.indexOf('\n  Widget ', exitFs + 1);
-    int end = source.length;
-    if (nextMethod > exitFs) end = nextMethod;
-    if (nextAny > exitFs && nextAny < end) end = nextAny;
-    final String body = source.substring(exitFs, end);
+      // 锚定**定义**而非裸符号：BUG-2043 后同文件里更早处有一个调用点
+      // （_releaseHandedOverNativeFullscreen），裸 indexOf 会先命中它、扫错方法体。
+      final int exitFs = source.indexOf(
+        'Future<void> _exitVideoNativeFullscreen()',
+      );
+      expect(exitFs, greaterThanOrEqualTo(0));
+      // Scan the method body: from its declaration to the next method.
+      final int nextMethod = source.indexOf('\n  Future<', exitFs + 1);
+      final int nextAny = source.indexOf('\n  Widget ', exitFs + 1);
+      int end = source.length;
+      if (nextMethod > exitFs) end = nextMethod;
+      if (nextAny > exitFs && nextAny < end) end = nextAny;
+      final String body = source.substring(exitFs, end);
 
-    // AppKit's toggleFullScreen can reset standardWindowButton.isHidden when it
-    // rebuilds the titlebar; the desktop branch must re-hide AFTER exiting.
-    final int defaultExit = body.indexOf('defaultExitNativeFullscreen()');
-    final int reHide = body.indexOf('setMacOSTrafficLightsHidden(true)');
-    expect(defaultExit, greaterThanOrEqualTo(0),
-        reason: 'desktop branch still exits native fullscreen via media_kit.');
-    expect(reHide, greaterThan(defaultExit),
+      // AppKit's toggleFullScreen can reset standardWindowButton.isHidden when it
+      // rebuilds the titlebar; the desktop branch must re-hide AFTER exiting.
+      final int defaultExit = body.indexOf('defaultExitNativeFullscreen()');
+      final int reHide = body.indexOf('setMacOSTrafficLightsHidden(true)');
+      expect(
+        defaultExit,
+        greaterThanOrEqualTo(0),
+        reason: 'desktop branch still exits native fullscreen via media_kit.',
+      );
+      expect(
+        reHide,
+        greaterThan(defaultExit),
         reason:
             'The desktop branch must re-assert the traffic-light hide after '
             'defaultExitNativeFullscreen(), because AppKit can reset the '
-            'button visibility when leaving fullscreen (BUG-973).');
-  });
+            'button visibility when leaving fullscreen (BUG-973).',
+      );
+    },
+  );
 }

--- a/fushi/test/widgets/fushi_focus_ring_test.dart
+++ b/fushi/test/widgets/fushi_focus_ring_test.dart
@@ -316,7 +316,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Column(
         children: <Widget>[
-          // Mirrors FushiWindowsTitleBar: the app/focus-ring subtree starts
+          // Mirrors FushiDesktopTitleBar: the app/focus-ring subtree starts
           // below a native-sized caption row instead of at view y = 0.
           const SizedBox(height: 48),
           Expanded(


### PR DESCRIPTION
三件 macOS 适配，同一批落地。

## ① 去掉 mac 顶部交通灯，改用与 Windows 一样的 MD3 自绘顶栏

`main()` 把 `setTitleBarStyle(hidden, windowButtonVisibility: false)` 从 Windows 扩到 macOS：隐藏系统标题栏**和**红黄绿三个按钮，窗口控制全部由自绘顶栏的 MD3 按钮提供。

- macOS 不挂 `DragToResizeArea`——`window_manager` 的 macOS 插件根本没有 `startResizing`（只有 Windows/Linux 实现），挂上去拖一下就是 `MissingPluginException`；而 AppKit 在 full-size content view 下仍自己拥有窗口四边的 resize 边框，本来就不需要 app 代劳。
- `FushiWindowsTitleBar` 随之改名 `FushiDesktopTitleBar`（源文件与守卫测试同名迁移），挂载门控收敛成那条启动闩，不再叠 `Platform.isWindows`。
- macOS 原生全屏经 `MacosFullscreenState`（NSWindowDelegate，覆盖快捷键 / 「显示」菜单 / 系统手势全部入口——`window_manager` 的 `WindowListener` 在 macOS 上收不到全屏通知，因为 macos_window_utils 占着 `NSWindow.delegate`）收起顶栏；退出全屏重申交通灯隐藏，AppKit 的 `toggleFullScreen` 会重建标题栏视图并复位 `standardWindowButton.isHidden`。

交通灯没了，围着它长出来的三处让位补丁一并删除：

- **BUG-869**：home 桌面壳两条 `SafeArea` 的 `kMacTitleBarHeight` 预留带；
- **BUG-973**：视频页「进页隐藏 / 退页恢复」交通灯——退页恢复恰恰把遮挡放回来；
- **BUG-1343 / BUG-1744**：阅读器自绘的 28pt 拖拽带 + 同高正文让位（`_macosWindowTitlebarInset`、`independentDocumentInsets` 的 `titlebarInset`）。

## ② mac 设置页与 Windows 同为双排

`FushiDesktopTitleBar.isEnabled` 在 macOS 也为真后，`_buildDesktopLayout` 自然走 Windows 那条「rail 常驻 + 内联 list-detail」分支，不再是「隐藏 rail + 页头返回箭头」的全屏设置。

## ③ mac 视频在 Retina 上发虚（BUG-2258，按用户指定参考 IINA）

media_kit 在 darwin 上把纹理**固定建成视频原生分辨率**（`VideoOutput.videoSize` 读 mpv 的 `dw/dh`），放大交给 Flutter 的 `FilterQuality.low` 双线性做 → Retina 下 1080p 片源在 1440×810pt 的框里每帧都被从 1920 拉到 2880 物理像素，整片发虚，而且 mpv 的缩放器与用户着色器完全用不上（缩放根本不在 mpv 里发生）。

新增 `VideoBackingRenderSize`：量出 `Video` 控件框的物理像素，按**片源宽高比**算出画面真正要占的像素，经 `VideoController.setSize` 交给 mpv——IINA 的 `convertToBacking` 同思路。按片源比例而不是框的比例下发是必须的：mpv 会在给定尺寸内保持比例并自行补黑边，比例一旦不等于片源，黑边会被烤进纹理，Flutter 侧的 `cover` / `fill` 就会连黑边一起裁 / 拉。防抖 180ms、±5% 内不动、4K 像素上限（darwin 走软件渲染路径 `TextureSW`，每帧成本与像素数线性相关）、仅 macOS；窗口与全屏两条 `Video` 都接。

## 验证

- `flutter analyze` 全绿；
- 定向 **156 tests** 全绿（新增/改写的 macOS 顶栏与 Retina 守卫、视频生命周期、阅读器 chrome、语料守卫等）；
- 目录枚举型守卫整批 **363 tests** 全绿。
- 真机复测未做（开发机是 Windows，无 Mac）——macOS 观感与 Retina 画质按仓库口径属 `implemented_unverified`。

https://claude.ai/code/session_01RMut3ie46po3BUCmYC2Rc6
