### PR TITLE
fix(extension): 浏览器扩展查词在普通网页上取正文所在句子当例句（BUG-2264）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2115 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2264](bugs/BUG-2264-ext-page-sentence.md) | ✅ | ✅ | 浏览器扩展查词/制卡不取页面所在句子 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2264-ext-page-sentence.md
+++ b/docs/bugs/BUG-2264-ext-page-sentence.md
@@ -1,0 +1,24 @@
+## BUG-2264 · 浏览器扩展查词/制卡不取页面所在句子
+- **报告**：2026-09-08（用户：「现在的浏览器拓展查词为什么不取所在句子」）
+- **真实性**：✅ 真 bug。制卡例句的来源全部绑在**字幕**上，没有一级从页面正文取句：
+  `tools/browser-extension/bridge-shim.js:30`
+  `var sentence = ctxSentence || cueText || trackText || (args[0] && args[0].popupSelectionText) || ''`
+  —— ⓪多句合一草稿、①Netflix 字幕 DOM、②当前字幕行（`fushiMineContext().window.text`）、③弹窗内选区。
+  在普通网页（无字幕轨、无视频）上前三级恒空，用户又没在弹窗里选任何文本 → 例句为空。
+  句子其实一直在页面 DOM 里：`tools/browser-extension/vendor/selection.js:140` 有一份与 app 阅读器
+  同源的 `getSentence(node, offset)`（跨文本节点扩句、跳振假名/`.ruby-reserve`、括号配平），manifest
+  把它装进了 content script，但**全仓零调用**（`grep -rn "getSentence" tools/browser-extension` 只有
+  定义处）。查词命中的 `(文本节点, 字符偏移)` 就在 `content.js` 的 mousemove 处理器手里
+  （`content.js:1861` 的 `hit`），发完查词就被丢掉，制卡时再也拿不回来。
+- **[x] ① 已修复** — `tools/browser-extension/content.js`：查词时把命中点存成锚点
+  （`fushiPendingLookupAnchor`，与 `fushiPendingCueWindow` 同一契约：每次查词刷新，不传即清空），
+  制卡要句子时才惰性调 `fushiSelection.getSentence` 并缓存（Shift 悬停是每几像素一次的高频路径，
+  不在那里算句），结果经 `fushiMineContext().pageSentence` 交出；`bridge-shim.js` 的例句优先级补上
+  第 ④ 级（排在弹窗内选区之后 → 字幕站点与用户显式选区行为逐字不变）。无句末标点的超长块
+  （> 200 字）判定为「没有可用句子」，宁可留空也不把一整段塞进 Anki 字段。
+- **[x] ② 已加自动化测试** — `tools/browser-extension/page-sentence.test.js`（8 条）：在受控 vm 里真装
+  bridge-shim + subtitle-adapters/providers + content.js，触发带 Shift 的 mousemove，断言
+  `pageSentence` = 命中点所在整句、该句真的进了 `/api/mine` 的 `sentence`、取句惰性且同一次查词只算
+  一次、换词必重算、侧栏直发词（无页面锚点）取不到句、超长块留空，以及两条不夺权守卫
+  （有字幕行时仍用字幕轨；有弹窗内选区时仍用选区）。
+- **备注**：只影响扩展侧；app 内阅读器/视频页走 Flutter handler，本来就有句子上下文，未改动。

--- a/tools/browser-extension/bridge-shim.js
+++ b/tools/browser-extension/bridge-shim.js
@@ -15,11 +15,15 @@ window.flutter_inappwebview = {
           };
           var ctx = (typeof window.fushiMineContext === 'function')
             ? window.fushiMineContext() : null;
-          // 例句三级优先：
+          // 例句四级优先：
           //   ① Netflix 字幕 DOM 直读——严格等于「此刻画面上那一行」，优先级最高且**保持原样**；
           //   ② 当前字幕行（`fushiMineContext`：整集拦截轨 / textTracks 收割 / 用户外挂字幕 /
           //      DOM 采样，站点无关）——此前这一级根本不存在，非 Netflix 的轨全被跳过；
-          //   ③ 弹窗内选区文本（原兜底）。
+          //   ③ 弹窗内选区文本（用户在释义里主动选的，显式意图）；
+          //   ④ 页面正文里这个词**所在的句子**（`fushiMineContext().pageSentence`，来自
+          //      `vendor/selection.js` 的 getSentence）——普通网页（无字幕轨、无视频）上
+          //      前三级恒空，用户报的「浏览器扩展查词不取所在句子」就是这一级从来不存在：
+          //      句子一直在页面 DOM 里，扩展装着与 app 阅读器同源的取句函数却没人调用。
           // ② 是这次补上的那一级：用户在 B 站挂了外挂字幕，轨就在 `fushiActiveFullTrack()` 里，
           // 面板和覆盖层都在用它，制卡却直接从 ① 掉到 ③ → 卡上没有句子。
           var cueText = (typeof extractNetflixCueText === 'function')
@@ -28,8 +32,9 @@ window.flutter_inappwebview = {
           // 多句合一（⓪，最高）：用户在「调整上下文」里选了上/下文 → 合成句（整轨
           // 现算，'\n' 连接）压过所有单句来源；裁切窗同样换成上下文并集。
           var ctxSentence = (ctx && ctx.contextSentence) ? ctx.contextSentence : '';
+          var pageSentence = (ctx && ctx.pageSentence) ? ctx.pageSentence : '';
           var sentence = ctxSentence || cueText || trackText
-            || (args[0] && args[0].popupSelectionText) || '';
+            || (args[0] && args[0].popupSelectionText) || pageSentence || '';
           // TODO-1271：判据是**能不能拿到可裁的原始媒体**，不是站点名（见 `fushiClipSource`）。
           // `mode:'queue'` = 必须先回放/逐条解析才拿得到媒体（Netflix 录制、YouTube 批量），
           // 只适合「看完一集统一生成」，保持既有行为不动。其余一切页面——普通网页、以及有字幕轨

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -325,6 +325,40 @@ window.fushiToast = function (text, sticky, openSettings) {
 // （无 cueWindow）清成 null 回落 DOM 采样。制卡入口 fushiEnqueue 优先消费它。null 表示无精确窗。
 let fushiPendingCueWindow = null;
 
+// 页面正文的「所在句子」——普通网页（没有字幕轨、没有视频）上制卡时例句的来源。
+//
+// 用户报「浏览器扩展查词不取所在句子」：制卡例句过去只有四级来源，全都绑在**字幕**上
+// （多句合一草稿 / Netflix 字幕 DOM / 当前字幕行 / 弹窗内选区）。在一篇普通文章上查词，
+// 前三级恒空、弹窗内又没选任何东西 → 卡上一句例句都没有。而句子明明就在页面 DOM 里：
+// `vendor/selection.js` 有一份与 app 阅读器同源的 `getSentence(node, offset)`（跨文本节点
+// 扩句、跳振假名/ruby-reserve、括号配平），扩展装了它却从来没有人调用过一次。
+//
+// 契约：查词命中的 (文本节点, 字符偏移) 在这里存成锚点，**不当场算句**——Shift 悬停是每几
+// 像素一次的高频路径，而 getSentence 在没有段落祖先时会退到 body 遍历。真正要句子的只有
+// 「点制卡」那一下，所以下面 fushiPageSentence() 惰性算一次并缓存到下次查词。
+let fushiPendingLookupAnchor = null; // { node, offset }；null = 本次查词没有页面锚点（侧栏路径）
+let fushiPendingPageSentence = null; // 惰性缓存：null = 还没算过；字符串 = 已算（含空串）
+// 无句末标点的长块（整段没有 。！？. ! ? 的页面）会让 getSentence 一路拼到块尾/body 尾。
+// 与其把几千字塞进 Anki 例句字段，不如判定「这里没有可用的句子」退回旧行为。
+const FUSHI_PAGE_SENTENCE_MAX = 200;
+function fushiPageSentence() {
+  if (typeof fushiPendingPageSentence === 'string') return fushiPendingPageSentence;
+  fushiPendingPageSentence = '';
+  const anchor = fushiPendingLookupAnchor;
+  const sel = window.fushiSelection;
+  if (!anchor || !anchor.node || !sel || typeof sel.getSentence !== 'function') {
+    return fushiPendingPageSentence;
+  }
+  try {
+    const sentence = String(sel.getSentence(anchor.node, anchor.offset) || '').trim();
+    if (sentence && sentence.length <= FUSHI_PAGE_SENTENCE_MAX) {
+      fushiPendingPageSentence = sentence;
+    }
+  } catch (_) { /* 节点已从 DOM 摘除 / 跨 shadow：无句子，退旧行为 */ }
+  return fushiPendingPageSentence;
+}
+window.fushiPageSentence = fushiPageSentence;
+
 let fushiYtCaptionsFetchedFor = null; // 已请求过的 videoId（防重复请求；SPA 切视频后 id 变即重取）
 let fushiYtDirectBridgeStartedAt = 0;
 let fushiYtDirectBridgeVideoId = null;
@@ -728,6 +762,9 @@ window.fushiMineContext = function () {
     documentTitle: documentTitle,
     contextSentence: composed ? composed.sentence : null,
     contextWindow: composed ? { startV: composed.startV, endV: composed.endV } : null,
+    // 普通网页的所在句（惰性算，见 fushiPageSentence）。字幕来源都空时才轮到它，
+    // 所以有字幕的页面行为逐字不变。
+    pageSentence: fushiPageSentence(),
   };
 };
 // 上下文草稿入队即清空，按钮状态按当前句身份查询真实队列，不能再用草稿合成句回查。
@@ -1891,7 +1928,7 @@ document.addEventListener('mousemove', (e) => {
   if (!term || !term.trim()) return;
   if (term === fushiLastTerm) return; // 同词去重：还在同一个词上就不重复查/重渲染
   fushiLastTerm = term;
-  fushiSendLookup(term, fushiAnchorRect);
+  fushiSendLookup(term, fushiAnchorRect, null, false, hit);
 });
 
 let fushiLastConnectionHintAt = 0;
@@ -1920,11 +1957,16 @@ function fushiShowConnectionFailure(resp) {
 // 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停正在播放的视频，并记下
 // fushiPausedForLookup；关闭查词弹窗时自动恢复（fushiRemoveContainer）。关闭该设置时
 // 任何站点都不因查词被暂停。
-function fushiSendLookup(term, anchorRect, cueWindow, fromSidePanel) {
+function fushiSendLookup(term, anchorRect, cueWindow, fromSidePanel, lookupAnchor) {
   if (window.fushiNestedPopups) window.fushiNestedPopups.clear();
   // TODO-1219 P3：每次查词刷新精确窗——面板行查词传 cueWindow（该行精确 [startMs,endMs]），
   // mousemove 划词不传则清空，使后续制卡回落 DOM 采样窗（live 视频 hover 取当前句）。
   fushiPendingCueWindow = cueWindow || null;
+  // 页面句锚点与精确窗同一契约：每次查词都刷新，不传即清空（侧栏把词直接交回来的那条路没有
+  // 页面命中点），绝不让上一次查词的句子跟到下一个词的卡上。
+  fushiPendingLookupAnchor =
+      lookupAnchor && lookupAnchor.node ? lookupAnchor : null;
+  fushiPendingPageSentence = null;
   fushiLookupFromSidePanel = fromSidePanel === true; // 关窗回执只发给真正的侧栏路径
   if (!term || !term.trim()) return;
   if (!fushiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
@@ -2079,7 +2121,7 @@ window.fushiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
     fushiLastAutoLookupKey = lookupKey;
   }
   fushiLastTerm = term || ''; // 与 mousemove 去重状态对齐，避免点后立刻 hover 同词重查
-  fushiSendLookup(term, anchorRect, cueWindow); // TODO-1219 P3：面板行传入精确窗
+  fushiSendLookup(term, anchorRect, cueWindow, false, hit); // TODO-1219 P3：面板行传入精确窗
 };
 // 原生 Side Panel 自己请求并渲染词典，视频页只保留精确 cue 窗（制卡媒体）以及可选的
 // “查词时暂停”。这里不创建弹窗、不读/写宿主 Selection，也不修改任何宿主文本节点。

--- a/tools/browser-extension/page-sentence.test.js
+++ b/tools/browser-extension/page-sentence.test.js
@@ -1,0 +1,249 @@
+// 用户报「浏览器扩展查词不取所在句子」的行为守卫。
+//
+// 根因：制卡例句的来源过去全部绑在**字幕**上——多句合一草稿 / Netflix 字幕 DOM / 当前字幕行 /
+// 弹窗内选区。在一篇普通文章上 Shift 悬停查词，前三级恒空、弹窗里也没选任何东西 → 卡上没有
+// 例句。而句子一直就在页面 DOM 里：`vendor/selection.js` 带着一份与 app 阅读器同源的
+// `getSentence(node, offset)`，扩展 manifest 装了它，却**从来没有任何代码调用过**
+// （零调用，grep 可证）。查词命中的 (文本节点, 偏移) 在 content.js 手里，制卡时却没人拿它取句。
+//
+// 这里断言的是接线本身：
+//   1) Shift 悬停查词后，fushiMineContext().pageSentence = 命中点所在的整句（惰性算一次并缓存）；
+//   2) 该句真的落进 bridge-shim 发出的 /api/mine 消息的 sentence 字段（普通网页立即出卡那条路）；
+//   3) 优先级不夺权：有字幕行 / 有弹窗内选区时，例句仍是原来那一级，页面句只在它们都空时兜底；
+//   4) 每次查词都重算：换词后不得把上一个词的句子带过去；侧栏直发词（无页面锚点）取不到句。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const CONTENT = path.join(__dirname, 'content.js');
+const BRIDGE = path.join(__dirname, 'bridge-shim.js');
+const ADAPTERS = path.join(__dirname, 'subtitle-adapters.js');
+const PROVIDERS = path.join(__dirname, 'subtitle-providers.js');
+const POPUP_SIZE = path.join(__dirname, 'popup-size.js');
+const DICT_MEDIA = path.join(__dirname, 'vendor', 'dict-media.js');
+
+// 一段真实文章的最小替身：一个文本节点，两句话。getSentence 的桩按句末标点切句，与
+// vendor/selection.js 的分隔符集合同语义（这里只需证明「宿主真的去调它了、拿对了锚点」）。
+const ARTICLE = '昨日は雨だった。今日は世界がまぶしい。';
+const ARTICLE_NODE = { textContent: ARTICLE, nodeType: 3 };
+
+function sentenceAt(text, offset) {
+  const enders = '。！？.!?\n';
+  let start = offset;
+  let end = offset;
+  while (start > 0 && !enders.includes(text[start - 1])) start--;
+  while (end < text.length && !enders.includes(text[end])) end++;
+  return text.slice(start, Math.min(end + 1, text.length)).trim();
+}
+
+// content.js + bridge-shim.js 装进同一个受控 content-script 世界（真实运行时里它们本来就
+// 同世界、同页面：manifest content_scripts 顺序是 bridge-shim → … → content）。
+function loadWorld(opts) {
+  const options = opts || {};
+  const sent = [];
+  const docListeners = Object.create(null);
+  const dataset = {};
+  const getSentenceCalls = [];
+  const selection = {
+    getCharacterAtPoint: () => ({
+      node: ARTICLE_NODE,
+      offset: options.offset === undefined ? 12 : options.offset,
+    }),
+    selectFromPosition: () => options.term || '世界',
+    getSelectionRect: () => ({ x: 10, y: 10, width: 20, height: 16 }),
+    highlightSelection: () => ({ x: 10, y: 10, width: 20, height: 16 }),
+    clearSelection() {},
+    getSentence: (node, offset) => {
+      getSentenceCalls.push({ node, offset });
+      if (options.sentence !== undefined) return options.sentence;
+      return sentenceAt(String(node.textContent || ''), offset);
+    },
+  };
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout: () => 0,
+    clearTimeout() {},
+    setInterval: () => 0,
+    clearInterval() {},
+    URL,
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    performance: { now: () => 1000, timeOrigin: 1700000000000 },
+    location: {
+      hostname: 'example.com',
+      href: 'https://example.com/a',
+      pathname: '/a',
+      origin: 'https://example.com',
+      search: '',
+    },
+  };
+  sandbox.document = {
+    documentElement: { dataset, setAttribute() {} },
+    head: { appendChild() {} },
+    body: { appendChild() {}, style: {} },
+    title: '記事タイトル',
+    fullscreenElement: null,
+    addEventListener: (t, fn) => { (docListeners[t] = docListeners[t] || []).push(fn); },
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    createElement: () => ({
+      style: {},
+      dataset: {},
+      classList: { add() {}, remove() {}, toggle() {} },
+      addEventListener() {},
+      removeEventListener() {},
+      appendChild() {},
+      setAttribute() {},
+      remove() {},
+      contains: () => false,
+    }),
+  };
+  sandbox.chrome = {
+    runtime: {
+      id: 'test-ext-id',
+      lastError: null,
+      onMessage: { addListener() {} },
+      sendMessage: (msg, cb) => {
+        // bridge-shim 加载时的 dictMediaConfig 探测与制卡无关，滤掉免得占住 sent[0]。
+        if (!msg || msg.type !== 'dictMediaConfig') sent.push(msg);
+        const reply = msg && msg.type === 'lookup'
+          ? { ok: true, data: { popupJson: '[]', result: { bestLength: 2 }, audioSources: [] } }
+          : { ok: true, data: { result: 'success' } };
+        if (typeof cb === 'function') cb(reply);
+        return Promise.resolve(reply);
+      },
+    },
+    storage: {
+      local: {
+        get: (_keys, cb) => { if (typeof cb === 'function') cb({}); return Promise.resolve({}); },
+        set: async () => {},
+      },
+      onChanged: { addListener() {} },
+    },
+  };
+  sandbox.window = {
+    addEventListener() {},
+    postMessage() {},
+    innerWidth: 1200,
+    innerHeight: 800,
+    matchMedia: () => ({ matches: false }),
+    fushiSelection: selection,
+  };
+  sandbox.window.window = sandbox.window;
+  vm.createContext(sandbox);
+  // manifest content_scripts 的真实顺序（同一 isolated world 里这些脚本互相提供全局）。
+  vm.runInContext(fs.readFileSync(BRIDGE, 'utf8'), sandbox, { filename: 'bridge-shim.js' });
+  vm.runInContext(fs.readFileSync(ADAPTERS, 'utf8'), sandbox, { filename: 'subtitle-adapters.js' });
+  vm.runInContext(fs.readFileSync(POPUP_SIZE, 'utf8'), sandbox, { filename: 'popup-size.js' });
+  vm.runInContext(fs.readFileSync(DICT_MEDIA, 'utf8'), sandbox, { filename: 'vendor/dict-media.js' });
+  vm.runInContext(fs.readFileSync(PROVIDERS, 'utf8'), sandbox, { filename: 'subtitle-providers.js' });
+  vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox, { filename: 'content.js' });
+
+  return {
+    sent,
+    getSentenceCalls,
+    windowObj: sandbox.window,
+    hover: (x, y) => {
+      const ev = {
+        shiftKey: true,
+        clientX: x === undefined ? 300 : x,
+        clientY: y === undefined ? 400 : y,
+        buttons: 0,
+      };
+      for (const fn of docListeners.mousemove || []) fn(ev);
+    },
+    mine: (fields) =>
+      sandbox.window.flutter_inappwebview.callHandler('mineEntry', fields || FIELDS),
+  };
+}
+
+const FIELDS = { expression: '世界', reading: 'せかい', popupSelectionText: '' };
+
+test('普通网页 Shift 悬停查词后，制卡上下文带上命中点所在的整句', () => {
+  const w = loadWorld();
+  w.hover();
+  assert.strictEqual(
+    w.windowObj.fushiMineContext().pageSentence,
+    '今日は世界がまぶしい。',
+    '页面 DOM 里的句子没有被取出来——这正是用户报的「查词不取所在句子」');
+});
+
+test('该句真的落进 /api/mine 的 sentence 字段（普通网页立即出卡）', async () => {
+  const w = loadWorld();
+  w.hover();
+  const ok = await w.mine();
+  assert.strictEqual(ok, true);
+  const mines = w.sent.filter((m) => m && m.type === 'mine');
+  assert.strictEqual(mines.length, 1, '普通网页应立即出卡，不进批量队列');
+  assert.strictEqual(mines[0].sentence, '今日は世界がまぶしい。', '卡上的例句仍是空的');
+});
+
+test('取句是惰性的：悬停本身不算句，要句子时才算，且同一次查词只算一次', async () => {
+  const w = loadWorld();
+  w.hover();
+  assert.strictEqual(w.getSentenceCalls.length, 0,
+    'Shift 悬停是每几像素一次的高频路径，不得在这里算句');
+  w.windowObj.fushiMineContext();
+  w.windowObj.fushiMineContext();
+  await w.mine();
+  assert.strictEqual(w.getSentenceCalls.length, 1, '同一次查词内取句结果必须缓存');
+  assert.strictEqual(w.getSentenceCalls[0].offset, 12,
+    '取句锚点必须是本次查词真正命中的字符偏移');
+});
+
+test('换词重查：不得把上一个词的句子带到下一张卡上', () => {
+  const w = loadWorld();
+  w.hover(300, 400);
+  assert.strictEqual(w.windowObj.fushiMineContext().pageSentence, '今日は世界がまぶしい。');
+  // 第二次查词命中前一句（偏移落在「昨日は雨だった。」内），词也换了 → 必须重算。
+  w.windowObj.fushiSelection.getCharacterAtPoint = () => ({ node: ARTICLE_NODE, offset: 3 });
+  w.windowObj.fushiSelection.selectFromPosition = () => '雨';
+  w.hover(600, 500);
+  assert.strictEqual(w.windowObj.fushiMineContext().pageSentence, '昨日は雨だった。',
+    '页面句没有跟着查词刷新，卡上会出现上一个词的句子');
+});
+
+test('侧栏把词直接交回来（没有页面命中点）时取不到句，行为与改动前一致', () => {
+  const w = loadWorld();
+  w.hover();
+  assert.ok(w.windowObj.fushiMineContext().pageSentence);
+  w.windowObj.fushiShowLookupFromSidePanel('世界', null, 0.5);
+  assert.strictEqual(w.windowObj.fushiMineContext().pageSentence, '',
+    '无页面锚点时必须留空，不得拿上一次悬停的句子顶替');
+});
+
+test('无句末标点的超长块不入卡：宁可没有例句，也不塞一整段进 Anki 字段', () => {
+  const w = loadWorld({ sentence: 'あ'.repeat(400) });
+  w.hover();
+  assert.strictEqual(w.windowObj.fushiMineContext().pageSentence, '',
+    '整段无标点时应判定「这里没有可用的句子」');
+});
+
+test('优先级不夺权：有当前字幕行时例句仍来自字幕轨', async () => {
+  const w = loadWorld();
+  w.hover();
+  const real = w.windowObj.fushiMineContext;
+  w.windowObj.fushiMineContext = () => Object.assign(real(), {
+    window: { text: '正道ではなく邪道', startV: 61000, endV: 64500 },
+    site: 'other',
+    clip: null,
+    youtubeId: null,
+    netflixId: null,
+    mineAtV: 62200,
+  });
+  await w.mine();
+  const mines = w.sent.filter((m) => m && m.type === 'mine');
+  assert.strictEqual(mines[0].sentence, '正道ではなく邪道',
+    '页面句抢了字幕行的位置——字幕站点的例句必须保持原样');
+});
+
+test('优先级不夺权：用户在弹窗里选了释义文本时，那份显式选区优先', async () => {
+  const w = loadWorld();
+  w.hover();
+  await w.mine(Object.assign({}, FIELDS, { popupSelectionText: '選んだテキスト' }));
+  const mines = w.sent.filter((m) => m && m.type === 'mine');
+  assert.strictEqual(mines[0].sentence, '選んだテキスト',
+    '用户在弹窗内主动选的文本是显式意图，不得被自动取的页面句盖掉');
+});


### PR DESCRIPTION
## 用户报告

「现在的浏览器拓展查词为什么不取所在句子」——在普通网页（不是视频站）上查词制卡，卡上的例句是空的。

## 根因

制卡例句的来源全部绑在**字幕**上，一级都没有从页面正文取句（`tools/browser-extension/bridge-shim.js:30`）：

```js
var sentence = ctxSentence || cueText || trackText || (args[0] && args[0].popupSelectionText) || '';
//             ⓪多句合一草稿  ①Netflix字幕DOM ②当前字幕行      ③弹窗内选区
```

在普通网页上前三级恒空、用户又没在弹窗里选任何文本 → 例句为空。

句子其实一直在页面 DOM 里：`vendor/selection.js:140` 带着一份与 app 阅读器同源的 `getSentence(node, offset)`（跨文本节点扩句、跳振假名 / `.ruby-reserve`、括号配平），manifest 把它装进了 content script，但**全仓零调用**——`grep -rn "getSentence" tools/browser-extension` 只有定义处那一行。查词命中的 `(文本节点, 字符偏移)` 就在 `content.js` 的 mousemove 处理器手里，发完查词就被丢掉，制卡时再也拿不回来。

## 改动

- `content.js`：查词时把命中点存成锚点 `fushiPendingLookupAnchor`（与 `fushiPendingCueWindow` 同一契约——每次查词刷新、不传即清空，绝不让上一个词的句子跟到下一张卡上）。**不当场算句**：Shift 悬停是每几像素一次的高频路径，而 `getSentence` 在没有段落祖先时会退到 body 遍历；真正要句子的只有「点制卡」那一下，所以惰性算一次并缓存到下次查词，经 `fushiMineContext().pageSentence` 交出。超过 200 字的无句末标点块判定为「这里没有可用的句子」——宁可留空也不把一整段塞进 Anki 字段。
- `bridge-shim.js`：例句优先级补上第 ④ 级，排在弹窗内选区**之后**。字幕站点（前三级命中）和用户在弹窗里显式选文本的行为**逐字不变**，这是纯增量的兜底级。

## 测试

新增 `tools/browser-extension/page-sentence.test.js`（8 条）：受控 vm 里真装 bridge-shim + subtitle-adapters/providers + content.js，触发带 Shift 的 mousemove，断言

1. `pageSentence` = 命中点所在整句；
2. 该句真的落进 `/api/mine` 的 `sentence` 字段；
3. 取句惰性（悬停不算句）且同一次查词只算一次；
4. 换词必重算；
5. 侧栏直发词（无页面锚点）取不到句；
6. 超长无标点块留空；
7. + 8. 两条不夺权守卫：有字幕行时仍用字幕轨、有弹窗内选区时仍用选区。

`node --test *.test.js` 扩展全套 498 条绿。

https://claude.ai/code/session_01NgXNjktKa1oMRQQmeQUhZr
