### PR TITLE
fix(lookup): 墨水屏模式下查词弹窗滑动关闭不再走补间动画（BUG-2266）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2114 条。点号进各自文件。
+> 共 2115 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2266](bugs/BUG-2266-eink-swipe-dismiss-animation.md) | ✅ | ✅ | 墨水屏模式：查词弹窗滑动关闭仍有滑出/弹回补间动画 |
 | [BUG-2256](bugs/BUG-2256-subtitle-pause-reveal-ignores-gate.md) | ✅ | ✅ | 关掉「悬停或点击显形」后，暂停仍会揭开被隐藏的字幕 |
 | [BUG-2255](bugs/BUG-2255-reader-sentence-seek-dom-identity.md) | ✅ | ✅ | 正文从本句播放误取上一条字幕 |
 | [BUG-2254](bugs/BUG-2254-jellyfin-fnos-x-emby-auth.md) | ✅ | ✅ | 飞牛影视 Jellyfin 兼容层要求 X-Emby-Authorization 认证头 |

--- a/docs/bugs/BUG-2266-eink-swipe-dismiss-animation.md
+++ b/docs/bugs/BUG-2266-eink-swipe-dismiss-animation.md
@@ -1,0 +1,8 @@
+## BUG-2266 · 墨水屏模式：查词弹窗滑动关闭仍有滑出/弹回补间动画
+- **报告**：2026-09-08（用户：墨水屏模式查词滑动关闭弹框需要跟 hoshi reader Android 一样取消动画）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart:66`（原 `initState` 里把 `AnimationController.duration` 恒定钉成 `_kSwipeSlideDuration` = 200ms，全程没读过主题的 eink 扩展）。
+  设置页 `eink_mode_hint` 明写「纯黑白主题、**无动画**」，`_BodySwipeDismissDetector`（弹窗正文横拖关，`dictionary_popup_layer.dart:1364`）与入场淡入（同文件 `:507`）都已按 eink 归零，唯独 `SwipeDismissWrapper` 漏了。
+  该 wrapper 是顶栏可拖区（`dictionary_popup_layer.dart:831`）与无顶栏层整窗滑关（同文件 `:906`，app 外查词页 `popup_dictionary_page.dart:384` 的嵌套返回层）的唯一实现，所以墨水屏上从顶栏 / 独立查词窗滑关时，仍会画 200ms 的「位移滑出屏外 + 淡出」或「弹回原位」补间——慢刷新屏上就是一串灰阶残影。
+- **[x] ① 已修复** — `SwipeDismissWrapper` 补 `didChangeDependencies`，用既有唯一入口 `einkSafeDuration(context, _kSwipeSlideDuration)` 设控制器时长（eink → `Duration.zero`），与 `_BodySwipeDismissDetector` 同款、跟随主题切换双向生效。`Duration.zero` 的 `animateTo` 当帧同步 complete，`onDismiss` 仍在完成回调里触发，关窗时序不变，只是不再画中间帧。顺带把 `dictionary_popup_layer.dart:1364` 手写的 `isEinkTheme ? Duration.zero : ...` 三元换成同一个 `einkSafeDuration` 助手（该助手的文档注释本就要求「别再手写三元」）。
+- **[x] ② 已加自动化测试** — `fushi/test/widgets/swipe_dismiss_wrapper_test.dart` 新增 group「SwipeDismissWrapper eink 取消滑关补间」3 条：过阈值松手后**只 pump 一帧**，非 eink 必须尚未 `onDismiss`（补间在跑）、eink 必须当帧就 `onDismiss`；外加 eink 未过阈值时弹回已归位（`Transform` 平移为 0）且不误关。判别力验证：临时移除 `didChangeDependencies` 后两条 eink 用例立刻红、非 eink 用例仍绿。
+- **备注**：只动补间时长，跟手期的 `Transform.translate` + `Opacity` 保持不变（与 Android 侧 `_BodySwipeDismissDetector` 的既有 eink 处理一致——手指按住时的实时跟随不是补间动画，去掉会让滑关失去方向反馈）。

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -1330,8 +1330,7 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
     super.didChangeDependencies();
     // 墨水屏模式：滑出/弹回补间归零（Duration.zero 的 forward 立即 complete，
     // onDismiss 时序不变，只是不再画补间帧）。跟随主题切换双向生效。
-    _controller.duration =
-        isEinkTheme(context) ? Duration.zero : _kSlideDuration;
+    _controller.duration = einkSafeDuration(context, _kSlideDuration);
   }
 
   @override

--- a/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
+++ b/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
+    show einkSafeDuration;
+
 /// TODO-407/716 单一真相：查词弹窗"水平滑动关闭"的位移阈值（px）。
 ///
 /// [sensitivity] 越高（越灵敏）阈值越小：0.6（默认）≈ 94px，1.0 → 30px，0 → 190px。
@@ -64,6 +67,16 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
         AnimationController(vsync: this, duration: _kSwipeSlideDuration)
           ..addListener(_onAnimTick)
           ..addStatusListener(_onAnimStatus);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 墨水屏模式：松手后的「补间滑出屏外 / 弹回原位」归零。[Duration.zero] 的
+    // `animateTo` 当帧就 complete，`onDismiss` 时序不变（仍在完成回调里关一层），
+    // 只是不再画中间帧——慢刷新屏上这段 200ms 位移+淡出是一串灰阶残影。
+    // 与弹窗正文的 `_BodySwipeDismissDetector` 同款处理，跟随主题切换双向生效。
+    _controller.duration = einkSafeDuration(context, _kSwipeSlideDuration);
   }
 
   @override

--- a/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
+++ b/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 import 'package:fushi/src/utils/misc/swipe_dismiss_wrapper.dart';
 
 void main() {
@@ -401,6 +402,73 @@ void main() {
       expect(highFired, isTrue);
       expect(lowFired, isFalse);
       expect(highFired, isNot(equals(lowFired)));
+    });
+  });
+  // 墨水屏模式：松手后的滑出/弹回补间必须归零（慢刷新屏上 200ms 位移+淡出 = 灰阶残影，
+  // 与弹窗正文 _BodySwipeDismissDetector 的既有 eink 处理同款）。判别力靠「只 pump 一帧」：
+  // 补间还在时该帧不可能 dismiss，归零后当帧就 dismiss。
+  group('SwipeDismissWrapper eink 取消滑关补间', () {
+    Widget buildEinkApp({required bool eink, required VoidCallback onDismiss}) {
+      return MaterialApp(
+        theme: ThemeData(
+          extensions: <ThemeExtension<dynamic>>[FushiEinkTheme(eink)],
+        ),
+        home: Scaffold(
+          body: SwipeDismissWrapper(
+            onDismiss: onDismiss,
+            child: const SizedBox(
+              width: 300,
+              height: 100,
+              child: ColoredBox(color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+    }
+
+    /// 过阈值横拖后松手，只 pump **一帧**，回报此刻是否已 dismiss。
+    Future<bool> dragAndPumpOneFrame(
+      WidgetTester tester, {
+      required bool eink,
+    }) async {
+      bool dismissed = false;
+      await tester.pumpWidget(
+        buildEinkApp(eink: eink, onDismiss: () => dismissed = true),
+      );
+      final Offset center = tester.getCenter(find.byType(SizedBox).first);
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(200, 0));
+      await gesture.up();
+      await tester.pump();
+      return dismissed;
+    }
+
+    testWidgets('非 eink：松手当帧仍在补间，尚未 onDismiss', (WidgetTester tester) async {
+      expect(await dragAndPumpOneFrame(tester, eink: false), isFalse);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('eink：补间归零，松手当帧即 onDismiss', (WidgetTester tester) async {
+      expect(await dragAndPumpOneFrame(tester, eink: true), isTrue);
+    });
+
+    testWidgets('eink 未过阈值：弹回同样不留补间，且不误关', (WidgetTester tester) async {
+      bool dismissed = false;
+      await tester.pumpWidget(
+        buildEinkApp(eink: true, onDismiss: () => dismissed = true),
+      );
+      final Offset center = tester.getCenter(find.byType(SizedBox).first);
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(60, 0));
+      await gesture.up();
+      await tester.pump();
+
+      expect(dismissed, isFalse);
+      // 补间归零 ⇒ 已回到原位，没有任何待跑的帧（pumpAndSettle 不会再推进动画）。
+      final Transform transform = tester.widget<Transform>(
+        find.byType(Transform).first,
+      );
+      expect(transform.transform.getTranslation().x, 0);
     });
   });
 }


### PR DESCRIPTION
## 问题

墨水屏模式下滑动关闭查词弹窗，仍会看到 200ms 的「位移滑出屏外 + 淡出」（或未过阈值时的「弹回原位」）补间——慢刷新屏上就是一串灰阶残影。设置页 `eink_mode_hint` 明写「纯黑白主题、**无动画**、线式高亮」，这里没兑现。

## 根因

`fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart` 里 `SwipeDismissWrapper` 的 `AnimationController` 时长在 `initState` 里被恒定钉成 `_kSwipeSlideDuration`（200ms），**全程没读过主题的 eink 扩展**。

同一条链路上的另外两处早就按 eink 归零了，唯独这条漏网：

- 弹窗正文横拖关 `_BodySwipeDismissDetector`（`dictionary_popup_layer.dart:1332` 的 `didChangeDependencies`）
- 弹窗入场淡入 `_PopupEntranceFade`（同文件 `:500`）

而 `SwipeDismissWrapper` 是**顶栏可拖区**（`dictionary_popup_layer.dart:824`）与**无顶栏层整窗滑关**（同文件 `:899`，即 app 外查词页 `popup_dictionary_page.dart:384` 的嵌套返回层）的唯一实现，所以这两条路径在墨水屏上始终带补间。

## 改动

1. `SwipeDismissWrapper` 补 `didChangeDependencies`，用既有唯一入口 `einkSafeDuration(context, _kSwipeSlideDuration)` 设控制器时长（eink → `Duration.zero`），与 `_BodySwipeDismissDetector` 同款、跟随主题切换双向生效。

   `Duration.zero` 的 `animateTo` 当帧同步 complete，`onDismiss` 仍在完成回调里触发，**关窗时序不变**，只是不再画中间帧。跟手期（手指按住时）的实时 `Transform.translate` + `Opacity` 保持不变——那不是补间动画，去掉会让滑关失去方向反馈。

2. 顺带把 `dictionary_popup_layer.dart` 里手写的 `isEinkTheme(context) ? Duration.zero : ...` 三元换成同一个 `einkSafeDuration` 助手（该助手的文档注释本就写着「共享组件与页面级 Animated* 统一走这里，别再手写三元」）。

## 测试

`fushi/test/widgets/swipe_dismiss_wrapper_test.dart` 新增 group「SwipeDismissWrapper eink 取消滑关补间」3 条。判据是**过阈值松手后只 pump 一帧**：

- 非 eink：该帧必须**尚未** `onDismiss`（补间还在跑）
- eink：该帧必须**已经** `onDismiss`
- eink 未过阈值：弹回已归位（`Transform` 平移为 0）且不误关

判别力实测：临时移除 `didChangeDependencies` 后，两条 eink 用例立刻红、非 eink 用例仍绿（确认守卫抓的是这处改动、且没有误改原有非 eink 行为）。

## 验证

- `flutter analyze`（全量，含 test 目录）：`No issues found!`
- 定向测试 104 条全绿：`swipe_dismiss_wrapper_test` / `dictionary_popup_swipe_close_test` / `dictionary_popup_layer_body_swipe_close_test` / `dictionary_popup_layer_test` / `base_source_page_barrier_swipe_close_test` / `popup_dictionary_external_fixes_test` / `popup_barrier_hit_alignment_test`
- `dart format --language-version=3.6 --set-exit-if-changed` 三个改动文件零 diff

https://claude.ai/code/session_01WGME7c9MYv8Ayb59H33pVc
