### PR TITLE
refactor(reader): 砍掉阅读统计浮层里的手动计时开关

### DIFF
--- a/fushi/integration_test/desktop_reader_chrome_shortcuts_itest.dart
+++ b/fushi/integration_test/desktop_reader_chrome_shortcuts_itest.dart
@@ -85,11 +85,6 @@ void main() {
           find.byKey(const ValueKey<String>('fushi_reader_stats_close'));
       expect(await waitFor(tester, statsClose), isTrue,
           reason: 'I must open the statistics dialog');
-      expect(
-        find.byKey(
-            const ValueKey<String>('fushi_reader_stats_tracking_toggle')),
-        findsOneWidget,
-      );
       await key(tester, LogicalKeyboardKey.escape);
       await pumpFor(tester, 4);
       expect(statsClose, findsNothing);

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -2235,8 +2235,6 @@ extension _ReaderChrome on _ReaderFushiPageState {
             child: ReaderStatisticsDialog(
               sessionTotals: _readingSessionTotals,
               loadBookTotals: _loadReaderBookStatTotals,
-              trackingPaused: () => _studyClockManualPause,
-              onToggleTracking: _toggleStudyClockManualPause,
               remainingChapterChars: remainingChapter,
               remainingBookChars: remainingBook,
             ),
@@ -2246,15 +2244,17 @@ extension _ReaderChrome on _ReaderFushiPageState {
     );
   }
 
-  /// 统计浮层「本次会话」旁的手动开关：暂停 → `stop()` 结算并封段；继续 →
-  /// `start()` 重锚 tick 起点开新段。旗标同时门住 [_ensureStudyClock] 与生命周期
-  /// resumed 的自动起表。
+  /// 手动计时开关：暂停 → `stop()` 结算并封段；继续 → `start()` 重锚 tick 起点开
+  /// 新段。旗标同时门住 [_ensureStudyClock] 与生命周期 resumed 的自动起表。
+  ///
+  /// 入口只有底部状态行左侧的计时器（[ReaderStatusFooter.onTapTracker]）——在正文
+  /// 里点，停 / 续当场生效。统计浮层里曾另有一个同功能按钮，但开浮层本身就经
+  /// [_withStudyClockPaused] 停表（BUG-2208），层内那个按钮改不动当下的运行态。
   void _toggleStudyClockManualPause() {
     _ensureStudyClock();
     final bool pause = !_studyClockManualPause;
     _rebuild(() => _studyClockManualPause = pause);
-    // 统一判据（BUG-2209）：统计浮层本身是弹层（modalDepth > 0），「继续」在关掉浮层
-    // 后才真正起表；切后台期间点「继续」也只是清旗、回前台再起。
+    // 统一判据（BUG-2209）：切后台期间点「继续」只是清旗、回前台再起表。
     _syncStudyClockRunState();
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -453,7 +453,7 @@ int absoluteCharOffsetOf({
 
 /// 阅读时钟「此刻可跑」的统一判据（BUG-2209 / BUG-2208）。
 ///
-/// 三个正交旗：用户在统计浮层手动暂停（[manualPause]）、app 切后台 / 桌面失焦
+/// 三个正交旗：用户点状态行计时器手动暂停（[manualPause]）、app 切后台 / 桌面失焦
 /// （[lifecycleStopped]）、阅读器面板 / 弹层 / 全页路由压在正文上（[modalDepth] > 0，
 /// 对齐 Hoshi Android 的 `modalPaused`）。任一为真都不算在读。页面里所有 start /
 /// stop 决策只经这一个判据——旧实现 `_ensureStudyClock` 只看手动暂停旗，后台听书
@@ -1791,7 +1791,7 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   /// （BUG-1052 / BUG-1107 的形状）。页面不再持有任何可被重锚的会话计数字段。
   StudyClock? _studyClock;
 
-  /// 用户在阅读统计浮层里手动暂停了会话计时。为 true 时 [_ensureStudyClock] /
+  /// 用户点底部状态行左侧的计时器手动暂停了会话计时。为 true 时 [_ensureStudyClock] /
   /// 生命周期 resumed 都不再 `start()`，直到用户再点一次继续；切屏自动暂停
   /// （BUG-892）与之正交——账仍只在 [StudyClock] 一本。
   bool _studyClockManualPause = false;

--- a/fushi/lib/src/reader/reader_statistics_dialog.dart
+++ b/fushi/lib/src/reader/reader_statistics_dialog.dart
@@ -11,9 +11,11 @@
 /// 数字反而看不全。纵向排一行给数值整条行宽，任何语言的标签和任何位数的数值都不
 /// 再互相挤。
 ///
-/// 手动计时开关是浮层底部的整宽按钮（[_TrackingToggleButton]），与底栏按钮同级
-/// （高度走 `density.controlHeight`）：它此前是「本次会话」小标题旁 18px 的紧凑
-/// IconButton，触摸目标远小于 48dp 的可点击下限，手机上难点中。
+/// 浮层里**没有**手动计时开关：打开这层的入口（`_openReadingStatistics`）本身经
+/// `_withStudyClockPaused` 停表（BUG-2208，浮层是弹层 → `modalDepth > 0`），看统计
+/// 期间计时恒停，层内再摆一个「暂停 / 继续」既改不动当下的运行态，又与「会话读数
+/// 冻结在打开那一刻」的表象自相矛盾。手动暂停的入口是底部状态行左侧的计时器
+/// （`ReaderStatusFooter.onTapTracker`）——在正文里点，停 / 续立刻生效。
 library;
 
 import 'dart:async';
@@ -122,8 +124,6 @@ class ReaderStatisticsDialog extends StatefulWidget {
     required this.loadBookTotals,
     required this.remainingChapterChars,
     required this.remainingBookChars,
-    required this.trackingPaused,
-    required this.onToggleTracking,
     this.tick = const Duration(seconds: 1),
   });
 
@@ -137,12 +137,6 @@ class ReaderStatisticsDialog extends StatefulWidget {
   final int? remainingBookChars;
   final Duration tick;
 
-  /// 会话计时是否被用户手动暂停（读口，每 tick 采样）。
-  final bool Function() trackingPaused;
-
-  /// 「本次会话」旁的 ▶/⏸：手动暂停 / 继续计时（切屏自动暂停之外的手动开关）。
-  final VoidCallback onToggleTracking;
-
   @override
   State<ReaderStatisticsDialog> createState() => _ReaderStatisticsDialogState();
 }
@@ -150,7 +144,7 @@ class ReaderStatisticsDialog extends StatefulWidget {
 class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
   Timer? _ticker;
   ReaderBookStatTotals? _book;
-  ({int seconds, int chars, bool active, bool paused})? _lastSnapshot;
+  ({int seconds, int chars, bool active})? _lastSnapshot;
 
   @override
   void initState() {
@@ -159,11 +153,10 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
     _ticker = Timer.periodic(widget.tick, (_) {
       if (!mounted) return;
       final StudySessionTotals s = widget.sessionTotals();
-      final ({int seconds, int chars, bool active, bool paused}) snap = (
+      final ({int seconds, int chars, bool active}) snap = (
         seconds: s.durationMs ~/ 1000,
         chars: s.chars,
         active: s.active,
-        paused: widget.trackingPaused(),
       );
       if (snap == _lastSnapshot) return;
       setState(() => _lastSnapshot = snap);
@@ -186,7 +179,6 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
     final ThemeData theme = Theme.of(context);
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final StudySessionTotals session = widget.sessionTotals();
-    final bool paused = widget.trackingPaused();
     final ReaderBookStatTotals book = _book ?? kEmptyReaderBookStatTotals;
     final double? finishCph = readerFinishCph(session: session, book: book);
     final int? chapterMs = estimateFinishMs(
@@ -271,14 +263,6 @@ class _ReaderStatisticsDialogState extends State<ReaderStatisticsDialog> {
                       value: bookMs == null ? '—' : formatStatClock(bookMs),
                     ),
                   ],
-                ),
-                SizedBox(height: tokens.spacing.page),
-                _TrackingToggleButton(
-                  paused: paused,
-                  onPressed: () {
-                    widget.onToggleTracking();
-                    setState(() {});
-                  },
                 ),
               ],
             ),
@@ -377,49 +361,6 @@ class _StatRows extends StatelessWidget {
           ],
         ],
       ),
-    );
-  }
-}
-
-/// 浮层底部的手动计时开关：整宽、底栏级高度（`density.controlHeight`）的按钮。
-///
-/// 暂停中用实心 [FilledButton]（计时停着是需要用户注意的非常态），计时中用
-/// tonal 变体。文案沿用旧 tooltip 的 `t.play` / `t.pause`——这两个 key 在 17 种
-/// 语言都有真翻译，新造一对「暂停计时 / 继续计时」只会在 15 种语言上回落成英文。
-/// key 沿用旧的紧凑 IconButton 那一个，桌面端快捷键集成测试按它断言浮层里有计时
-/// 开关。
-class _TrackingToggleButton extends StatelessWidget {
-  const _TrackingToggleButton({required this.paused, required this.onPressed});
-
-  final bool paused;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final Widget icon = Icon(
-      paused ? Icons.play_arrow_rounded : Icons.pause_rounded,
-    );
-    final Widget label = Text(paused ? t.play : t.pause);
-    const ValueKey<String> key = ValueKey<String>(
-      'fushi_reader_stats_tracking_toggle',
-    );
-    return SizedBox(
-      width: double.infinity,
-      height: tokens.density.controlHeight,
-      child: paused
-          ? FilledButton.icon(
-              key: key,
-              onPressed: onPressed,
-              icon: icon,
-              label: label,
-            )
-          : FilledButton.tonalIcon(
-              key: key,
-              onPressed: onPressed,
-              icon: icon,
-              label: label,
-            ),
     );
   }
 }

--- a/fushi/lib/src/reader/reader_status_footer.dart
+++ b/fushi/lib/src/reader/reader_status_footer.dart
@@ -131,7 +131,8 @@ class ReaderStatusFooter extends StatefulWidget {
   /// 点状态行空白处：与顶部进度 pill 同语义——唤出 / 收起控制栏。
   final VoidCallback? onTap;
 
-  /// 点左侧「计时器 + 字/时 + 时长」：切换手动暂停计时（少进一次菜单）。
+  /// 点左侧「计时器 + 字/时 + 时长」：切换手动暂停计时。这是手动停 / 续表的**唯一**
+  /// 入口——统计浮层里曾有一个同功能按钮，但开浮层本身就停表，层内开关改不动运行态。
   final VoidCallback? onTapTracker;
 
   /// 点右侧进度数字：直接打开阅读统计浮层。

--- a/fushi/test/reader/reader_statistics_dialog_test.dart
+++ b/fushi/test/reader/reader_statistics_dialog_test.dart
@@ -148,7 +148,7 @@ void main() {
     );
   });
 
-  group('浮层排版（窄屏不截断 + 计时开关是底栏级按钮）', () {
+  group('浮层排版（窄屏不截断）', () {
     /// 320dp 是仓库里最窄的在售机型宽度（见 FushiDialogFrame 的 BUG-1184 注释），
     /// 数值取到「五位字数 + 五位速度 + 带小时位的时钟」这种最长形态。
     const StudySessionTotals session = (
@@ -157,11 +157,7 @@ void main() {
       active: true,
     );
 
-    Future<void> pumpDialog(
-      WidgetTester tester, {
-      required bool paused,
-      VoidCallback? onToggle,
-    }) async {
+    Future<void> pumpDialog(WidgetTester tester) async {
       tester.view.physicalSize = const Size(320, 2400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
@@ -179,8 +175,6 @@ void main() {
                 ),
                 remainingChapterChars: 12345,
                 remainingBookChars: 654321,
-                trackingPaused: () => paused,
-                onToggleTracking: onToggle ?? () {},
                 tick: const Duration(days: 1),
               ),
             ),
@@ -195,7 +189,7 @@ void main() {
         tester.pumpWidget(const SizedBox.shrink());
 
     testWidgets('320dp 窄屏上标签在左、数值在右，且没有一格被挤到溢出', (WidgetTester tester) async {
-      await pumpDialog(tester, paused: false);
+      await pumpDialog(tester);
       expect(
         tester.takeException(),
         isNull,
@@ -227,29 +221,18 @@ void main() {
       await disposeDialog(tester);
     });
 
-    testWidgets('计时开关是整宽、底栏级高度的按钮，不是紧凑小图标', (WidgetTester tester) async {
-      int toggled = 0;
-      await pumpDialog(tester, paused: false, onToggle: () => toggled++);
-      final Finder toggle = find.byKey(
-        const ValueKey<String>('fushi_reader_stats_tracking_toggle'),
-      );
-      final Size size = tester.getSize(toggle);
+    testWidgets('浮层里不再有手动计时开关：看统计期间计时本来就停着', (WidgetTester tester) async {
+      await pumpDialog(tester);
       expect(
-        size.height,
-        greaterThanOrEqualTo(48),
-        reason: '触摸目标不得低于 48dp（旧的紧凑 IconButton 只有 40）',
+        find.byKey(
+          const ValueKey<String>('fushi_reader_stats_tracking_toggle'),
+        ),
+        findsNothing,
+        reason: '开浮层经 _withStudyClockPaused 停表（BUG-2208），层内开关改不动运行态',
       );
-      expect(size.width, greaterThan(200), reason: '整宽按钮，与底栏按钮同一级别');
-      expect(find.text(t.pause), findsOneWidget);
-      await tester.tap(toggle);
-      expect(toggled, 1);
-      await disposeDialog(tester);
-    });
-
-    testWidgets('暂停中按钮切成「播放」文案 + 播放图标', (WidgetTester tester) async {
-      await pumpDialog(tester, paused: true);
-      expect(find.text(t.play), findsOneWidget);
       expect(find.text(t.pause), findsNothing);
+      expect(find.text(t.play), findsNothing);
+      expect(find.byType(FilledButton), findsNothing);
       await disposeDialog(tester);
     });
   });


### PR DESCRIPTION
## 为什么

打开统计浮层的入口 `_openReadingStatistics` 本身裹在 `_withStudyClockPaused` 里（BUG-2208）：浮层是弹层 → `modalDepth > 0` → 统一判据 `studyClockMayRun` 恒为 false，**看统计期间计时必停**。

于是层内那个「暂停 / 继续」按钮改不动当下的运行态：

- 点「暂停」只是给关掉浮层**之后**置旗；
- 点「继续」在浮层里也不会起表（modalDepth 仍 > 0）；
- 而浮层上方的会话读数又冻结在打开那一刻——按钮的图标状态与用户看到的读数互相矛盾。

## 改了什么

- 删掉浮层底部的 `_TrackingToggleButton`，连带 `ReaderStatisticsDialog` 的 `trackingPaused` / `onToggleTracking` 两个参数，以及每秒采样快照里的 `paused` 字段（读数快照不再跟计时态重建）。
- 手动停 / 续表的入口**保留且唯一**：底部状态行左侧的计时器（`ReaderStatusFooter.onTapTracker` → `_toggleStudyClockManualPause`），在正文里点、当场生效。
- `_studyClockManualPause` 旗、`studyClockMayRun` 的三旗判据、生命周期与弹层两枚旗**都不动**——这不是删机制，只是删一个位置不对的入口。
- 相关文档注释同步到「入口在状态行」的事实。

## 测试

- `fushi/test/reader/reader_statistics_dialog_test.dart`：原来的两条「计时开关是底栏级按钮 / 暂停态切播放文案」换成反向守卫——浮层里查不到 `fushi_reader_stats_tracking_toggle`、没有 play/pause 文案、没有 FilledButton；320dp 窄屏排版用例保留。
- `fushi/integration_test/desktop_reader_chrome_shortcuts_itest.dart`：删掉对该 key 的存在性断言，浮层开合仍按关闭键断言。

## 验证

- `flutter analyze`（含 test 目录）：No issues found。
- 定向：`reader_statistics_dialog_test` / `reader_study_clock_policy_test` / `reader_study_clock_gate_guard_static_test` / `statistics_write_convergence_guard_test` —— 50 tests，全绿，退出码 0。
- 51 条目录枚举型守卫整批：362 tests（与基线一致）；其中 7 条失败经基点对账为 `develop` 既有红（MD3 4 条 / focus 架构 / 横向拖拽 / file_picker），与本 PR 无关。

https://claude.ai/code/session_01D2VLepLdHq3uVbT5mJdDKj
