### PR TITLE
fix: 修复 Android 保留引擎与 Windows 快速重开交接

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2126 条。点号进各自文件。
+> 共 2128 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2280](bugs/BUG-2280-android-detach-retained-engine.md) | 🚧 | 🚧 | Android快速重开复用已关库引擎 |
+| [BUG-2279](bugs/BUG-2279-rapid-reopen-mutex.md) | 🚧 | 🚧 | Windows快速重开未等待旧实例退出 |
 | [BUG-2277](bugs/BUG-2277-ext-page-sentence.md) | ✅ | ✅ | 浏览器扩展查词/制卡不取页面所在句子 |
 | [BUG-2276](bugs/BUG-2276-macos-reader-panel-transparent-barrier.md) | ✅ | ✅ | macOS 阅读设置/导航抽屉打开后点正文不关闭 |
 | [BUG-2275](bugs/BUG-2275-cloudflare-challenge-proxy.md) | ✅ | ✅ | Cloudflare验证网页未继承手动代理 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,8 +33,8 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-2280](bugs/BUG-2280-android-detach-retained-engine.md) | 🚧 | 🚧 | Android快速重开复用已关库引擎 |
-| [BUG-2279](bugs/BUG-2279-rapid-reopen-mutex.md) | 🚧 | 🚧 | Windows快速重开未等待旧实例退出 |
+| [BUG-2280](bugs/BUG-2280-android-detach-retained-engine.md) | ✅ | ✅ | Android快速重开复用已关库引擎 |
+| [BUG-2279](bugs/BUG-2279-rapid-reopen-mutex.md) | ✅ | ✅ | Windows快速重开未等待旧实例退出 |
 | [BUG-2277](bugs/BUG-2277-ext-page-sentence.md) | ✅ | ✅ | 浏览器扩展查词/制卡不取页面所在句子 |
 | [BUG-2276](bugs/BUG-2276-macos-reader-panel-transparent-barrier.md) | ✅ | ✅ | macOS 阅读设置/导航抽屉打开后点正文不关闭 |
 | [BUG-2275](bugs/BUG-2275-cloudflare-challenge-proxy.md) | ✅ | ✅ | Cloudflare验证网页未继承手动代理 |

--- a/docs/bugs/BUG-2279-rapid-reopen-mutex.md
+++ b/docs/bugs/BUG-2279-rapid-reopen-mutex.md
@@ -1,11 +1,11 @@
 ## BUG-2279 · Windows快速重开未等待旧实例退出
 - **报告**：2026-09-08（用户：关闭 Fushi 后快速重开，手机和电脑感觉卡死，怀疑数据库没关完）
 - **真实性**：✅ 真 bug（Windows 互斥所有权缺陷已用隔离 Win32 探针验证；用户整机卡死尚未复现）。
-- **[x] ① 根因修复已实现** — `e2d614f2e9`：`SingleInstanceMutex` 首次创建即取得所有权，主线程持有到退出，只有 owner 释放；失败不启动无保护引擎，窗口已隐藏/不存在时等待真实交接。
+- **[x] ① 根因修复已实现** — `7c420f2b42`：`SingleInstanceMutex` 首次创建即取得所有权，主线程持有到退出，只有 owner 释放；失败不启动无保护引擎，窗口已隐藏/不存在时等待真实交接。
 - **[x] ② 自动化测试** — `fushi/windows/runner/tests/single_instance_mutex_test.cpp` 用真实 Win32 子进程和线程验证活实例不可接管、退出后接管、多候选互斥、非 owner 清理、正常释放、创建失败。`run_single_instance_mutex_test.ps1` 以 MSVC C++17 `/W4 /WX` 编译运行通过；相关 Flutter 守卫已同步，5 文件共 37 项定向测试通过。
 - **根因**：`fushi/windows/runner/main.cpp:182` 使用 `CreateMutexW(nullptr, FALSE, ...)`，首实例只保留句柄，没有取得所有权，后续也没有首次 acquire。`:194` 和 `:210` 却用 `WaitForSingleInstanceMutex` 判断旧进程已退出，未被拥有的 mutex 会立即返回 `WAIT_OBJECT_0`。
 - **真实路径**：`fushi/lib/main.dart:876` 隐藏退出中的窗口，随后 flush、关闭 DB、原生 WebView 清理。此期间新进程命中隐藏窗口分支，等待立即成功并继续启动，旧进程仍在清理，失去原本对 DB / WebView 资源交接的串行保护。自动重启标志分支同样受影响。
 - **验证**：独立随机命名 mutex，不接触运行中 Fushi 的真实锁。第一线程保持句柄不关闭，第二线程 CreateMutex 返回 `ERROR_ALREADY_EXISTS=183`；原实现 `initialOwner=false` 时 wait 返回 `0`；对照 `initialOwner=true` 时第二线程等待 100ms 返回 `WAIT_TIMEOUT=258`。证明的是交接保护失效，不是证明双连接一定令 SQLite 死锁。
 - **现有测试缺口**：`fushi/test/platform/windows_restart_single_instance_guard_test.dart:55-71` 只检查等待调用和分支字串，未验证首实例实际拥有锁。
-- **验证**：最终 `flutter analyze --no-pub` 通过。相邻 76 文件检查 775 项通过、4 项失败：既有 macOS 阅读器守卫（所读源码与测试未改）及 3 项 Bug 编号工具测试（包含超时/断言，工具代码未改）；不将该批记为全绿。
+- **验证**：最终 `flutter analyze --no-pub` 通过。初次相邻 76 文件检查 775 项通过、4 项失败。接到最新 develop 后，3 项编号工具失败用串行/2 分钟上限复测全部通过；旧 macOS 断言已由目标分支替换，当前整份 7 项通过。未把初次整批记录改写为全绿。
 - **边界**：`implemented_unverified`：未做完整 Windows 应用构建/真实 Fushi 重开 E2E。原生隔离测试证明锁交接，不证明所有 WebView/播放设备路径。旧未修复二进制不拥有锁，新版不能追补其所有权；首次换版须完全退出旧版，再验证修复版本之间的重开。Win32 官方契约：https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexa 。

--- a/docs/bugs/BUG-2279-rapid-reopen-mutex.md
+++ b/docs/bugs/BUG-2279-rapid-reopen-mutex.md
@@ -1,11 +1,11 @@
 ## BUG-2279 · Windows快速重开未等待旧实例退出
 - **报告**：2026-09-08（用户：关闭 Fushi 后快速重开，手机和电脑感觉卡死，怀疑数据库没关完）
 - **真实性**：✅ 真 bug（Windows 互斥所有权缺陷已用隔离 Win32 探针验证；用户整机卡死尚未复现）。
-- **[ ] ① 未修复** —
-- **[ ] ② 未加自动化测试** —
+- **[x] ① 根因修复已实现** — `e2d614f2e9`：`SingleInstanceMutex` 首次创建即取得所有权，主线程持有到退出，只有 owner 释放；失败不启动无保护引擎，窗口已隐藏/不存在时等待真实交接。
+- **[x] ② 自动化测试** — `fushi/windows/runner/tests/single_instance_mutex_test.cpp` 用真实 Win32 子进程和线程验证活实例不可接管、退出后接管、多候选互斥、非 owner 清理、正常释放、创建失败。`run_single_instance_mutex_test.ps1` 以 MSVC C++17 `/W4 /WX` 编译运行通过；相关 Flutter 守卫已同步，5 文件共 37 项定向测试通过。
 - **根因**：`fushi/windows/runner/main.cpp:182` 使用 `CreateMutexW(nullptr, FALSE, ...)`，首实例只保留句柄，没有取得所有权，后续也没有首次 acquire。`:194` 和 `:210` 却用 `WaitForSingleInstanceMutex` 判断旧进程已退出，未被拥有的 mutex 会立即返回 `WAIT_OBJECT_0`。
 - **真实路径**：`fushi/lib/main.dart:876` 隐藏退出中的窗口，随后 flush、关闭 DB、原生 WebView 清理。此期间新进程命中隐藏窗口分支，等待立即成功并继续启动，旧进程仍在清理，失去原本对 DB / WebView 资源交接的串行保护。自动重启标志分支同样受影响。
 - **验证**：独立随机命名 mutex，不接触运行中 Fushi 的真实锁。第一线程保持句柄不关闭，第二线程 CreateMutex 返回 `ERROR_ALREADY_EXISTS=183`；原实现 `initialOwner=false` 时 wait 返回 `0`；对照 `initialOwner=true` 时第二线程等待 100ms 返回 `WAIT_TIMEOUT=258`。证明的是交接保护失效，不是证明双连接一定令 SQLite 死锁。
 - **现有测试缺口**：`fushi/test/platform/windows_restart_single_instance_guard_test.dart:55-71` 只检查等待调用和分支字串，未验证首实例实际拥有锁。
-- **修复方向**：建立首实例拥有并持续持有锁的完整契约，验证旧进程存活时新线程/进程不能接管、旧进程退出后能接管；同时覆盖普通重开和自动重启。
-- **边界**：本轮只检查和登记；未修改产品代码，未运行真实应用关闭重开 E2E，也未验证用户已安装二进制与当前源码一致。Win32 官方契约：https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexa 。
+- **验证**：最终 `flutter analyze --no-pub` 通过。相邻 76 文件检查 775 项通过、4 项失败：既有 macOS 阅读器守卫（所读源码与测试未改）及 3 项 Bug 编号工具测试（包含超时/断言，工具代码未改）；不将该批记为全绿。
+- **边界**：`implemented_unverified`：未做完整 Windows 应用构建/真实 Fushi 重开 E2E。原生隔离测试证明锁交接，不证明所有 WebView/播放设备路径。旧未修复二进制不拥有锁，新版不能追补其所有权；首次换版须完全退出旧版，再验证修复版本之间的重开。Win32 官方契约：https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexa 。

--- a/docs/bugs/BUG-2279-rapid-reopen-mutex.md
+++ b/docs/bugs/BUG-2279-rapid-reopen-mutex.md
@@ -1,0 +1,11 @@
+## BUG-2279 · Windows快速重开未等待旧实例退出
+- **报告**：2026-09-08（用户：关闭 Fushi 后快速重开，手机和电脑感觉卡死，怀疑数据库没关完）
+- **真实性**：✅ 真 bug（Windows 互斥所有权缺陷已用隔离 Win32 探针验证；用户整机卡死尚未复现）。
+- **[ ] ① 未修复** —
+- **[ ] ② 未加自动化测试** —
+- **根因**：`fushi/windows/runner/main.cpp:182` 使用 `CreateMutexW(nullptr, FALSE, ...)`，首实例只保留句柄，没有取得所有权，后续也没有首次 acquire。`:194` 和 `:210` 却用 `WaitForSingleInstanceMutex` 判断旧进程已退出，未被拥有的 mutex 会立即返回 `WAIT_OBJECT_0`。
+- **真实路径**：`fushi/lib/main.dart:876` 隐藏退出中的窗口，随后 flush、关闭 DB、原生 WebView 清理。此期间新进程命中隐藏窗口分支，等待立即成功并继续启动，旧进程仍在清理，失去原本对 DB / WebView 资源交接的串行保护。自动重启标志分支同样受影响。
+- **验证**：独立随机命名 mutex，不接触运行中 Fushi 的真实锁。第一线程保持句柄不关闭，第二线程 CreateMutex 返回 `ERROR_ALREADY_EXISTS=183`；原实现 `initialOwner=false` 时 wait 返回 `0`；对照 `initialOwner=true` 时第二线程等待 100ms 返回 `WAIT_TIMEOUT=258`。证明的是交接保护失效，不是证明双连接一定令 SQLite 死锁。
+- **现有测试缺口**：`fushi/test/platform/windows_restart_single_instance_guard_test.dart:55-71` 只检查等待调用和分支字串，未验证首实例实际拥有锁。
+- **修复方向**：建立首实例拥有并持续持有锁的完整契约，验证旧进程存活时新线程/进程不能接管、旧进程退出后能接管；同时覆盖普通重开和自动重启。
+- **边界**：本轮只检查和登记；未修改产品代码，未运行真实应用关闭重开 E2E，也未验证用户已安装二进制与当前源码一致。Win32 官方契约：https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createmutexa 。

--- a/docs/bugs/BUG-2280-android-detach-retained-engine.md
+++ b/docs/bugs/BUG-2280-android-detach-retained-engine.md
@@ -1,11 +1,13 @@
 ## BUG-2280 · Android快速重开复用已关库引擎
 - **报告**：2026-09-08（用户：手机快速关闭重开感觉卡死）
 - **真实性**：✅ 真 bug（Android 保留引擎与关库生命周期契约冲突已沿应用、依赖和 Flutter 原生源码确认；用户设备症状尚未复现）。
-- **[ ] ① 未修复** —
-- **[ ] ② 未加自动化测试** —
+- **[x] ① 根因修复已实现** — `e2d614f2e9`：Android view 的 inactive/hidden/paused/detached 统一保留式 flush，不设置终止标志、不关闭引擎所有的 DB/服务。已有 flush 之后收到的新请求串行补存，避免遗漏旧快照之后新增的 deferred 写。
+- **[x] ② 自动化测试** — `fushi/test/startup/android_view_lifecycle_test.dart` 使用真实 Drift DB 验证 detached/resumed 后继续读写、未完成 flush 时重开及新增 deferred 写的串行落库、后续回调保留。`exit_flush_test.dart` 验证 Android 接线不进入破坏性退出分支；5 文件共 37 项定向测试通过。
 - **根因**：`fushi/lib/main.dart:800-802` 对 Android `detached` 调用退出清理，`:994-995` 置 `_shutdownStarted`，`:1019` 关闭数据库；`:789-791` resumed 仅刷新配色，没有取消仍在飞的退出清理或恢复已关闭的资源。
 - **真实路径**：`fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java:59` 继承 `AudioServiceActivity`。`pubspec.lock:101-108` 解析为 audio_service 0.18.18；其 `AudioServiceActivity.java:12-13` 提供插件缓存引擎，`AudioServicePlugin.java:70-113` 复用 audio_service_engine，`:116-123` 明确在新 Activity 已绑定时保留引擎。本机 Flutter 的 `FlutterActivityAndFragmentDelegate.java:805-810` 脱离时发送 detached，而 `FlutterActivity.java:1081-1087` 对宿主提供引擎默认不销毁。因而 Activity 销毁不等于应用引擎结束。
 - **后果**：`fushi/lib/src/models/app_model.dart:6522-6533` 关库还会标记未初始化、撤销观察者、停止后台服务；快速恢复的旧引擎可能继续使用这些资源，甚至先恢复界面、随后被尚未完成的退出清理关闭数据库。问题是关闭了仍需复用的资源，不能简化为数据库关闭不完全。
 - **触发边界**：Activity 销毁后音频引擎仍保留，或新 Activity 在旧服务销毁引擎前重新绑定。普通返回桌面只走 inactive/paused/hidden 的保留式 flush，不能据此直接认定触发。进程完全终止后冷启动也不属于复用旧引擎路径。
-- **修复方向**：将 view 脱离与 engine/进程终止分开管理，保留引擎时只做可恢复的持久化；补 detached → resumed 以及清理未完成便 resumed 的行为测试，证明同一引擎仍能读写 DB 和使用后台服务。
-- **验证边界**：本轮只检查和登记；未修改产品代码，未做 Android 真机/E2E。iOS 未找到同等缓存主引擎复用证据，不外推为 iOS 已确诊。
+- **验证**：最终 `flutter analyze --no-pub` 通过；最新代码 `flutter build apk --debug --no-pub` 通过。相邻 76 文件检查 775 项通过、4 项失败，详见 BUG-2279；不将该批记为全绿。
+- **模拟器验证**：API 34 x86_64 上安装最终 APK，返回桌面立即重开 PID 5944 不变；`CLEAR_TASK | NEW_TASK` 重建 Activity 后，同一 FFmpegKit 插件实例从旧 Activity 重附着新 Activity，只有最初一次 Dart VM service 启动，确认引擎真实复用。延后约 30 秒 onboarding 仍正常渲染，无关库异常或 FATAL。证据在本工作区 `.codex-test/android-reopen-recreate-logcat.txt`、`android-reopen-device-logcat.txt`、`android-reopen-capture-screen.png`。APK SHA256 `AFDEF68BC3956DFE77127F59C0B8DEF5F378DA6B3A70DA2D3923D8916F1CFF1D`。
+- **验证边界**：`implemented_unverified`：尚未完成音频服务保活下 Activity 销毁并复用相同引擎的设备 E2E，单测不替代该门槛。iOS 未找到同等缓存主引擎复用证据，不外推为 iOS 已确诊。
+- **模拟器独立缺口**：x86_64 的 ffmpeg-kit 报缺少 `libffmpegkit_abidetect.so`，未导致此次启动/重建崩溃；未测真实音频播放、阅读位置保存和完整首页交互。未修改用户真实安装。

--- a/docs/bugs/BUG-2280-android-detach-retained-engine.md
+++ b/docs/bugs/BUG-2280-android-detach-retained-engine.md
@@ -1,0 +1,11 @@
+## BUG-2280 · Android快速重开复用已关库引擎
+- **报告**：2026-09-08（用户：手机快速关闭重开感觉卡死）
+- **真实性**：✅ 真 bug（Android 保留引擎与关库生命周期契约冲突已沿应用、依赖和 Flutter 原生源码确认；用户设备症状尚未复现）。
+- **[ ] ① 未修复** —
+- **[ ] ② 未加自动化测试** —
+- **根因**：`fushi/lib/main.dart:800-802` 对 Android `detached` 调用退出清理，`:994-995` 置 `_shutdownStarted`，`:1019` 关闭数据库；`:789-791` resumed 仅刷新配色，没有取消仍在飞的退出清理或恢复已关闭的资源。
+- **真实路径**：`fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java:59` 继承 `AudioServiceActivity`。`pubspec.lock:101-108` 解析为 audio_service 0.18.18；其 `AudioServiceActivity.java:12-13` 提供插件缓存引擎，`AudioServicePlugin.java:70-113` 复用 audio_service_engine，`:116-123` 明确在新 Activity 已绑定时保留引擎。本机 Flutter 的 `FlutterActivityAndFragmentDelegate.java:805-810` 脱离时发送 detached，而 `FlutterActivity.java:1081-1087` 对宿主提供引擎默认不销毁。因而 Activity 销毁不等于应用引擎结束。
+- **后果**：`fushi/lib/src/models/app_model.dart:6522-6533` 关库还会标记未初始化、撤销观察者、停止后台服务；快速恢复的旧引擎可能继续使用这些资源，甚至先恢复界面、随后被尚未完成的退出清理关闭数据库。问题是关闭了仍需复用的资源，不能简化为数据库关闭不完全。
+- **触发边界**：Activity 销毁后音频引擎仍保留，或新 Activity 在旧服务销毁引擎前重新绑定。普通返回桌面只走 inactive/paused/hidden 的保留式 flush，不能据此直接认定触发。进程完全终止后冷启动也不属于复用旧引擎路径。
+- **修复方向**：将 view 脱离与 engine/进程终止分开管理，保留引擎时只做可恢复的持久化；补 detached → resumed 以及清理未完成便 resumed 的行为测试，证明同一引擎仍能读写 DB 和使用后台服务。
+- **验证边界**：本轮只检查和登记；未修改产品代码，未做 Android 真机/E2E。iOS 未找到同等缓存主引擎复用证据，不外推为 iOS 已确诊。

--- a/docs/bugs/BUG-2280-android-detach-retained-engine.md
+++ b/docs/bugs/BUG-2280-android-detach-retained-engine.md
@@ -1,13 +1,13 @@
 ## BUG-2280 · Android快速重开复用已关库引擎
 - **报告**：2026-09-08（用户：手机快速关闭重开感觉卡死）
 - **真实性**：✅ 真 bug（Android 保留引擎与关库生命周期契约冲突已沿应用、依赖和 Flutter 原生源码确认；用户设备症状尚未复现）。
-- **[x] ① 根因修复已实现** — `e2d614f2e9`：Android view 的 inactive/hidden/paused/detached 统一保留式 flush，不设置终止标志、不关闭引擎所有的 DB/服务。已有 flush 之后收到的新请求串行补存，避免遗漏旧快照之后新增的 deferred 写。
+- **[x] ① 根因修复已实现** — `7c420f2b42`：Android view 的 inactive/hidden/paused/detached 统一保留式 flush，不设置终止标志、不关闭引擎所有的 DB/服务。已有 flush 之后收到的新请求串行补存，避免遗漏旧快照之后新增的 deferred 写。
 - **[x] ② 自动化测试** — `fushi/test/startup/android_view_lifecycle_test.dart` 使用真实 Drift DB 验证 detached/resumed 后继续读写、未完成 flush 时重开及新增 deferred 写的串行落库、后续回调保留。`exit_flush_test.dart` 验证 Android 接线不进入破坏性退出分支；5 文件共 37 项定向测试通过。
 - **根因**：`fushi/lib/main.dart:800-802` 对 Android `detached` 调用退出清理，`:994-995` 置 `_shutdownStarted`，`:1019` 关闭数据库；`:789-791` resumed 仅刷新配色，没有取消仍在飞的退出清理或恢复已关闭的资源。
 - **真实路径**：`fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java:59` 继承 `AudioServiceActivity`。`pubspec.lock:101-108` 解析为 audio_service 0.18.18；其 `AudioServiceActivity.java:12-13` 提供插件缓存引擎，`AudioServicePlugin.java:70-113` 复用 audio_service_engine，`:116-123` 明确在新 Activity 已绑定时保留引擎。本机 Flutter 的 `FlutterActivityAndFragmentDelegate.java:805-810` 脱离时发送 detached，而 `FlutterActivity.java:1081-1087` 对宿主提供引擎默认不销毁。因而 Activity 销毁不等于应用引擎结束。
 - **后果**：`fushi/lib/src/models/app_model.dart:6522-6533` 关库还会标记未初始化、撤销观察者、停止后台服务；快速恢复的旧引擎可能继续使用这些资源，甚至先恢复界面、随后被尚未完成的退出清理关闭数据库。问题是关闭了仍需复用的资源，不能简化为数据库关闭不完全。
 - **触发边界**：Activity 销毁后音频引擎仍保留，或新 Activity 在旧服务销毁引擎前重新绑定。普通返回桌面只走 inactive/paused/hidden 的保留式 flush，不能据此直接认定触发。进程完全终止后冷启动也不属于复用旧引擎路径。
-- **验证**：最终 `flutter analyze --no-pub` 通过；最新代码 `flutter build apk --debug --no-pub` 通过。相邻 76 文件检查 775 项通过、4 项失败，详见 BUG-2279；不将该批记为全绿。
-- **模拟器验证**：API 34 x86_64 上安装最终 APK，返回桌面立即重开 PID 5944 不变；`CLEAR_TASK | NEW_TASK` 重建 Activity 后，同一 FFmpegKit 插件实例从旧 Activity 重附着新 Activity，只有最初一次 Dart VM service 启动，确认引擎真实复用。延后约 30 秒 onboarding 仍正常渲染，无关库异常或 FATAL。证据在本工作区 `.codex-test/android-reopen-recreate-logcat.txt`、`android-reopen-device-logcat.txt`、`android-reopen-capture-screen.png`。APK SHA256 `AFDEF68BC3956DFE77127F59C0B8DEF5F378DA6B3A70DA2D3923D8916F1CFF1D`。
+- **验证**：最终 `flutter analyze --no-pub` 通过；最新代码 `flutter build apk --debug --no-pub` 通过。初次相邻检查与接到最新 develop 后的失败项复测见 BUG-2279。重放后 37 项定向测试再次通过、Android APK 再构建通过。
+- **模拟器验证**：重放到最新 develop 前，在 API 34 x86_64 上安装当时最终 APK（后续 Android 生命周期修复代码未变），返回桌面立即重开 PID 5944 不变；`CLEAR_TASK | NEW_TASK` 重建 Activity 后，同一 FFmpegKit 插件实例从旧 Activity 重附着新 Activity，只有最初一次 Dart VM service 启动，确认引擎真实复用。延后约 30 秒 onboarding 仍正常渲染，无关库异常或 FATAL。证据在本工作区 `.codex-test/android-reopen-recreate-logcat.txt`、`android-reopen-device-logcat.txt`、`android-reopen-capture-screen.png`。APK SHA256 `AFDEF68BC3956DFE77127F59C0B8DEF5F378DA6B3A70DA2D3923D8916F1CFF1D`。
 - **验证边界**：`implemented_unverified`：尚未完成音频服务保活下 Activity 销毁并复用相同引擎的设备 E2E，单测不替代该门槛。iOS 未找到同等缓存主引擎复用证据，不外推为 iOS 已确诊。
 - **模拟器独立缺口**：x86_64 的 ffmpeg-kit 报缺少 `libffmpegkit_abidetect.so`，未导致此次启动/重建崩溃；未测真实音频播放、阅读位置保存和完整首页交互。未修改用户真实安装。

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -56,6 +56,7 @@ import 'package:fushi/src/sync/sync_settings_schema.dart'
     show backupImportRestart, dataRootMigrationRestart;
 import 'package:fushi/src/startup/webview_prewarm.dart';
 import 'package:fushi/src/startup/exit_flush_registry.dart';
+import 'package:fushi/src/startup/android_view_lifecycle.dart';
 import 'package:fushi/src/sync/book_exit_sync_scope.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/anki/ankimobile_repository.dart';
@@ -694,7 +695,7 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
   /// 缺；WAL 崩溃安全，超时放行只损失一次 checkpoint，不损失已提交的数据。
   static const Duration _closeDatabaseOnExitTimeout = Duration(seconds: 3);
 
-  Future<void>? _androidBackgroundFlushInFlight;
+  final AndroidViewLifecycle _androidViewLifecycle = AndroidViewLifecycle();
 
   /// 守卫：Windows 安装器 handoff reconcile 的 post-frame 调度只挂一个。
   bool _windowsUpdateHandoffScheduled = false;
@@ -828,18 +829,10 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
       return;
     }
     if (Platform.isAndroid) {
-      switch (state) {
-        case AppLifecycleState.inactive:
-        case AppLifecycleState.paused:
-        case AppLifecycleState.hidden:
-          unawaited(_flushActivePagesForAndroidBackground());
-          return;
-        case AppLifecycleState.detached:
-          unawaited(_flushAndCloseForLifecycleDetach());
-          return;
-        case AppLifecycleState.resumed:
-          return;
-      }
+      // BUG-2280: AudioServiceActivity can detach while its cached engine
+      // survives. A new Activity must retain that engine's DB and services.
+      unawaited(_androidViewLifecycle.handleState(state));
+      return;
     }
     // `detached` = the app is about to be terminated (the engine is detaching
     // from the view). Tear down Bonsoir's mDNS event sources here as a fallback
@@ -1012,36 +1005,9 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
         '[Fushi] exit step "$label" took ${watch.elapsedMilliseconds}ms');
   }
 
-  /// Android 退后台不是退出：只做保留式 flush，页面回前台后仍继续持有回调。
-  ///
-  /// 页面本身也会在 paused/hidden 尝试 flush，但那是 fire-and-forget；这里给
-  /// Android 一个 app-level 汇聚点，确保 reader/video/audiobook 的 pending 位置写穿。
-  Future<void> _flushActivePagesForAndroidBackground() async {
-    final Future<void>? existing = _androidBackgroundFlushInFlight;
-    if (existing != null) {
-      return existing;
-    }
-
-    final Future<void> run = () async {
-      try {
-        await ExitFlushRegistry.instance.flushAll(clearCallbacks: false);
-      } catch (e) {
-        debugPrint('[Fushi] android background flush failed: $e');
-      }
-    }();
-    _androidBackgroundFlushInFlight = run;
-    try {
-      await run;
-    } finally {
-      if (identical(_androidBackgroundFlushInFlight, run)) {
-        _androidBackgroundFlushInFlight = null;
-      }
-    }
-  }
-
   /// 停掉 Bonsoir 的 LAN 广播 + 发现（mDNS 事件源），再 flush 活跃页面并 close DB。
   ///
-  /// 仅作 `detached` 生命周期兜底（移动端 / 不经 window_manager 的退出路径）。桌面
+  /// 仅作非 Android 的 `detached` 生命周期兜底。Android view 脱离不代表引擎退出。桌面
   /// 点 X 走 [_flushAndExitForWindowClose]（flush + closeDB + exit(0)），不再到这里。
   /// 超时上限收紧到 1.5s（TODO-086）：原生 stop 不归时放行，避免拖住退出。
   Future<void> _flushAndCloseForLifecycleDetach() async {
@@ -1059,11 +1025,6 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
     }
 
     try {
-      final Future<void>? pendingBackgroundFlush =
-          _androidBackgroundFlushInFlight;
-      if (pendingBackgroundFlush != null) {
-        await pendingBackgroundFlush;
-      }
       await ExitFlushRegistry.instance.flushAll();
     } catch (e) {
       debugPrint('[Fushi] lifecycle detach flush failed: $e');

--- a/fushi/lib/src/startup/android_view_lifecycle.dart
+++ b/fushi/lib/src/startup/android_view_lifecycle.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'package:fushi/src/startup/exit_flush_registry.dart';
+
+/// Activity attachment is shorter-lived than audio_service's cached engine.
+///
+/// Persist pending page writes when the view goes away, including detached,
+/// without shutting down engine-owned databases, services, or registrations.
+/// A subsequent Activity can attach even while this flush is still running.
+class AndroidViewLifecycle {
+  AndroidViewLifecycle({ExitFlushRegistry? registry})
+      : _registry = registry ?? ExitFlushRegistry.instance;
+
+  final ExitFlushRegistry _registry;
+  Future<void>? _flushInFlight;
+  bool _flushRequested = false;
+
+  Future<void> handleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        return Future<void>.value();
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+        return _flush();
+    }
+  }
+
+  Future<void> _flush() {
+    _flushRequested = true;
+    final Future<void>? pending = _flushInFlight;
+    if (pending != null) return pending;
+    final Completer<void> completion = Completer<void>();
+    _flushInFlight = completion.future;
+    unawaited(_drain(completion));
+    return completion.future;
+  }
+
+  Future<void> _drain(Completer<void> completion) async {
+    try {
+      do {
+        _flushRequested = false;
+        await _registry.flushAll(clearCallbacks: false);
+        // A later view event can arrive after the registry took its snapshot.
+        // Drain that request serially so newly deferred page writes are saved.
+      } while (_flushRequested);
+      completion.complete();
+    } catch (error, stack) {
+      completion.completeError(error, stack);
+    } finally {
+      _flushInFlight = null;
+    }
+  }
+}

--- a/fushi/test/native/windows_single_instance_guard_static_test.dart
+++ b/fushi/test/native/windows_single_instance_guard_static_test.dart
@@ -23,7 +23,8 @@ void main() {
     final String src = read('windows/runner/main.cpp');
 
     // 必须是真正的运行期检查（GetLastError），而非仅注释提到。
-    expect(src.contains('GetLastError() == ERROR_ALREADY_EXISTS'), isTrue,
+    expect(read('windows/runner/single_instance_mutex.h')
+        .contains('GetLastError() == ERROR_ALREADY_EXISTS'), isTrue,
         reason: '必须检测 GetLastError()==ERROR_ALREADY_EXISTS（真单实例守卫）');
     // TODO-935：数据迁移自动重启会以 detached 模式拉起带 --fushi-restarted 标志的新
     // 进程，但旧进程此刻仍持单实例互斥量。带该标志命中已有实例时必须**等待**旧进程
@@ -54,7 +55,7 @@ void main() {
         reason: '第二实例退出前必须经 WM_COPYDATA 把视频路径转交首实例（不能丢路径）');
 
     // 转交必须发生在 ERROR_ALREADY_EXISTS 早退分支内（退出之前）。
-    final int idx = src.indexOf('GetLastError() == ERROR_ALREADY_EXISTS');
+    final int idx = src.indexOf('if (another_instance)');
     final int exitIdx = src.indexOf('return EXIT_SUCCESS;', idx >= 0 ? idx : 0);
     final int handoffIdx = src.indexOf('::fushi::SendExternalVideoPath(');
     expect(idx >= 0 && handoffIdx > idx && handoffIdx < exitIdx, isTrue,

--- a/fushi/test/platform/windows_restart_single_instance_guard_test.dart
+++ b/fushi/test/platform/windows_restart_single_instance_guard_test.dart
@@ -38,6 +38,7 @@ void main() {
 
     test('native runner：带重启标志检测到已有实例时等待互斥量、不直接退出', () {
       final String src = readSource('windows/runner/main.cpp');
+      final String mutex = readSource('windows/runner/single_instance_mutex.h');
 
       // native 侧重启标志常量字面量必须与 Dart 侧一致。
       expect(
@@ -52,7 +53,7 @@ void main() {
       // 把 another_instance 置回 false 继续启动（而不是直接前置旧窗口退出）。
       expect(src.contains('HasRestartMarker()'), isTrue,
           reason: 'runner must detect the restart marker in argv');
-      expect(src.contains('WaitForSingleInstanceMutex('), isTrue,
+      expect(src.contains('single_instance_mutex.Wait('), isTrue,
           reason: 'runner must wait for the old instance to release the mutex '
               'instead of bailing out on a restart');
       expect(
@@ -64,10 +65,10 @@ void main() {
 
       // 等待逻辑接受 WAIT_OBJECT_0 / WAIT_ABANDONED（旧进程释放或未释放就退出都算
       // 「旧实例已走、本进程接管」），并加超时上界避免永久卡死。
-      expect(src.contains('WAIT_ABANDONED'), isTrue,
+      expect(mutex.contains('WAIT_ABANDONED'), isTrue,
           reason: 'an abandoned mutex (old process exited without release) '
               'must also count as taking over single-instance ownership');
-      expect(src.contains('WaitForSingleInstanceMutex(single_instance_mutex'),
+      expect(src.contains('single_instance_mutex.Wait(10000)'),
           isTrue,
           reason: 'the wait must be bounded so a stuck old process cannot hang '
               'the restart forever');

--- a/fushi/test/startup/android_view_lifecycle_test.dart
+++ b/fushi/test/startup/android_view_lifecycle_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/startup/android_view_lifecycle.dart';
+import 'package:fushi/src/startup/exit_flush_registry.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+void main() {
+  late FushiDatabase db;
+  late AndroidViewLifecycle lifecycle;
+  final ExitFlushRegistry registry = ExitFlushRegistry.instance;
+
+  setUp(() async {
+    registry.clear();
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    await db.setPref('position', '0');
+    lifecycle = AndroidViewLifecycle(registry: registry);
+  });
+
+  tearDown(() async {
+    registry.clear();
+    await db.close();
+  });
+
+  test(
+    'BUG-2280 detach and reattach retain DB and later page flushes',
+    () async {
+      int position = 12;
+      registry.register(() => db.setPref('position', position.toString()));
+
+      await lifecycle.handleState(AppLifecycleState.detached);
+      expect(await db.getPref('position'), '12');
+      await lifecycle.handleState(AppLifecycleState.resumed);
+      await db.setPref('service-write', 'still-running');
+      expect(await db.getPref('service-write'), 'still-running');
+
+      position = 24;
+      await lifecycle.handleState(AppLifecycleState.detached);
+      expect(await db.getPref('position'), '24');
+      expect(registry.callbackCount, 1);
+    },
+  );
+
+  test(
+    'reattach during pending flush never schedules a later DB shutdown',
+    () async {
+      final Completer<void> release = Completer<void>();
+      int calls = 0;
+      int active = 0;
+      int maxActive = 0;
+      registry.register(() async {
+        calls++;
+        active++;
+        if (active > maxActive) maxActive = active;
+        await release.future;
+        await db.setPref('position', calls.toString());
+        active--;
+      });
+
+      final Future<void> paused = lifecycle.handleState(
+        AppLifecycleState.paused,
+      );
+      await lifecycle.handleState(AppLifecycleState.resumed);
+      await db.setPref('foreground-write', 'during-flush');
+      registry.defer(() => db.setPref('newly-disposed-page', 'saved'));
+      final Future<void> detached = lifecycle.handleState(
+        AppLifecycleState.detached,
+      );
+      expect(identical(paused, detached), isTrue);
+      release.complete();
+      await detached;
+      expect(calls, 2);
+      expect(maxActive, 1, reason: 'queued flushes must run serially');
+      expect(await db.getPref('newly-disposed-page'), 'saved');
+      expect(registry.deferredCount, 0);
+      expect(await db.getPref('foreground-write'), 'during-flush');
+
+      await db.setPref('foreground-write', 'after-flush');
+      await lifecycle.handleState(AppLifecycleState.detached);
+      expect(await db.getPref('position'), '3');
+      expect(await db.getPref('foreground-write'), 'after-flush');
+    },
+  );
+
+  test(
+    'background states persist pages and consume disposed-page writes once',
+    () async {
+      int writes = 0;
+      int deferred = 0;
+      registry.register(() async {
+        await db.setPref('position', (++writes).toString());
+      });
+      registry.defer(() async {
+        deferred++;
+        await db.setPref('disposed-page', '42');
+      });
+      for (final AppLifecycleState state in <AppLifecycleState>[
+        AppLifecycleState.inactive,
+        AppLifecycleState.hidden,
+        AppLifecycleState.paused,
+        AppLifecycleState.detached,
+      ]) {
+        await lifecycle.handleState(state);
+      }
+      expect(await db.getPref('position'), '4');
+      expect(await db.getPref('disposed-page'), '42');
+      expect(deferred, 1);
+      await lifecycle.handleState(AppLifecycleState.resumed);
+      expect(writes, 4);
+    },
+  );
+}

--- a/fushi/test/startup/desktop_window_state_memory_test.dart
+++ b/fushi/test/startup/desktop_window_state_memory_test.dart
@@ -196,7 +196,7 @@ void main() {
           reason: '必须能把「正在退出」和「正常运行」区分开');
       final int probeAt = runner.indexOf('::IsWindowVisible(exiting)');
       final int waitAt =
-          runner.indexOf('WaitForSingleInstanceMutex', probeAt);
+          runner.indexOf('single_instance_mutex.Wait', probeAt);
       expect(waitAt, greaterThan(probeAt),
           reason: '认出它在退出之后要等它释放互斥量，然后本进程按首实例正常启动');
       final int handoffAt =

--- a/fushi/test/startup/exit_flush_test.dart
+++ b/fushi/test/startup/exit_flush_test.dart
@@ -185,35 +185,25 @@ void main() {
           reason: '根因B：Bonsoir 退出超时从 3s 收紧到 1.5s');
     });
 
-    test('Android background lifecycle flushes active page callbacks', () {
-      final int hookAt =
-          main.indexOf('_flushActivePagesForAndroidBackground() async');
-      expect(hookAt, greaterThanOrEqualTo(0),
-          reason: 'Android pause/hidden needs an app-level awaited flush; '
-              'page-local unawaited flush can lose the write if the process is '
-              'reclaimed immediately after backgrounding');
-      final String body = main.substring(hookAt);
-      expect(body.contains('flushAll(clearCallbacks: false)'), isTrue,
-          reason: 'background flush must retain page callbacks for a later '
-              'resume/exit cycle');
-
+    test('Android view events return before destructive detach cleanup', () {
       final int lifecycleAt = main
           .indexOf('void didChangeAppLifecycleState(AppLifecycleState state)');
       expect(lifecycleAt, greaterThanOrEqualTo(0));
-      final String lifecycle = main.substring(lifecycleAt);
-      expect(lifecycle.contains('AppLifecycleState.paused'), isTrue);
-      expect(lifecycle.contains('AppLifecycleState.hidden'), isTrue);
-      expect(
-          lifecycle.contains('_flushActivePagesForAndroidBackground()'), isTrue,
-          reason: 'Android paused/hidden must trigger the retained flush');
+      final int androidAt = main.indexOf('if (Platform.isAndroid)', lifecycleAt);
+      final int androidEnd = main.indexOf('\n    }', androidAt);
+      final String android = main.substring(androidAt, androidEnd);
+      expect(android, contains('_androidViewLifecycle.handleState(state)'));
+      expect(android, contains('return;'));
+      expect(android, isNot(contains('_flushAndCloseForLifecycleDetach')));
+      expect(android, isNot(contains('closeDatabase')));
+      expect(android, isNot(contains('_shutdownStarted')));
     });
 
-    test('detached lifecycle flushes active pages and closes the database', () {
+    test('non-Android detach fallback flushes before closing the database', () {
       final int hookAt =
           main.indexOf('_flushAndCloseForLifecycleDetach() async');
       expect(hookAt, greaterThanOrEqualTo(0),
-          reason: 'mobile detached is the last chance before engine/process '
-              'teardown, so it must run the same data durability gate as exit');
+          reason: 'non-Android fallback must retain its existing exit gate');
 
       final String body = main.substring(hookAt);
       final int flushAt = body.indexOf('ExitFlushRegistry.instance.flushAll()');

--- a/fushi/windows/runner/main.cpp
+++ b/fushi/windows/runner/main.cpp
@@ -8,6 +8,7 @@
 #include "crash_dump.h"
 #include "external_video_handoff.h"
 #include "flutter_window.h"
+#include "single_instance_mutex.h"
 #include "utils.h"
 
 namespace {
@@ -59,24 +60,6 @@ bool HasRestartMarker() {
   }
   ::LocalFree(argv);
   return found;
-}
-
-// 等待旧实例释放单实例互斥量（[mutex] 由 CreateMutexW 返回、本进程未持有所有权）。
-// 自动重启时旧进程已开始退出序列（prepareForProcessExit + exit(0)），但「拉起新进程」
-// 与「旧进程真正退出」之间有一小段并发窗口：此刻互斥量仍被旧进程持有，新进程裸调
-// CreateMutexW 会拿到 ERROR_ALREADY_EXISTS 而被误判成「二次启动」直接退出，导致重启
-// 落空——数据已迁移但应用从未以新数据根重新初始化（用户感知「弹了下进度就重启、位置没变」）。
-// 这里用 WaitForSingleObject 阻塞到旧进程退出（其句柄关闭 → 互斥量被遗弃 → 本进程拿到
-// WAIT_ABANDONED/WAIT_OBJECT_0 即取得所有权），加超时上界避免旧进程异常不退时永久卡死。
-// 返回 true = 已取得所有权可继续启动；false = 超时（旧实例仍在，按二次启动语义放弃）。
-bool WaitForSingleInstanceMutex(HANDLE mutex, DWORD timeout_ms) {
-  if (mutex == nullptr) {
-    return false;
-  }
-  const DWORD wait = ::WaitForSingleObject(mutex, timeout_ms);
-  // WAIT_OBJECT_0：正常取得；WAIT_ABANDONED：上一持有者（旧进程）未释放就退出，所有权
-  // 移交本进程——对单实例守卫语义而言同样是「旧实例已走、我接管」，可继续启动。
-  return wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED;
 }
 
 // TODO-1003: 本进程是否为自动化集成测试 runner。itest harness（tool/run_windows_itest.ps1）
@@ -174,15 +157,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // 集成测试 runner（FUSHI_TEST_HIDDEN 非空）跳过整套单实例守卫——见 IsTestRunnerMode
   // 注释：否则撞用户实例的互斥量会在引擎初始化前退出，itest 无法 attach。
   const bool test_runner = IsTestRunnerMode();
-  HANDLE single_instance_mutex = nullptr;
-  bool another_instance = false;
-  if (!test_runner) {
-    ::SetLastError(ERROR_SUCCESS);
-    single_instance_mutex =
-        ::CreateMutexW(nullptr, FALSE, L"FushiSingleInstanceMutex");
-    another_instance = single_instance_mutex != nullptr &&
-                       ::GetLastError() == ERROR_ALREADY_EXISTS;
+  ::fushi::SingleInstanceMutex single_instance_mutex(
+      L"FushiSingleInstanceMutex", !test_runner);
+  if (!test_runner && !single_instance_mutex.valid()) {
+    ::OutputDebugStringW(L"Fushi: cannot acquire single-instance guard.\n");
+    return EXIT_FAILURE;  // Fail closed: never start an unguarded engine.
   }
+  bool another_instance = !test_runner && !single_instance_mutex.owns();
   // TODO-935 BUG 修复：数据迁移后的自动重启会以 detached 模式拉起带 [kRestartMarkerArg]
   // 的新进程，但此刻旧进程尚未走完退出序列、仍持有单实例互斥量。若直接按「二次启动」
   // 退出本进程，则重启落空：数据已迁到新根、data_root pref 已写，但应用从未重新初始化
@@ -191,7 +172,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // AppPaths.resolve() 即读到新 data_root。等待加 10s 上界，旧进程异常不退时退回二次
   // 启动语义（前置旧窗口 + 退出），不永久卡死。普通用户二次点击图标无此标志，行为不变。
   if (another_instance && HasRestartMarker()) {
-    if (WaitForSingleInstanceMutex(single_instance_mutex, 10000)) {
+    if (single_instance_mutex.Wait(10000)) {
       another_instance = false;  // 已接管单实例所有权：按首实例正常启动。
     }
   }
@@ -201,13 +182,14 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // 是两头落空：文件转交给一个马上就没的进程 = 路径整个丢掉；前置一个看不见的窗口
   // = 用户双击视频「点了没反应」（TODO-904 修过的正是这个形态）。
   //
+  // 窗口已销毁或尚未创建时也必须等待所有权，不能凭窗口不存在放行。
   // 判据用「主窗口不可见」：本 app 没有托盘，`windowManager.hide()` 全仓只有退出链
   // 那一个调用点，所以不可见 ⇔ 正在退出。等它释放互斥量再按首实例正常启动——复用
   // 重启标志那条路已经在用的等待机械，新实例自己就能打开那个视频。
   if (another_instance && !test_runner) {
     const HWND exiting = ::FindWindowW(nullptr, L"Fushi");
-    if (exiting != nullptr && !::IsWindowVisible(exiting)) {
-      if (WaitForSingleInstanceMutex(single_instance_mutex, 10000)) {
+    if (exiting == nullptr || !::IsWindowVisible(exiting)) {
+      if (single_instance_mutex.Wait(10000)) {
         another_instance = false;
       }
     }
@@ -231,8 +213,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
       }
       ::SetForegroundWindow(existing);
     }
-    ::ReleaseMutex(single_instance_mutex);
-    ::CloseHandle(single_instance_mutex);
     return EXIT_SUCCESS;
   }
 

--- a/fushi/windows/runner/single_instance_mutex.h
+++ b/fushi/windows/runner/single_instance_mutex.h
@@ -1,0 +1,51 @@
+#ifndef RUNNER_SINGLE_INSTANCE_MUTEX_H_
+#define RUNNER_SINGLE_INSTANCE_MUTEX_H_
+
+#include <windows.h>
+
+namespace fushi {
+
+// BUG-2279: Creating a handle is not ownership. Keep the main thread's
+// ownership until after the Flutter window/engine have been destroyed.
+// Use only on the creating thread (Win32 mutex ownership is thread-affine).
+class SingleInstanceMutex {
+ public:
+  explicit SingleInstanceMutex(const wchar_t* name, bool enabled = true) {
+    if (!enabled) return;
+    ::SetLastError(ERROR_SUCCESS);
+    handle_ = ::CreateMutexW(nullptr, TRUE, name);
+    const bool existing = ::GetLastError() == ERROR_ALREADY_EXISTS;
+    owns_ = handle_ != nullptr && !existing;
+    // A prior process can already be gone while another candidate still has
+    // an open handle. Object existence alone must not prevent taking over.
+    if (handle_ != nullptr && existing) Wait(0);
+  }
+
+  ~SingleInstanceMutex() {
+    if (owns_) ::ReleaseMutex(handle_);
+    if (handle_ != nullptr) ::CloseHandle(handle_);
+  }
+
+  SingleInstanceMutex(const SingleInstanceMutex&) = delete;
+  SingleInstanceMutex& operator=(const SingleInstanceMutex&) = delete;
+
+  bool valid() const { return handle_ != nullptr; }
+  bool owns() const { return owns_; }
+
+  bool Wait(DWORD timeout_ms) {
+    // Avoid recursively acquiring a Win32 mutex: one release must suffice.
+    if (owns_) return true;
+    if (handle_ == nullptr) return false;
+    const DWORD result = ::WaitForSingleObject(handle_, timeout_ms);
+    owns_ = result == WAIT_OBJECT_0 || result == WAIT_ABANDONED;
+    return owns_;
+  }
+
+ private:
+  HANDLE handle_ = nullptr;
+  bool owns_ = false;
+};
+
+}  // namespace fushi
+
+#endif  // RUNNER_SINGLE_INSTANCE_MUTEX_H_

--- a/fushi/windows/runner/tests/run_single_instance_mutex_test.ps1
+++ b/fushi/windows/runner/tests/run_single_instance_mutex_test.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio/Installer/vswhere.exe'
+$installation = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+if (!$installation) { throw 'MSVC x64 tools are required for the native mutex test.' }
+$vcvars = Join-Path $installation 'VC/Auxiliary/Build/vcvars64.bat'
+$outputDir = Join-Path ([IO.Path]::GetTempPath()) ('fushi-mutex-test-' + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $outputDir | Out-Null
+$source = Join-Path $PSScriptRoot 'single_instance_mutex_test.cpp'
+$command = @"
+@echo off
+call "$vcvars" >nul
+if errorlevel 1 exit /b 1
+cl /nologo /std:c++17 /EHsc /W4 /WX "$source" /Fo"$outputDir/test.obj" /Fe"$outputDir/test.exe"
+if errorlevel 1 exit /b 1
+"$outputDir/test.exe"
+"@
+$script = Join-Path $outputDir 'build.cmd'
+Set-Content -LiteralPath $script -Value $command -Encoding ascii
+& cmd /c $script
+if ($LASTEXITCODE -ne 0) { throw "Native mutex test failed; artifacts: $outputDir" }
+Write-Host "Native mutex test artifacts: $outputDir"

--- a/fushi/windows/runner/tests/single_instance_mutex_test.cpp
+++ b/fushi/windows/runner/tests/single_instance_mutex_test.cpp
@@ -1,0 +1,114 @@
+#include "../single_instance_mutex.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+void Check(bool ok, const char* message) {
+  if (!ok) {
+    std::cerr << "FAIL: " << message << " error=" << GetLastError() << '\n';
+    std::exit(1);
+  }
+}
+
+int wmain(int argc, wchar_t** argv) {
+  if (argc == 3) {
+    fushi::SingleInstanceMutex owner(argv[1]);
+    Check(owner.valid() && owner.owns(), "child owns new mutex");
+    HANDLE ready = OpenEventW(EVENT_MODIFY_STATE, FALSE, argv[2]);
+    Check(ready != nullptr && SetEvent(ready), "child ready");
+    // The parent terminates this isolated test process, exercising kernel
+    // abandonment exactly as exit(0)/a crash does without C++ stack unwinding.
+    Sleep(INFINITE);
+    return 1;
+  }
+
+  const std::wstring name = L"Local\\FushiMutexTest-" +
+                            std::to_wstring(GetCurrentProcessId());
+  const std::wstring ready_name = name + L"-ready";
+  HANDLE ready = CreateEventW(nullptr, TRUE, FALSE, ready_name.c_str());
+  Check(ready != nullptr, "create ready event");
+  wchar_t exe[MAX_PATH];
+  Check(GetModuleFileNameW(nullptr, exe, MAX_PATH) != 0, "test executable");
+  std::wstring command = L"\"" + std::wstring(exe) + L"\" \"" + name +
+                         L"\" \"" + ready_name + L"\"";
+  STARTUPINFOW startup = {};
+  startup.cb = sizeof(startup);
+  PROCESS_INFORMATION child = {};
+  Check(CreateProcessW(nullptr, command.data(), nullptr, nullptr, FALSE,
+                       CREATE_NO_WINDOW, nullptr, nullptr, &startup, &child),
+        "launch isolated owner process");
+  Check(WaitForSingleObject(ready, 5000) == WAIT_OBJECT_0, "owner became ready");
+
+  {
+    fushi::SingleInstanceMutex candidate(name.c_str());
+    Check(candidate.valid() && !candidate.owns(), "live owner blocks takeover");
+    Check(!candidate.Wait(30), "bounded wait cannot steal a live owner");
+  }
+  fushi::SingleInstanceMutex successor(name.c_str());
+  Check(!successor.owns(), "destroying non-owner did not release owner's lock");
+  Check(TerminateProcess(child.hProcess, 0), "end isolated owner");
+  Check(WaitForSingleObject(child.hProcess, 5000) == WAIT_OBJECT_0, "owner exited");
+  Check(successor.Wait(5000), "abandoned ownership transfers after process exit");
+  Check(successor.Wait(0), "repeat wait does not acquire recursively");
+
+  // Two candidates race after their old owner releases. Keep the winner alive
+  // until the loser has timed out: exactly one may enter engine startup.
+  HANDLE gate = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  HANDLE release_winner = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+  std::atomic<int> entered{0};
+  std::atomic<int> finished_wait{0};
+  const std::wstring race_name = name + L"-race";
+  // Keep a non-owning handle open so this is the same kernel object after the
+  // old owner's destructor; creating a fresh object would hide bad releases.
+  HANDLE race_handle = nullptr;
+  auto compete = [&]() {
+    WaitForSingleObject(gate, INFINITE);
+    fushi::SingleInstanceMutex candidate(race_name.c_str());
+    const bool acquired = candidate.Wait(100);
+    if (acquired) ++entered;
+    ++finished_wait;
+    if (acquired) WaitForSingleObject(release_winner, INFINITE);
+  };
+  std::thread first;
+  std::thread second;
+  {
+    fushi::SingleInstanceMutex old(race_name.c_str());
+    Check(old.owns(), "race old owner acquired");
+    Check(old.Wait(0), "owner wait is idempotent");
+    race_handle = OpenMutexW(SYNCHRONIZE, FALSE, race_name.c_str());
+    Check(race_handle != nullptr, "retain race object identity");
+    first = std::thread(compete);
+    second = std::thread(compete);
+  }
+  SetEvent(gate);
+  const ULONGLONG deadline = GetTickCount64() + 5000;
+  while (finished_wait.load() < 2 && GetTickCount64() < deadline) Sleep(1);
+  Check(finished_wait == 2 && entered == 1, "only one concurrent successor enters");
+  SetEvent(release_winner);
+  first.join();
+  second.join();
+  {
+    fushi::SingleInstanceMutex next(race_name.c_str());
+    Check(next.owns(), "normal destructor releases for later launch");
+  }
+
+  // Name collision with another kernel object makes CreateMutex fail. It must
+  // stay invalid/non-owning, never silently opt out of the guard.
+  fushi::SingleInstanceMutex invalid(ready_name.c_str());
+  Check(!invalid.valid() && !invalid.owns() && !invalid.Wait(0),
+        "creation failure never grants ownership");
+  fushi::SingleInstanceMutex disabled(name.c_str(), false);
+  Check(!disabled.valid() && !disabled.owns(), "test runner opt-out owns no mutex");
+  CloseHandle(child.hThread);
+  CloseHandle(child.hProcess);
+  CloseHandle(ready);
+  CloseHandle(gate);
+  CloseHandle(release_winner);
+  CloseHandle(race_handle);
+  std::cout << "PASS: live owner, non-owner cleanup, process-exit takeover, "
+               "concurrent successors, normal release, creation failure, test opt-out\n";
+  return 0;
+}


### PR DESCRIPTION
快速关闭并重开可能让 Android 复用已被关闭数据库的音频引擎，或让 Windows 新实例在旧实例清理完成前启动。本 PR 修正两个资源生命周期契约（BUG-2279 / BUG-2280）。

- Android view 脱离只保存待写数据，保留引擎拥有的数据库、后台服务和页面回调；保存期间的新请求串行补存，包含旧快照之后新增的 deferred 写。
- Windows 首实例真正取得并持续持有命名互斥量，只由 owner 释放；新实例等待真实交接，创建失败不绕过保护。包含原生多进程/线程行为测试。

验证：
- 接到最新 develop 并解决生成索引冲突后，37 项定向 Flutter 测试通过，全量 flutter analyze --no-pub 通过，Android debug APK 再构建通过。
- MSVC /W4 /WX 原生测试通过：存活 owner、退出接管、多候选竞争、非 owner 清理、正常释放、创建失败。
- API 34 模拟器返回桌面重开、CLEAR_TASK|NEW_TASK 重建 Activity 后 PID 和插件实例不变，确认同引擎复用；延后约 30 秒界面正常，无关库异常。设备验证发生在更新目标分支之前；Android 生命周期修复代码保持相同。
- 初次相邻 76 文件检查 775 通过、4 失败。更新目标分支后，3 项 Bug 编号工具失败串行复测通过；旧 macOS 断言已由目标分支替换，当前该文件 7 项通过。没有将初次整批结果改写为全绿。
- Bug 编号跨分支检查通过。

尚未验证：Windows 完整应用构建及真实重开、手机音频保活与阅读位置保存的完整 E2E、iOS。模拟器 x86_64 存在独立 ffmpeg-kit ABI 库缺失警告，未修本轮范围外问题。旧未修复 Windows 二进制不拥有锁，首次换版须先完全退出旧版；本修复保证修复版本间的交接。
