### PR TITLE
fix(eink): 墨水屏选中态与高亮可见性——对齐上游 Hoshi-Reader-Android

### DIFF
--- a/fushi/lib/src/models/theme_notifier.dart
+++ b/fushi/lib/src/models/theme_notifier.dart
@@ -1328,12 +1328,65 @@ class ThemeNotifier extends ChangeNotifier {
           borderRadius: FushiBorderRadius.control,
         ),
       ),
+      // E-ink：M3 只用 `secondaryContainer` 填充表达选中段，而墨水屏方案把它
+      // 塌缩成了页面底色——选中段与相邻段逐像素相同，全仓调用点又一律
+      // `showSelectedIcon: false`，连勾选形状这条兜底都没有。`side` 由整条按钮
+      // 的 states 解析（Flutter 的 `segmentStyleFor` 不把 side 下发到分段），
+      // 做不出按段差异；反色填充是剩下唯一的通道，也是上游 HSA 的做法——它的
+      // eink scheme 直接把 `secondaryContainer` 定义成前景色。失效态返回 null
+      // 交回 M3 默认，不动既有的失效观感。填充/前景都不改几何，不影响分段条
+      // 的宽度估算与 overflow 守卫。
+      segmentedButtonTheme: eink
+          ? SegmentedButtonThemeData(
+              style: ButtonStyle(
+                backgroundColor: WidgetStateProperty.resolveWith<Color?>((
+                  Set<WidgetState> states,
+                ) {
+                  if (states.contains(WidgetState.disabled)) return null;
+                  return states.contains(WidgetState.selected)
+                      ? cs.onSurface
+                      : cs.surface;
+                }),
+                foregroundColor: WidgetStateProperty.resolveWith<Color?>((
+                  Set<WidgetState> states,
+                ) {
+                  if (states.contains(WidgetState.disabled)) return null;
+                  return states.contains(WidgetState.selected)
+                      ? cs.surface
+                      : cs.onSurface;
+                }),
+                iconColor: WidgetStateProperty.resolveWith<Color?>((
+                  Set<WidgetState> states,
+                ) {
+                  if (states.contains(WidgetState.disabled)) return null;
+                  return states.contains(WidgetState.selected)
+                      ? cs.surface
+                      : cs.onSurface;
+                }),
+              ),
+            )
+          : const SegmentedButtonThemeData(),
       chipTheme: ChipThemeData(
         shape: RoundedRectangleBorder(
           borderRadius: FushiBorderRadius.chip,
         ),
         side: BorderSide(color: cs.outlineVariant),
-        selectedColor: cs.secondaryContainer,
+        // E-ink：同一个塌缩——`secondaryContainer` 等于页面底色，`showCheckmark`
+        // 又关掉了 M3 唯一的形状信号，选中与未选中的 chip 逐像素相同（字体库那
+        // 排「用途」FilterChip 就栽在这）。反色填充 + 配对 label 色补回信号；
+        // labelStyle 必须从 `labelLarge` 派生，直接给裸 TextStyle 会把 chip 的
+        // 字号字族一起替换掉。
+        selectedColor: eink ? cs.onSurface : cs.secondaryContainer,
+        labelStyle: eink
+            ? (tt.labelLarge ?? const TextStyle()).copyWith(
+                color: WidgetStateColor.resolveWith(
+                  (Set<WidgetState> states) =>
+                      states.contains(WidgetState.selected)
+                      ? cs.surface
+                      : cs.onSurface,
+                ),
+              )
+            : null,
         showCheckmark: false,
       ),
       filledButtonTheme: FilledButtonThemeData(

--- a/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -26,6 +26,55 @@ import 'package:fushi/src/shortcuts/input_binding.dart' show GamepadButton;
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/utils.dart';
 
+/// 未揭开插图的遮罩视觉：普通屏「模糊图 + 蒙层 + 图标」，墨水屏「实心遮板 + 图标」。
+///
+/// 墨水屏不走模糊有两个理由，都不是审美偏好：慢刷新面板渲染不出干净的高斯过渡，
+/// 留下的是一片残影；而灰阶下「一张糊图」在观感上就等于「这张图本身不高清」，
+/// 遮罩的意图一点都传达不到，用户只会以为画廊坏了。实心遮板一眼可辨是盖住的。
+Widget maskedIllustrationCover(
+  BuildContext context,
+  Widget img, {
+  double sigma = 16,
+  Color scrim = const Color(0x33000000),
+  required double iconSize,
+}) {
+  final ColorScheme scheme = Theme.of(context).colorScheme;
+  if (isEinkTheme(context)) {
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        ColoredBox(color: scheme.surface),
+        Center(
+          child: Icon(
+            Icons.visibility_off_outlined,
+            color: scheme.onSurface,
+            size: iconSize,
+          ),
+        ),
+      ],
+    );
+  }
+  return Stack(
+    fit: StackFit.expand,
+    children: <Widget>[
+      ClipRect(
+        child: ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: sigma, sigmaY: sigma),
+          child: img,
+        ),
+      ),
+      ColoredBox(color: scrim),
+      Center(
+        child: Icon(
+          Icons.visibility_off_outlined,
+          color: Colors.white70,
+          size: iconSize,
+        ),
+      ),
+    ],
+  );
+}
+
 /// 一张插画：解码用的字节 + 源磁盘文件（复制/分享需要真实文件路径）+ reveal key。
 class _Illustration {
   const _Illustration({
@@ -79,7 +128,8 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
   final Set<String> _revealed = <String>{};
 
   /// 防剧透遮罩总开关：与阅读器同一偏好（`ttu_blur_images`）。开着时未揭开的图
-  /// 一律遮罩；**关着时仍按阅读进度遮「还没读到」的那些**（见 [_progressIndex]）。
+  /// 一律遮罩；**关着时仍按阅读进度遮「还没读到」的那些**——但只在这本书真有
+  /// 阅读位置行时才成立（见 [_progressIndex] / [_loadReadProgress]）。
   bool get _blurEnabled =>
       ReaderFushiSource.readerSettings?.blurImages ?? false;
 
@@ -87,8 +137,9 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
   /// 或目录不是合法 EPUB（解析失败）→ 不按进度遮罩，退回旧行为。
   IllustrationProgressIndex? _progressIndex;
 
-  /// 本书当前阅读位置（与 `ReaderPosition` 同坐标）。没有位置行 = 一次没读过，
-  /// 按章首 (0, 0) 处理：除封面/开篇之外的插图都算「还没读到」。
+  /// 本书当前阅读位置（与 `ReaderPosition` 同坐标）。只有查到位置行才会被填上，
+  /// 同时 [_progressIndex] 才会挂上去——没读过的书不按进度遮罩，见
+  /// [_loadReadProgress]。
   int _readChapterIndex = 0;
   int _readNormCharOffset = 0;
 
@@ -130,10 +181,14 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
       final IllustrationProgressIndex index =
           await compute(buildIllustrationProgressIndex, widget.extractDir);
       if (!mounted) return;
+      // 没有位置行 = 这本一次都没打开过。退化成 (0, 0) 会把开篇之后的每一张插图
+      // 都判成「还没读到」，整个画廊糊成一片，而用户没有任何开关能关掉它——
+      // 那已经不是防剧透，是画廊坏了。没读过就不按进度遮罩，只留总开关。
+      if (position == null) return;
       setState(() {
         _progressIndex = index;
-        _readChapterIndex = position?.sectionIndex ?? 0;
-        _readNormCharOffset = position?.normCharOffset ?? 0;
+        _readChapterIndex = position.sectionIndex;
+        _readNormCharOffset = position.normCharOffset;
       });
     } catch (e, stack) {
       // 目录不是合法 EPUB（FormatException）等：退回「不按进度遮罩」，不影响看图。
@@ -312,7 +367,7 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
     );
   }
 
-  /// 缩略图：未遮罩直接原图；遮罩则模糊 + 蒙层 + 图标。
+  /// 缩略图：未遮罩直接原图；遮罩走 [maskedIllustrationCover]。
   Widget _thumb(_Illustration im, bool blurred) {
     final Widget img = Image.memory(
       im.bytes,
@@ -320,27 +375,7 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
       errorBuilder: (_, __, ___) =>
           const Center(child: Icon(Icons.broken_image_outlined)),
     );
-    return blurred ? _blurCover(img) : img;
-  }
-
-  /// 防剧透遮罩视觉：模糊图 + 半透明蒙层 + 「点击查看」图标。点击揭开由外层 onTap 处理。
-  Widget _blurCover(Widget img) {
-    return Stack(
-      fit: StackFit.expand,
-      children: <Widget>[
-        ClipRect(
-          child: ImageFiltered(
-            imageFilter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
-            child: img,
-          ),
-        ),
-        const ColoredBox(color: Color(0x33000000)),
-        const Center(
-          child: Icon(Icons.visibility_off_outlined,
-              color: Colors.white70, size: 36),
-        ),
-      ],
-    );
+    return blurred ? maskedIllustrationCover(context, img, iconSize: 36) : img;
   }
 
   void _openFullScreen(int initialIndex) {
@@ -618,26 +653,16 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
                   ),
                 );
                 if (_isBlurred(im)) {
-                  // 遮罩态：模糊全屏 + 图标，点击揭开（揭开前不许缩放/复制/分享，防剧透）。
+                  // 遮罩态：点击揭开（揭开前不许缩放/复制/分享，防剧透）。
                   return GestureDetector(
                     behavior: HitTestBehavior.opaque,
                     onTap: () => _revealCurrent(im),
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: <Widget>[
-                        ClipRect(
-                          child: ImageFiltered(
-                            imageFilter:
-                                ImageFilter.blur(sigmaX: 24, sigmaY: 24),
-                            child: Center(child: image),
-                          ),
-                        ),
-                        const ColoredBox(color: Color(0x66000000)),
-                        const Center(
-                          child: Icon(Icons.visibility_off_outlined,
-                              color: Colors.white70, size: 48),
-                        ),
-                      ],
+                    child: maskedIllustrationCover(
+                      context,
+                      Center(child: image),
+                      sigma: 24,
+                      scrim: const Color(0x66000000),
+                      iconSize: 48,
                     ),
                   );
                 }

--- a/fushi/lib/src/reader/reader_content_styles.dart
+++ b/fushi/lib/src/reader/reader_content_styles.dart
@@ -762,10 +762,14 @@ ${einkMode ? _einkOverrideCss(einkDark: einkDark) : ''}
   /// 设计对齐 Hoshi-Reader-Android 的 E-ink 适配：
   /// - 高亮全部从「半透明色块背景」改为**线式标记**——色块在墨水屏上是一大片
   ///   抖动灰阶，且每次高亮移动都触发大面积刷新；下划线只刷新贴近文字的一条线。
-  ///   查词选区=粗实线、有声书跟随=虚线、搜索命中=双线、收藏句=保留原下划线但
+  ///   查词选区=粗实线、有声书跟随=细实线、搜索命中=双线、收藏句=保留原下划线但
   ///   去掉色块（五色在灰阶屏上不可分，线本身就是收藏语义）。
-  /// - `--fushi-reader-eink-mode: 1` 点亮 JS 侧既有的 isEInkMode() 分支
-  ///   （reader_visual_novel_scripts / 连续模式滚动缓动短路）。
+  /// - 跟读线用**实线**而非虚线：上游 HSA 的墨水屏跟读高亮是 overlay 层画的
+  ///   1.5px 实心直线条（reader-popup-host.js `renderSasayakiHighlight`），
+  ///   虚线在慢刷新屏上每段短划都是独立的黑白跳变，既更脏也更难一眼定位当前句。
+  /// - `--fushi-reader-eink-mode: 1` 供 JS 侧读：连续模式跟随滚动短路成瞬时
+  ///   （reader_pagination_scripts）。VN 侧不再据此分流——跟读高亮在所有模式
+  ///   下都走同一条 inline wrapper 路径，正是本文件这些线式规则的作用对象。
   /// - 关掉书籍自带的 transition/animation，慢刷新屏上任何补间都是残影。
   static String _einkOverrideCss({required bool einkDark}) {
     final String fg = einkDark ? '#fff' : '#000';
@@ -809,7 +813,7 @@ ruby.fushi-selection-ruby-active {
   background-color: transparent;
   color: inherit;
   text-decoration-line: underline;
-  text-decoration-style: dashed;
+  text-decoration-style: solid;
   text-decoration-color: $fg;
   text-decoration-thickness: 0.10em;
   text-underline-offset: 0.18em;
@@ -818,7 +822,7 @@ ruby.fushi-sentence-audio-ruby-active {
   background-color: transparent !important;
   color: inherit !important;
   text-decoration-line: underline !important;
-  text-decoration-style: dashed !important;
+  text-decoration-style: solid !important;
   text-decoration-color: $fg !important;
   text-decoration-thickness: 0.10em !important;
   text-underline-offset: 0.18em !important;
@@ -827,7 +831,7 @@ ruby.fushi-sentence-audio-ruby-active {
   background-color: transparent !important;
   color: inherit !important;
   text-decoration-line: underline !important;
-  text-decoration-style: dashed !important;
+  text-decoration-style: solid !important;
   text-decoration-color: $fg !important;
   text-decoration-thickness: 0.10em !important;
   text-underline-offset: 0.18em !important;

--- a/fushi/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/fushi/lib/src/reader/reader_visual_novel_scripts.dart
@@ -14,8 +14,13 @@
 //   * `notifyRestoreComplete` forwards to InAppWebView's `onRestoreComplete`
 //     handler instead of hoshi's native `FushiReaderRestore.postMessage`.
 //   * media-semantics is an M0 no-op stub (images render from cloned chapter
-//     markup); Sasayaki / highlights / E-Ink overlay are M1 (their hoshi calls
-//     are guarded by `window.fushiHighlights` / popupHost checks, safe at M0).
+//     markup); highlights are M1 (guarded by `window.fushiHighlights`).
+//   * Sasayaki cues always take the inline `.fushi-sentence-audio-cue` wrapper
+//     path, in e-ink too. hoshi swaps to a native rect overlay under e-ink
+//     (`popupHost.renderSentenceAudioHighlight`); Hibiki never ported that host,
+//     so the branch rendered nothing at all and the read-along highlight was
+//     invisible in VN + e-ink. The wrapper class is what the e-ink CSS bar rule
+//     in `ReaderContentStyles` targets, so one path now serves every mode.
 //   * Config placeholders become Dart interpolation; `clickAdvance` is NOT a
 //     hoshi JS concern -- the host (webview.part.dart) binds blank-tap ->
 //     `paginate("forward")`.
@@ -785,7 +790,6 @@ window.fushiReader = {
   sentenceAudioCuesSignature: null,
   cueWrappers: new Map(),
   cueSourceRanges: new Map(),
-  cueGeometryRanges: new Map(),
   nodeStartOffsets: new WeakMap(),
   nodeStartRawOffsets: new WeakMap(),
   contentStream: null,
@@ -817,9 +821,6 @@ window.fushiReader = {
   },
   readerCssVariable: function(name) {
     return window.getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  },
-  isEInkMode: function() {
-    return this.readerCssVariable('--fushi-reader-eink-mode') === '1';
   },
   isFurigana: function(node) {
     var el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
@@ -2838,81 +2839,17 @@ $sharedInitViewport
     }
     return wrapped;
   },
-  buildSentenceAudioGeometryRanges: function(cueRanges) {
-    var geometryRanges = new Map();
-    for (var i = 0; i < cueRanges.length; i++) {
-      var id = cueRanges[i].id;
-      var ranges = cueRanges[i].ranges;
-      if (!ranges.length) continue;
-      var cueGeometryRanges = [];
-      for (var j = 0; j < ranges.length; j++) {
-        var segment = ranges[j];
-        var range = document.createRange();
-        range.setStart(segment.node, segment.start);
-        range.setEnd(segment.node, segment.end);
-        cueGeometryRanges.push(range);
-      }
-      if (cueGeometryRanges.length) geometryRanges.set(id, cueGeometryRanges);
-    }
-    return geometryRanges;
-  },
   prepareSentenceAudioInlineTargets: function(cueRanges) {
-    if (!this.isEInkMode()) {
-      this.wrapSentenceAudioCueRanges(cueRanges);
-      this.buildNodeOffsets();
-    }
+    this.wrapSentenceAudioCueRanges(cueRanges);
+    this.buildNodeOffsets();
   },
   ensureSentenceAudioInlineTargetsForCue: function(cueId) {
-    if (this.isEInkMode() || this.sentenceAudioInlineTargetsForCue(cueId).length) return;
+    if (this.sentenceAudioInlineTargetsForCue(cueId).length) return;
     var cue = this.sentenceAudioCueMap.get(cueId);
     if (!cue) return;
     var cueRanges = this.collectSentenceAudioCueRanges([cue]);
     this.rememberSentenceAudioCueSources(cueRanges);
     this.prepareSentenceAudioInlineTargets(cueRanges);
-  },
-  ensureSentenceAudioCueGeometry: function(cue) {
-    var cueId = typeof cue === 'string' ? cue : cue && cue.id;
-    if (!cueId) return;
-    var existing = this.cueGeometryRanges.get(cueId);
-    if (existing && existing.length) return;
-    var cueObject = this.sentenceAudioCueForInput(cue) || this.sentenceAudioCueMap.get(cueId);
-    if (!cueObject) return;
-    var cueRanges = this.collectSentenceAudioCueRanges([cueObject]);
-    this.rememberSentenceAudioCueSources(cueRanges);
-    var geometryRanges = this.buildSentenceAudioGeometryRanges(cueRanges).get(cueId) || [];
-    if (geometryRanges.length) this.cueGeometryRanges.set(cueId, geometryRanges);
-  },
-  sentenceAudioOverlayRects: function(cueId) {
-    var ranges = this.cueGeometryRanges.get(cueId) || [];
-    var rects = [];
-    ranges.forEach(function(range) {
-      if (window.fushiRubyGeometry) {
-        window.fushiRubyGeometry.rectsForRange(range).forEach(function(rect) { rects.push(rect); });
-      } else {
-        Array.from(range.getClientRects()).forEach(function(rect) {
-          rects.push({ x: rect.x, y: rect.y, width: rect.width, height: rect.height });
-        });
-      }
-    });
-    return window.fushiRubyGeometry ? window.fushiRubyGeometry.mergeInlineRects(rects) : rects;
-  },
-  renderSentenceAudioOverlay: function() {
-    if (!this.activeCueId || !this.isEInkMode()) {
-      this.clearSentenceAudioOverlay();
-      return;
-    }
-    if (window.fushiReaderPopupHost && window.fushiReaderPopupHost.renderSentenceAudioHighlight) {
-      window.fushiReaderPopupHost.renderSentenceAudioHighlight({
-        rects: this.sentenceAudioOverlayRects(this.activeCueId),
-        eInkMode: true,
-        verticalWriting: this.isVertical()
-      });
-    }
-  },
-  clearSentenceAudioOverlay: function() {
-    if (window.fushiReaderPopupHost && window.fushiReaderPopupHost.clearSentenceAudioHighlight) {
-      window.fushiReaderPopupHost.clearSentenceAudioHighlight();
-    }
   },
   clearInlineSentenceAudioCue: function(cueId) {
     var clearWrappers = function(wrappers) {
@@ -2935,13 +2872,10 @@ $sharedInitViewport
   },
   clearSentenceAudioCuePresentation: function() {
     this.clearInlineSentenceAudioCue();
-    this.clearSentenceAudioOverlay();
   },
   clearCurrentSentenceAudioScreenTargets: function() {
     this.cueSourceRanges.clear();
-    this.cueGeometryRanges.clear();
     this.cueWrappers.clear();
-    this.clearSentenceAudioOverlay();
   },
   clearSentenceAudioTargets: function() {
     this.clearSentenceAudioCuePresentation();
@@ -2951,7 +2885,6 @@ $sharedInitViewport
     });
     this.cueWrappers.clear();
     this.cueSourceRanges.clear();
-    this.cueGeometryRanges.clear();
     this.buildNodeOffsets();
   },
   applySentenceAudioCues: function(cues) {
@@ -3003,25 +2936,13 @@ $sharedInitViewport
     this.activeCueId = null;
   },
   refreshSentenceAudioCuePresentation: function() {
-    if (!this.activeCueId) {
-      this.clearSentenceAudioOverlay();
-      return;
-    }
+    if (!this.activeCueId) return;
     this.clearInlineSentenceAudioCue(this.activeCueId);
     var cue = this.sentenceAudioCueMap.get(this.activeCueId);
     var screen = this.screens && this.screens[this.currentScreenIndex];
-    if (!cue || !this.sentenceAudioCueIntersectsScreen(cue, screen) || !this.revealComplete) {
-      this.clearSentenceAudioOverlay();
-      return;
-    }
-    if (this.isEInkMode()) {
-      this.ensureSentenceAudioCueGeometry(cue);
-      this.renderSentenceAudioOverlay();
-    } else {
-      this.clearSentenceAudioOverlay();
-      this.ensureSentenceAudioInlineTargetsForCue(this.activeCueId);
-      this.applyInlineSentenceAudioCue(this.activeCueId);
-    }
+    if (!cue || !this.sentenceAudioCueIntersectsScreen(cue, screen) || !this.revealComplete) return;
+    this.ensureSentenceAudioInlineTargetsForCue(this.activeCueId);
+    this.applyInlineSentenceAudioCue(this.activeCueId);
   },
   resetSentenceAudioCues: function() {
     this.clearSentenceAudioTargets();

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -657,15 +657,26 @@ class FushiSelectableChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final ColorScheme colors = Theme.of(context).colorScheme;
-    final Color foreground =
-        selected ? colors.onPrimaryContainer : tokens.surfaces.onSurface;
+    final bool eink = isEinkTheme(context);
+    // E-ink：`primaryContainer` 与 `onPrimaryContainer` 双双塌缩到页面底色/前景，
+    // 于是选中态既没有填充差异、边框还从 outlineVariant 变成了底色——选中的
+    // chip 比未选中的更没有边，是个负信号。反色填充是墨水屏上唯一稳定可辨的
+    // 选中通道（与 segmentedButtonTheme / chipTheme 的处理同源）。
+    final Color selectedFill = eink
+        ? colors.onSurface
+        : colors.primaryContainer;
+    final Color foreground = selected
+        ? (eink ? colors.surface : colors.onPrimaryContainer)
+        : tokens.surfaces.onSurface;
     // 仅图标模式（TODO-640）：图标当作 chip 的 label（不再放进 avatar + 文字），
     // chip 收成正方裸图标；需 leadingIcon 非空才生效，否则退化为普通文字 chip。
     final bool effectiveIconOnly = iconOnly && leadingIcon != null;
     final Widget? effectiveAvatar = effectiveIconOnly
         ? null
         : (avatar ??
-            (leadingIcon == null ? null : Icon(leadingIcon, size: 18)));
+              (leadingIcon == null
+                  ? null
+                  : Icon(leadingIcon, size: 18, color: foreground)));
     final Widget labelWidget = effectiveIconOnly
         ? Icon(leadingIcon, size: 18, color: foreground)
         : Text(
@@ -683,11 +694,13 @@ class FushiSelectableChip extends StatelessWidget {
       labelPadding: effectiveIconOnly ? EdgeInsets.zero : null,
       selected: selected,
       showCheckmark: false,
-      selectedColor: colors.primaryContainer,
+      selectedColor: selectedFill,
       backgroundColor: Colors.transparent,
       labelStyle: tokens.type.controlLabel.copyWith(color: foreground),
       side: BorderSide(
-        color: selected ? colors.primaryContainer : colors.outlineVariant,
+        color: selected
+            ? (eink ? colors.outline : colors.primaryContainer)
+            : colors.outlineVariant,
       ),
       shape: RoundedRectangleBorder(borderRadius: tokens.radii.chipRadius),
       visualDensity: VisualDensity.compact,

--- a/fushi/test/reader/reader_eink_mode_test.dart
+++ b/fushi/test/reader/reader_eink_mode_test.dart
@@ -8,9 +8,9 @@ import 'package:fushi/src/reader/reader_content_styles.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
 
 /// 墨水屏模式（eink_mode）守卫：
-///  1. 阅读器 CSS 生成器的 eink 分支——纯黑白正文、线式高亮、关过渡、
-///     `--fushi-reader-eink-mode: 1`（JS 侧 isEInkMode() 与连续模式跟随滚动
-///     瞬时化都读它）；关掉时逐项不出现（零行为变化）。
+///  1. 阅读器 CSS 生成器的 eink 分支——纯黑白正文、线式高亮（一律直线条）、关过渡、
+///     `--fushi-reader-eink-mode: 1`（连续模式跟随滚动瞬时化读它）；关掉时逐项
+///     不出现（零行为变化）。
 ///  2. buildEinkColorScheme——纯黑白 ColorScheme（手工构造，不走 fromSeed），
 ///     surfaceTint/shadow 透明（e-ink 不能有 elevation 灰阶）。
 ///  3. eink_mode 必须在 Profile 快照黑名单里（设备属性，切 Profile 不回滚）。
@@ -36,10 +36,14 @@ void main() {
       // 关过渡：书籍自带动画一并压掉。
       expect(css, contains('transition: none !important'));
       expect(css, contains('animation: none !important'));
-      // 线式高亮：查词=实线、sasayaki=虚线、搜索=双线。
-      expect(css, contains('text-decoration-style: dashed'));
+      // 线式高亮：查词=粗实线、sasayaki=细实线、搜索=双线。
+      expect(css, contains('text-decoration-style: solid'));
       expect(css, contains('text-decoration-style: double'));
       expect(css, contains('text-decoration-line: underline'));
+      // sasayaki 跟读线必须是直线条，不得回退成虚线：上游 HSA 的墨水屏跟读高亮
+      // 是 overlay 画的 1.5px 实心线，虚线的每段短划在慢刷新屏上都是独立黑白
+      // 跳变，既更脏也更难一眼定位当前句。
+      expect(css, isNot(contains('text-decoration-style: dashed')));
     });
 
     test('einkMode=true honours einkDark (white-on-black)', () async {
@@ -71,7 +75,8 @@ void main() {
       final ReaderSettings settings = await _defaultSettings();
       final String css = ReaderContentStyles.css(settings: settings);
       expect(css, isNot(contains('--fushi-reader-eink-mode')));
-      expect(css, isNot(contains('text-decoration-style: dashed')));
+      // 线式高亮整套只属于 eink 分支，非 eink 输出里一条都不该有。
+      expect(css, isNot(contains('text-decoration-style')));
       // sasayaki 仍是色块填充（背景变量非 transparent）。
       expect(css, contains('--fushi-sentence-audio-background-color: rgba'));
     });

--- a/fushi/test/widgets/eink_selection_visibility_test.dart
+++ b/fushi/test/widgets/eink_selection_visibility_test.dart
@@ -1,0 +1,213 @@
+// 墨水屏「选中态可见性」守卫。
+//
+// eink ColorScheme 是纯黑白：每个容器角色都塌缩成页面底色。凡是**只靠容器填充
+// 色**表达选中的控件，墨水屏下选中与未选中就是逐像素相同——分段选择器（M3 只
+// 用 secondaryContainer 填充选中段，而全仓调用点一律 showSelectedIcon: false，
+// 连勾选形状这条兜底都没有）和字体库那排「用途」FilterChip 都栽在这。
+//
+// 这里钉三件事：
+//   1. eink 下选中态与未选中态的填充/前景**必须不同**（可见性本身）；
+//   2. 反色方向正确（选中 = 前景色填充 + 底色文字），对齐上游 Hoshi-Reader-Android
+//      ——它的 eink scheme 直接把 secondaryContainer 定义成前景色；
+//   3. 非 eink 下零行为变化。
+//
+// 刻意不走边框/字重：分段条的宽度估算（settings_shared.estimateSegmentedStripWidth）
+// 与 overflow 守卫吃固有宽度，改几何会把它们一起带红。填充与前景不改几何。
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+
+Color? _resolve(
+  WidgetStateProperty<Color?>? property,
+  Set<WidgetState> states,
+) {
+  return property?.resolve(states);
+}
+
+void main() {
+  late FushiDatabase db;
+  late ThemeNotifier notifier;
+
+  TextTheme textThemeBuilder() => const TextTheme();
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    notifier = ThemeNotifier(db, textThemeBuilder);
+    await Future<void>.delayed(Duration.zero);
+  });
+
+  tearDown(() async {
+    notifier.dispose();
+    await db.close();
+  });
+
+  group('segmentedButtonTheme', () {
+    test('eink：选中段反色填充，与未选中段不同色', () async {
+      await notifier.setEinkMode(true);
+      final ThemeData theme = notifier.theme;
+      final ColorScheme cs = theme.colorScheme;
+      final ButtonStyle? style = theme.segmentedButtonTheme.style;
+      expect(style, isNotNull, reason: 'eink 必须提供分段按钮主题，否则选中不可见');
+
+      final Color? selectedBg = _resolve(style!.backgroundColor, <WidgetState>{
+        WidgetState.selected,
+      });
+      final Color? plainBg = _resolve(style.backgroundColor, <WidgetState>{});
+      final Color? selectedFg = _resolve(style.foregroundColor, <WidgetState>{
+        WidgetState.selected,
+      });
+      final Color? plainFg = _resolve(style.foregroundColor, <WidgetState>{});
+
+      // 这条才是 bug 本身：塌缩前两者都是 cs.surface。
+      expect(selectedBg, isNot(plainBg));
+      expect(selectedFg, isNot(plainFg));
+      expect(selectedBg, cs.onSurface);
+      expect(plainBg, cs.surface);
+      expect(selectedFg, cs.surface);
+      expect(plainFg, cs.onSurface);
+      // 图标跟着文字翻，否则黑底上的黑图标照样消失。
+      expect(
+        _resolve(style.iconColor, <WidgetState>{WidgetState.selected}),
+        cs.surface,
+      );
+    });
+
+    test('eink：失效态回落 M3 默认（不接管失效观感）', () async {
+      await notifier.setEinkMode(true);
+      final ButtonStyle style = notifier.theme.segmentedButtonTheme.style!;
+      expect(
+        _resolve(style.backgroundColor, <WidgetState>{WidgetState.disabled}),
+        isNull,
+      );
+      expect(
+        _resolve(style.foregroundColor, <WidgetState>{WidgetState.disabled}),
+        isNull,
+      );
+    });
+
+    test('非 eink：零行为变化（不挂任何分段按钮主题）', () async {
+      expect(notifier.einkMode, isFalse);
+      expect(notifier.theme.segmentedButtonTheme.style, isNull);
+    });
+  });
+
+  group('chipTheme', () {
+    test('eink：选中 chip 反色填充 + 配对 label 色', () async {
+      await notifier.setEinkMode(true);
+      final ThemeData theme = notifier.theme;
+      final ColorScheme cs = theme.colorScheme;
+
+      expect(theme.chipTheme.selectedColor, cs.onSurface);
+      expect(
+        theme.chipTheme.selectedColor,
+        isNot(cs.surface),
+        reason: '塌缩前 selectedColor == secondaryContainer == 页面底色',
+      );
+
+      // label 色必须按 selected 分流，否则黑底黑字。
+      final Color? labelColor = theme.chipTheme.labelStyle?.color;
+      expect(labelColor, isA<WidgetStateColor>());
+      final WidgetStateColor stateColor = labelColor! as WidgetStateColor;
+      expect(
+        stateColor.resolve(<WidgetState>{WidgetState.selected}),
+        cs.surface,
+      );
+      expect(stateColor.resolve(<WidgetState>{}), cs.onSurface);
+    });
+
+    test('eink：label 样式仍从 labelLarge 派生（不吞字号字族）', () async {
+      await notifier.setEinkMode(true);
+      final ThemeNotifier typed = ThemeNotifier(
+        db,
+        () => const TextTheme(
+          labelLarge: TextStyle(fontSize: 17, fontFamily: 'Sentinel'),
+        ),
+      );
+      addTearDown(typed.dispose);
+      // 新 notifier 必须真的把 eink 偏好读进来，否则 labelStyle 恒为 null，
+      // 这条断言会变成永远绿的空壳。
+      await typed.refreshFromDb();
+      expect(typed.einkMode, isTrue);
+      final TextStyle? label = typed.theme.chipTheme.labelStyle;
+      expect(label?.fontSize, 17);
+      expect(label?.fontFamily, 'Sentinel');
+    });
+
+    test('非 eink：零行为变化', () async {
+      final ThemeData theme = notifier.theme;
+      expect(
+        theme.chipTheme.selectedColor,
+        theme.colorScheme.secondaryContainer,
+      );
+      expect(theme.chipTheme.labelStyle, isNull);
+    });
+  });
+
+  group('FushiSelectableChip', () {
+    Widget app({required bool eink, required bool selected}) {
+      return MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          colorScheme: eink
+              ? buildEinkColorScheme(Brightness.light)
+              : ColorScheme.fromSeed(seedColor: Colors.indigo),
+          extensions: <ThemeExtension<dynamic>>[FushiEinkTheme(eink)],
+        ),
+        home: Scaffold(
+          body: Center(
+            child: FushiSelectableChip(
+              label: 'Theme',
+              leadingIcon: Icons.star,
+              selected: selected,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('eink：选中 chip 反色填充，边框不再消失', (WidgetTester tester) async {
+      await tester.pumpWidget(app(eink: true, selected: true));
+      final ChoiceChip chip = tester.widget<ChoiceChip>(
+        find.byType(ChoiceChip),
+      );
+
+      // 塌缩前：填充 = primaryContainer = 白 = 页面底色，且边框也是白——选中的
+      // chip 比未选中的更没有边，是个负信号。
+      expect(chip.selectedColor, Colors.black);
+      expect(chip.labelStyle?.color, Colors.white);
+      expect(chip.side!.color, Colors.black);
+    });
+
+    testWidgets('eink：leading 图标跟着前景翻色', (WidgetTester tester) async {
+      await tester.pumpWidget(app(eink: true, selected: true));
+      final ChoiceChip chip = tester.widget<ChoiceChip>(
+        find.byType(ChoiceChip),
+      );
+      final Icon avatar = chip.avatar! as Icon;
+      expect(
+        avatar.color,
+        Colors.white,
+        reason: 'avatar 不着色就会取 chip 默认 onSurfaceVariant（黑），黑底黑图标',
+      );
+    });
+
+    testWidgets('非 eink：仍用 primaryContainer（零行为变化）', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(app(eink: false, selected: true));
+      final Element context = tester.element(find.byType(ChoiceChip));
+      final ChoiceChip chip = tester.widget<ChoiceChip>(
+        find.byType(ChoiceChip),
+      );
+      final ColorScheme cs = Theme.of(context).colorScheme;
+      expect(chip.selectedColor, cs.primaryContainer);
+      expect(chip.side!.color, cs.primaryContainer);
+    });
+  });
+}


### PR DESCRIPTION
按 HSA（Hoshi-Reader-Android）逐项比对墨水屏适配，修四类「看不出选中 / 看不见高亮 / 看着像坏了」。

## 1. 分段选择器 + 字体库 chip：选中态零信息

同一个根因。eink ColorScheme 把**每个**容器角色都塌缩成页面底色：

```dart
secondaryContainer: bg,   // light 下 = Colors.white = 页面底色
onSecondaryContainer: fg,
```

而 M3 的 `SegmentedButton` 只用 `secondaryContainer` 填充表达选中段、`Chip` 只用它当 `selectedColor`。代入之后：

| 通道 | 选中 | 未选中 |
|---|---|---|
| 填充 | `secondaryContainer` = 白 | 透明 → surface = 白 |
| 前景 | `onSecondaryContainer` = 黑 | `onSurface` = 黑 |
| 边框 | `outline` 同宽同色 | 同左 |

不是对比度低，是**逐像素相同**。而全仓调用点又一律 `showSelectedIcon: false` / `showCheckmark: false`，连形状兜底都没有。

对照 HSA：它的 eink scheme 把**强调容器**定义成前景色（`secondaryContainer = content`、`onSecondaryContainer = background`），只有 surface 类才塌缩到背景，所以「选中 = 反色填充」天然成立。本仓两类容器都塌缩到背景，选中态便无处落脚。

修法（不动 ColorScheme 语义，避免大面积纯黑与十余处黑底黑字回归，理由见文末）：

- `theme_notifier`：新增 eink 分支的 `segmentedButtonTheme`（选中段反色填充 + 前景/图标同步翻转，失效态返回 `null` 交回 M3 默认）；给 `chipTheme` 补 eink 分支——它是 `_buildThemeData` 里**唯一漏掉 eink 补偿**的一项（Switch / Card / Divider 早已各自补过）。label 色用 `WidgetStateColor` 按 selected 分流，并从 `labelLarge` 派生以免吞掉 chip 的字号字族。
- `FushiSelectableChip`：eink 下 `primaryContainer` 与边框色双双塌缩，**选中的 chip 比未选中的更没有边**，是个负信号。改反色填充 + `outline` 边框；leading 图标跟着前景翻色（原先无 `color`，黑底上取默认 `onSurfaceVariant` 即黑图标）。

字体库那排「用途」用的是裸 `FilterChip`，全部走全局 `chipTheme`，故一处修复即覆盖。

> 为什么不用边框/字重表达选中：`side` 由整条按钮的 states 解析（Flutter 的 `segmentStyleFor` 不把 `side` 下发到分段），做不出按段差异；且改几何会牵连 `estimateSegmentedStripWidth` 与既有的分段条 overflow 守卫。反色填充不改几何。

## 2. VN + 墨水屏：跟读高亮完全不显示

**不是**选择器失配，也**不是** VN 没实现高亮。VN 在 eink 时主动跳过 inline class 路径，改调：

```js
window.fushiReaderPopupHost.renderSentenceAudioHighlight({ rects, eInkMode: true, ... })
```

`fushiReaderPopupHost` 是 HSA 里由 Android 原生宿主绘制的矩形 overlay，移植时从没带过来——**全仓只有引用、没有定义**，`&&` 守卫让它静默 no-op。于是 eink 下 `cueWrappers` 恒空，`.fushi-sentence-audio-cue` 节点根本不存在，现成的 CSS 规则没有任何 DOM 可匹配。文件头注释也写明 E-Ink overlay 是没做的 M1。

删掉整条只服务于这个幽灵对象的 overlay/geometry 死链（`renderSentenceAudioOverlay` / `clearSentenceAudioOverlay` / `ensureSentenceAudioCueGeometry` / `sentenceAudioOverlayRects` / `buildSentenceAudioGeometryRanges` / `cueGeometryRanges` / `isEInkMode`，文件外零引用），让 VN 与分页模式走同一条 inline wrapper 路径，现成的 eink CSS 规则即刻命中。

## 3. 墨水屏高亮改直线条

跟读高亮原为虚线（`dashed 0.10em`）。HSA 的 eink 跟读高亮是 overlay 画的 **1.5px 实心直线条**（`reader-popup-host.js` `renderSasayakiHighlight`，贴每行 box 下边缘、竖排贴右边缘）。虚线的每段短划在慢刷新屏上都是独立黑白跳变，更脏也更难一眼定位当前句。三条规则统一改 `solid`，守卫测试同步钉住「不得回退成虚线」。

## 4. 插画画廊「图片很糊」

**不是分辨率问题**：图片库与阅读器画廊全程原始字节全分辨率解码，无 `cacheWidth` / `ResizeImage` / 低 `FilterQuality` / 灰阶抖动处理。真凶是未读遮罩：

- **书没有阅读位置行时整本全糊**：`position?.sectionIndex ?? 0` 退化成 (0, 0)，开篇之后每张插图都判成「还没读到」，而这条判据与用户可见的「图片模糊（防剧透）」开关无关——**没有任何 UI 能关掉它**。改成没读过就不按进度遮罩，只留防剧透总开关。
- **墨水屏下 `ImageFilter.blur` 是错的**：慢刷新面板出不了干净的高斯过渡，只留残影；而灰阶下一张糊图观感就等于「这图本身不高清」，遮罩意图完全传达不到。改成实心遮板 + 图标，一眼可辨是盖住的而不是坏的。

## 验证

基线 `develop` @ `44c721e8`。

- `flutter analyze` — `No issues found!`（exit 0）
- 定向测试 **272 全过、零失败**：`eink_selection_visibility_test`（新增）、`fushi_material_components_test`、`fushi_card_eink_border_test`、`reader_eink_mode_test`、`md3_design_system_static_test`、`settings_segmented_overflow_test`、`custom_fonts_dialog_page_test`、`theme_notifier_test`、`illustrations_viewer_unread_blur_test`、`vn_shell_smoke_test`、`pr912_vn_shim_behavior_test`、`reader_script_compactor_test`（后者用 `node --check` 真解析改动后的 VN 载荷，装配完整性一并覆盖）
- 新增守卫 `fushi/test/widgets/eink_selection_visibility_test.dart`：钉住 eink 下选中/未选中必须不同色、反色方向正确、**非 eink 零行为变化**（含失效态回落 M3、label 不吞字号两条边角）

未做真机墨水屏复测（无设备）。

## 未做（留作后续）

- **未翻转 eink ColorScheme 的容器极性**。完全对齐 HSA 需把 `primary/secondary/tertiary/errorContainer` 翻成前景色；审计显示会命中 15 处黑底黑字回归（`FushiListItem` 选中行、`FushiCard` 选中卡、`FushiDropdown`、`switchTheme` 轨道、`video_discovery_page` 警告横幅、多处半透明容器转中灰等），并在墨水屏上造出大块纯黑（刷新慢、残影重），而现有测试对该翻转零保护。本 PR 只让小面积强调控件吃到反色红利，大面积选中件继续用既有的描边/字重。
- 画廊另两处已定位未修：双页合并（spread）章的插图因章号错位被误遮；遮罩态需点两下才进全屏。
- HSA 的查词选区在 eink 下是**空心方框**（overlay 四条边），本仓仍是下划线；跟读线也仍是 CSS `text-decoration` 而非 overlay 实心条——形态接近，但未移植 overlay 层。

https://claude.ai/code/session_01DvFRqmXn5PJqwniNVQK4c6
