### PR TITLE
feat(reader): 正文字重可调（CSS font-weight 100~900，默认 400 不注入）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 76143 (4479 per locale)
+/// Strings: 76160 (4480 per locale)
 ///
-/// Built on 2026-09-08 at 13:52 UTC
+/// Built on 2026-09-08 at 15:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6210,6 +6210,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  String get reader_font_weight => 'Font weight';
 }
 
 // Path: <root>
@@ -16727,6 +16728,8 @@ class _StringsAr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'وزن الخط';
 }
 
 // Path: <root>
@@ -27471,6 +27474,8 @@ class _StringsDe extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Schriftstärke';
 }
 
 // Path: <root>
@@ -38268,6 +38273,8 @@ class _StringsEs extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Grosor de fuente';
 }
 
 // Path: <root>
@@ -49099,6 +49106,8 @@ class _StringsFr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Graisse de police';
 }
 
 // Path: <root>
@@ -59733,6 +59742,8 @@ class _StringsId extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Ketebalan font';
 }
 
 // Path: <root>
@@ -70458,6 +70469,8 @@ class _StringsIt extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Spessore carattere';
 }
 
 // Path: <root>
@@ -80563,6 +80576,8 @@ class _StringsJa extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'フォントの太さ';
 }
 
 // Path: <root>
@@ -90678,6 +90693,8 @@ class _StringsKo extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => '글꼴 굵기';
 }
 
 // Path: <root>
@@ -101361,6 +101378,8 @@ class _StringsNl extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Letterdikte';
 }
 
 // Path: <root>
@@ -112096,6 +112115,8 @@ class _StringsPtBr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Espessura da fonte';
 }
 
 // Path: <root>
@@ -122809,6 +122830,8 @@ class _StringsRu extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Насыщенность шрифта';
 }
 
 // Path: <root>
@@ -133320,6 +133343,8 @@ class _StringsTh extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'น้ำหนักฟอนต์';
 }
 
 // Path: <root>
@@ -143949,6 +143974,8 @@ class _StringsTr extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Yazı tipi kalınlığı';
 }
 
 // Path: <root>
@@ -154549,6 +154576,8 @@ class _StringsVi extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => 'Độ đậm phông chữ';
 }
 
 // Path: <root>
@@ -164283,6 +164312,8 @@ class _StringsZhCn extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       '已重排 ${count} 张新卡；${skipped} 张已不再是新卡，未改动。';
+  @override
+  String get reader_font_weight => '字体粗细';
 }
 
 // Path: <root>
@@ -174076,6 +174107,8 @@ class _StringsZhHk extends _StringsEn {
   String anki_reposition_done_skipped(
           {required Object count, required Object skipped}) =>
       'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+  @override
+  String get reader_font_weight => '字型粗細';
 }
 
 /// Flat map(s) containing all translations.
@@ -183287,6 +183320,8 @@ extension on _StringsEn {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Font weight';
       default:
         return null;
     }
@@ -192493,6 +192528,8 @@ extension on _StringsAr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'وزن الخط';
       default:
         return null;
     }
@@ -201744,6 +201781,8 @@ extension on _StringsDe {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Schriftstärke';
       default:
         return null;
     }
@@ -210986,6 +211025,8 @@ extension on _StringsEs {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Grosor de fuente';
       default:
         return null;
     }
@@ -220237,6 +220278,8 @@ extension on _StringsFr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Graisse de police';
       default:
         return null;
     }
@@ -229459,6 +229502,8 @@ extension on _StringsId {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Ketebalan font';
       default:
         return null;
     }
@@ -238703,6 +238748,8 @@ extension on _StringsIt {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Spessore carattere';
       default:
         return null;
     }
@@ -247874,6 +247921,8 @@ extension on _StringsJa {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'フォントの太さ';
       default:
         return null;
     }
@@ -257049,6 +257098,8 @@ extension on _StringsKo {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return '글꼴 굵기';
       default:
         return null;
     }
@@ -266286,6 +266337,8 @@ extension on _StringsNl {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Letterdikte';
       default:
         return null;
     }
@@ -275518,6 +275571,8 @@ extension on _StringsPtBr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Espessura da fonte';
       default:
         return null;
     }
@@ -284757,6 +284812,8 @@ extension on _StringsRu {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Насыщенность шрифта';
       default:
         return null;
     }
@@ -293968,6 +294025,8 @@ extension on _StringsTh {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'น้ำหนักฟอนต์';
       default:
         return null;
     }
@@ -303194,6 +303253,8 @@ extension on _StringsTr {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Yazı tipi kalınlığı';
       default:
         return null;
     }
@@ -312414,6 +312475,8 @@ extension on _StringsVi {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return 'Độ đậm phông chữ';
       default:
         return null;
     }
@@ -321554,6 +321617,8 @@ extension on _StringsZhCn {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             '已重排 ${count} 张新卡；${skipped} 张已不再是新卡，未改动。';
+      case 'reader_font_weight':
+        return '字体粗细';
       default:
         return null;
     }
@@ -330703,6 +330768,8 @@ extension on _StringsZhHk {
       case 'anki_reposition_done_skipped':
         return ({required Object count, required Object skipped}) =>
             'Repositioned ${count} new cards; ${skipped} were skipped because they are no longer new.';
+      case 'reader_font_weight':
+        return '字型粗細';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Could not end $process. Please end it manually, then retry.",
   "yomitan_port_kill_protected": "$process is a critical system process — Fushi will not end it. Change the port instead.",
   "yomitan_port_kill_self_instance": "This process is another running instance of this app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Font weight"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "تعذر إنهاء $process. يرجى إنهاؤها يدوياً ثم إعادة المحاولة.",
   "yomitan_port_kill_protected": "$process هي عملية نظام حرجة — لن يقوم Fushi بإنهائها. غيّر المنفذ بدلاً من ذلك.",
   "yomitan_port_kill_self_instance": "هذه العملية هي نسخة أخرى قيد التشغيل من هذا التطبيق.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "وزن الخط"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "$process konnte nicht beendet werden. Bitte beenden Sie ihn manuell und versuchen Sie es erneut.",
   "yomitan_port_kill_protected": "$process ist ein kritischer Systemprozess – Fushi wird ihn nicht beenden. Ändern Sie stattdessen den Port.",
   "yomitan_port_kill_self_instance": "Dieser Prozess ist eine weitere laufende Instanz dieser App.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Schriftstärke"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "No se pudo finalizar $process. Finalícelo manualmente, luego reintente.",
   "yomitan_port_kill_protected": "$process es un proceso crítico del sistema — Fushi no lo finalizará. Cambie el puerto en su lugar.",
   "yomitan_port_kill_self_instance": "Este proceso es otra instancia en ejecución de esta app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Grosor de fuente"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Impossible d'arrêter $process. Veuillez l'arrêter manuellement, puis réessayez.",
   "yomitan_port_kill_protected": "$process est un processus système critique — Fushi ne l'arrêtera pas. Changez de port à la place.",
   "yomitan_port_kill_self_instance": "Ce processus est une autre instance en cours d'exécution de cette application.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Graisse de police"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Tidak bisa mengakhiri $process. Silakan akhiri secara manual, lalu coba lagi.",
   "yomitan_port_kill_protected": "$process adalah proses sistem penting — Fushi tidak akan mengakhirinya. Ganti port saja.",
   "yomitan_port_kill_self_instance": "Proses ini adalah instance lain dari aplikasi ini yang sedang berjalan.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Ketebalan font"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Impossibile terminare $process. Terminalo manualmente, poi riprova.",
   "yomitan_port_kill_protected": "$process è un processo di sistema critico — Fushi non lo terminerà. Cambia la porta.",
   "yomitan_port_kill_self_instance": "Questo processo è un'altra istanza in esecuzione di questa app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Spessore carattere"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "$processを終了できませんでした。手動で終了してから再試行してください。",
   "yomitan_port_kill_protected": "$processは重要なシステムプロセスです — Fushiでは終了しません。代わりにポートを変更してください。",
   "yomitan_port_kill_self_instance": "このプロセスは、このアプリの別のインスタンスです。",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "フォントの太さ"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "$process를 종료할 수 없습니다. 수동으로 종료한 후 다시 시도하세요.",
   "yomitan_port_kill_protected": "$process는 중요한 시스템 프로세스입니다. Fushi가 종료하지 않습니다. 대신 포트를 변경하세요.",
   "yomitan_port_kill_self_instance": "이 프로세스는 이 앱의 다른 실행 중인 인스턴스입니다.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "글꼴 굵기"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Kon $process niet beëindigen. Beëindig het handmatig en probeer opnieuw.",
   "yomitan_port_kill_protected": "$process is een kritiek systeemproces — Fushi beëindigt het niet. Wijzig de poort.",
   "yomitan_port_kill_self_instance": "Dit proces is een andere draaiende instantie van deze app.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Letterdikte"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Não foi possível encerrar $process. Encerre manualmente e tente novamente.",
   "yomitan_port_kill_protected": "$process é um processo crítico do sistema — o Fushi não vai encerrá-lo. Mude a porta.",
   "yomitan_port_kill_self_instance": "Este processo é outra instância deste app em execução.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Espessura da fonte"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Не удалось завершить $process. Пожалуйста, завершите его вручную, затем повторите.",
   "yomitan_port_kill_protected": "$process — критический системный процесс, Fushi не будет его завершать. Измените порт.",
   "yomitan_port_kill_self_instance": "Этот процесс — другой запущенный экземпляр данного приложения.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Насыщенность шрифта"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "ไม่สามารถจบ $process ได้ กรุณาจบด้วยตนเองแล้วลองใหม่",
   "yomitan_port_kill_protected": "$process เป็นโปรเซสระบบที่สำคัญ — Fushi จะไม่จบโปรเซสนี้ เปลี่ยนพอร์ตแทน",
   "yomitan_port_kill_self_instance": "โปรเซสนี้เป็นอินสแตนซ์อื่นของแอปนี้ที่กำลังทำงานอยู่",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "น้ำหนักฟอนต์"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "$process sonlandırılamadı. Lütfen manuel olarak sonlandırıp tekrar deneyin.",
   "yomitan_port_kill_protected": "$process kritik bir sistem işlemidir — Fushi onu sonlandırmaz. Bunun yerine portu değiştirin.",
   "yomitan_port_kill_self_instance": "Bu işlem, uygulamanın çalışan başka bir örneğidir.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Yazı tipi kalınlığı"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "Không thể kết thúc $process. Vui lòng kết thúc thủ công rồi thử lại.",
   "yomitan_port_kill_protected": "$process là tiến trình hệ thống quan trọng — Fushi sẽ không kết thúc nó. Hãy đổi cổng thay vì vậy.",
   "yomitan_port_kill_self_instance": "Tiến trình này là một phiên bản đang chạy khác của ứng dụng.",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "Độ đậm phông chữ"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "无法结束 $process，请手动结束该进程后重试。",
   "yomitan_port_kill_protected": "$process 是关键系统进程，Fushi 不会结束它；请改用其他端口。",
   "yomitan_port_kill_self_instance": "该进程是本应用的另一个正在运行的实例。",
-  "anki_reposition_done_skipped": "已重排 $count 张新卡；$skipped 张已不再是新卡，未改动。"
+  "anki_reposition_done_skipped": "已重排 $count 张新卡；$skipped 张已不再是新卡，未改动。",
+  "reader_font_weight": "字体粗细"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4477,5 +4477,6 @@
   "yomitan_port_kill_failed": "無法結束 $process，請手動結束該進程後重試。",
   "yomitan_port_kill_protected": "$process 是關鍵系統進程，Fushi 不會結束它；請改用其他端口。",
   "yomitan_port_kill_self_instance": "該進程是本應用的另一個正在運行的實例。",
-  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new."
+  "anki_reposition_done_skipped": "Repositioned $count new cards; $skipped were skipped because they are no longer new.",
+  "reader_font_weight": "字型粗細"
 }

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -1504,6 +1504,18 @@ class ReaderFushiSource extends ReaderMediaSource {
     onSettingsChangedLive?.call();
   }
 
+  /// 正文字重。UI 侧（SettingsStepperItem）值域是 double，存储与 CSS 侧是整数轴，
+  /// 故在此边界一次性 `round()`，不让 `400.0` 这类值流进 CSS 生成器。
+  double get readerFontWeight => (readerSettings?.fontWeight ??
+          getPreference<int>(key: 'font_weight', defaultValue: 400))
+      .toDouble();
+  Future<void> setReaderFontWeight(double v) async {
+    final int weight = v.round();
+    await (readerSettings?.setFontWeight(weight) ??
+        setPreference<int>(key: 'font_weight', value: weight));
+    onSettingsChangedLive?.call();
+  }
+
   double get lyricsFontSize =>
       readerSettings?.lyricsFontSize ??
       getPreference<double>(key: 'lyrics_font_size', defaultValue: 24);

--- a/fushi/lib/src/reader/reader_content_styles.dart
+++ b/fushi/lib/src/reader/reader_content_styles.dart
@@ -42,6 +42,7 @@ typedef _LayoutCssArgs = ({
   bool isVertical,
   _ThemeColors colors,
   String resolvedFontFamily,
+  String fontWeightCss,
   String textSpacingCss,
   String paddingCss,
   String gridCss,
@@ -315,6 +316,17 @@ class ReaderContentStyles {
     final String textSpacingCss =
         'line-height: ${settings.lineHeight} !important;';
 
+    // 正文字重。只声明在 `body` 上，靠继承覆盖正文——不下放到 `p`/`*`，因为 UA
+    // 样式表给 `<strong>`/`<b>` 的是相对值 `bolder`：挂在 body 上时加粗仍相对用户
+    // 选定的基准再上一档（400→700、600→900），书里的强调不会被抹平；一旦改成
+    // 通配选择器 + !important 就会把 `<strong>` 一起钉死成同一字重。
+    // 400 = CSS `normal` 是默认值，此时整条声明不注入：书自带样式表原样生效，
+    // 与本功能引入前的渲染完全一致（零回归），与 `textIndentCss`/`gridCss` 的
+    // 「默认值产出空串」同构。
+    final int fontWeight = settings.fontWeight;
+    final String fontWeightCss =
+        fontWeight == 400 ? '' : 'font-weight: $fontWeight !important;';
+
     final String gridCss = settings.enableTextJustification
         ? ''
         : '''
@@ -399,6 +411,7 @@ svg.block-img.blurred {
       isVertical: isVertical,
       colors: colors,
       resolvedFontFamily: resolvedFontFamily,
+      fontWeightCss: fontWeightCss,
       textSpacingCss: textSpacingCss,
       paddingCss: paddingCss,
       gridCss: gridCss,
@@ -873,6 +886,7 @@ a {
     final ReaderSettings settings = a.settings;
     final _ThemeColors colors = a.colors;
     final String resolvedFontFamily = a.resolvedFontFamily;
+    final String fontWeightCss = a.fontWeightCss;
     final String textSpacingCss = a.textSpacingCss;
     final String paddingCss = a.paddingCss;
     final String gridCss = a.gridCss;
@@ -904,6 +918,7 @@ html, body {
 body {
   font-family: $resolvedFontFamily !important;
   font-size: ${settings.fontSize}px !important;
+  $fontWeightCss
   -webkit-text-size-adjust: none !important;
   overflow-wrap: anywhere !important;
   $textSpacingCss
@@ -987,6 +1002,7 @@ html::before {
     final bool isVertical = a.isVertical;
     final _ThemeColors colors = a.colors;
     final String resolvedFontFamily = a.resolvedFontFamily;
+    final String fontWeightCss = a.fontWeightCss;
     final String textSpacingCss = a.textSpacingCss;
     final String paddingCss = a.paddingCss;
     final String gridCss = a.gridCss;
@@ -1018,6 +1034,7 @@ html, body {
 body {
   font-family: $resolvedFontFamily !important;
   font-size: ${settings.fontSize}px !important;
+  $fontWeightCss
   -webkit-text-size-adjust: none !important;
   overflow-wrap: anywhere !important;
   box-sizing: border-box !important;
@@ -1072,6 +1089,7 @@ body {
     final bool isVertical = a.isVertical;
     final _ThemeColors colors = a.colors;
     final String resolvedFontFamily = a.resolvedFontFamily;
+    final String fontWeightCss = a.fontWeightCss;
     final String textSpacingCss = a.textSpacingCss;
     final String paddingCss = a.paddingCss;
     final String gridCss = a.gridCss;
@@ -1120,6 +1138,7 @@ html, body {
 body {
   font-family: $resolvedFontFamily !important;
   font-size: ${settings.fontSize}px !important;
+  $fontWeightCss
   -webkit-text-size-adjust: none !important;
   overflow-wrap: anywhere !important;
   $textSpacingCss

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -185,6 +185,14 @@ class ReaderSettings {
   double get fontSize => _get<double>('font_size', 22);
   Future<void> setFontSize(double v) => _set<double>('font_size', v);
 
+  /// 正文字重（CSS `font-weight` 数值轴 100~900，步进 100）。默认 400 = CSS
+  /// `normal`，此时 [ReaderContentStyles] **不发** `font-weight` 声明——书自带
+  /// 样式表按原样生效，零行为变化（与 `text_indentation`/`paragraph_spacing`
+  /// 的「默认值不注入」同一约定）。存 int 而非 double：字重是整数轴，存 double
+  /// 会让 `toString()` 落 `400.0` 并直接生成非法 CSS。
+  int get fontWeight => _get<int>('font_weight', 400);
+  Future<void> setFontWeight(int v) => _set<int>('font_weight', v);
+
   double get lyricsFontSize => _get<double>('lyrics_font_size', 24);
   Future<void> setLyricsFontSize(double v) =>
       _set<double>('lyrics_font_size', v);

--- a/fushi/lib/src/settings/settings_schema_reading.dart
+++ b/fushi/lib/src/settings/settings_schema_reading.dart
@@ -71,7 +71,7 @@ SettingsDestination buildReadingDestination() {
             controlBelow: true,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 4,
+              order: 5,
             ),
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
@@ -98,7 +98,7 @@ SettingsDestination buildReadingDestination() {
             controlBelow: true,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 5,
+              order: 6,
             ),
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
@@ -132,7 +132,7 @@ SettingsDestination buildReadingDestination() {
                 c.readerSource.readerSpreadMode != 'off',
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 6,
+              order: 7,
             ),
             // label 用本地化全称（从右到左/从左到右），不再用只有排版从业者
             // 认识的 RTL/LTR 缩写；分段条过宽时 _SegmentedStripHost 自带横向
@@ -164,7 +164,7 @@ SettingsDestination buildReadingDestination() {
             visible: isVertical,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 13,
+              order: 14,
             ),
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
@@ -192,7 +192,7 @@ SettingsDestination buildReadingDestination() {
             controlBelow: true,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 12,
+              order: 13,
             ),
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
@@ -250,6 +250,27 @@ SettingsDestination buildReadingDestination() {
               notifyReaderSettingsChanged(c);
             },
           ),
+          // 正文字重。纯 CSS 键（只改 body 的 `font-weight`，不动几何），故走
+          // notifyReaderSettingsChanged 的活样式热替换，不需要重排章节。
+          // 400 = CSS `normal` 是默认值，落到生成器是「不发声明」= 书自带样式原样。
+          SettingsStepperItem(
+            id: 'reading_display.font_weight',
+            title: t.reader_font_weight,
+            icon: Icons.format_bold,
+            min: 100,
+            max: 900,
+            step: 100,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 2,
+            ),
+            value: (SettingsContext c) => c.readerSource.readerFontWeight,
+            format: (double v) => '${v.round()}',
+            onChanged: (SettingsContext c, double v) {
+              c.readerSource.setReaderFontWeight(v);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
           SettingsStepperItem(
             id: 'reading_display.line_height',
             title: t.reader_line_height,
@@ -259,7 +280,7 @@ SettingsDestination buildReadingDestination() {
             step: 0.1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 2,
+              order: 3,
             ),
             value: (SettingsContext c) => c.readerSource.readerLineHeight,
             format: (double v) => v.toStringAsFixed(2),
@@ -278,7 +299,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 3,
+              order: 4,
             ),
             value: (SettingsContext c) => c.readerSource.readerTextIndentation,
             format: (double v) => '${v.round()}',
@@ -298,7 +319,7 @@ SettingsDestination buildReadingDestination() {
             step: 0.1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 18,
+              order: 19,
             ),
             value: (SettingsContext c) => c.readerSource.readerParagraphSpacing,
             format: (double v) => '${v.toStringAsFixed(1)}em',
@@ -320,7 +341,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 7,
+              order: 8,
             ),
             value: (SettingsContext c) =>
                 c.readerSource.readerPageColumns.toDouble(),
@@ -343,7 +364,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 8,
+              order: 9,
             ),
             value: (SettingsContext c) => c.readerSource.readerMarginTop,
             format: (double v) => '${v.round()}%',
@@ -361,7 +382,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 9,
+              order: 10,
             ),
             value: (SettingsContext c) => c.readerSource.readerMarginBottom,
             format: (double v) => '${v.round()}%',
@@ -379,7 +400,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 10,
+              order: 11,
             ),
             value: (SettingsContext c) => c.readerSource.readerMarginLeft,
             format: (double v) => '${v.round()}%',
@@ -397,7 +418,7 @@ SettingsDestination buildReadingDestination() {
             step: 1,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 11,
+              order: 12,
             ),
             value: (SettingsContext c) => c.readerSource.readerMarginRight,
             format: (double v) => '${v.round()}%',
@@ -681,7 +702,7 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.format_align_justify,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 14,
+              order: 15,
             ),
             value: (SettingsContext c) =>
                 c.readerSource.readerEnableTextJustification,
@@ -697,7 +718,7 @@ SettingsDestination buildReadingDestination() {
             visible: isVertical,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 15,
+              order: 16,
             ),
             value: (SettingsContext c) =>
                 c.readerSource.readerEnableVerticalFontKerning,
@@ -713,7 +734,7 @@ SettingsDestination buildReadingDestination() {
             visible: isVertical,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 16,
+              order: 17,
             ),
             value: (SettingsContext c) => c.readerSource.readerEnableFontVPAL,
             onChanged: (SettingsContext c, bool value) {
@@ -727,7 +748,7 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.style_outlined,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 17,
+              order: 18,
             ),
             value: (SettingsContext c) =>
                 c.readerSource.readerPrioritizeReaderStyles,
@@ -744,7 +765,7 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.blur_on_outlined,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 19,
+              order: 20,
             ),
             value: (SettingsContext c) => c.readerSource.readerBlurImages,
             onChanged: (SettingsContext c, bool value) {
@@ -764,7 +785,7 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.collections_bookmark_outlined,
             reader: const ReaderPlacement(
               group: ReaderGroup.layout,
-              order: 20,
+              order: 21,
             ),
             value: (SettingsContext c) => c.readerSource.readerMergeImagePages,
             onChanged: (SettingsContext c, bool value) {

--- a/fushi/test/settings/reader_font_weight_test.dart
+++ b/fushi/test/settings/reader_font_weight_test.dart
@@ -1,0 +1,184 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/reader/reader_content_styles.dart';
+import 'package:fushi/src/reader/reader_settings.dart';
+import 'package:fushi/src/settings/settings_context.dart';
+import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_schema.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 阅读器正文字重（`reading_display.font_weight`）。与字号一样是纯 CSS 键：写穿
+/// `ReaderSettings` → `ReaderContentStyles` 在 `body` 上发 `font-weight` →
+/// `onSettingsChangedLive` 热替换 `<style>`。这里守三条不变式：
+///  ① schema 值域是 CSS 数值轴 100~900 / 步进 100（不是 Flutter 的 w100..w900 索引）；
+///  ② **默认 400 不发声明**——书自带样式表原样生效，功能引入前后渲染一致（零回归）；
+///  ③ 非默认值写穿 DB 并落进三种视图模式（paginated / continuous / vn）的正文 CSS，
+///     且是整数（`font-weight: 700`，绝不能是 double 往返出来的非法 `700.0`）。
+void main() {
+  /// 从真实 schema 取这条 stepper（保证测的是生产配置，不是测试自拟副本）。
+  SettingsStepperItem readerFontWeightItem(SettingsContext settingsContext) {
+    return buildSettingsSchema(settingsContext)
+        .expand((SettingsDestination d) => d.sections)
+        .expand((SettingsSection s) => s.items)
+        .whereType<SettingsStepperItem>()
+        .firstWhere(
+          (SettingsStepperItem i) => i.id == 'reading_display.font_weight',
+        );
+  }
+
+  group('reader font weight (schema)', () {
+    late FushiDatabase db;
+
+    setUp(() async {
+      db = FushiDatabase.forTesting(NativeDatabase.memory());
+      MediaSource.setDatabase(db);
+      final ReaderSettings readerSettings = ReaderSettings(db);
+      await readerSettings.refreshFromDb();
+      ReaderFushiSource.readerSettings = readerSettings;
+    });
+
+    tearDown(() async {
+      ReaderFushiSource.readerSettings = null;
+      await db.close();
+    });
+
+    testWidgets('stepper walks the CSS 100..900 axis and defaults to 400', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Consumer(
+              builder: (BuildContext context, WidgetRef ref, _) {
+                final SettingsContext settingsContext = SettingsContext(
+                  context: context,
+                  appModel: AppModel(testPlatformServices()),
+                  ref: ref,
+                  readerSource: ReaderFushiSource.instance,
+                  refresh: () {},
+                );
+                final SettingsStepperItem item = readerFontWeightItem(
+                  settingsContext,
+                );
+                expect(item.min, 100, reason: 'CSS font-weight 数值轴下界');
+                expect(item.max, 900, reason: 'CSS font-weight 数值轴上界');
+                expect(item.step, 100, reason: '字重按档走，不是连续值');
+                expect(
+                  item.value(settingsContext),
+                  400,
+                  reason: '默认 400 = CSS normal',
+                );
+                expect(item.format(400), '400', reason: '展示成整数档位，不能出现 400.0');
+                // 落在「排版」组里字号的紧邻位（order 1 是字号）。
+                expect(item.reader!.group, ReaderGroup.layout);
+                expect(item.reader!.order, 2);
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('reader font weight (behavior)', () {
+    Future<ReaderSettings> freshSettings() async {
+      final FushiDatabase db = FushiDatabase.forTesting(
+        NativeDatabase.memory(),
+      );
+      addTearDown(db.close);
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      return settings;
+    }
+
+    test('default 400 emits no font-weight declaration at all', () async {
+      final ReaderSettings settings = await freshSettings();
+      expect(settings.fontWeight, 400);
+
+      for (final String mode in <String>['paginated', 'continuous', 'vn']) {
+        await settings.setViewMode(mode);
+        final String css = ReaderContentStyles.css(settings: settings);
+        expect(
+          css,
+          isNot(contains('font-weight')),
+          reason: '默认值必须不注入任何 font-weight：书自带样式表原样生效（零回归）[$mode]',
+        );
+      }
+    });
+
+    test('a non-default weight persists and reaches the body CSS', () async {
+      final ReaderSettings settings = await freshSettings();
+      await settings.setFontWeight(700);
+      expect(settings.fontWeight, 700);
+
+      for (final String mode in <String>['paginated', 'continuous', 'vn']) {
+        await settings.setViewMode(mode);
+        final String css = ReaderContentStyles.css(settings: settings);
+        expect(
+          css,
+          contains('font-weight: 700 !important;'),
+          reason: '三种视图模式的 body 都要带上用户选的字重 [$mode]',
+        );
+        expect(
+          css,
+          isNot(contains('font-weight: 700.0')),
+          reason: '字重是整数轴，double 往返出来的 700.0 是非法 CSS [$mode]',
+        );
+      }
+    });
+
+    test('the weight survives a DB round-trip', () async {
+      final FushiDatabase db = FushiDatabase.forTesting(
+        NativeDatabase.memory(),
+      );
+      addTearDown(db.close);
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      await settings.setFontWeight(300);
+
+      final ReaderSettings restored = ReaderSettings(db);
+      await restored.refreshFromDb();
+      expect(restored.fontWeight, 300, reason: '字重必须真写穿 DB');
+      expect(
+        ReaderContentStyles.css(settings: restored),
+        contains('font-weight: 300 !important;'),
+      );
+    });
+
+    test(
+      'the source facade rounds and fires the live-apply callback',
+      () async {
+        final FushiDatabase db = FushiDatabase.forTesting(
+          NativeDatabase.memory(),
+        );
+        addTearDown(db.close);
+        final ReaderSettings settings = ReaderSettings(db);
+        await settings.refreshFromDb();
+        ReaderFushiSource.readerSettings = settings;
+        addTearDown(() => ReaderFushiSource.readerSettings = null);
+
+        int calls = 0;
+        ReaderFushiSource.onSettingsChangedLive = () => calls++;
+        addTearDown(() => ReaderFushiSource.onSettingsChangedLive = null);
+
+        // stepper 的值域是 double；边界必须 round 成整数再进存储 / CSS。
+        await ReaderFushiSource.instance.setReaderFontWeight(600.0);
+
+        expect(calls, 1, reason: '纯 CSS 键必须触发活样式热替换');
+        expect(settings.fontWeight, 600);
+        expect(ReaderFushiSource.instance.readerFontWeight, 600.0);
+        expect(
+          ReaderContentStyles.css(settings: settings),
+          contains('font-weight: 600 !important;'),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 做了什么

阅读器排版组新增「字体粗细」步进项，与「字体大小」紧邻，可把正文字重在 CSS 数值轴 100~900 之间按 100 一档调整。

之前阅读器只能调字号 / 行距 / 缩进 / 段距，没有字重：细字体在墨水屏和高亮度环境下发虚，用户只能换一个整字体族来变粗。

## 实现

| 层 | 改动 |
|---|---|
| 持久化 | `ReaderSettings.fontWeight` / `setFontWeight`，pref key `src:reader_fushi:font_weight`，默认 `400` |
| CSS | `ReaderContentStyles` 新增 `fontWeightCss`，经 `_LayoutCssArgs` 分发到 paginated / continuous / vn 三个 `body {}` 块 |
| 活应用 | `ReaderFushiSource.setReaderFontWeight` 触发 `onSettingsChangedLive`，走既有 `_applyStylesLive` 热替换 `<style>` |
| UI | `settings_schema_reading.dart` 的 `section_typography` 加一条 `SettingsStepperItem`（min 100 / max 900 / step 100），同时出现在设置页与书内快捷设置面板 |
| i18n | `reader_font_weight`，经 `i18n_sync` 补齐 17 语言并逐语言翻译 |

### 两个设计决定

**1. 声明只挂在 `body` 上，不下放到 `p` / `*`。**
UA 样式表给 `<strong>` / `<b>` 的是**相对值** `bolder`。挂在 `body` 上时，书里的强调仍然相对用户选定的基准再上一档（400→700、600→900），层次不会被抹平；一旦改成通配选择器 + `!important`，`<strong>` 就会和正文钉死成同一字重。

**2. 默认 400（= CSS `normal`）时整条声明不注入。**
不是发一条 `font-weight: 400`，而是产出空串——书自带样式表原样生效，功能引入前后渲染完全一致（零回归）。与既有 `textIndentCss` / `gridCss` 的「默认值产出空串」同构。

**3. 存 `int` 而非 `double`。** 字重是整数轴；存 double 会让 `_set` 的 `toString()` 落 `400.0`，直接生成非法 CSS。stepper 的值域是 double，故在 `ReaderFushiSource` 边界一次性 `round()`。

`ReaderGroup.layout` 的 order 取 2（字号是 1），其后各项顺延一位，以满足既有的「order 连续无洞」守卫。

## 测试

新增 `fushi/test/settings/reader_font_weight_test.dart`（从真实 schema 取项，不是测试自拟副本）：

- schema 值域 100~900 / 步进 100 / 默认 400 / 展示为整数 / 落在 layout 组字号紧邻位
- **默认 400 时三种视图模式都不含任何 `font-weight`**（零回归）
- 非默认值在 paginated / continuous / vn 三模式都落进正文 CSS，且是 `font-weight: 700`（断言不出现 `700.0`）
- DB 往返保值
- facade 的 `round()` + `onSettingsChangedLive` 活应用回调触发

## 验证

- `flutter analyze lib test` → No issues found
- `flutter test test/settings/reader_font_weight_test.dart test/settings/reader_font_size_cap_test.dart test/settings/reader_settings_reorg_guard_test.dart test/reader/reader_content_styles_test.dart test/i18n/ test/models/preference_keys_guard_test.dart` → 130 passed，退出码 0

https://claude.ai/code/session_01LPjr6tgfkG2x666XERMJAD
