### PR TITLE
fix(anki): 移除 AnkiDroid 安装识别和 API 实例缓存

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2111 条。点号进各自文件。
+> 共 2112 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2278](bugs/BUG-2278-ankidroid-live-target.md) | ✅ | ✅ | AnkiDroid识别与API实例缓存导致安装或启用后仍无法连接 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/bugs/BUG-2278-ankidroid-live-target.md
+++ b/docs/bugs/BUG-2278-ankidroid-live-target.md
@@ -1,0 +1,7 @@
+## BUG-2278 · AnkiDroid识别与API实例缓存导致安装或启用后仍无法连接
+- **报告**：2026-09-08（用户：已安装 AnkiDroid，新手引导「测试连接」仍报不可用，要求根治缓存）
+- **真实性**：✅ 真 bug。`fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidTarget.java:110` 的旧实现把首次 PackageManager 查询（包括 null）永久缓存，且没有调用方使缓存失效；安装、卸载或启用外部 API 不保证重启 Fushi。`fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java:28` 的旧实现又在构造时固定 provider，使后续操作继续使用 null 或旧安装实例。真实生产 Java 配合可变 PackageManager 边界回放，旧版本三个状态转换场景均触发 AssertionError。
+- **[x] ① 已修复** — 删除解析结果缓存和手动失效入口；每次解析重新查 PackageManager。Helper 不保留 provider 字段，每个查询操作获取当前 provider，并在该操作内复用同一个局部实例。提交：见本文件所属修复提交。
+- **[x] ② 已加自动化测试** — `fushi/test/android/ankidroid_live_target_test.dart`：真实生产 Java 的同进程不可用→可用→不可用、并行版→主包→并行版、禁用→启用三个行为场景，以及 Helper 不保留旧 provider 的守卫；旧版三个行为场景均失败，修复版均通过。
+- **备注**：设备原始路径尚未复测（ADB 无连接设备）；JVM 测试模拟 Android PackageManager 边界，不等同真实手机授权端到端验证。
+- **验证**：`flutter test test/android/ankidroid_live_target_test.dart test/android/ankidroid_parallel_build_guard_test.dart --no-pub` 退出 0、13 项通过；`flutter analyze --no-pub` 无问题；完整 JDK 21 下 `:app:compileDebugJavaWithJavac` 退出 0。Release Java 编译因缺少 `android/key.properties` 在配置阶段受阻，未出发布包。首次测试/Debug 编译的 SQLite 下载失败已通过当前进程代理解决；精简运行时缺少 RMI 的构建失败已通过完整 JDK 解决。

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidHelper.java
@@ -25,19 +25,15 @@ public class AnkiDroidHelper {
     private static final String DECK_REF_DB = "com.ichi2.anki.api.decks";
     private static final String MODEL_REF_DB = "com.ichi2.anki.api.models";
 
-    private AnkiProvider mApi;
-    private Context mContext;
+    private final Context mContext;
 
     public AnkiDroidHelper(Context context) {
         mContext = context.getApplicationContext();
-        // BUG-2195：主包仍是 AddContentApi（逐行委托、行为不变），并行版走自建的
-        // ContentResolver 实现。一个都没装时为 null——调用点在此之前都被
-        // isApiAvailable 挡住了。
-        mApi = AnkiProviders.forContext(mContext);
     }
 
+    /** 按当前可用安装创建 provider，不保留启动时的 null 或旧安装实例。 */
     public AnkiProvider getApi() {
-        return mApi;
+        return AnkiProviders.forContext(mContext);
     }
 
     /**
@@ -129,12 +125,13 @@ public class AnkiDroidHelper {
      */
     private SparseArray<List<AnkiNote>> findDuplicateNotesByKeys(
             long modelId, List<String> keys) {
+        final AnkiProvider api = getApi();
         // BUG-2195：AnkiProvider 只暴露单 key 查重（两个实现都能可靠支持），多 key
         // 版在这里按 key 逐个查。本方法只服务下面那个从上游 sample 抄来的
         // removeDuplicates —— 它全仓无调用，保留只为不删上游对照代码。
         final SparseArray<List<AnkiNote>> result = new SparseArray<>();
         for (int i = 0; i < keys.size(); i++) {
-            final List<AnkiNote> found = mApi.findDuplicateNotes(modelId, keys.get(i));
+            final List<AnkiNote> found = api.findDuplicateNotes(modelId, keys.get(i));
             if (found != null && !found.isEmpty()) {
                 result.put(i, found);
             }
@@ -188,16 +185,17 @@ public class AnkiDroidHelper {
      * @return the model ID or null if something went wrong
      */
     public Long findModelIdByName(String modelName, int numFields) {
+        final AnkiProvider api = getApi();
         SharedPreferences modelsDb = mContext.getSharedPreferences(MODEL_REF_DB, Context.MODE_PRIVATE);
         long prefsModelId = modelsDb.getLong(modelName, -1L);
         // if we have a reference saved to modelName and it exists and has at least numFields then return it
         if ((prefsModelId != -1L)
-                && (mApi.getModelName(prefsModelId) != null)
-                && (mApi.getFieldList(prefsModelId) != null)
-                && (mApi.getFieldList(prefsModelId).length >= numFields)) { // could potentially have been renamed
+                && (api.getModelName(prefsModelId) != null)
+                && (api.getFieldList(prefsModelId) != null)
+                && (api.getFieldList(prefsModelId).length >= numFields)) { // could potentially have been renamed
             return prefsModelId;
         }
-        Map<Long, String> modelList = mApi.getModelList(numFields);
+        Map<Long, String> modelList = api.getModelList(numFields);
         if (modelList != null) {
             for (Map.Entry<Long, String> entry : modelList.entrySet()) {
                 if (entry.getValue().equals(modelName)) {
@@ -220,16 +218,17 @@ public class AnkiDroidHelper {
      * @return the did of the deck in Anki
      */
     public Long findDeckIdByName(String deckName) {
+        final AnkiProvider api = getApi();
         SharedPreferences decksDb = mContext.getSharedPreferences(DECK_REF_DB, Context.MODE_PRIVATE);
         // Look for deckName in the deck list
-        Long did = getDeckId(deckName);
+        Long did = getDeckId(api, deckName);
         if (did != null) {
             // If the deck was found then return it's id
             return did;
         } else {
             // Otherwise try to check if we have a reference to a deck that was renamed and return that
             did = decksDb.getLong(deckName, -1);
-            if (did != -1 && mApi.getDeckName(did) != null) {
+            if (did != -1 && api.getDeckName(did) != null) {
                 return did;
             } else {
                 // If the deck really doesn't exist then return null
@@ -243,8 +242,8 @@ public class AnkiDroidHelper {
      * @param deckName Exact name of deck (note: deck names are unique in Anki)
      * @return the ID of the deck that has given name, or null if no deck was found or API error
      */
-    private Long getDeckId(String deckName) {
-        Map<Long, String> deckList = mApi.getDeckList();
+    private Long getDeckId(AnkiProvider api, String deckName) {
+        Map<Long, String> deckList = api.getDeckList();
         if (deckList != null) {
             for (Map.Entry<Long, String> entry : deckList.entrySet()) {
                 if (entry.getValue().equalsIgnoreCase(deckName)) {

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidTarget.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiDroidTarget.java
@@ -31,7 +31,7 @@ import android.net.Uri;
  *
  * <p>本类把「装的是哪一个」变成一次显式解析：逐个候选 authority 去
  * {@link PackageManager#resolveContentProvider}，命中即得包名 / authority / 权限名
- * 三件套。解析结果进程内缓存（安装/卸载会重启进程，缓存不会过期成谎话）。
+ * 三件套。每次访问都查询 PackageManager：安装、卸载或启用 API 不保证重启本进程。
  */
 public final class AnkiDroidTarget {
 
@@ -59,8 +59,6 @@ public final class AnkiDroidTarget {
         MAIN_PACKAGE + ".debug",
     };
 
-    private static volatile AnkiDroidTarget sCached;
-    private static volatile boolean sResolved;
 
     /** 安装包名，例如 {@code com.ichi2.anki.A}。 */
     public final String packageName;
@@ -110,30 +108,14 @@ public final class AnkiDroidTarget {
      * 那种情况下包查得到、provider 查不到，而我们真正需要的是后者。
      */
     public static AnkiDroidTarget resolve(Context context) {
-        if (sResolved) return sCached;
-        synchronized (AnkiDroidTarget.class) {
-            if (sResolved) return sCached;
-            AnkiDroidTarget found = null;
-            final PackageManager pm = context.getPackageManager();
-            for (final String candidate : CANDIDATE_PACKAGES) {
-                final ProviderInfo info =
-                    pm.resolveContentProvider(authorityFor(candidate), 0);
-                if (info != null) {
-                    found = new AnkiDroidTarget(candidate);
-                    break;
-                }
+        final PackageManager pm = context.getPackageManager();
+        for (final String candidate : CANDIDATE_PACKAGES) {
+            final ProviderInfo info =
+                pm.resolveContentProvider(authorityFor(candidate), 0);
+            if (info != null) {
+                return new AnkiDroidTarget(candidate);
             }
-            sCached = found;
-            sResolved = true;
-            return found;
         }
-    }
-
-    /** 仅供测试/诊断：丢弃缓存，下次 {@link #resolve} 重新探测。 */
-    public static void invalidateCache() {
-        synchronized (AnkiDroidTarget.class) {
-            sCached = null;
-            sResolved = false;
-        }
+        return null;
     }
 }

--- a/fushi/test/android/ankidroid_live_target_test.dart
+++ b/fushi/test/android/ankidroid_live_target_test.dart
@@ -1,0 +1,218 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// Executes the production resolver on the JVM. Only the Android boundary is
+/// replaced: PackageManager exposes a mutable set of currently enabled providers.
+/// Each scenario changes that set within one Java process, without invalidation.
+void main() {
+  const String javaRoot = 'android/app/src/main/java/app/fushi/reader';
+  late Directory sandbox;
+
+  String jdkTool(String name) {
+    final String? javaHome = Platform.environment['JAVA_HOME'];
+    if (javaHome != null) {
+      final File executable = File(
+        '$javaHome/bin/$name${Platform.isWindows ? '.exe' : ''}',
+      );
+      if (executable.existsSync()) return executable.path;
+    }
+    return name;
+  }
+
+  setUpAll(() async {
+    sandbox = Directory.systemTemp.createTempSync('ankidroid-live-target-');
+    addTearDown(() => sandbox.deleteSync(recursive: true));
+    final List<String> sources = <String>[];
+    for (final MapEntry<String, String> fixture in _javaFixtures.entries) {
+      final File source = File('${sandbox.path}/${fixture.key}');
+      source.parent.createSync(recursive: true);
+      source.writeAsStringSync(fixture.value);
+      sources.add(source.path);
+    }
+    final File production = File('$javaRoot/AnkiDroidTarget.java');
+    sources.add(production.absolute.path);
+    final ProcessResult compile = await Process.run(jdkTool('javac'), <String>[
+      '-encoding',
+      'UTF-8',
+      '-d',
+      sandbox.path,
+      ...sources,
+    ]);
+    expect(
+      compile.exitCode,
+      0,
+      reason:
+          'Production Java must compile: ${compile.stdout}\n'
+          '${compile.stderr}',
+    );
+  });
+
+  for (final String scenario in <String>[
+    'absent-available-absent',
+    'parallel-main-priority',
+    'provider-disabled-reenabled',
+  ]) {
+    test('resolver observes $scenario within the same process', () async {
+      final ProcessResult result = await Process.run(jdkTool('java'), <String>[
+        '-cp',
+        sandbox.path,
+        'app.fushi.reader.LiveTargetHarness',
+        scenario,
+      ]);
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+      expect(result.stdout.toString().trim(), 'PASS $scenario');
+    });
+  }
+
+  test('long-lived helper resolves its provider on each operation', () {
+    final String helper = maskComments(
+      File('$javaRoot/AnkiDroidHelper.java').readAsStringSync(),
+    );
+    expect(
+      RegExp(
+        r'private\s+(?:final\s+)?AnkiProvider\s+\w+\s*[;=]',
+      ).hasMatch(helper),
+      isFalse,
+      reason: 'A helper may outlive installation, removal or provider changes.',
+    );
+    expect(
+      methodBody(helper, 'public AnkiProvider getApi()'),
+      contains('AnkiProviders.forContext(mContext)'),
+      reason:
+          'Rechecking availability must also refresh the provider instance.',
+    );
+    for (final String signature in <String>[
+      'private SparseArray<List<AnkiNote>> findDuplicateNotesByKeys(',
+      'public Long findModelIdByName(',
+      'public Long findDeckIdByName(',
+    ]) {
+      expect(
+        methodBody(helper, signature),
+        contains('getApi()'),
+        reason: '$signature must use a current operation-local provider.',
+      );
+    }
+  });
+}
+
+const Map<String, String> _javaFixtures = <String, String>{
+  'android/content/Context.java': r'''
+package android.content;
+import android.content.pm.PackageManager;
+public abstract class Context {
+    public abstract PackageManager getPackageManager();
+}
+''',
+  'android/content/pm/PackageManager.java': r'''
+package android.content.pm;
+public abstract class PackageManager {
+    public abstract ProviderInfo resolveContentProvider(String authority, int flags);
+}
+''',
+  'android/content/pm/ProviderInfo.java': r'''
+package android.content.pm;
+public class ProviderInfo {}
+''',
+  'android/net/Uri.java': r'''
+package android.net;
+// The resolver does not use Uri; these signatures compile its unrelated rebase API.
+public abstract class Uri {
+    public abstract String getAuthority();
+    public abstract Builder buildUpon();
+    public abstract static class Builder {
+        public abstract Builder authority(String authority);
+        public abstract Uri build();
+    }
+}
+''',
+  'app/fushi/reader/LiveTargetHarness.java': r'''
+package app.fushi.reader;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.pm.ProviderInfo;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class LiveTargetHarness {
+    private static final String MAIN = "com.ichi2.anki";
+    private static final String PARALLEL = MAIN + ".A";
+
+    private static final class MutablePackages extends PackageManager {
+        final Set<String> authorities = new HashSet<>();
+
+        void enable(String packageName) {
+            authorities.add(packageName + ".flashcards");
+        }
+
+        void disable(String packageName) {
+            authorities.remove(packageName + ".flashcards");
+        }
+
+        @Override public ProviderInfo resolveContentProvider(String authority, int flags) {
+            return authorities.contains(authority) ? new ProviderInfo() : null;
+        }
+    }
+
+    private static final class Device extends Context {
+        final MutablePackages packages = new MutablePackages();
+        @Override public PackageManager getPackageManager() { return packages; }
+    }
+
+    private static void expectTarget(Device device, String expected) {
+        AnkiDroidTarget actual = AnkiDroidTarget.resolve(device);
+        if (expected == null) {
+            if (actual != null) throw new AssertionError("Expected unavailable, got " + actual.packageName);
+            return;
+        }
+        if (actual == null || !expected.equals(actual.packageName)) {
+            throw new AssertionError("Expected " + expected + ", got " +
+                (actual == null ? "unavailable" : actual.packageName));
+        }
+        if (!(expected + ".flashcards").equals(actual.authority) ||
+            !(expected + ".permission.READ_WRITE_DATABASE").equals(actual.permission)) {
+            throw new AssertionError("Provider authority and permission must follow the selected package");
+        }
+        if (actual.isMainBuild() != MAIN.equals(expected)) {
+            throw new AssertionError("Provider implementation selection must follow the selected package");
+        }
+    }
+
+    public static void main(String[] args) {
+        Device device = new Device();
+        switch (args[0]) {
+            case "absent-available-absent":
+                expectTarget(device, null);
+                device.packages.enable(MAIN);
+                expectTarget(device, MAIN);
+                device.packages.disable(MAIN);
+                expectTarget(device, null);
+                break;
+            case "parallel-main-priority":
+                device.packages.enable(PARALLEL);
+                expectTarget(device, PARALLEL);
+                device.packages.enable(MAIN);
+                expectTarget(device, MAIN);
+                device.packages.disable(MAIN);
+                expectTarget(device, PARALLEL);
+                device.packages.disable(PARALLEL);
+                expectTarget(device, null);
+                break;
+            case "provider-disabled-reenabled":
+                device.packages.enable(MAIN);
+                expectTarget(device, MAIN);
+                device.packages.disable(MAIN);
+                expectTarget(device, null);
+                device.packages.enable(MAIN);
+                expectTarget(device, MAIN);
+                break;
+            default: throw new AssertionError("Unknown scenario: " + args[0]);
+        }
+        System.out.println("PASS " + args[0]);
+    }
+}
+''',
+};


### PR DESCRIPTION
AnkiDroid 首次不可用时，Fushi 会永久缓存 null；用户随后安装或启用 API，再点「测试连接」仍会失败。Helper 还保存启动时的 provider，单独清理识别缓存无法覆盖后续查询。

删除安装识别的正负缓存和手动失效入口，每次操作重新查询 PackageManager；Helper 按操作获取当前 provider，并在操作内复用局部实例。保留主包优先和并行版兼容。记录 BUG-2278。

验证：
- 13 项定向测试通过，覆盖同进程安装/卸载、禁用/启用、并行版/主包切换；旧版三个 Java 行为场景均断言失败。
- flutter analyze --no-pub 无问题。
- 完整 JDK 21 下 :app:compileDebugJavaWithJavac 通过。
- BUG 索引与跨分支编号检查通过。

未验证：没有连接的 Android 设备，尚未复测真实授权 UI；Release Java 编译因缺少 android/key.properties 在配置阶段受阻，未生成发布包。本地未跑全量测试，交由 CI。
