### PR TITLE
feat(profile): 语言级 Profile 绑定（schema v99）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 76143 (4479 per locale)
+/// Strings: 76177 (4481 per locale)
 ///
-/// Built on 2026-09-08 at 13:52 UTC
+/// Built on 2026-09-08 at 15:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6210,6 +6210,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  String get profile_language_bindings => 'Language bindings';
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -16727,6 +16730,11 @@ class _StringsAr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -27471,6 +27479,11 @@ class _StringsDe extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -38268,6 +38281,11 @@ class _StringsEs extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -49099,6 +49117,11 @@ class _StringsFr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -59733,6 +59756,11 @@ class _StringsId extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -70458,6 +70486,11 @@ class _StringsIt extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -80563,6 +80596,11 @@ class _StringsJa extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -90678,6 +90716,11 @@ class _StringsKo extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -101361,6 +101404,11 @@ class _StringsNl extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -112096,6 +112144,11 @@ class _StringsPtBr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -122809,6 +122862,11 @@ class _StringsRu extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -133320,6 +133378,11 @@ class _StringsTh extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -143949,6 +144012,11 @@ class _StringsTr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -154549,6 +154617,11 @@ class _StringsVi extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 // Path: <root>
@@ -164283,6 +164356,11 @@ class _StringsZhCn extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       '已重排 ${count} 张新卡；${skipped} 张已不再是新卡，未改动。';
+  @override
+  String get profile_language_bindings => '语言绑定';
+  @override
+  String get profile_language_bindings_hint =>
+      '在条目已标注内容语言时生效。EPUB 会自动读取文件里的声明；其它格式需要在条目上手动指定。';
 }
 
 // Path: <root>
@@ -174076,6 +174154,11 @@ class _StringsZhHk extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get profile_language_bindings => 'Language bindings';
+  @override
+  String get profile_language_bindings_hint =>
+      'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
 }
 
 /// Flat map(s) containing all translations.
@@ -183287,6 +183370,10 @@ extension on _StringsEn {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -192493,6 +192580,10 @@ extension on _StringsAr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -201744,6 +201835,10 @@ extension on _StringsDe {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -210986,6 +211081,10 @@ extension on _StringsEs {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -220237,6 +220336,10 @@ extension on _StringsFr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -229459,6 +229562,10 @@ extension on _StringsId {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -238703,6 +238810,10 @@ extension on _StringsIt {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -247874,6 +247985,10 @@ extension on _StringsJa {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -257049,6 +257164,10 @@ extension on _StringsKo {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -266286,6 +266405,10 @@ extension on _StringsNl {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -275518,6 +275641,10 @@ extension on _StringsPtBr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -284757,6 +284884,10 @@ extension on _StringsRu {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -293968,6 +294099,10 @@ extension on _StringsTh {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -303194,6 +303329,10 @@ extension on _StringsTr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -312414,6 +312553,10 @@ extension on _StringsVi {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }
@@ -321554,6 +321697,10 @@ extension on _StringsZhCn {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             '已重排 ${count} 张新卡；${skipped} 张已不再是新卡，未改动。';
+      case 'profile_language_bindings':
+        return '语言绑定';
+      case 'profile_language_bindings_hint':
+        return '在条目已标注内容语言时生效。EPUB 会自动读取文件里的声明；其它格式需要在条目上手动指定。';
       default:
         return null;
     }
@@ -330703,6 +330850,10 @@ extension on _StringsZhHk {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'profile_language_bindings':
+        return 'Language bindings';
+      case 'profile_language_bindings_hint':
+        return 'Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Fushi will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "تعذر إنهاء $process. يرجى إنهاؤها يدوياً ثم إعادة المحاولة.",
   "yomitan_port_kill_protected": "$process هي عملية نظام حرجة — لن يقوم Fushi بإنهائها. غيّر المنفذ بدلاً من ذلك.",
   "yomitan_port_kill_self_instance": "هذه العملية هي نسخة أخرى قيد التشغيل من هذا التطبيق.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "$process konnte nicht beendet werden. Bitte beenden Sie ihn manuell und versuchen Sie es erneut.",
   "yomitan_port_kill_protected": "$process ist ein kritischer Systemprozess – Fushi wird ihn nicht beenden. Ändern Sie stattdessen den Port.",
   "yomitan_port_kill_self_instance": "Dieser Prozess ist eine weitere laufende Instanz dieser App.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "No se pudo finalizar $process. Finalícelo manualmente, luego reintente.",
   "yomitan_port_kill_protected": "$process es un proceso crítico del sistema — Fushi no lo finalizará. Cambie el puerto en su lugar.",
   "yomitan_port_kill_self_instance": "Este proceso es otra instancia en ejecución de esta app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Impossible d'arrêter $process. Veuillez l'arrêter manuellement, puis réessayez.",
   "yomitan_port_kill_protected": "$process est un processus système critique — Fushi ne l'arrêtera pas. Changez de port à la place.",
   "yomitan_port_kill_self_instance": "Ce processus est une autre instance en cours d'exécution de cette application.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Tidak bisa mengakhiri $process. Silakan akhiri secara manual, lalu coba lagi.",
   "yomitan_port_kill_protected": "$process adalah proses sistem penting — Fushi tidak akan mengakhirinya. Ganti port saja.",
   "yomitan_port_kill_self_instance": "Proses ini adalah instance lain dari aplikasi ini yang sedang berjalan.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Impossibile terminare $process. Terminalo manualmente, poi riprova.",
   "yomitan_port_kill_protected": "$process è un processo di sistema critico — Fushi non lo terminerà. Cambia la porta.",
   "yomitan_port_kill_self_instance": "Questo processo è un'altra istanza in esecuzione di questa app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "$processを終了できませんでした。手動で終了してから再試行してください。",
   "yomitan_port_kill_protected": "$processは重要なシステムプロセスです — Fushiでは終了しません。代わりにポートを変更してください。",
   "yomitan_port_kill_self_instance": "このプロセスは、このアプリの別のインスタンスです。",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "$process를 종료할 수 없습니다. 수동으로 종료한 후 다시 시도하세요.",
   "yomitan_port_kill_protected": "$process는 중요한 시스템 프로세스입니다. Fushi가 종료하지 않습니다. 대신 포트를 변경하세요.",
   "yomitan_port_kill_self_instance": "이 프로세스는 이 앱의 다른 실행 중인 인스턴스입니다.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Kon $process niet beëindigen. Beëindig het handmatig en probeer opnieuw.",
   "yomitan_port_kill_protected": "$process is een kritiek systeemproces — Fushi beëindigt het niet. Wijzig de poort.",
   "yomitan_port_kill_self_instance": "Dit proces is een andere draaiende instantie van deze app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Não foi possível encerrar $process. Encerre manualmente e tente novamente.",
   "yomitan_port_kill_protected": "$process é um processo crítico do sistema — o Fushi não vai encerrá-lo. Mude a porta.",
   "yomitan_port_kill_self_instance": "Este processo é outra instância deste app em execução.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Не удалось завершить $process. Пожалуйста, завершите его вручную, затем повторите.",
   "yomitan_port_kill_protected": "$process — критический системный процесс, Fushi не будет его завершать. Измените порт.",
   "yomitan_port_kill_self_instance": "Этот процесс — другой запущенный экземпляр данного приложения.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "ไม่สามารถจบ $process ได้ กรุณาจบด้วยตนเองแล้วลองใหม่",
   "yomitan_port_kill_protected": "$process เป็นโปรเซสระบบที่สำคัญ — Fushi จะไม่จบโปรเซสนี้ เปลี่ยนพอร์ตแทน",
   "yomitan_port_kill_self_instance": "โปรเซสนี้เป็นอินสแตนซ์อื่นของแอปนี้ที่กำลังทำงานอยู่",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "$process sonlandırılamadı. Lütfen manuel olarak sonlandırıp tekrar deneyin.",
   "yomitan_port_kill_protected": "$process kritik bir sistem işlemidir — Fushi onu sonlandırmaz. Bunun yerine portu değiştirin.",
   "yomitan_port_kill_self_instance": "Bu işlem, uygulamanın çalışan başka bir örneğidir.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "Không thể kết thúc $process. Vui lòng kết thúc thủ công rồi thử lại.",
   "yomitan_port_kill_protected": "$process là tiến trình hệ thống quan trọng — Fushi sẽ không kết thúc nó. Hãy đổi cổng thay vì vậy.",
   "yomitan_port_kill_self_instance": "Tiến trình này là một phiên bản đang chạy khác của ứng dụng.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "无法结束 $process，请手动结束该进程后重试。",
   "yomitan_port_kill_protected": "$process 是关键系统进程，Fushi 不会结束它；请改用其他端口。",
   "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。",
-  "anki_reposition_done_skipped": "已重排 $count 张新卡；$skipped 张已不再是新卡，未改动。"
+  "anki_reposition_done_skipped": "已重排 $count 张新卡；$skipped 张已不再是新卡，未改动。",
+  "profile_language_bindings": "语言绑定",
+  "profile_language_bindings_hint": "在条目已标注内容语言时生效。EPUB 会自动读取文件里的声明；其它格式需要在条目上手动指定。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4477,5 +4477,7 @@
   "yomitan_port_kill_failed": "無法結束 $process，請手動結束該進程後重試。",
   "yomitan_port_kill_protected": "$process 是關鍵系統進程，Fushi 不會結束它；請改用其他端口。",
   "yomitan_port_kill_self_instance": "該進程是本應用的另一個正在運行的實例。",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "profile_language_bindings": "Language bindings",
+  "profile_language_bindings_hint": "Applies when an item has its content language set. EPUB books read it from the file; for other formats set it on the item itself."
 }

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -1054,14 +1054,29 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     // TODO-2936：应用「漫画」媒体类型 / 本书 book 级的 Profile 绑定（与 EPUB/
     // 视频阅读器同范式：非致命、与开书链并行；漫画的 bookKey 就是 Profile 的
     // book 级 entryKey，见 book_format_convert.dart 的身份说明）。
-    unawaited(
-      ref
-          .read(profileViewModelProvider.notifier)
-          .autoApplyBinding(
-            bookUid: widget.bookKey,
-            mediaType: ProfileMediaKind.manga,
-          ),
-    );
+    unawaited(_resolveAndApplyMangaProfile());
+  }
+
+  /// 解析并应用 Profile 绑定（book 级 > 语言级 > 'manga' 媒体类型级 > 当前激活）。
+  ///
+  /// 漫画与 EPUB 共用 `epub_books` 表，语言取该行的 `language` 列。**注意当前它
+  /// 对漫画基本恒为 NULL**：`manga_importer` 的插入不带 language（CBZ / 图片包
+  /// 没有任何语言声明可读，PDF 也没有稳定的 `dc:language` 对应物），只有用户手动
+  /// 指定过的行才有值。通道在此接通，值有没有是数据侧的事——恒 NULL 时语言级整级
+  /// 跳过，行为与接通前逐字节一致。
+  Future<void> _resolveAndApplyMangaProfile() async {
+    String? languageTag;
+    try {
+      languageTag =
+          (await appModel.database.getEpubBook(widget.bookKey))?.language;
+    } catch (e, st) {
+      debugPrint('[MangaFushi] 读内容语言失败（非致命，退回媒体类型绑定）: $e\n$st');
+    }
+    await ref.read(profileViewModelProvider.notifier).autoApplyBinding(
+          bookUid: widget.bookKey,
+          languageTag: languageTag,
+          mediaType: ProfileMediaKind.manga,
+        );
   }
 
   @override

--- a/fushi/lib/src/migration/migration_manifest.dart
+++ b/fushi/lib/src/migration/migration_manifest.dart
@@ -79,6 +79,7 @@ class MigrationManifest {
     'profile_settings',
     'media_type_profiles',
     'book_profiles',
+    'language_profiles',
   ];
 
   Map<String, Object?> toJson() => <String, Object?>{

--- a/fushi/lib/src/pages/implementations/galgame_home_page.dart
+++ b/fushi/lib/src/pages/implementations/galgame_home_page.dart
@@ -282,11 +282,13 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
       if (!installed || !mounted) return;
       final GalHookSessionController controller =
           widget.sessionController ?? GalHookSessionController.instance;
-      // TODO-2936：应用「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // TODO-2936：应用语言级 / 「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // 语言取该游戏卡上用户指定的 `galgames.language`（hook 文本无语言声明可读）。
       unawaited(
-        ref
-            .read(profileViewModelProvider.notifier)
-            .autoApplyBinding(mediaType: ProfileMediaKind.game),
+        ref.read(profileViewModelProvider.notifier).autoApplyBinding(
+              languageTag: game.language,
+              mediaType: ProfileMediaKind.game,
+            ),
       );
       final GalHookLaunchResult result = await controller.launchGame(
         game.exePath,

--- a/fushi/lib/src/pages/implementations/games_library_page.dart
+++ b/fushi/lib/src/pages/implementations/games_library_page.dart
@@ -593,11 +593,15 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       if (!installed || !mounted) return;
       final GalHookSessionController session =
           widget.sessionController ?? GalHookSessionController.instance;
-      // TODO-2936：应用「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // TODO-2936：应用语言级 / 「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // 语言取该游戏卡上用户指定的 `galgames.language`——hook 文本没有任何语言声明
+      // 可读，这是唯一来源；没指定就是 null，语言级整级跳过。**不能**像上面的词头
+      // 语言那样回落全局默认：那会把所有未标注游戏一起路由到同一个 Profile。
       unawaited(
-        ref
-            .read(profileViewModelProvider.notifier)
-            .autoApplyBinding(mediaType: ProfileMediaKind.game),
+        ref.read(profileViewModelProvider.notifier).autoApplyBinding(
+              languageTag: game.language,
+              mediaType: ProfileMediaKind.game,
+            ),
       );
       final GalHookLaunchResult result = await session.launchGame(
         game.exePath,

--- a/fushi/lib/src/pages/implementations/profile_management_page.dart
+++ b/fushi/lib/src/pages/implementations/profile_management_page.dart
@@ -139,6 +139,19 @@ class _ProfileManagementBodyState extends ConsumerState<ProfileManagementBody> {
             ),
           ],
         ),
+        // 语言绑定的优先级高于上面的媒体类型绑定、低于书架上的单条目绑定
+        // （book > language > mediaType > 当前激活）。
+        AdaptiveSettingsSection(
+          title: t.profile_language_bindings,
+          children: [
+            AdaptiveSettingsRow(
+              title: t.profile_language_bindings_hint,
+              titleMaxLines: 4,
+            ),
+            for (final String tag in _languageBindingTags(uiState))
+              _buildLanguageRow(tag, uiState, vm),
+          ],
+        ),
       ],
     );
   }
@@ -238,6 +251,55 @@ class _ProfileManagementBodyState extends ConsumerState<ProfileManagementBody> {
   // ---------------------------------------------------------------------------
   // Media-type binding rows
   // ---------------------------------------------------------------------------
+
+  // ---------------------------------------------------------------------------
+  // Language binding rows
+  // ---------------------------------------------------------------------------
+
+  /// 要铺出来的语言标签：内容语言选择器的标准候选（用户能在条目上设的那几个）
+  /// 打头，后面接「已绑定但不在标准候选里」的标签。
+  ///
+  /// 后半段不是多余的：`EpubBooks.language` 是从 EPUB 的 `dc:language` 自动回填
+  /// 的，值域是整个 BCP-47（一本法语书就会写进 `fr`）。少了这一段，用户给这类
+  /// 语言建的绑定会在 UI 上彻底消失——看不见、也改不掉，只能观察到「Profile 莫名
+  /// 其妙自己切了」。
+  List<String> _languageBindingTags(ProfileUiState uiState) {
+    final List<String> standard = <String>[
+      for (final ({String? tag, String label}) option
+          in kContentLanguageOptions)
+        if (option.tag != null) option.tag!,
+    ];
+    final List<String> extras = uiState.languageBindings.keys
+        .where((String tag) => !standard.contains(tag))
+        .toList()
+      ..sort();
+    return <String>[...standard, ...extras];
+  }
+
+  Widget _buildLanguageRow(
+    String languageTag,
+    ProfileUiState uiState,
+    ProfileViewModel vm,
+  ) {
+    final int? boundId = uiState.languageBindings[languageTag];
+    return AdaptiveSettingsPickerRow<int?>(
+      title: contentLanguageLabelOf(languageTag),
+      selected: boundId,
+      materialWidth: 176,
+      options: [
+        AdaptiveSettingsPickerOption<int?>(
+          value: null,
+          label: t.profile_media_none,
+        ),
+        for (final p in uiState.profiles)
+          AdaptiveSettingsPickerOption<int?>(
+            value: p.id,
+            label: p.name,
+          ),
+      ],
+      onChanged: (int? id) => vm.setLanguageBinding(languageTag, id),
+    );
+  }
 
   Widget _buildMediaTypeRow(
     String label,

--- a/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
@@ -137,6 +137,13 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
 
       final String bookKey = widget.bookKey;
 
+      // 两张内容表都查一次：媒体类型判定只需要知道「有没有」，但语言级绑定要读
+      // 它们的 language 列。`audiobooks` 表自身**没有** language 列——有声书的
+      // 语言跟着它配对的 srt_books / epub_books 行走，所以这里不按 mediaType
+      // 分支去取，两张都取、SRT 优先（有声书多数配 SRT）。
+      final srtRow = await db.getSrtBookByBookKey(bookKey);
+      final epubRow = await db.getEpubBook(bookKey);
+
       ProfileMediaKind mediaType;
       if (mediaTypeOverride != null) {
         mediaType = mediaTypeOverride;
@@ -145,15 +152,16 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
         final abRow = await db.getAudiobookByBookKey(bookKey);
         if (abRow != null) {
           mediaType = ProfileMediaKind.audiobook;
-        } else {
-          final srtRow = await db.getSrtBookByBookKey(bookKey);
-          if (srtRow != null) {
-            mediaType = ProfileMediaKind.srtbook;
-          }
+        } else if (srtRow != null) {
+          mediaType = ProfileMediaKind.srtbook;
         }
       }
 
-      await profileVm.autoApplyBinding(bookUid: bookKey, mediaType: mediaType);
+      await profileVm.autoApplyBinding(
+        bookUid: bookKey,
+        languageTag: srtRow?.language ?? epubRow?.language,
+        mediaType: mediaType,
+      );
     } catch (e, st) {
       debugPrint(
         '[ReaderFushi] profile resolution failed (non-fatal): $e\n$st',

--- a/fushi/lib/src/pages/implementations/texthooker_page.dart
+++ b/fushi/lib/src/pages/implementations/texthooker_page.dart
@@ -917,6 +917,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       return;
     }
     // TODO-2936：应用「游戏」媒体类型的 Profile 绑定（非致命、与附着并行）。
+    // 这条入口附着的是用户挑的任意外部窗口，不对应任何游戏库条目，拿不到内容语言
+    // ——**故意不传** languageTag（而不是拿全局默认凑一个值），语言级整级跳过。
     unawaited(
       ref
           .read(profileViewModelProvider.notifier)
@@ -968,11 +970,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         _appModel.galgameRepo.games,
         executable,
       );
-      // TODO-2936：应用「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // TODO-2936：应用语言级 / 「游戏」媒体类型的 Profile 绑定（非致命、与启动并行）。
+      // 语言跟着上面按 exe 路径回查到的库条目走；库里没有这个 exe（临时选的文件）
+      // → null → 语言级整级跳过，与回查不到启动参数时同一条退路。
       unawaited(
-        ref
-            .read(profileViewModelProvider.notifier)
-            .autoApplyBinding(mediaType: ProfileMediaKind.game),
+        ref.read(profileViewModelProvider.notifier).autoApplyBinding(
+              languageTag: known?.language,
+              mediaType: ProfileMediaKind.game,
+            ),
       );
       final GalHookLaunchResult result = await _session.launchGame(
         executable,

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -2119,11 +2119,25 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   /// 优先 per-book（[widget.bookUid]）绑定，其次媒体类型级 'video' 绑定，
   /// 都无则维持当前活跃 profile。镜像 [_ReaderAudiobook._resolveAndApplyProfile]
   /// 的非致命范式：失败只记日志、不打断视频加载。
-  Future<void> _resolveAndApplyVideoProfile() =>
-      ref.read(profileViewModelProvider.notifier).autoApplyBinding(
-            bookUid: widget.bookUid,
-            mediaType: ProfileMediaKind.video,
-          );
+  Future<void> _resolveAndApplyVideoProfile() async {
+    // 语言级绑定要读 `video_books.language`。本方法与视频加载并行跑，那边的
+    // `_bookRow` 此刻还没赋值，所以这里自己读一次（主键查询）。远端视频没有本地
+    // 行 → language 为 null → 语言级整级跳过，落到 'video' 媒体类型绑定。
+    //
+    // 查询失败必须与 autoApplyBinding 一样非致命：这条链绝不能打断视频加载。
+    String? languageTag;
+    try {
+      languageTag =
+          (await widget.repo.getByBookUid(widget.bookUid))?.language;
+    } catch (e, st) {
+      debugPrint('[VideoFushi] 读内容语言失败（非致命，退回媒体类型绑定）: $e\n$st');
+    }
+    await ref.read(profileViewModelProvider.notifier).autoApplyBinding(
+          bookUid: widget.bookUid,
+          languageTag: languageTag,
+          mediaType: ProfileMediaKind.video,
+        );
+  }
 
   /// TODO-1213：切换加载阶段并刷新加载态 UI（mounted 守卫）。离开「下载字幕」阶段时
   /// 一并清字幕进度（其它阶段无确定性进度，转 indeterminate）。

--- a/fushi/lib/src/profile/language_binding.dart
+++ b/fushi/lib/src/profile/language_binding.dart
@@ -1,0 +1,79 @@
+/// 语言级 Profile 绑定的**键归一化**——唯一真值源。
+///
+/// ## 为什么必须归一
+///
+/// 内容语言列（`EpubBooks.language` / `SrtBooks.language` / `VideoBooks.language`
+/// / `Galgames.language`）存的是原始 BCP-47，同一种语言在库里可能以 `ja`、
+/// `ja-JP`、`zh-Hans`、`zh-Hant-TW` 等多种形态出现（EPUB 的 `dc:language` 写什么
+/// 就是什么，用户手填的更自由）。若绑定表直接拿原串当主键，用户绑了 `ja` 而书里
+/// 写的是 `ja-JP`，绑定就**静默不生效**——没有报错、没有日志，只是「设了没用」。
+/// 这正是最难归因的一类缺陷，所以写入与查询两侧都过这个函数，一处收敛。
+///
+/// ## 保留 script、丢弃 region
+///
+/// `zh-Hans` 与 `zh-Hant` 必须保持区分：词典和字体链都分简繁，把它们并成 `zh`
+/// 会让两套配置塌成一套。而 region（`zh-CN` 的 `CN`、`ja-JP` 的 `JP`）对「用哪套
+/// 词典 / 哪个 Anki 牌组」没有任何影响，保留它只会制造更多不相等的键。
+library;
+
+/// BCP-47 的「语言未确定」码。EPUB 的 `dc:language` 里确实会出现，语义上等同于
+/// 「没标注」，因此与空串同等对待——绝不能让它变成一个所有未标注内容共用的
+/// 伪语言键。
+const String _kUndeterminedTag = 'und';
+
+/// 把任意形态的语言标签归一成绑定键。
+///
+/// 规则：保留 `language`（小写）与可选的 `script`（首字母大写）子标签，丢弃
+/// region / variant / extension。无法识别为合法语言标签时返回空串。
+///
+/// 返回空串 = 「语言未知」，调用方应当据此**跳过语言级绑定**（而不是拿空串去
+/// 查表）。
+///
+/// - `ja` / `ja-JP` / `JA_jp` → `ja`
+/// - `zh-Hant-TW` → `zh-Hant`
+/// - `zh-CN` → `zh`
+/// - `` / `   ` / `und` / `!!` → ``
+String normalizeLanguageBinding(String? raw) {
+  final String trimmed = raw?.trim() ?? '';
+  if (trimmed.isEmpty) return '';
+
+  // Java 风格的 `zh_Hans_CN` 与 BCP-47 的 `zh-Hans-CN` 视为同一形态：DB 列是
+  // 自由文本，两种写法都可能被写进来。
+  final List<String> parts = trimmed
+      .replaceAll('_', '-')
+      .split('-')
+      .where((String s) => s.isNotEmpty)
+      .toList();
+  if (parts.isEmpty) return '';
+
+  final String language = parts.first.toLowerCase();
+  if (!_isLanguageSubtag(language)) return '';
+  if (language == _kUndeterminedTag) return '';
+
+  for (final String part in parts.skip(1)) {
+    if (_isScriptSubtag(part)) {
+      return '$language-${_titleCase(part)}';
+    }
+  }
+  return language;
+}
+
+/// 语言子标签：2–8 个字母（BCP-47 的 `language` 产生式；3 位的 ISO 639-3 与
+/// 更长的注册码都落在这个区间内）。
+bool _isLanguageSubtag(String s) =>
+    s.length >= 2 && s.length <= 8 && _isAllAlpha(s);
+
+/// 文字系统子标签：恰好 4 个字母（`Hans` / `Hant` / `Latn` / `Kana`…）。
+bool _isScriptSubtag(String s) => s.length == 4 && _isAllAlpha(s);
+
+bool _isAllAlpha(String s) {
+  for (int i = 0; i < s.length; i++) {
+    final int c = s.codeUnitAt(i);
+    final bool isAlpha = (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A);
+    if (!isAlpha) return false;
+  }
+  return true;
+}
+
+String _titleCase(String s) =>
+    s[0].toUpperCase() + s.substring(1).toLowerCase();

--- a/fushi/lib/src/profile/profile_repository.dart
+++ b/fushi/lib/src/profile/profile_repository.dart
@@ -5,6 +5,7 @@ import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/media/media_source.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/profile/language_binding.dart';
 import 'package:fushi/src/profile/profile_keys.dart';
 import 'package:fushi/src/sync/backup_service.dart'
     show rebaseFontCatalogJson, rebaseFontListJson;
@@ -341,6 +342,37 @@ class ProfileRepository {
   Future<void> removeMediaTypeBinding(ProfileMediaKind mediaType) =>
       _db.deleteMediaTypeProfile(mediaType.dbValue);
 
+  /// 全部语言绑定（key = **归一化后**的语言标签，如 `ja` / `zh-Hant`）。
+  ///
+  /// 读侧也过一次 [normalizeLanguageBinding]：存量行理论上都是写侧归一过的，
+  /// 但 DB 是自由文本列，手工改库 / 旧备份导入都可能塞进未归一的键。读侧再归一
+  /// 一次让它们至少能被 UI 看见并改掉，而不是变成一行永远命不中的幽灵绑定。
+  /// 归一后为空的行（`und` / 垃圾串）直接丢弃——它们不对应任何可路由的语言。
+  Future<Map<String, int>> getAllLanguageBindings() async {
+    final rows = await _db.getAllLanguageProfiles();
+    final Map<String, int> out = <String, int>{};
+    for (final r in rows) {
+      final String key = normalizeLanguageBinding(r.languageTag);
+      if (key.isEmpty) continue;
+      out[key] = r.profileId;
+    }
+    return out;
+  }
+
+  /// 绑定一种内容语言到某 Profile。[languageTag] 可以是任意形态的 BCP-47 串，
+  /// 落库前统一归一；归一后为空（语言不可识别）时不写入。
+  Future<void> setLanguageBinding(String languageTag, int profileId) async {
+    final String key = normalizeLanguageBinding(languageTag);
+    if (key.isEmpty) return;
+    await _db.setLanguageProfile(key, profileId);
+  }
+
+  Future<void> removeLanguageBinding(String languageTag) async {
+    final String key = normalizeLanguageBinding(languageTag);
+    if (key.isEmpty) return;
+    await _db.deleteLanguageProfile(key);
+  }
+
   Future<int?> getBookProfileId(String bookUid) async {
     final row = await _db.getBookProfile(bookUid);
     return row?.profileId;
@@ -352,13 +384,31 @@ class ProfileRepository {
   Future<void> removeBookProfile(String bookUid) =>
       _db.deleteBookProfile(bookUid);
 
+  /// 解析该打开哪个 Profile：**book > language > mediaType > active**。
+  ///
+  /// 语言排在 book 之下、mediaType 之上：book 级是用户对单个条目的明确指令，压过
+  /// 一切；而「用哪套词典 / 哪个 Anki 牌组」由内容语言决定的程度，远高于由「这是
+  /// EPUB 还是视频」决定的程度——300 本书不可能一本本绑 book 级，媒体类型又粗到
+  /// 把日文书和英文书归成同一个 `epub`。
+  ///
+  /// [languageTag] 传原始内容语言串即可（内部归一）。**为空 / 不可识别时整级跳过**，
+  /// 落到 mediaType，行为与语言绑定引入前逐字节一致。调用方绝不应为了「填一个值」
+  /// 而把全局默认内容语言喂进来：那会让所有未标注条目一起路由到同一个 Profile，
+  /// 且用户改一次全局默认就整批跳档——那不是按语言绑定，是多了一个全局开关。
   Future<int> resolveProfileId({
     required String? bookUid,
+    String? languageTag,
     required ProfileMediaKind? mediaType,
   }) async {
     if (bookUid != null) {
       final bookProfileId = await getBookProfileId(bookUid);
       if (bookProfileId != null) return bookProfileId;
+    }
+
+    final String languageKey = normalizeLanguageBinding(languageTag);
+    if (languageKey.isNotEmpty) {
+      final langRow = await _db.getLanguageProfile(languageKey);
+      if (langRow != null) return langRow.profileId;
     }
 
     if (mediaType != null) {

--- a/fushi/lib/src/profile/profile_view_model.dart
+++ b/fushi/lib/src/profile/profile_view_model.dart
@@ -99,11 +99,17 @@ class ProfileUiState {
     this.profiles = const [],
     this.activeProfileId = -1,
     this.mediaTypeBindings = const {},
+    this.languageBindings = const {},
     this.isLoading = false,
   });
   final List<ProfileRow> profiles;
   final int activeProfileId;
   final Map<String, int> mediaTypeBindings;
+
+  /// 语言绑定：key = 归一化语言标签（`ja` / `zh-Hant`），value = profileId。
+  /// 与 [mediaTypeBindings] 不同，它是**开放值域**——没有固定枚举可以铺死，UI 只
+  /// 能列出已有绑定 + 一个添加入口。
+  final Map<String, int> languageBindings;
   final bool isLoading;
 
   ProfileRow? get activeProfile {
@@ -117,12 +123,14 @@ class ProfileUiState {
     List<ProfileRow>? profiles,
     int? activeProfileId,
     Map<String, int>? mediaTypeBindings,
+    Map<String, int>? languageBindings,
     bool? isLoading,
   }) =>
       ProfileUiState(
         profiles: profiles ?? this.profiles,
         activeProfileId: activeProfileId ?? this.activeProfileId,
         mediaTypeBindings: mediaTypeBindings ?? this.mediaTypeBindings,
+        languageBindings: languageBindings ?? this.languageBindings,
         isLoading: isLoading ?? this.isLoading,
       );
 }
@@ -159,25 +167,33 @@ class ProfileViewModel extends StateNotifier<ProfileUiState> {
     final profiles = await _repo.getAllProfiles();
     final activeId = await _repo.getActiveProfileId();
     final bindings = await _repo.getAllMediaTypeBindings();
+    final languageBindings = await _repo.getAllLanguageBindings();
     state = ProfileUiState(
       profiles: profiles,
       activeProfileId: activeId,
       mediaTypeBindings: bindings,
+      languageBindings: languageBindings,
     );
   }
 
   Future<void> reload() => _load();
 
-  /// TODO-2936：解析绑定（book 级 > 媒体类型级 > 当前激活）并在结果与当前激活
+  /// TODO-2936：解析绑定（book 级 > 语言级 > 媒体类型级 > 当前激活）并在结果与当前激活
   /// 不同时切换。各媒体入口（阅读器 / 视频 / 漫画开页、gal launch/attach、浏览
   /// 器扩展查词）共用的非致命入口：失败只记日志，绝不打断调用方的加载/查词链。
+  /// [languageTag]：该条目的**内容语言**原始串（`EpubBooks.language` /
+  /// `VideoBooks.language` / `Galgames.language` 等列的值），由 repository 归一。
+  /// 拿不到就不传——绝不要拿全局默认内容语言来填（理由见 [ProfileRepository.
+  /// resolveProfileId] 的文档）。
   Future<void> autoApplyBinding({
     String? bookUid,
+    String? languageTag,
     required ProfileMediaKind mediaType,
   }) async {
     try {
       final int resolvedId = await _repo.resolveProfileId(
         bookUid: bookUid,
+        languageTag: languageTag,
         mediaType: mediaType,
       );
       final int currentActiveId = await _repo.getActiveProfileId();
@@ -255,6 +271,19 @@ class ProfileViewModel extends StateNotifier<ProfileUiState> {
     }
     state = state.copyWith(
       mediaTypeBindings: await _repo.getAllMediaTypeBindings(),
+    );
+  }
+
+  /// 绑定 / 解绑一种内容语言（[profileId] 为 null 即解绑）。[languageTag] 传任意
+  /// 形态的 BCP-47 串，归一在 repository 层做。
+  Future<void> setLanguageBinding(String languageTag, int? profileId) async {
+    if (profileId == null) {
+      await _repo.removeLanguageBinding(languageTag);
+    } else {
+      await _repo.setLanguageBinding(languageTag, profileId);
+    }
+    state = state.copyWith(
+      languageBindings: await _repo.getAllLanguageBindings(),
     );
   }
 

--- a/fushi/lib/src/sync/backup_merge_engine.dart
+++ b/fushi/lib/src/sync/backup_merge_engine.dart
@@ -1212,6 +1212,15 @@ class BackupMergeEngine {
       'WHERE NOT EXISTS (SELECT 1 FROM book_profiles AS m '
       'WHERE m.book_key = sbp.book_key)',
     );
+    await _db.customStatement(
+      'INSERT INTO language_profiles (language_tag, profile_id) '
+      'SELECT slp.language_tag, tp.id '
+      'FROM $_srcAlias.language_profiles AS slp '
+      'JOIN $_srcAlias.profiles AS sp ON sp.id = slp.profile_id '
+      'JOIN profiles AS tp ON tp.name = sp.name '
+      'WHERE NOT EXISTS (SELECT 1 FROM language_profiles AS m '
+      'WHERE m.language_tag = slp.language_tag)',
+    );
   }
 
   /// Bookmarks dedupe-union by {book_uid, section_index, norm_char_offset,

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -103,7 +103,8 @@ enum BackupCategory {
   settings,
 
   /// Configuration profiles -- the `profiles`, `profile_settings`,
-  /// `media_type_profiles` and `book_profiles` tables. Stripped from the DB
+  /// `media_type_profiles`, `book_profiles` and `language_profiles` tables.
+  /// Stripped from the DB
   /// copy when unticked; on import the LOCAL device's profiles are preserved
   /// instead of being wiped to empty. Included by default.
   profiles,
@@ -578,7 +579,7 @@ const List<String> _statisticsTables = <String>[
   'galgame_sessions',
 ];
 
-/// The four profile-layer tables in CHILD-first order, so a DELETE sweep of
+/// The five profile-layer tables in CHILD-first order, so a DELETE sweep of
 /// the `profiles` category (TODO-1193) never trips an enforced FK to
 /// `profiles`. The reverse of [_settingsLayerTables] (which is parent-first
 /// for INSERT).
@@ -586,6 +587,7 @@ const List<String> _profilesLayerTablesChildFirst = <String>[
   'profile_settings',
   'media_type_profiles',
   'book_profiles',
+  'language_profiles',
   'profiles',
 ];
 

--- a/fushi/lib/src/sync/backup_service/restore.part.dart
+++ b/fushi/lib/src/sync/backup_service/restore.part.dart
@@ -605,6 +605,7 @@ class BackupRestoreService {
     'profile_settings',
     'media_type_profiles',
     'book_profiles',
+    'language_profiles',
   ];
 
   /// Restore a backup (overwrite mode), replacing the current database files.

--- a/fushi/test/database/collection_relations_test.dart
+++ b/fushi/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final FushiDatabase db = await openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/fushi/test/database/downgrade_protection_test.dart
+++ b/fushi/test/database/downgrade_protection_test.dart
@@ -8,7 +8,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 /// Downgrade protection guard (root-cause fix for the recurring "old app
 /// downgrades & destroys the user DB" incidents).
 ///
-/// Constructs an on-disk DB whose user_version (99) is far HIGHER than the
+/// Constructs an on-disk DB whose user_version (999) is far HIGHER than the
 /// code's schemaVersion, with a real table + rows, then opens it via
 /// FushiDatabase. The open MUST be refused with FushiDatabaseDowngradeException
 /// and — crucially — the DB file's tables and rows MUST be left completely
@@ -29,13 +29,13 @@ void main() {
     }
   });
 
-  /// Seeds a future-version DB file directly via sqlite3: user_version = 99
+  /// Seeds a future-version DB file directly via sqlite3: user_version = 999
   /// (much newer than any code schemaVersion) plus a user table with rows that
   /// stand in for real user data.
   void seedFutureVersionDb() {
     final db = sqlite3.sqlite3.open(dbPath);
     try {
-      db.execute('PRAGMA user_version = 99');
+      db.execute('PRAGMA user_version = 999');
       db.execute(
         'CREATE TABLE precious_user_data ('
         'id INTEGER PRIMARY KEY, payload TEXT NOT NULL)',
@@ -56,7 +56,7 @@ void main() {
       final versionRow = db.select('PRAGMA user_version');
       expect(
         versionRow.first.values.first,
-        99,
+        999,
         reason: 'user_version must be left unchanged (no migration ran)',
       );
 
@@ -144,7 +144,7 @@ void main() {
       await database.getAllEpubBooks();
       fail('expected FushiDatabaseDowngradeException');
     } on FushiDatabaseDowngradeException catch (e) {
-      expect(e.dbVersion, 99);
+      expect(e.dbVersion, 999);
       expect(e.appSchemaVersion, database.schemaVersion);
       expect(e.appSchemaVersion, lessThan(e.dbVersion));
     }

--- a/fushi/test/database/full_ladder_migration_v1_test.dart
+++ b/fushi/test/database/full_ladder_migration_v1_test.dart
@@ -206,6 +206,7 @@ void main() {
           'video_hourly_logs',
           'favorite_words',
           'mining_statistics',
+          'language_profiles',
         ]),
       );
     });

--- a/fushi/test/database/migration_test.dart
+++ b/fushi/test/database/migration_test.dart
@@ -730,6 +730,7 @@ void main() {
           'dictionary_history',
           'profiles',
           'profile_settings',
+          'language_profiles',
           'book_tags',
           'tag_assignments',
           'reader_positions',
@@ -1080,7 +1081,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 paired peers 表). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 98,
+      expect(db.schemaVersion, 99,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1157,7 +1158,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 98,
+      expect(db.schemaVersion, 99,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1315,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 98,
+      expect(db.schemaVersion, 99,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1366,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
     });
 
     test(
@@ -1375,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 98,
+      expect(db.schemaVersion, 99,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1409,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 98,
+      expect(db.schemaVersion, 99,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1449,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1480,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1514,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1526,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1562,7 +1563,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 98);
+      expect(db.schemaVersion, 99);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/fushi/test/database/migration_v40_collections_test.dart
+++ b/fushi/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
   });
 }

--- a/fushi/test/database/migration_v51_pdf_format_test.dart
+++ b/fushi/test/database/migration_v51_pdf_format_test.dart
@@ -109,6 +109,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
   });
 }

--- a/fushi/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/fushi/test/database/migration_v53_manga_reading_mode_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
   });
 }

--- a/fushi/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/fushi/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
   });
 }

--- a/fushi/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/fushi/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v57_naming_unification_test.dart
+++ b/fushi/test/database/migration_v57_naming_unification_test.dart
@@ -191,7 +191,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v60_reading_pages_test.dart
+++ b/fushi/test/database/migration_v60_reading_pages_test.dart
@@ -64,7 +64,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 99, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/fushi/test/database/migration_v61_collection_cover_path_test.dart
+++ b/fushi/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
-    expect(db.schemaVersion, 98);
+    expect(version.read<int>('user_version'), 99);
+    expect(db.schemaVersion, 99);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -280,6 +280,7 @@ void main() {
         'study_segment_tombstones',
         'web_mine_queue',
         'video_file_specs',
+        'language_profiles',
       },
       reason: '除 v64 的 collection_scrape_meta、v65 的 Mihon 五表、v66 的 '
           'collection_relations、v68 的 media_images、v77 视频来源刮削表、'
@@ -287,8 +288,9 @@ void main() {
           'v80 的 media_open_history（取代 media_items）、v89 的 '
           'manga_chapter_states（漫画每章阅读状态）与 v92 的 study_segments / '
           'study_segment_tombstones（学习统计唯一事实表 + 按身份墓碑）、'
-          'v93 的 web_mine_queue（网页播放器自动制卡队列）与 v95 的 '
-          'video_file_specs（视频文件技术规格探测缓存）外，'
+          'v93 的 web_mine_queue（网页播放器自动制卡队列）、v95 的 '
+          'video_file_specs（视频文件技术规格探测缓存）与 v99 的 '
+          'language_profiles（语言级 Profile 绑定）外，'
           '升级不得新增任何表',
     );
   });
@@ -307,7 +309,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
+    expect(version.read<int>('user_version'), 99);
   });
 
   test(
@@ -338,7 +340,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,7 +105,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
     expect(await _userVersion(db), db.schemaVersion);
 
     // v63 真跑了：两处废弃偏好都没了。

--- a/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
+++ b/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
@@ -77,7 +77,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v75 给 galgames 加 japanese_locale_mode（每游戏转区档位）');
 
     final List<QueryRow> columns =

--- a/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
+++ b/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
@@ -86,7 +86,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v76 给 lookup_mining_counters 的 book_key 进唯一键');
 
     final List<LookupMiningCounterRow> rows =

--- a/fushi/test/database/migration_v79_tag_assignments_test.dart
+++ b/fushi/test/database/migration_v79_tag_assignments_test.dart
@@ -114,7 +114,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
 
     final List<TagAssignmentRow> rows = await db.getAllTagAssignments();
     expect(rows, hasLength(5), reason: '5 张表各 1 行有效映射（孤儿 srt 行丢弃）');

--- a/fushi/test/database/migration_v80_media_open_history_test.dart
+++ b/fushi/test/database/migration_v80_media_open_history_test.dart
@@ -61,7 +61,7 @@ CREATE TABLE media_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98);
+    expect(db.schemaVersion, 99);
 
     final rows = await db.getAllMediaOpenHistory();
     expect(rows, hasLength(2), reason: '迁移零丢行');

--- a/fushi/test/database/migration_v82_subtable_uid_test.dart
+++ b/fushi/test/database/migration_v82_subtable_uid_test.dart
@@ -131,7 +131,7 @@ CREATE TABLE revealed_images (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98, reason: 'v82 = 四子表书键切 uid');
+    expect(db.schemaVersion, 99, reason: 'v82 = 四子表书键切 uid');
 
     // ── reader_positions：跨书族，epub 命中换 uid，SRT 照抄 ──
     expect(await count(db, 'reader_positions'), 2, reason: '迁移零丢行');

--- a/fushi/test/database/migration_v83_entrykey_uid_test.dart
+++ b/fushi/test/database/migration_v83_entrykey_uid_test.dart
@@ -128,7 +128,7 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 98,
+    expect(db.schemaVersion, 99,
         reason: 'v83 = shelf_entries / media_collection_items epub 键切 uid');
 
     // ── shelf_entries：epub 命中换 uid、透传照抄、非 epub 照抄、零丢行 ──

--- a/fushi/test/database/migration_v84_preferences_updated_at_test.dart
+++ b/fushi/test/database/migration_v84_preferences_updated_at_test.dart
@@ -53,8 +53,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
-    expect(db.schemaVersion, 98);
+    expect(version.read<int>('user_version'), 99);
+    expect(db.schemaVersion, 99);
 
     // 存量行零丢失——改名是用户数据，迁移丢一行就是丢一个书名。
     expect(await db.getPref(_overrideKey), 's:母设备改的名');

--- a/fushi/test/database/migration_v85_video_last_played_at_test.dart
+++ b/fushi/test/database/migration_v85_video_last_played_at_test.dart
@@ -94,8 +94,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
-    expect(db.schemaVersion, 98);
+    expect(version.read<int>('user_version'), 99);
+    expect(db.schemaVersion, 99);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(4), reason: '迁移丢一行就是丢一部视频的观看记录');

--- a/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
+++ b/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
@@ -87,8 +87,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
-    expect(db.schemaVersion, 98);
+    expect(version.read<int>('user_version'), 99);
+    expect(db.schemaVersion, 99);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(2), reason: '迁移丢一行就是丢一部视频的记录');

--- a/fushi/test/database/migration_v88_content_language_rest_test.dart
+++ b/fushi/test/database/migration_v88_content_language_rest_test.dart
@@ -94,7 +94,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(hasColumn(probe, 'video_books', 'language'), isTrue);
       expect(hasColumn(probe, 'srt_books', 'language'), isTrue);
       expect(hasColumn(probe, 'galgames', 'language'), isTrue);

--- a/fushi/test/database/migration_v90_download_proxy_merge_test.dart
+++ b/fushi/test/database/migration_v90_download_proxy_merge_test.dart
@@ -129,8 +129,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 98);
-    expect(db.schemaVersion, 98);
+    expect(version.read<int>('user_version'), 99);
+    expect(db.schemaVersion, 99);
 
     expect(await _prefs(db), <String, String>{
       'theme': 's:dark',

--- a/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
+++ b/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
@@ -95,7 +95,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(
           hasColumn(probe, 'media_collections', 'subtitle_language'), isTrue);
       expect(hasColumn(probe, 'media_collections', 'subtitle_release_group'),

--- a/fushi/test/database/migration_v94_download_identity_json_test.dart
+++ b/fushi/test/database/migration_v94_download_identity_json_test.dart
@@ -99,7 +99,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(hasColumn(probe, 'video_download_jobs', 'identity_json'), isTrue);
       expect(hasColumn(probe, 'video_download_subscriptions', 'identity_json'),
           isTrue);

--- a/fushi/test/database/migration_v95_video_file_specs_test.dart
+++ b/fushi/test/database/migration_v95_video_file_specs_test.dart
@@ -88,7 +88,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(hasTable(probe, 'video_file_specs'), isTrue);
     } finally {
       probe.dispose();

--- a/fushi/test/database/migration_v96_dictionary_expanded_languages_test.dart
+++ b/fushi/test/database/migration_v96_dictionary_expanded_languages_test.dart
@@ -97,7 +97,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       expect(hasColumn(probe, 'dictionary_metadata', 'expanded_languages_json'),
           isTrue);
     } finally {

--- a/fushi/test/database/migration_v97_schema_drift_repair_test.dart
+++ b/fushi/test/database/migration_v97_schema_drift_repair_test.dart
@@ -116,7 +116,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
       for (final (String table, String column) in <(String, String)>[
         ('epub_books', 'language'),
         ('dictionary_metadata', 'language_override'),
@@ -159,7 +159,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 98);
+      expect(probe.select('PRAGMA user_version').first.values.first, 99);
     } finally {
       probe.dispose();
     }

--- a/fushi/test/database/migration_v99_language_profiles_test.dart
+++ b/fushi/test/database/migration_v99_language_profiles_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+/// v99：新表 `language_profiles`（语言级 Profile 绑定）。
+///
+/// 纯新增表，无损：旧库升级后表为空 = 没有任何语言绑定 = Profile 解析链在语言这
+/// 一级恒空转、直接落到 mediaType，与升级前逐字节一致。下面三条分别钉住「旧数据
+/// 零丢失」「新表可用且带索引」「FK cascade 生效」。
+void main() {
+  /// 造一个 v98 形态的库：建好全表后把 v99 的产物删掉、版本号写回 98。
+  Future<String> seedV98Database(Directory directory) async {
+    final String path = '${directory.path}/test.db';
+    final FushiDatabase original = FushiDatabase.atFile(
+      path,
+      isMainProcess: false,
+    );
+    final int profileId = await original.insertProfile(
+      ProfilesCompanion.insert(
+        name: '日语',
+        createdAt: 111,
+        updatedAt: 222,
+      ),
+    );
+    await original.setMediaTypeProfile('epub', profileId);
+    await original.setBookProfile('book-key-1', profileId);
+    await original.close();
+
+    final sqlite3.Database raw = sqlite3.sqlite3.open(path);
+    try {
+      raw.execute('DROP INDEX IF EXISTS idx_language_profiles_profile');
+      raw.execute('DROP TABLE IF EXISTS language_profiles');
+      raw.execute('PRAGMA user_version = 98');
+    } finally {
+      raw.dispose();
+    }
+    return path;
+  }
+
+  test('v98 → v99 建出 language_profiles，且既有 Profile 绑定零丢失', () async {
+    final Directory directory =
+        Directory.systemTemp.createTempSync('language_profiles_v99');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final String path = await seedV98Database(directory);
+
+    final FushiDatabase upgraded = FushiDatabase.atFile(
+      path,
+      isMainProcess: false,
+    );
+    addTearDown(upgraded.close);
+
+    // 迁移终点 = 代码版本。
+    expect(
+      (await upgraded.customSelect('PRAGMA user_version').getSingle())
+          .read<int>('user_version'),
+      upgraded.schemaVersion,
+    );
+    expect(upgraded.schemaVersion, 99);
+
+    // 升级前就有的 Profile 与两类既有绑定原样还在（Never break userspace）。
+    final List<ProfileRow> profiles = await upgraded.getAllProfiles();
+    expect(profiles, hasLength(1));
+    expect(profiles.single.name, '日语');
+    expect(profiles.single.createdAt, 111);
+    expect((await upgraded.getMediaTypeProfile('epub'))?.profileId,
+        profiles.single.id);
+    expect((await upgraded.getBookProfile('book-key-1'))?.profileId,
+        profiles.single.id);
+
+    // 新表存在且为空 —— 空 = 语言级绑定整级空转 = 升级前行为。
+    expect(await upgraded.getAllLanguageProfiles(), isEmpty);
+
+    // 新表可读写，主键 upsert 生效。
+    await upgraded.setLanguageProfile('ja', profiles.single.id);
+    expect((await upgraded.getLanguageProfile('ja'))?.profileId,
+        profiles.single.id);
+    await upgraded.setLanguageProfile('ja', profiles.single.id);
+    expect(await upgraded.getAllLanguageProfiles(), hasLength(1));
+
+    await upgraded.deleteLanguageProfile('ja');
+    expect(await upgraded.getLanguageProfile('ja'), isNull);
+  });
+
+  test('v99 迁移路径上索引一并建出（_ensureIndexes 不跑升级路径）', () async {
+    final Directory directory =
+        Directory.systemTemp.createTempSync('language_profiles_v99_idx');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final String path = await seedV98Database(directory);
+
+    final FushiDatabase upgraded = FushiDatabase.atFile(
+      path,
+      isMainProcess: false,
+    );
+    // drift 是惰性打开：构造 FushiDatabase 不会跑迁移，必须先发一条真查询。
+    // 少了这一句，下面的探针查到的是**没迁移过**的库，断言会以「索引没建出来」
+    // 的形态假红，指向一个并不存在的实现缺陷。
+    expect(await upgraded.getAllLanguageProfiles(), isEmpty);
+    await upgraded.close();
+
+    final sqlite3.Database probe = sqlite3.sqlite3.open(path);
+    try {
+      final sqlite3.ResultSet indexes = probe.select(
+        "SELECT name FROM sqlite_master WHERE type = 'index' "
+        "AND tbl_name = 'language_profiles'",
+      );
+      expect(
+        indexes.map((sqlite3.Row r) => r['name']),
+        contains('idx_language_profiles_profile'),
+        reason: '升级路径不跑 _ensureIndexes，索引必须由 v99 台阶内联建出',
+      );
+    } finally {
+      probe.dispose();
+    }
+  });
+
+  test('删 Profile 时语言绑定随之 cascade 清除', () async {
+    final Directory directory =
+        Directory.systemTemp.createTempSync('language_profiles_v99_fk');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final String path = await seedV98Database(directory);
+
+    final FushiDatabase upgraded = FushiDatabase.atFile(
+      path,
+      isMainProcess: false,
+    );
+    addTearDown(upgraded.close);
+
+    final ProfileRow profile = (await upgraded.getAllProfiles()).single;
+    await upgraded.setLanguageProfile('zh-Hant', profile.id);
+    expect(await upgraded.getAllLanguageProfiles(), hasLength(1));
+
+    await upgraded.deleteProfile(profile.id);
+    expect(
+      await upgraded.getAllLanguageProfiles(),
+      isEmpty,
+      reason: 'profileId 是 cascade 外键，删 Profile 不能留下悬空绑定',
+    );
+  });
+}

--- a/fushi/test/profile/language_binding_test.dart
+++ b/fushi/test/profile/language_binding_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/profile/language_binding.dart';
+
+/// 语言级 Profile 绑定键归一化的契约。
+///
+/// 这个函数是「用户绑了 `ja`、书里写的是 `ja-JP`，绑定为什么不生效」这类静默
+/// 失效的唯一防线：写入侧与查询侧都过它，两侧结果必须逐字相等。下面每条用例
+/// 对应一种真实会进到 DB 列里的写法。
+void main() {
+  group('normalizeLanguageBinding', () {
+    test('裸语言码原样保留（已是归一形态）', () {
+      expect(normalizeLanguageBinding('ja'), 'ja');
+      expect(normalizeLanguageBinding('en'), 'en');
+      expect(normalizeLanguageBinding('zh'), 'zh');
+    });
+
+    test('丢弃 region 子标签——它不影响用哪套词典/牌组', () {
+      expect(normalizeLanguageBinding('ja-JP'), 'ja');
+      expect(normalizeLanguageBinding('en-US'), 'en');
+      expect(normalizeLanguageBinding('en-GB'), 'en');
+      expect(normalizeLanguageBinding('zh-CN'), 'zh');
+      // 数字型 region（BCP-47 允许 3 位数字，如拉丁美洲 419）同样丢弃。
+      expect(normalizeLanguageBinding('es-419'), 'es');
+    });
+
+    test('保留 script 子标签——简繁是两套配置，不能塌成一个键', () {
+      expect(normalizeLanguageBinding('zh-Hans'), 'zh-Hans');
+      expect(normalizeLanguageBinding('zh-Hant'), 'zh-Hant');
+      expect(normalizeLanguageBinding('zh-Hans-CN'), 'zh-Hans');
+      expect(normalizeLanguageBinding('zh-Hant-TW'), 'zh-Hant');
+      expect(normalizeLanguageBinding('zh-Hant-HK'), 'zh-Hant');
+    });
+
+    test('大小写归一：语言小写、script 首字母大写', () {
+      expect(normalizeLanguageBinding('JA'), 'ja');
+      expect(normalizeLanguageBinding('Ja-Jp'), 'ja');
+      expect(normalizeLanguageBinding('ZH-HANT-TW'), 'zh-Hant');
+      expect(normalizeLanguageBinding('zh-hant'), 'zh-Hant');
+    });
+
+    test('下划线分隔（Java locale 风格）与连字符等价', () {
+      expect(normalizeLanguageBinding('ja_JP'), 'ja');
+      expect(normalizeLanguageBinding('zh_Hans_CN'), 'zh-Hans');
+      expect(normalizeLanguageBinding('ZH_hant_tw'), 'zh-Hant');
+    });
+
+    test('前后空白不影响结果', () {
+      expect(normalizeLanguageBinding('  ja  '), 'ja');
+      expect(normalizeLanguageBinding('\tzh-Hant\n'), 'zh-Hant');
+    });
+
+    test('空 / null / 纯空白 → 空串（语言未知）', () {
+      expect(normalizeLanguageBinding(null), '');
+      expect(normalizeLanguageBinding(''), '');
+      expect(normalizeLanguageBinding('   '), '');
+      expect(normalizeLanguageBinding('-'), '');
+      expect(normalizeLanguageBinding('--'), '');
+    });
+
+    test('und（BCP-47 未确定）等同于没标注，绝不成为伪语言键', () {
+      expect(normalizeLanguageBinding('und'), '');
+      expect(normalizeLanguageBinding('UND'), '');
+      expect(normalizeLanguageBinding('und-JP'), '');
+    });
+
+    test('非法输入 → 空串，而不是一个垃圾键', () {
+      expect(normalizeLanguageBinding('!!'), '');
+      expect(normalizeLanguageBinding('123'), '');
+      expect(normalizeLanguageBinding('j'), ''); // 单字母不是合法语言子标签
+      expect(normalizeLanguageBinding('日本語'), '');
+      expect(normalizeLanguageBinding('verylonglanguagetag'), ''); // >8 字母
+    });
+
+    test('三字母 ISO 639-3 语言码合法', () {
+      expect(normalizeLanguageBinding('yue'), 'yue');
+      expect(normalizeLanguageBinding('yue-Hant-HK'), 'yue-Hant');
+    });
+
+    test('幂等：归一结果再归一一次不变', () {
+      const List<String> inputs = <String>[
+        'ja-JP',
+        'zh-Hant-TW',
+        'EN_us',
+        'yue-Hant-HK',
+        'und',
+        '!!',
+      ];
+      for (final String input in inputs) {
+        final String once = normalizeLanguageBinding(input);
+        expect(
+          normalizeLanguageBinding(once),
+          once,
+          reason: '归一必须幂等，否则写入键与查询键会漂开：$input',
+        );
+      }
+    });
+
+    test('同语言的不同写法折叠到同一个键（本函数存在的理由）', () {
+      final Set<String> japanese = <String>{
+        normalizeLanguageBinding('ja'),
+        normalizeLanguageBinding('ja-JP'),
+        normalizeLanguageBinding('JA'),
+        normalizeLanguageBinding('ja_jp'),
+        normalizeLanguageBinding(' ja-JP '),
+      };
+      expect(japanese, <String>{'ja'});
+    });
+  });
+}

--- a/fushi/test/profile/media_type_binding_new_kinds_guard_test.dart
+++ b/fushi/test/profile/media_type_binding_new_kinds_guard_test.dart
@@ -58,8 +58,15 @@ void main() {
       'lib/src/pages/implementations/texthooker_page.dart',
     ]) {
       final String src = read(path);
+      // 判据拆成两段（与上面 manga 那条同形），**不**匹配整串调用字面量：
+      // `autoApplyBinding` 的参数列表会增长（v99 加了 languageTag），一旦多一个
+      // 具名参数或被 dart format 折行，整串字面量就再也匹配不上——那时守卫报的是
+      // 「从没应用过绑定」，而真相是「调用还在，只是多了个参数」，把人引向完全
+      // 错误的方向。两段式判据钉的是「这个文件确实调了它、且确实是 game 类型」，
+      // 参数怎么长都不影响。
       expect(
-        src.contains('autoApplyBinding(mediaType: ProfileMediaKind.game)'),
+        src.contains('autoApplyBinding(') &&
+            src.contains('mediaType: ProfileMediaKind.game'),
         isTrue,
         reason: '$path starts a gal hook session but never applies the '
             '"game" media-type Profile binding (TODO-2936)',
@@ -69,9 +76,7 @@ void main() {
     final String texthooker =
         read('lib/src/pages/implementations/texthooker_page.dart');
     expect(
-      'autoApplyBinding(mediaType: ProfileMediaKind.game)'
-          .allMatches(texthooker)
-          .length,
+      'mediaType: ProfileMediaKind.game'.allMatches(texthooker).length,
       greaterThanOrEqualTo(2),
       reason: 'texthooker must apply the game binding on BOTH the launch and '
           'the attach-to-running-game entry (TODO-2936)',

--- a/fushi/test/profile/profile_repository_test.dart
+++ b/fushi/test/profile/profile_repository_test.dart
@@ -277,31 +277,130 @@ void main() {
       expect(await db.getPref('font_size'), '20'); // normal restore still works
     });
 
-    test('resolveProfileId precedence: book > mediaType > active', () async {
+    test('resolveProfileId precedence: book > language > mediaType > active',
+        () async {
       final db = await _openDb();
       final repo = _repo(db);
       final a = await repo.createProfile('A');
       final b = await repo.createProfile('B');
       final c = await repo.createProfile('C');
+      final l = await repo.createProfile('L');
       await repo.setActiveProfileId(c);
       // 命名统一 Phase 3.4：绑定 API 收口为 ProfileMediaKind（落库串不变）。
       await repo.setMediaTypeBinding(ProfileMediaKind.epub, b);
       await repo.setBookProfile('book/1', a);
+      await repo.setLanguageBinding('ja', l);
 
       expect(
           await repo.resolveProfileId(
-              bookUid: 'book/1', mediaType: ProfileMediaKind.epub),
-          a); // book binding wins
+              bookUid: 'book/1',
+              languageTag: 'ja',
+              mediaType: ProfileMediaKind.epub),
+          a); // book binding wins over everything
+      expect(
+          await repo.resolveProfileId(
+              bookUid: 'book/none',
+              languageTag: 'ja',
+              mediaType: ProfileMediaKind.epub),
+          l); // language wins over mediaType
       expect(
           await repo.resolveProfileId(
               bookUid: 'book/none', mediaType: ProfileMediaKind.epub),
-          b); // mediaType wins when no book binding
+          b); // mediaType wins when no book/language binding
+      expect(
+          await repo.resolveProfileId(
+              bookUid: 'book/none',
+              languageTag: 'en',
+              mediaType: ProfileMediaKind.epub),
+          b); // unbound language falls through to mediaType
       expect(await repo.resolveProfileId(bookUid: null, mediaType: null),
           c); // active fallback
       expect(
           await repo.resolveProfileId(
               bookUid: 'book/none', mediaType: ProfileMediaKind.lyrics),
           c); // full fallthrough to active (kind bound to nothing)
+    });
+
+    test('语言级绑定按归一化键匹配：ja-JP / JA_jp / zh-Hant-TW 都命中', () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      final active = await repo.createProfile('Active');
+      final japanese = await repo.createProfile('日语');
+      final traditional = await repo.createProfile('繁中');
+      await repo.setActiveProfileId(active);
+
+      // 写侧传原始形态，落库的是归一化键。
+      await repo.setLanguageBinding('ja-JP', japanese);
+      await repo.setLanguageBinding('zh-Hant-TW', traditional);
+      expect(await repo.getAllLanguageBindings(),
+          <String, int>{'ja': japanese, 'zh-Hant': traditional});
+
+      // 读侧传各种形态都要命中同一个 Profile —— 这正是归一化存在的理由：
+      // 内容语言列里 `ja` / `ja-JP` / `ja_JP` 都可能出现。
+      for (final String tag in <String>['ja', 'ja-JP', 'JA', 'ja_jp', ' ja ']) {
+        expect(
+          await repo.resolveProfileId(
+              bookUid: null, languageTag: tag, mediaType: null),
+          japanese,
+          reason: '「$tag」应命中归一化键 ja 的绑定',
+        );
+      }
+
+      // 简繁不能塌成一个键。
+      expect(
+        await repo.resolveProfileId(
+            bookUid: null, languageTag: 'zh-Hans-CN', mediaType: null),
+        active,
+        reason: 'zh-Hans 未绑定，不能命中 zh-Hant 的绑定',
+      );
+    });
+
+    test('语言不可识别时整级跳过，行为与引入语言绑定前一致', () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      final active = await repo.createProfile('Active');
+      final byKind = await repo.createProfile('ByKind');
+      final byLanguage = await repo.createProfile('ByLanguage');
+      await repo.setActiveProfileId(active);
+      await repo.setMediaTypeBinding(ProfileMediaKind.epub, byKind);
+      await repo.setLanguageBinding('ja', byLanguage);
+
+      // null / 空串 / 纯空白 / und / 垃圾串一律跳过语言级，落到 mediaType。
+      for (final String? tag in <String?>[null, '', '   ', 'und', '!!', '123']) {
+        expect(
+          await repo.resolveProfileId(
+              bookUid: null,
+              languageTag: tag,
+              mediaType: ProfileMediaKind.epub),
+          byKind,
+          reason: '「$tag」不是可识别语言，必须落到 mediaType 级而不是别的地方',
+        );
+      }
+
+      // 归一化后为空的键也绝不能写进绑定表（否则会成为一个吃掉所有未标注内容的
+      // 幽灵绑定）。
+      await repo.setLanguageBinding('und', byLanguage);
+      await repo.setLanguageBinding('', byLanguage);
+      expect(await repo.getAllLanguageBindings(),
+          <String, int>{'ja': byLanguage});
+    });
+
+    test('删 Profile 时其语言绑定 cascade 清除', () async {
+      final db = await _openDb();
+      // 本文件的内存库走 `FushiDatabase.forTesting`，不经 `_openDbFile` 的
+      // `PRAGMA foreign_keys = ON`（那条只设在文件库路径上），所以默认 FK 是关的，
+      // cascade 一律不触发。生产库是文件库、FK 开着，这里显式对齐生产，否则这条
+      // 断言测的是「SQLite 关着外键时什么都不会发生」——恒真且毫无信息。
+      await db.customStatement('PRAGMA foreign_keys = ON');
+      final repo = _repo(db);
+      final keep = await repo.createProfile('Keep');
+      final drop = await repo.createProfile('Drop');
+      await repo.setActiveProfileId(keep);
+      await repo.setLanguageBinding('ja', drop);
+      await repo.setLanguageBinding('en', keep);
+
+      await repo.deleteProfile(drop);
+      expect(await repo.getAllLanguageBindings(), <String, int>{'en': keep});
     });
 
     test('TODO-2936: manga/game/browser kinds bind and resolve like the rest',

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -794,6 +794,14 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'profiles/Manga': _kMediaTypeBindingEvidence,
   'profiles/Game': _kMediaTypeBindingEvidence,
   'profiles/Browser': _kMediaTypeBindingEvidence,
+  // 语言绑定（v99）与上面八行同理：写的是 `language_profiles` 表，prefs diff 里
+  // 结构上看不到。行标签是内容语言选择器的自称显示名（`contentLanguageLabelOf`），
+  // 与 `kContentLanguageOptions` 一一对应——那份候选变了，这里要跟着变。
+  'profiles/日本語 (ja)': _kLanguageBindingEvidence,
+  'profiles/简体中文 (zh-Hans)': _kLanguageBindingEvidence,
+  'profiles/繁體中文 (zh-Hant)': _kLanguageBindingEvidence,
+  'profiles/한국어 (ko)': _kLanguageBindingEvidence,
+  'profiles/English (en)': _kLanguageBindingEvidence,
   // 制卡字号写的是 SharedPreferences 里的 AnkiSettings JSON blob（与本表既有的
   // cardCreation 开关同因），消费点是 composeLapisCss(fontScalePercent:)。
   'cardCreation/Card font scale':
@@ -851,6 +859,13 @@ const String _kMediaTypeBindingEvidence =
     'test/profile/media_type_binding_video_guard_test.dart + '
     'test/profile/profile_repository_test.dart + '
     'test/database/profiles_test.dart';
+
+/// 语言级 Profile 绑定（v99）的证据链：归一化键的契约、四级优先级（book >
+/// language > mediaType > active）、以及建表 + cascade 的迁移测试。
+const String _kLanguageBindingEvidence =
+    'test/profile/language_binding_test.dart + '
+    'test/profile/profile_repository_test.dart + '
+    'test/database/migration_v99_language_profiles_test.dart';
 
 /// 焦点驱动的 settings schema **全分组**覆盖测试（Phase 1 Task 4）。
 ///

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -633,6 +633,7 @@ void _requireOneVideoMetadataOwner({
   ProfileSettings,
   MediaTypeProfiles,
   BookProfiles,
+  LanguageProfiles,
   SyncBaselines,
   VideoBooks,
   VideoWatchStatistics,
@@ -725,7 +726,7 @@ class FushiDatabase extends _$FushiDatabase
   final bool _isMainProcess;
 
   @override
-  int get schemaVersion => 98;
+  int get schemaVersion => 99;
 
   /// v97：把 v52 / v57 / v87 / v88 四级台阶里「加列 / 改列名」的幂等语句重放一次，
   /// 补齐漂移库（版本号先于这些台阶被写高的库）。每条都先查 `_columnExists`，
@@ -3026,6 +3027,24 @@ class FushiDatabase extends _$FushiDatabase
               await m.addColumn(
                   mediaCollections, mediaCollections.sourceFolderPath);
             }
+          }
+          if (from < 99) {
+            // v99（语言级 Profile 绑定）：新表 language_profiles，把「这种内容语言用
+            // 哪个 Profile」补进 Profile 的自动解析链（book > language > mediaType >
+            // active）。与 v95 同款的纯新增表范式。
+            //
+            // 无损：旧库升级后表为空 = 没有任何语言绑定 = 解析链在语言这一级恒空转、
+            // 直接落到 mediaType，与升级前逐字节一致（Never break userspace）。
+            // 幂等：fresh DB 由 onCreate 的 createAll 建好；重复升级被 _tableExists 短路。
+            if (!await _tableExists('language_profiles')) {
+              await m.createTable(languageProfiles);
+            }
+            // 索引与建表同步内联：`_ensureIndexes` 只在 onCreate 与个别迁移步里跑，
+            // 升级路径不会自动补上（与 v9 同款处理）。
+            await customStatement(
+              'CREATE INDEX IF NOT EXISTS idx_language_profiles_profile '
+              'ON language_profiles (profile_id)',
+            );
           }
         },
         onCreate: (m) async {

--- a/packages/fushi_core/lib/src/database/database.g.dart
+++ b/packages/fushi_core/lib/src/database/database.g.dart
@@ -10105,6 +10105,236 @@ class BookProfilesCompanion extends UpdateCompanion<BookProfileRow> {
   }
 }
 
+class $LanguageProfilesTable extends LanguageProfiles
+    with TableInfo<$LanguageProfilesTable, LanguageProfileRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $LanguageProfilesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _languageTagMeta = const VerificationMeta(
+    'languageTag',
+  );
+  @override
+  late final GeneratedColumn<String> languageTag = GeneratedColumn<String>(
+    'language_tag',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _profileIdMeta = const VerificationMeta(
+    'profileId',
+  );
+  @override
+  late final GeneratedColumn<int> profileId = GeneratedColumn<int>(
+    'profile_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES profiles (id) ON DELETE CASCADE',
+    ),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [languageTag, profileId];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'language_profiles';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<LanguageProfileRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('language_tag')) {
+      context.handle(
+        _languageTagMeta,
+        languageTag.isAcceptableOrUnknown(
+          data['language_tag']!,
+          _languageTagMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_languageTagMeta);
+    }
+    if (data.containsKey('profile_id')) {
+      context.handle(
+        _profileIdMeta,
+        profileId.isAcceptableOrUnknown(data['profile_id']!, _profileIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_profileIdMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {languageTag};
+  @override
+  LanguageProfileRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return LanguageProfileRow(
+      languageTag: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}language_tag'],
+      )!,
+      profileId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}profile_id'],
+      )!,
+    );
+  }
+
+  @override
+  $LanguageProfilesTable createAlias(String alias) {
+    return $LanguageProfilesTable(attachedDatabase, alias);
+  }
+}
+
+class LanguageProfileRow extends DataClass
+    implements Insertable<LanguageProfileRow> {
+  final String languageTag;
+  final int profileId;
+  const LanguageProfileRow({
+    required this.languageTag,
+    required this.profileId,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['language_tag'] = Variable<String>(languageTag);
+    map['profile_id'] = Variable<int>(profileId);
+    return map;
+  }
+
+  LanguageProfilesCompanion toCompanion(bool nullToAbsent) {
+    return LanguageProfilesCompanion(
+      languageTag: Value(languageTag),
+      profileId: Value(profileId),
+    );
+  }
+
+  factory LanguageProfileRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return LanguageProfileRow(
+      languageTag: serializer.fromJson<String>(json['languageTag']),
+      profileId: serializer.fromJson<int>(json['profileId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'languageTag': serializer.toJson<String>(languageTag),
+      'profileId': serializer.toJson<int>(profileId),
+    };
+  }
+
+  LanguageProfileRow copyWith({String? languageTag, int? profileId}) =>
+      LanguageProfileRow(
+        languageTag: languageTag ?? this.languageTag,
+        profileId: profileId ?? this.profileId,
+      );
+  LanguageProfileRow copyWithCompanion(LanguageProfilesCompanion data) {
+    return LanguageProfileRow(
+      languageTag: data.languageTag.present
+          ? data.languageTag.value
+          : this.languageTag,
+      profileId: data.profileId.present ? data.profileId.value : this.profileId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('LanguageProfileRow(')
+          ..write('languageTag: $languageTag, ')
+          ..write('profileId: $profileId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(languageTag, profileId);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LanguageProfileRow &&
+          other.languageTag == this.languageTag &&
+          other.profileId == this.profileId);
+}
+
+class LanguageProfilesCompanion extends UpdateCompanion<LanguageProfileRow> {
+  final Value<String> languageTag;
+  final Value<int> profileId;
+  final Value<int> rowid;
+  const LanguageProfilesCompanion({
+    this.languageTag = const Value.absent(),
+    this.profileId = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  LanguageProfilesCompanion.insert({
+    required String languageTag,
+    required int profileId,
+    this.rowid = const Value.absent(),
+  }) : languageTag = Value(languageTag),
+       profileId = Value(profileId);
+  static Insertable<LanguageProfileRow> custom({
+    Expression<String>? languageTag,
+    Expression<int>? profileId,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (languageTag != null) 'language_tag': languageTag,
+      if (profileId != null) 'profile_id': profileId,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  LanguageProfilesCompanion copyWith({
+    Value<String>? languageTag,
+    Value<int>? profileId,
+    Value<int>? rowid,
+  }) {
+    return LanguageProfilesCompanion(
+      languageTag: languageTag ?? this.languageTag,
+      profileId: profileId ?? this.profileId,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (languageTag.present) {
+      map['language_tag'] = Variable<String>(languageTag.value);
+    }
+    if (profileId.present) {
+      map['profile_id'] = Variable<int>(profileId.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('LanguageProfilesCompanion(')
+          ..write('languageTag: $languageTag, ')
+          ..write('profileId: $profileId, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $SyncBaselinesTable extends SyncBaselines
     with TableInfo<$SyncBaselinesTable, SyncBaselineRow> {
   @override
@@ -23708,8 +23938,11 @@ class GalgameRow extends DataClass implements Insertable<GalgameRow> {
 
   /// 该游戏的「日语区域（转区）」档位：`'auto'` / `'on'` / `'off'`（BUG-1477）。
   ///
-  /// 空串 = 用户没设过，解析层回落 `auto`（**不是** off —— 转区是用户明确要过的
-  /// 功能，老行/老用户不能因为加了这一列就被莫名关掉）。
+  /// 空串 = 用户没设过，解析层回落 `off`（见 `galgame_japanese_locale.dart` 的
+  /// `kGalDefaultJapaneseLocaleMode`）。**注意这与 v75 落地时的语义相反**：当时
+  /// 空串回落 `auto`，2026-09-07 按用户要求改为 `off`——不能在用户没选过的时候
+  /// 就替他用 CP932 重新拉起游戏进程。主动选过自动的行落的是字面量 `'auto'`，
+  /// 不受影响。
   ///
   /// 与 [upscalingMode] / [launchArgs] 同类，都是「用户为该游戏设的启动期配置」。
   /// 为什么必须每游戏一档而不是全局开关：同一个库里日文原版和汉化版并存，
@@ -50375,6 +50608,9 @@ abstract class _$FushiDatabase extends GeneratedDatabase {
   late final $MediaTypeProfilesTable mediaTypeProfiles =
       $MediaTypeProfilesTable(this);
   late final $BookProfilesTable bookProfiles = $BookProfilesTable(this);
+  late final $LanguageProfilesTable languageProfiles = $LanguageProfilesTable(
+    this,
+  );
   late final $SyncBaselinesTable syncBaselines = $SyncBaselinesTable(this);
   late final $VideoBooksTable videoBooks = $VideoBooksTable(this);
   late final $VideoWatchStatisticsTable videoWatchStatistics =
@@ -50515,6 +50751,7 @@ abstract class _$FushiDatabase extends GeneratedDatabase {
     profileSettings,
     mediaTypeProfiles,
     bookProfiles,
+    languageProfiles,
     syncBaselines,
     videoBooks,
     videoWatchStatistics,
@@ -50613,6 +50850,13 @@ abstract class _$FushiDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('book_profiles', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'profiles',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('language_profiles', kind: UpdateKind.delete)],
     ),
     WritePropagation(
       on: TableUpdateQuery.onTableName(
@@ -56681,6 +56925,27 @@ final class $$ProfilesTableReferences
       manager.$state.copyWith(prefetchedData: cache),
     );
   }
+
+  static MultiTypedResultKey<$LanguageProfilesTable, List<LanguageProfileRow>>
+  _languageProfilesRefsTable(_$FushiDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.languageProfiles,
+        aliasName: 'profiles__id__language_profiles__profile_id',
+      );
+
+  $$LanguageProfilesTableProcessedTableManager get languageProfilesRefs {
+    final manager = $$LanguageProfilesTableTableManager(
+      $_db,
+      $_db.languageProfiles,
+    ).filter((f) => f.profileId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _languageProfilesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 }
 
 class $$ProfilesTableFilterComposer
@@ -56778,6 +57043,31 @@ class $$ProfilesTableFilterComposer
           }) => $$BookProfilesTableFilterComposer(
             $db: $db,
             $table: $db.bookProfiles,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> languageProfilesRefs(
+    Expression<bool> Function($$LanguageProfilesTableFilterComposer f) f,
+  ) {
+    final $$LanguageProfilesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.languageProfiles,
+      getReferencedColumn: (t) => t.profileId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$LanguageProfilesTableFilterComposer(
+            $db: $db,
+            $table: $db.languageProfiles,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -56914,6 +57204,31 @@ class $$ProfilesTableAnnotationComposer
     );
     return f(composer);
   }
+
+  Expression<T> languageProfilesRefs<T extends Object>(
+    Expression<T> Function($$LanguageProfilesTableAnnotationComposer a) f,
+  ) {
+    final $$LanguageProfilesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.languageProfiles,
+      getReferencedColumn: (t) => t.profileId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$LanguageProfilesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.languageProfiles,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$ProfilesTableTableManager
@@ -56933,6 +57248,7 @@ class $$ProfilesTableTableManager
             bool profileSettingsRefs,
             bool mediaTypeProfilesRefs,
             bool bookProfilesRefs,
+            bool languageProfilesRefs,
           })
         > {
   $$ProfilesTableTableManager(_$FushiDatabase db, $ProfilesTable table)
@@ -56983,6 +57299,7 @@ class $$ProfilesTableTableManager
                 profileSettingsRefs = false,
                 mediaTypeProfilesRefs = false,
                 bookProfilesRefs = false,
+                languageProfilesRefs = false,
               }) {
                 return PrefetchHooks(
                   db: db,
@@ -56990,6 +57307,7 @@ class $$ProfilesTableTableManager
                     if (profileSettingsRefs) db.profileSettings,
                     if (mediaTypeProfilesRefs) db.mediaTypeProfiles,
                     if (bookProfilesRefs) db.bookProfiles,
+                    if (languageProfilesRefs) db.languageProfiles,
                   ],
                   addJoins: null,
                   getPrefetchedDataCallback: (items) async {
@@ -57057,6 +57375,27 @@ class $$ProfilesTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (languageProfilesRefs)
+                        await $_getPrefetchedData<
+                          ProfileRow,
+                          $ProfilesTable,
+                          LanguageProfileRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$ProfilesTableReferences
+                              ._languageProfilesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$ProfilesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).languageProfilesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.profileId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                     ];
                   },
                 );
@@ -57081,6 +57420,7 @@ typedef $$ProfilesTableProcessedTableManager =
         bool profileSettingsRefs,
         bool mediaTypeProfilesRefs,
         bool bookProfilesRefs,
+        bool languageProfilesRefs,
       })
     >;
 typedef $$ProfileSettingsTableCreateCompanionBuilder =
@@ -57942,6 +58282,281 @@ typedef $$BookProfilesTableProcessedTableManager =
       $$BookProfilesTableUpdateCompanionBuilder,
       (BookProfileRow, $$BookProfilesTableReferences),
       BookProfileRow,
+      PrefetchHooks Function({bool profileId})
+    >;
+typedef $$LanguageProfilesTableCreateCompanionBuilder =
+    LanguageProfilesCompanion Function({
+      required String languageTag,
+      required int profileId,
+      Value<int> rowid,
+    });
+typedef $$LanguageProfilesTableUpdateCompanionBuilder =
+    LanguageProfilesCompanion Function({
+      Value<String> languageTag,
+      Value<int> profileId,
+      Value<int> rowid,
+    });
+
+final class $$LanguageProfilesTableReferences
+    extends
+        BaseReferences<
+          _$FushiDatabase,
+          $LanguageProfilesTable,
+          LanguageProfileRow
+        > {
+  $$LanguageProfilesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $ProfilesTable _profileIdTable(_$FushiDatabase db) =>
+      db.profiles.createAlias('language_profiles__profile_id__profiles__id');
+
+  $$ProfilesTableProcessedTableManager get profileId {
+    final $_column = $_itemColumn<int>('profile_id')!;
+
+    final manager = $$ProfilesTableTableManager(
+      $_db,
+      $_db.profiles,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_profileIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$LanguageProfilesTableFilterComposer
+    extends Composer<_$FushiDatabase, $LanguageProfilesTable> {
+  $$LanguageProfilesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get languageTag => $composableBuilder(
+    column: $table.languageTag,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$ProfilesTableFilterComposer get profileId {
+    final $$ProfilesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.profileId,
+      referencedTable: $db.profiles,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProfilesTableFilterComposer(
+            $db: $db,
+            $table: $db.profiles,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$LanguageProfilesTableOrderingComposer
+    extends Composer<_$FushiDatabase, $LanguageProfilesTable> {
+  $$LanguageProfilesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get languageTag => $composableBuilder(
+    column: $table.languageTag,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$ProfilesTableOrderingComposer get profileId {
+    final $$ProfilesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.profileId,
+      referencedTable: $db.profiles,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProfilesTableOrderingComposer(
+            $db: $db,
+            $table: $db.profiles,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$LanguageProfilesTableAnnotationComposer
+    extends Composer<_$FushiDatabase, $LanguageProfilesTable> {
+  $$LanguageProfilesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get languageTag => $composableBuilder(
+    column: $table.languageTag,
+    builder: (column) => column,
+  );
+
+  $$ProfilesTableAnnotationComposer get profileId {
+    final $$ProfilesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.profileId,
+      referencedTable: $db.profiles,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ProfilesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.profiles,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$LanguageProfilesTableTableManager
+    extends
+        RootTableManager<
+          _$FushiDatabase,
+          $LanguageProfilesTable,
+          LanguageProfileRow,
+          $$LanguageProfilesTableFilterComposer,
+          $$LanguageProfilesTableOrderingComposer,
+          $$LanguageProfilesTableAnnotationComposer,
+          $$LanguageProfilesTableCreateCompanionBuilder,
+          $$LanguageProfilesTableUpdateCompanionBuilder,
+          (LanguageProfileRow, $$LanguageProfilesTableReferences),
+          LanguageProfileRow,
+          PrefetchHooks Function({bool profileId})
+        > {
+  $$LanguageProfilesTableTableManager(
+    _$FushiDatabase db,
+    $LanguageProfilesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$LanguageProfilesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$LanguageProfilesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$LanguageProfilesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> languageTag = const Value.absent(),
+                Value<int> profileId = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => LanguageProfilesCompanion(
+                languageTag: languageTag,
+                profileId: profileId,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String languageTag,
+                required int profileId,
+                Value<int> rowid = const Value.absent(),
+              }) => LanguageProfilesCompanion.insert(
+                languageTag: languageTag,
+                profileId: profileId,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$LanguageProfilesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({profileId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (profileId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.profileId,
+                                referencedTable:
+                                    $$LanguageProfilesTableReferences
+                                        ._profileIdTable(db),
+                                referencedColumn:
+                                    $$LanguageProfilesTableReferences
+                                        ._profileIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$LanguageProfilesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$FushiDatabase,
+      $LanguageProfilesTable,
+      LanguageProfileRow,
+      $$LanguageProfilesTableFilterComposer,
+      $$LanguageProfilesTableOrderingComposer,
+      $$LanguageProfilesTableAnnotationComposer,
+      $$LanguageProfilesTableCreateCompanionBuilder,
+      $$LanguageProfilesTableUpdateCompanionBuilder,
+      (LanguageProfileRow, $$LanguageProfilesTableReferences),
+      LanguageProfileRow,
       PrefetchHooks Function({bool profileId})
     >;
 typedef $$SyncBaselinesTableCreateCompanionBuilder =
@@ -88158,6 +88773,8 @@ class $FushiDatabaseManager {
       $$MediaTypeProfilesTableTableManager(_db, _db.mediaTypeProfiles);
   $$BookProfilesTableTableManager get bookProfiles =>
       $$BookProfilesTableTableManager(_db, _db.bookProfiles);
+  $$LanguageProfilesTableTableManager get languageProfiles =>
+      $$LanguageProfilesTableTableManager(_db, _db.languageProfiles);
   $$SyncBaselinesTableTableManager get syncBaselines =>
       $$SyncBaselinesTableTableManager(_db, _db.syncBaselines);
   $$VideoBooksTableTableManager get videoBooks =>

--- a/packages/fushi_core/lib/src/database/database_infra.part.dart
+++ b/packages/fushi_core/lib/src/database/database_infra.part.dart
@@ -55,6 +55,10 @@ mixin _FushiDbInfra on _$FushiDatabase {
         'book_profiles',
         'CREATE INDEX IF NOT EXISTS idx_book_profiles_profile ON book_profiles (profile_id)'
       ],
+      [
+        'language_profiles',
+        'CREATE INDEX IF NOT EXISTS idx_language_profiles_profile ON language_profiles (profile_id)'
+      ],
       // bookmarks 索引 v82 起换 book_uid 列，移出本清单（清单会被早期迁移步
       // 调用，彼时新列不存在）：v82 步与 onCreate 成对内联维护。
       [

--- a/packages/fushi_core/lib/src/database/database_tags_sync.part.dart
+++ b/packages/fushi_core/lib/src/database/database_tags_sync.part.dart
@@ -743,6 +743,29 @@ mixin _FushiDbTagsSync on _$FushiDatabase, _FushiDbInfra {
       (delete(mediaTypeProfiles)..where((t) => t.mediaType.equals(mediaType)))
           .go();
 
+  // ── language profiles ────────────────────────────────────────────
+  // 键是**归一化后**的语言标签（`normalizeLanguageBinding`），不是内容语言列里
+  // 的原始 BCP-47 串。归一在 fushi 侧的 ProfileRepository 做，这层只存取。
+  Future<List<LanguageProfileRow>> getAllLanguageProfiles() =>
+      select(languageProfiles).get();
+
+  Future<LanguageProfileRow?> getLanguageProfile(String languageTag) =>
+      (select(languageProfiles)
+            ..where((t) => t.languageTag.equals(languageTag)))
+          .getSingleOrNull();
+
+  Future<void> setLanguageProfile(String languageTag, int profileId) =>
+      into(languageProfiles).insertOnConflictUpdate(
+        LanguageProfilesCompanion.insert(
+          languageTag: languageTag,
+          profileId: profileId,
+        ),
+      );
+
+  Future<int> deleteLanguageProfile(String languageTag) =>
+      (delete(languageProfiles)..where((t) => t.languageTag.equals(languageTag)))
+          .go();
+
   // ── book profiles ────────────────────────────────────────────────
   Future<BookProfileRow?> getBookProfile(String bookKey) =>
       (select(bookProfiles)..where((t) => t.bookKey.equals(bookKey)))

--- a/packages/fushi_core/lib/src/database/tables.dart
+++ b/packages/fushi_core/lib/src/database/tables.dart
@@ -577,6 +577,24 @@ class BookProfiles extends Table {
   Set<Column> get primaryKey => {bookKey};
 }
 
+// ── language_profiles ───────────────────────────────────────────────
+// 「这种内容语言用哪个 Profile」。与 [MediaTypeProfiles] 同构、同性质：都是
+// Profile 的自动解析绑定，只是路由键不同（语言 vs 媒体类型）。
+//
+// [languageTag] 是**归一化后**的键（`normalizeLanguageBinding`：保留 language +
+// script、丢 region，如 `ja` / `zh-Hant`），不是内容语言列里的原始 BCP-47 串。
+// 写入与查询两侧都必须过那个函数，否则用户绑了 `ja` 而书里写 `ja-JP` 会静默
+// 不生效。
+@DataClassName('LanguageProfileRow')
+class LanguageProfiles extends Table {
+  TextColumn get languageTag => text()();
+  IntColumn get profileId =>
+      integer().references(Profiles, #id, onDelete: KeyAction.cascade)();
+
+  @override
+  Set<Column> get primaryKey => {languageTag};
+}
+
 // ── sync_baselines ──────────────────────────────────────────────────
 // 每本书每个同步维度「上次同步成功时双方一致的版本」（共同祖先），
 // 用于三方分叉检测。assetKey = sanitizeTtuFilename(book.title)（跨设备稳定）。

--- a/packages/fushi_core/test/migration_downgrade_test.dart
+++ b/packages/fushi_core/test/migration_downgrade_test.dart
@@ -14,7 +14,7 @@ import 'package:fushi_core/fushi_core.dart';
 /// app layer catches it and shows an "update your app" notice.
 ///
 /// These tests therefore assert the OPPOSITE of the old ones: the open must be
-/// REFUSED (throw), never silently rebuilt. Seeds user_version = 99 (well above
+/// REFUSED (throw), never silently rebuilt. Seeds user_version = 999 (well above
 /// the current schema) to force the `from > to` path regardless of how high the
 /// real [FushiDatabase.schemaVersion] climbs, so the guard never goes stale on a
 /// schema bump.
@@ -22,7 +22,7 @@ Future<FushiDatabase> _openDowngradedFromFuture() async {
   return FushiDatabase.forTesting(
     NativeDatabase.memory(
       setup: (rawDb) {
-        // Seed a DB that claims to be a FUTURE version (99 > current) with a
+        // Seed a DB that claims to be a FUTURE version (999 > current) with a
         // real row, so a destructive rebuild (if it ever regressed back) would
         // be observable as data loss.
         rawDb.execute('''
@@ -45,7 +45,7 @@ CREATE TABLE epub_books (
           "(book_key, title, epub_path, extract_dir, chapter_count, chapters_json, imported_at) "
           "VALUES ('stale future row', 'stale future row', '/x.epub', '/x', 0, '[]', 0)",
         );
-        rawDb.execute('PRAGMA user_version = 99');
+        rawDb.execute('PRAGMA user_version = 999');
       },
     ),
   );
@@ -93,7 +93,7 @@ CREATE TABLE book_tag_mappings (
         rawDb.execute(
           "INSERT INTO book_tag_mappings (book_key, tag_id) VALUES ('b', 1)",
         );
-        rawDb.execute('PRAGMA user_version = 99');
+        rawDb.execute('PRAGMA user_version = 999');
       },
     ),
   );
@@ -105,13 +105,13 @@ void main() {
     final FushiDatabase db = await _openDowngradedFromFuture();
     addTearDown(db.close);
 
-    // Reading forces the lazy DB to open, which triggers onUpgrade(99 -> current)
+    // Reading forces the lazy DB to open, which triggers onUpgrade(999 -> current)
     // and must throw the protection exception instead of dropping/rebuilding.
     await expectLater(
       db.customSelect('PRAGMA user_version').getSingle(),
       throwsA(isA<FushiDatabaseDowngradeException>()
           .having((FushiDatabaseDowngradeException e) => e.dbVersion,
-              'dbVersion', 99)
+              'dbVersion', 999)
           .having((FushiDatabaseDowngradeException e) => e.appSchemaVersion,
               'appSchemaVersion', db.schemaVersion)),
       reason: 'a newer-schema DB must be refused to protect user data, '

--- a/packages/fushi_core/test/migration_paired_peers_v31_test.dart
+++ b/packages/fushi_core/test/migration_paired_peers_v31_test.dart
@@ -51,8 +51,14 @@ CREATE TABLE epub_books (
   );
 }
 
-/// 手写一个「未来版本」库（user_version = 99 > 代码 schemaVersion）以强制走降级
-/// 保护分支，且 99 恒大于任何未来 bump 不会 stale。
+/// 手写一个「未来版本」库（user_version = 999 > 代码 schemaVersion）以强制走降级
+/// 保护分支。
+///
+/// 这个数必须**远高于**当前 schemaVersion，不能只高一点：原本写的是 99，schema
+/// bump 到 99 时 `99 > 99` 变成假，降级分支不再触发，本文件与另外两个降级守卫
+/// （`migration_downgrade_test.dart`、`fushi/test/database/downgrade_protection_test.dart`）
+/// 一起转红。而这两个包内测试只有 CI 的 package tests 跑，本地按功能域挑的定向
+/// 测试结构上永远选不到它们——所以 bump schema 时请顺手确认这里仍然远大于。
 FushiDatabase _openDowngradedFromFuture() {
   return FushiDatabase.forTesting(
     NativeDatabase.memory(
@@ -70,7 +76,7 @@ CREATE TABLE fushi_paired_peers (
           "INSERT INTO fushi_paired_peers "
           "(peer_id, token, paired_at_ms) VALUES ('p-future', 'tok', 1)",
         );
-        raw.execute('PRAGMA user_version = 99');
+        raw.execute('PRAGMA user_version = 999');
       },
     ),
   );
@@ -182,7 +188,7 @@ void main() {
       db.customSelect('PRAGMA user_version').getSingle(),
       throwsA(isA<FushiDatabaseDowngradeException>()
           .having((FushiDatabaseDowngradeException e) => e.dbVersion,
-              'dbVersion', 99)
+              'dbVersion', 999)
           .having((FushiDatabaseDowngradeException e) => e.appSchemaVersion,
               'appSchemaVersion', db.schemaVersion)),
       reason: 'a newer-schema DB must be refused, never destructively rebuilt',


### PR DESCRIPTION
## 做了什么

Profile 的自动解析链补上缺失的一级：

```
book > language > mediaType > active     （原来是 book > mediaType > active）
```

新表 `language_profiles` 与既有 `media_type_profiles` 逐字同构（一个文本键 + 一个 cascade `profileId`），不引入新概念。

## 为什么语言排在 mediaType 之上

「按语言用不同配置」原本落不了地：300 本书不可能一本本绑 book 级，而 `mediaType` 又粗到把日文书和英文书归成同一个 `epub`。「用哪套词典 / 哪个 Anki 牌组」由**内容语言**决定的程度，远高于由「这是 EPUB 还是视频」决定的程度。

book 级仍然压过一切——那是用户对单个条目的明确指令。

## 归一化：这个功能能不能用的关键

内容语言列存的是原始 BCP-47，同一种语言在库里可能写成 `ja` / `ja-JP` / `zh-Hans` / `zh-Hant-TW`。绑定键不归一，用户绑了 `ja` 而书里是 `ja-JP` 就**静默失效**——没报错、没日志，只是「设了没用」，是最难归因的一类缺陷。

`normalizeLanguageBinding` 保留 `language` + `script`、丢 region（**简繁必须分开**：词典和字体都分简繁，并成 `zh` 会让两套配置塌成一套），写入与查询两侧都过它，一处收敛。

## 故意不做的事：不传全局默认内容语言

语言取值只用 `explicit` + `metadata` 两档，不传 `globalDefault`。

因为 `defaultContentLanguage` 是个恒有值的全局偏好。带上它，语言档就**永远非 null**，结果是所有未标注条目全部路由到同一个 Profile，且用户改一次全局默认就整批跳档。那不叫「按语言绑定」，那叫「多了一个全局开关」——用 active profile 就够了，根本不需要新表。

语言为空 / 不可识别（含 `und`）时整级跳过，行为与引入前逐字节一致。

## 入口

| 入口 | 语言来源 |
|---|---|
| reader | `srt_books.language` ?? `epub_books.language`（`audiobooks` 表无该列，语言跟着配对行走） |
| video | `video_books.language` |
| manga | `epub_books.language`（共用该表） |
| galgame ×3 | `galgames.language`（hook 文本无语言声明可读，只有用户指定值） |
| texthooker 附着外部窗口 | **故意不传**——附着的是任意外部窗口，不对应任何库条目 |

## 已知数据侧缺口（本次不处理，通道先接通）

- `manga_importer` / PDF 重建插入不带 `language` → 漫画、PDF 恒 NULL（CBZ 与图片包没有任何语言声明可读，PDF 也没有稳定的 `dc:language` 对应物——所谓「回填」落到实处仍是让用户手动指定，不是新能力）
- `audiobooks` 表无 `language` 列（**故意不顺手加**：加一根当前没有任何代码读写的列，就是把「以后大概会用到」写进 schema；有声书语言该独立存还是跟着配对行走，这件事没想清楚）
- v87 前的存量行全 NULL，且不自动回填

实际生效面 = 正规 EPUB 自动回填的那批（`epub_importer.dart` 是全仓唯一自动落库点）+ 用户手动设过语言的条目。UI 上有说明文案讲清这一点，避免用户以为绑定坏了。

## schema 98 → 99 的连带面

- 48 处版本断言、迁移全表白名单、两处 `containsAll` 表清单
- 🔴 **三处降级守卫**原本用 `PRAGMA user_version = 99` 伪造「比代码新的库」，bump 后 `99 > 99` 为假、降级分支不再触发，三条一起转红——一并抬到 999 并记下教训。其中两条在 `packages/fushi_core/test/`，**只有 CI 的 package tests 跑，本地按功能域挑的定向测试结构上永远选不到**
- 备份导出 / 恢复 / 合并导入 / 迁移清单**四处表登记**（漏了会让用户备份恢复后语言绑定静默丢失）
- `media_type_binding` 守卫的整串字面量判据改成两段式：`autoApplyBinding` 的参数列表会增长，字面量匹配一加参数就报「从没应用过绑定」，把人引向完全错误的方向

## 验证

| 范围 | 结果 |
|---|---|
| `packages/fushi_core` 全部测试 | 82 ✅ |
| `test/database` | 649 ✅ |
| `test/profile` + `test/sync` + `test/i18n` | 2642 ✅ |
| `test/settings` | 397 ✅ |
| 目录枚举型守卫 52 条 | 364 ✅ |
| `flutter analyze`（含 test） | 零问题 ✅ |
| `dart analyze`（fushi_core） | 零问题 ✅ |

守卫基线 362 → 364 的 +2 是期间漂移（`6fe3fcc280`、`572a90b5a3` 等改过守卫文件），非本 PR 引入——本 PR 未触碰这 52 个文件中的任何一个。

真机验证未做。
