### PR TITLE
feat(reader): 状态行的计时块从左下角挪到右下角，与进度并排

### DIFF
--- a/fushi/lib/src/reader/reader_status_footer.dart
+++ b/fushi/lib/src/reader/reader_status_footer.dart
@@ -8,9 +8,14 @@ import 'package:fushi/src/reader/reader_chrome_floating.dart'
 
 /// 各平台共用的阅读器底部状态行。
 ///
-/// 一条极简、常驻、**挤压式**（占预留高、正文永不压到它下面）的状态行：
-///  * 左：阅读追踪——计时器图标 + `<字/时> / h <本次时长>`（如 `0 / h 0:00`）；
-///  * 右：字数进度——`<已读> / <总字数>  <百分比>%`。
+/// 一条极简、常驻、**挤压式**（占预留高、正文永不压到它下面）的状态行。两段读数都
+/// 贴**右下角**，顺序与播放条唤出时的 [ReaderStatusInline] 一致：
+///  * 阅读追踪——计时器图标 + `<字/时> / h <本次时长>`（如 `0 / h 0:00`）；
+///  * 字数进度——`<已读> / <总字数>  <百分比>%`。
+///
+/// 追踪块此前独自钉在**左**下角：底部信息被劈成左右两个角，视线要在两角之间跳；而
+/// 有声书播放条一唤出（[ReaderStatusInline]），同一串数字又整体飞到右端，两条底部形态
+/// 互换时读数横跨整屏跳位。两段并排贴右后，底部读数只有一处落点。
 ///
 /// 它取代顶部进度 pill：进度数字统一放在右下角；窄屏文案省略，完整统计仍可点击查看。
 ///
@@ -60,7 +65,7 @@ String formatReadingSessionClock(int durationMs) {
   return '$minutes:$ss';
 }
 
-/// 左侧阅读追踪文案：`<字/时> / h <本次时长>`。
+/// 阅读追踪文案：`<字/时> / h <本次时长>`。
 String readerTrackerLabel(StudySessionTotals totals) {
   final int cph = readingCharsPerHour(
     chars: totals.chars,
@@ -69,9 +74,9 @@ String readerTrackerLabel(StudySessionTotals totals) {
   return '$cph / h  ${formatReadingSessionClock(totals.durationMs)}';
 }
 
-/// 右侧进度文案：`<已读> / <总字数>  <百分比>%`，与顶部进度 pill 同一格式；
+/// 进度文案：`<已读> / <总字数>  <百分比>%`，与顶部进度 pill 同一格式；
 /// 本章字数已知时再接一段括号 `(<本章已读> / <本章总字数> <本章百分比>%)`。
-/// 总字数未知 / 为 0 时返回 null（右侧不画）。
+/// 总字数未知 / 为 0 时返回 null（不画这一段）。
 String? readerProgressLabel({
   required int? current,
   required int? total,
@@ -114,7 +119,7 @@ class ReaderStatusFooter extends StatefulWidget {
   final int? currentChars;
   final int? totalChars;
 
-  /// 本章已读 / 本章总字数（右侧括号段；任一未知则不画括号）。
+  /// 本章已读 / 本章总字数（进度后的括号段；任一未知则不画括号）。
   final int? chapterCurrentChars;
   final int? chapterTotalChars;
 
@@ -131,10 +136,10 @@ class ReaderStatusFooter extends StatefulWidget {
   /// 点状态行空白处：与顶部进度 pill 同语义——唤出 / 收起控制栏。
   final VoidCallback? onTap;
 
-  /// 点左侧「计时器 + 字/时 + 时长」：切换手动暂停计时（少进一次菜单）。
+  /// 点计时块「计时器 + 字/时 + 时长」：切换手动暂停计时（少进一次菜单）。
   final VoidCallback? onTapTracker;
 
-  /// 点右侧进度数字：直接打开阅读统计浮层。
+  /// 点进度数字：直接打开阅读统计浮层。
   final VoidCallback? onTapProgress;
 
   @override
@@ -163,6 +168,23 @@ class _ReaderStatusFooterState extends State<ReaderStatusFooter> {
     super.dispose();
   }
 
+  /// 状态行里可点的一段（计时块 / 进度数字）。命中区**撑满整条行高**：裸文字 + 14px
+  /// 图标的行盒只有十几 px 高，指针（尤其手指）要精确戳中那一行才有反应；撑满后整条
+  /// 28px 高的那一段都可点。只扩竖向、不加横向内边距——右端 16 的边距是与顶部 pill /
+  /// inline 形态共用的视觉基线，补一层横向 padding 会把进度数字从右缘往里推。行高不
+  /// 能为命中区加高（视觉高度 == 预留高度是 chrome 铁律，加高就是挤正文），48dp 级别
+  /// 的计时开关在统计浮层底部那颗整宽按钮上。
+  Widget _hitTarget({required Widget child, VoidCallback? onTap}) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: SizedBox(
+        height: widget.height,
+        child: Center(widthFactor: 1, child: child),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final StudySessionTotals totals = widget.sessionTotals();
@@ -189,17 +211,20 @@ class _ReaderStatusFooterState extends State<ReaderStatusFooter> {
           height: widget.height,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
+            // 两段读数并排贴右：Row 主轴 end 对齐把它们一起推到右缘，追踪块不再被
+            // Expanded 的进度段挤到左角。窄屏保护不变——追踪块仍最多占 40% 宽、
+            // 两段都 ellipsis，谁放不下谁先省略，行永远不溢出。
             child: LayoutBuilder(
                 builder: (BuildContext context, BoxConstraints constraints) {
               return Row(
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
                   ConstrainedBox(
                     constraints: BoxConstraints(
                       maxWidth:
                           constraints.maxWidth * (progress == null ? 1 : .4),
                     ),
-                    child: GestureDetector(
-                      behavior: HitTestBehavior.opaque,
+                    child: _hitTarget(
                       onTap: widget.onTapTracker,
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
@@ -228,22 +253,18 @@ class _ReaderStatusFooterState extends State<ReaderStatusFooter> {
                     ),
                   ),
                   if (progress != null)
-                    Expanded(
+                    Flexible(
                       child: Padding(
                         padding: const EdgeInsets.only(left: 8),
-                        child: Align(
-                          alignment: Alignment.centerRight,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: widget.onTapProgress,
-                            child: Text(
-                              progress,
-                              key: const ValueKey<String>(
-                                  'fushi_status_progress'),
-                              style: style,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
+                        child: _hitTarget(
+                          onTap: widget.onTapProgress,
+                          child: Text(
+                            progress,
+                            key:
+                                const ValueKey<String>('fushi_status_progress'),
+                            style: style,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
                       ),

--- a/fushi/test/reader/reader_status_footer_test.dart
+++ b/fushi/test/reader/reader_status_footer_test.dart
@@ -207,6 +207,50 @@ void main() {
       expect(trackerTaps, 1);
       expect(progressTaps, 1);
     });
+
+    // 追踪块此前钉在左下角、进度在右下角，底部读数被劈成两个角；播放条一唤出
+    // （ReaderStatusInline）同一串数字又整体飞到右端。两段现在并排贴右，与 inline
+    // 同序：计时块在左、进度在右。
+    testWidgets('tracker and progress sit together at the right end',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(totals: () => (durationMs: 0, chars: 0, active: true)),
+      );
+      final Rect strip = tester.getRect(find.byType(ReaderStatusFooter));
+      final Rect tracker = tester
+          .getRect(find.byKey(const ValueKey<String>('fushi_status_tracker')));
+      final Rect progress = tester
+          .getRect(find.byKey(const ValueKey<String>('fushi_status_progress')));
+
+      expect(tracker.right, lessThanOrEqualTo(progress.left),
+          reason: '与 inline 形态同序：计时块在进度左边');
+      // 判据是「两段挨在一起」而不是「都在右半边」——两段文字合起来本就可能超过半屏。
+      expect(progress.left - tracker.right, lessThanOrEqualTo(24),
+          reason: '两段之间只隔一个间距，不再被撑成左右两角');
+      expect(strip.right - progress.right, closeTo(16, 0.5),
+          reason: '右端内边距仍是 16，进度贴着右缘');
+      expect(tracker.left - strip.left, greaterThan(32),
+          reason: '左端留白（点它唤出 / 收起 chrome），计时块不再钉在左下角');
+    });
+
+    testWidgets('tracker hit box spans the full strip height',
+        (WidgetTester tester) async {
+      int trackerTaps = 0;
+      await tester.pumpWidget(
+        host(
+          totals: () => (durationMs: 0, chars: 0, active: true),
+          onTapTracker: () => trackerTaps++,
+        ),
+      );
+      final Rect strip = tester.getRect(find.byType(ReaderStatusFooter));
+      final Rect tracker = tester
+          .getRect(find.byKey(const ValueKey<String>('fushi_status_tracker')));
+
+      // 裸文字行盒只有十几 px 高；命中区撑满整条 28px 后，贴着行顶 / 行底也点得中。
+      await tester.tapAt(Offset(tracker.center.dx, strip.top + 2));
+      await tester.tapAt(Offset(tracker.center.dx, strip.bottom - 2));
+      expect(trackerTaps, 2, reason: '计时块命中区要撑满整条行高，不是只有那一行文字');
+    });
   });
 
   group('source-scan guards', () {


### PR DESCRIPTION
## 问题

底部状态行把「计时器图标 + `<字/时> / h <本次时长>`」钉在**左**下角，进度数字在右下角，底部读数被劈成两个角：视线要在左下 / 右下之间跳。而有声书播放条一唤出（`ReaderStatusInline`），同一串数字又整体飞到右端——两条底部形态互换时读数横跨整屏跳位。手机上那颗 14px 的计时图标孤零零钉在左下角尤其突兀，命中区也只有那一行文字那么高。

| 现状 | 目标（播放条唤出时本来就是这样） |
|---|---|
| 计时块在左下角，进度在右下角 | 计时块 + 进度并排贴右下角 |

## 改动

`fushi/lib/src/reader/reader_status_footer.dart`

- **两段读数并排贴右**：`Row` 主轴 `end` 对齐把它们一起推到右缘，追踪块不再被 `Expanded` 的进度段挤到左角；进度段随之从 `Expanded` 改 `Flexible`（不再需要吃掉剩余空间来把自己顶到右边）。顺序与 `ReaderStatusInline` 一致：计时块在左、进度在右。
- **窄屏保护一字未动**：追踪块仍最多占 40% 宽、两段仍都 `ellipsis`，谁放不下谁先省略，320px 下行不溢出（既有守卫 `320px footer keeps long counts inside and actions accessible` 照旧绿）。
- **左端留白**仍是「点空白唤出 / 收起 chrome」的命中面（外层 `GestureDetector` 不动）。
- **命中区撑满整条行高**（新的 `_hitTarget`）：裸文字 + 14px 图标的行盒只有十几 px 高，指针尤其手指要精确戳中那一行才有反应。只扩竖向、**不加横向内边距**——右端 16 的边距是与顶部 pill / inline 共用的视觉基线，补横向 padding 会把进度数字从右缘往里推。行高不能为命中区加高（视觉高度 == 预留高度是 chrome 铁律，加高就是挤正文）；48dp 级别的计时开关仍在统计浮层底部那颗整宽按钮上。

## 测试

`fushi/test/reader/reader_status_footer_test.dart` 新增两条：

- **两段并排贴右**：计时块在进度左边、二者间距 ≤ 24、进度距右缘 16、左端留白 > 32。判据取「两段挨在一起」而不是「都在右半边」——两段文字合起来本就可能超过半屏，那种断言会假红。
- **计时块命中区撑满行高**：贴行顶 / 行底各点一次都要触发 `onTapTracker`。

## 验证

- `flutter analyze`：`No issues found!`
- `flutter test test/reader/reader_status_footer_test.dart`：18 条全绿（含既有的 320px 窄屏不溢出 + 两段可点、BUG-1692 RepaintBoundary 守卫）。

https://claude.ai/code/session_0129W9mYhWuNLvxapnEAC1X8
