### PR TITLE
feat(discovery): nyaa 小说源按做种排序、疑似漫画标记与过滤三态

### DIFF
--- a/docs/specs/2026-09-08-nyaa-novel-discovery-filters.md
+++ b/docs/specs/2026-09-08-nyaa-novel-discovery-filters.md
@@ -1,0 +1,76 @@
+# 发现页 Nyaa 小说源：做种排序、疑似漫画标记、Nyaa 过滤三态
+
+状态：设计稿（2026-09-08），等用户确认后实施。对应用户报告：Fushi 里下小说时，nyaa 源在【发现】里搜到的有些其实是漫画，而且小说种子死种多。
+
+## 0. 已核实的事实
+
+- 小说域映射到 Nyaa 分类 `3_0`（Literature 全部，`app_model.dart:4714`，全应用唯一一处决策）。Nyaa 的 3_1 英译 / 3_2 非英译 / 3_3 生肉里轻小说与扫图漫画、同人志图包混放，站方没有「小说 vs 漫画」维度。下游 `nyaa_discovery_source.dart:74-90` 零过滤直通，`categoryId` 被丢弃。
+- 查询串只有 `q / c / f`（`nyaa_client.dart:475-483`），Nyaa 默认按发布时间倒序；结果页不排序、不过滤，只把 `↑seeders` 拼进副标题。
+- **RSS 强制忽略排序**：nyaa 后端 `search.py` 两处写死（ES 路径 "Only allow ID, desc if RSS"，DB 路径 "Force sort by id desc if rss"），且只返回 75 条、忽略分页；实测同参数 RSS 首条做种 34、HTML 首条 288。HTML 搜索页尊重 `s=seeders&o=desc`。关键词搜索走 Elasticsearch 最多 1000 条（14 页），无关键词浏览最多 100 页。响应 gzip。
+- Nyaa `f`：`0` 全部 / `1` 排除 remake / `2` 仅 trusted / `3` 仅完结批次（后端有、UI 不露出、无文档）。HTML 行颜色优先级 `deleted > hidden > remake(红) > trusted(绿)`，trusted 用户的 remake 只显示红，trusted 信息被吞；RSS 独立给 `nyaa:trusted` / `nyaa:remake`。
+- 别人怎么做：Jackett/Prowlarr 的 `nyaasi.yml` 把 3_x 一律映射成 Books(7000)，不区分小说/漫画，暴露 `filter-id`（默认 0）与 `sort`，2 秒/请求节流；`lnrelease-discord-bot` 逐条抓 `/view/<id>` 文件列表只留含 `.epub` 的；`chaptr` 用出版社/发布者词表且自注「不过滤时 Literature RSS 约 98% 是漫画」「stick/lucaz 假阳性高」；Kavita/myne 以 `(Digital)` 等括号标签识别漫画。**没有现成的成熟分类器**。
+- 命名规范（wotaku）：括号形状即类型——`()` 漫画、`{}` 条漫、`[]` 轻小说。漫画 `Title v01 (2021) (Digital) (1r0n).cbz`，LN `Title v01 [Yen Press] [Stick].epub`。
+- 体积（实测 3_1/3_2/3_3 各 75 条 + LN 合集 5654 文件）：LN EPUB 每卷 p50 14.8 MiB、p99 45 MiB；英文数字版漫画 70–500 MiB/卷（典型 150–350）；日文生肉漫画 50–220；重叠区 30–60 MiB。3_1 做种榜前 75 条约 54 漫画 / 21 小说。
+- 0 做种：所有交互式 UI（Nyaa 官方、AnimeTosho、qBittorrent 插件、Beastwick TUI）都不隐藏，只沉底/灰显；只有 Sonarr 这类全自动抓取默认 `MinimumSeeders = 1`。
+
+## 1. 首屏走 HTML + 服务端按做种排序
+
+- `NyaaClient` 搜索统一走 HTML 搜索页（`_parseNyaaHtmlSearch` 已能解析 seeders / leechers / category / 行颜色），新增 `sort` / `order` 参数，默认 `s=seeders&o=desc`；`page=rss` 分支只保留 `parseNyaaRss` 给测试与旧调用方，不再作生产首屏。
+- HTML 行 class 映射：`success` → `trusted = true`，`danger` → `remake = true`（文档注明 remake 会盖掉 trusted）。
+- 分页上限：关键词搜索 14 页 / 浏览 100 页，越界返回空而不是抛错。
+- 请求节奏对齐 Jackett：同一 host 至少间隔 2 秒。
+
+## 2. 做种数：排序 + 「隐藏无人做种」
+
+- `DiscoveryResourceItem` 已有 `seeders` / `leechers`；新增 `category`（Nyaa `categoryId`）、`trusted` / `remake`。
+- 源内按做种降序（服务端已排；本地再做稳定排序兜底），跨源仍按 source priority 串接不打乱。
+- 新偏好 `discovery_hide_zero_seeders`（bool，**默认开**，用户 2026-09-08 拍板；调研显示交互式 UI 通行做法是不隐藏只沉底，记录为反对意见）。发现页筛选条给一个可切换 chip；隐藏时显示「已隐藏 N 条无人做种」一行，点一下即显示。未隐藏时 0 做种条目灰显。
+
+## 3. 疑似漫画标记（默认开启的过滤开关，不硬删）
+
+- 纯函数 `classifyNyaaLiterature({title, sizeBytes, categoryId})` → `manga / novel / undecided / audiobook`，放 `fushi/lib/src/media/discovery/nyaa_literature_classifier.dart`。先 `html.unescape`，正则不区分大小写。打分：漫画分 M、小说分 N；`M − N ≥ 2` → manga；`N − M ≥ 2` → novel；其余 undecided（**保留显示**）。
+
+**强漫画 +3**
+
+| 判据 | 正则 |
+|---|---|
+| 括号源标签 | `\((Digital(?:-[\w ]+)?\|c2c\|Scans?(?:ned)?\|Colou?red(?: Manga\| Comics)?)\)` |
+| 容器名 | `\b(cbz\|cbr\|cb7\|cbt)\b` |
+| 类型词 | `\b(Manga\|Manhwa\|Manhua\|Webtoon\|Doujinshi?\|Scanlations?\|Tankobon\|Omake\|One-?shot)\b`；日文 `一般コミック\|コミック\|漫画\|週刊\|月刊\|雑誌\|ジャンプ\|マガジン\|サンデー` |
+| 章节编号 | `\b(?:c\|ch\|chapter)\.?\s?\d{1,4}(?:\.\d)?\b`、`\b\d{3,4}\s*[-–~]\s*\d{3,4}\b`、`\d{3}-\d{3}\s+as\s+v\d{2}` |
+| 周更包 | `Weekly .*Chapter Updates\|\bWeek \d{1,2}\b` |
+
+**中漫画 +2**：年份括号后接括号 `\(\d{4}(?:-\d{4})?\)\s*\(`；图片格式 `\b(JXL\|JPEG-?XL\|WebP)\b`；漫画专属组 `\b(1r0n\|\w+-Empire\|\w+-DCP\|Shizu\|Kaos\|Rillant\|Trite\|0v3r\|Colored Council\|PapriKa\+\|Chromatique\|aKraa\|Kileko)\b`；版本词 `\b(Omnibus\|Deluxe Edition\|Perfect Edition\|Master Edition\|2-in-1)\b`。
+
+**强小说 +3**
+
+| 判据 | 正则 |
+|---|---|
+| 类型词 | `\b(Light ?Novels?\|LNs?\|WN\|Web Novel\|Ranobe)\b`、`(?<!Graphic )\bNovels?\b`、`ライトノベル\|ラノベ\|一般小説\|小説\|轻小说\|輕小說` |
+| 电子书格式 | `\b(EPUB\|AZW3?\|MOBI)\b` |
+| LN 专属出版社 | `\[?(Yen Press\|Yen On\|J-?Novel Club\|Cross Infinite World\|Tentai Books\|Hanashi Media\|One Peace Books\|Sol Press\|Airship)\]?` |
+| LN 专属发布者 | `\b(CleanBookGuy\|faratnis\|Antithetical\|Zaphkiel\|vgperson\|Skeweds\|Mochiguma\|SpicyEPUBs\|Baka-Tsuki\|LNWNCentral)\b` |
+
+**中小说 +2**：尾部连续方括号且不含年份 `(\[[^\]\d]{2,}\]\s*){2,}$`；双栖出版社在方括号内 `\[(Seven Seas(?: Siren)?\|Vertical\|Kodansha\|Viz\|Square Enix\|Dark Horse)\]`；JNC 分级 `\b(Premium\|Prepub)\b`；阅读平台 `\b(Kobo\|Kindle(?:HQ)?\|iBooks\|Google Play)\b`。
+
+**中性 / 弱**：`PDF` 小说 +1；`BookWalker` 小说 +1；`LuCaZ / Stick / Ushi / Oak / nao` **0 分**（两种都发，只能靠括号形状）；`v01`、`v01-v10`、`第NN巻`、`Complete`、`[English]`、前导 `[Group]` 全部中性；`Audiobook|MP3|M4B|FLAC|M4A` → audiobook，不参与判定。
+
+**体积规则**（先从标题解析卷数 n；标题含 `Collection|Pack|Dump|Anthology|Bundle|SiteRip` 或 n 解析失败且总体积 > 2 GiB 则跳过）：每卷 < 25 MiB 小说 +2；25–60 MiB 0；60–150 MiB 漫画 +2；> 150 MiB 漫画 +3；n 未知且单文件形态总体积 > 150 MiB 漫画 +2；n 未知总体积 < 30 MiB 小说 +1。
+
+- 应用点：`NyaaDiscoverySource` 映射层给小说域结果打 `contentHint`；发现页新偏好 `discovery_hide_suspected_manga`（bool，默认开）只隐藏 manga 档，undecided 保留；隐藏计数行同上。
+- 不做逐条 `/view/<id>` 文件列表抓取（每条一次请求）；作为二期「点开详情时按需判定」。
+- 语料测试：table-driven，正例/反例取自调研样本（`Sousou no Frieren v01-14 (Digital) (1r0n)` 漫画；`Re:ZERO v01-29 [Yen Press] [Stick]` 小说；`Kemono Jihen v01-21 (Digital) (Stick)` 漫画；`Youjo Senki v24-27 (2024-2025) (Digital) (Ushi)` 漫画——chaptr 语料把它错标成 LN，正是「发布组名不能当信号」的反例；`Gundam The Origin v01-24 (Digital) (BookWalker) (JP)` 漫画）。
+
+## 4. Nyaa 过滤三态 + 徽标
+
+- 新偏好 `discovery_nyaa_quality_filter`（int 0/1/2，**默认 0**，与 Nyaa UI / Prowlarr / Flexget 一致；只有 Sonarr 的全自动场景默认排除 remake）。发现页 Nyaa 过滤菜单：「全部 / 排除 remake / 仅信任发布者」，透传为 `f`。
+- 卡片徽标：trusted 绿 / remake 红，来自 HTML 行 class。
+- 不暴露 `f=3`。
+
+## 5. 测试与验证
+
+- `nyaa_client_test.dart`：HTML 首屏 + `s/o` 参数 + 行 class → trusted/remake + 越界页返回空。
+- `nyaa_discovery_source_test.dart`：`category` / `contentHint` 透传；现有 `c=3_0` 断言保留（分类本身不改）。
+- `nyaa_literature_classifier_test.dart`：规则表语料。
+- `media_discovery_page_test.dart`：隐藏无人做种 / 隐藏疑似漫画两个开关的显示与计数行；Nyaa 过滤三态写穿偏好。
+- 真机：Windows 上在发现页搜一个常见 LN 系列，截图对比开关前后。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 75446 (4438 per locale)
+/// Strings: 75633 (4449 per locale)
 ///
-/// Built on 2026-09-07 at 14:27 UTC
+/// Built on 2026-09-08 at 06:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6145,6 +6145,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'AniList is rate-limiting this app right now. Wait a moment and retry.';
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  String get discovery_hidden_show => 'Show';
+  String get discovery_nyaa_filter_all => 'All';
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  String get discovery_badge_trusted => 'Trusted';
+  String get discovery_badge_remake => 'Remake';
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -16556,6 +16569,30 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -27194,6 +27231,30 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -37885,6 +37946,30 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -48610,6 +48695,30 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -59138,6 +59247,30 @@ class _StringsId extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -69757,6 +69890,30 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -79756,6 +79913,30 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -89765,6 +89946,30 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -100342,6 +100547,30 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -110971,6 +111200,30 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -121578,6 +121831,30 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -131983,6 +132260,30 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -142506,6 +142807,30 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -153000,6 +153325,30 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 // Path: <root>
@@ -162635,6 +162984,30 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+  @override
+  String get discovery_filter_hide_zero_seeders => '隐藏无人做种';
+  @override
+  String get discovery_filter_hide_suspected_manga => '隐藏疑似漫画';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '已隐藏 ${n} 条无人做种';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '已隐藏 ${n} 条疑似漫画';
+  @override
+  String get discovery_hidden_show => '显示';
+  @override
+  String get discovery_nyaa_filter_all => '全部';
+  @override
+  String get discovery_nyaa_filter_no_remakes => '排除 remake';
+  @override
+  String get discovery_nyaa_filter_trusted_only => '仅信任发布者';
+  @override
+  String get discovery_badge_trusted => '信任发布者';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => '疑似漫画';
 }
 
 // Path: <root>
@@ -172323,6 +172696,30 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_anilist_error_unreachable =>
       '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+  @override
+  String get discovery_filter_hide_zero_seeders => 'Hide unseeded';
+  @override
+  String get discovery_filter_hide_suspected_manga => 'Hide suspected manga';
+  @override
+  String discovery_hidden_zero_seeders_count({required Object n}) =>
+      '${n} unseeded hidden';
+  @override
+  String discovery_hidden_suspected_manga_count({required Object n}) =>
+      '${n} suspected manga hidden';
+  @override
+  String get discovery_hidden_show => 'Show';
+  @override
+  String get discovery_nyaa_filter_all => 'All';
+  @override
+  String get discovery_nyaa_filter_no_remakes => 'No remakes';
+  @override
+  String get discovery_nyaa_filter_trusted_only => 'Trusted only';
+  @override
+  String get discovery_badge_trusted => 'Trusted';
+  @override
+  String get discovery_badge_remake => 'Remake';
+  @override
+  String get discovery_content_hint_manga => 'Suspected manga';
 }
 
 /// Flat map(s) containing all translations.
@@ -181442,6 +181839,28 @@ extension on _StringsEn {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -190556,6 +190975,28 @@ extension on _StringsAr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -199715,6 +200156,28 @@ extension on _StringsDe {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -208865,6 +209328,28 @@ extension on _StringsEs {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -218024,6 +218509,28 @@ extension on _StringsFr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -227154,6 +227661,28 @@ extension on _StringsId {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -236306,6 +236835,28 @@ extension on _StringsIt {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -245385,6 +245936,28 @@ extension on _StringsJa {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -254468,6 +255041,28 @@ extension on _StringsKo {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -263613,6 +264208,28 @@ extension on _StringsNl {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -272753,6 +273370,28 @@ extension on _StringsPtBr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -281900,6 +282539,28 @@ extension on _StringsRu {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -291019,6 +291680,28 @@ extension on _StringsTh {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -300153,6 +300836,28 @@ extension on _StringsTr {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -309281,6 +309986,28 @@ extension on _StringsVi {
         return 'AniList is rate-limiting this app right now. Wait a moment and retry.';
       case 'video_anilist_error_unreachable':
         return 'Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }
@@ -318330,6 +319057,28 @@ extension on _StringsZhCn {
         return 'AniList 正在对本应用限流。稍等一会儿再重试。';
       case 'video_anilist_error_unreachable':
         return '连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。';
+      case 'discovery_filter_hide_zero_seeders':
+        return '隐藏无人做种';
+      case 'discovery_filter_hide_suspected_manga':
+        return '隐藏疑似漫画';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '已隐藏 ${n} 条无人做种';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '已隐藏 ${n} 条疑似漫画';
+      case 'discovery_hidden_show':
+        return '显示';
+      case 'discovery_nyaa_filter_all':
+        return '全部';
+      case 'discovery_nyaa_filter_no_remakes':
+        return '排除 remake';
+      case 'discovery_nyaa_filter_trusted_only':
+        return '仅信任发布者';
+      case 'discovery_badge_trusted':
+        return '信任发布者';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return '疑似漫画';
       default:
         return null;
     }
@@ -327387,6 +328136,28 @@ extension on _StringsZhHk {
         return 'AniList 正在對本應用限流。稍等一會兒再重試。';
       case 'video_anilist_error_unreachable':
         return '連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。';
+      case 'discovery_filter_hide_zero_seeders':
+        return 'Hide unseeded';
+      case 'discovery_filter_hide_suspected_manga':
+        return 'Hide suspected manga';
+      case 'discovery_hidden_zero_seeders_count':
+        return ({required Object n}) => '${n} unseeded hidden';
+      case 'discovery_hidden_suspected_manga_count':
+        return ({required Object n}) => '${n} suspected manga hidden';
+      case 'discovery_hidden_show':
+        return 'Show';
+      case 'discovery_nyaa_filter_all':
+        return 'All';
+      case 'discovery_nyaa_filter_no_remakes':
+        return 'No remakes';
+      case 'discovery_nyaa_filter_trusted_only':
+        return 'Trusted only';
+      case 'discovery_badge_trusted':
+        return 'Trusted';
+      case 'discovery_badge_remake':
+        return 'Remake';
+      case 'discovery_content_hint_manga':
+        return 'Suspected manga';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Leave blank to use the bundled app API key.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "اتركه فارغًا لاستخدام مفتاح API المضمّن في التطبيق.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Leer lassen, um den enthaltenen API-Schlüssel der App zu verwenden.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Déjalo vacío para usar la clave API incluida en la aplicación.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Laissez vide pour utiliser la clé API incluse dans l’application.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Biarkan kosong untuk menggunakan kunci API bawaan aplikasi.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Lascia vuoto per usare la chiave API inclusa nell’app.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "空欄の場合、アプリ内蔵の API キーを使用します。",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "비워 두면 앱에 내장된 API 키를 사용합니다.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Laat leeg om de meegeleverde API-sleutel van de app te gebruiken.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Deixe vazio para usar a chave API incluída no aplicativo.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Оставьте пустым, чтобы использовать встроенный ключ API приложения.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "เว้นว่างไว้เพื่อใช้คีย์ API ที่มีอยู่ในแอป",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Uygulamayla gelen API anahtarını kullanmak için boş bırakın.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "Để trống để dùng khóa API tích hợp trong ứng dụng.",
   "video_anilist_error_api_disabled": "AniList has temporarily disabled its public API because of server-side stability problems. This is not a problem with your network or proxy - the request reached AniList and was refused. Please try again later.",
   "video_anilist_error_rate_limited": "AniList is rate-limiting this app right now. Wait a moment and retry.",
-  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings."
+  "video_anilist_error_unreachable": "Cannot reach AniList (graphql.anilist.co). Check your network connection, or configure a proxy in download settings.",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "留空使用应用内置 API 密钥。",
   "video_anilist_error_api_disabled": "AniList 官方因服务器稳定性问题暂时停用了公开 API。这不是你的网络或代理的问题——请求已经打到 AniList 并被它当面拒绝了。请稍后再试。",
   "video_anilist_error_rate_limited": "AniList 正在对本应用限流。稍等一会儿再重试。",
-  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。"
+  "video_anilist_error_unreachable": "连不上 AniList（graphql.anilist.co）。请检查网络连接，或在下载设置中配置代理。",
+  "discovery_filter_hide_zero_seeders": "隐藏无人做种",
+  "discovery_filter_hide_suspected_manga": "隐藏疑似漫画",
+  "discovery_hidden_zero_seeders_count": "已隐藏 ${n} 条无人做种",
+  "discovery_hidden_suspected_manga_count": "已隐藏 ${n} 条疑似漫画",
+  "discovery_hidden_show": "显示",
+  "discovery_nyaa_filter_all": "全部",
+  "discovery_nyaa_filter_no_remakes": "排除 remake",
+  "discovery_nyaa_filter_trusted_only": "仅信任发布者",
+  "discovery_badge_trusted": "信任发布者",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "疑似漫画"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4436,5 +4436,16 @@
   "video_opensubtitles_app_key_hint": "留空以使用應用程式內置的 API 金鑰。",
   "video_anilist_error_api_disabled": "AniList 官方因伺服器穩定性問題暫時停用了公開 API。這不是你的網絡或代理的問題——請求已經打到 AniList 並被它當面拒絕了。請稍後再試。",
   "video_anilist_error_rate_limited": "AniList 正在對本應用限流。稍等一會兒再重試。",
-  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。"
+  "video_anilist_error_unreachable": "連不上 AniList（graphql.anilist.co）。請檢查網絡連接，或在下載設定中配置代理。",
+  "discovery_filter_hide_zero_seeders": "Hide unseeded",
+  "discovery_filter_hide_suspected_manga": "Hide suspected manga",
+  "discovery_hidden_zero_seeders_count": "${n} unseeded hidden",
+  "discovery_hidden_suspected_manga_count": "${n} suspected manga hidden",
+  "discovery_hidden_show": "Show",
+  "discovery_nyaa_filter_all": "All",
+  "discovery_nyaa_filter_no_remakes": "No remakes",
+  "discovery_nyaa_filter_trusted_only": "Trusted only",
+  "discovery_badge_trusted": "Trusted",
+  "discovery_badge_remake": "Remake",
+  "discovery_content_hint_manga": "Suspected manga"
 }

--- a/fushi/lib/src/media/discovery/discovery_models.dart
+++ b/fushi/lib/src/media/discovery/discovery_models.dart
@@ -126,6 +126,10 @@ final class DiscoveryResourceItem extends DiscoveryEntry {
     this.note,
     this.gameLocalization,
     this.isDownloadable = true,
+    this.category,
+    this.trusted = false,
+    this.remake = false,
+    this.contentHint = DiscoveryContentHint.none,
   });
 
   /// 源内稳定 id（去重/防重复入队的身份键；语义源自定义：文件路径、种子页 URL 等）。
@@ -172,6 +176,44 @@ final class DiscoveryResourceItem extends DiscoveryEntry {
 
   /// false 表示该来源只支持展示/辨认，当前下载模块没有可执行 payload。
   final bool isDownloadable;
+
+  /// 源内分类 id（nyaa `categoryId`，如 `3_1` = Literature English-translated）；
+  /// 源不给分类时为 null。
+  final String? category;
+
+  /// 源标记的 trusted 发布（nyaa HTML 行 class `success`）。
+  final bool trusted;
+
+  /// 源标记的 remake（nyaa HTML 行 class `danger`）。nyaa 的行颜色只有一种，
+  /// remake 会盖掉 trusted——两者同真在 HTML 路径上不会出现。
+  final bool remake;
+
+  /// 标题/体积推断出的内容形态，见 [DiscoveryContentHint]。默认 [DiscoveryContentHint.none]
+  /// = 源没跑分类器（非 nyaa 小说域、OPDS、直链源）。
+  final DiscoveryContentHint contentHint;
+}
+
+/// 资源条目的内容形态提示：Nyaa Literature（`3_x`）里轻小说与扫图漫画、同人志
+/// 图包混放，站方没有「小说 vs 漫画」维度，只能靠标题命名规范 + 体积推断
+/// （`nyaa_literature_classifier.dart`）。
+///
+/// 这是**提示**不是事实：发现页默认只隐藏 [manga] 档，[undecided] 保留显示，
+/// 用户随时能一键显示被隐藏的条目。
+enum DiscoveryContentHint {
+  /// 判定为漫画（漫画分领先小说分 ≥ 2）。
+  manga,
+
+  /// 判定为小说。
+  novel,
+
+  /// 两边信号打平或都没有：保留显示。
+  undecided,
+
+  /// 有声书（`Audiobook|MP3|M4B|FLAC|M4A`），不参与小说/漫画判定。
+  audiobook,
+
+  /// 该条目没有跑分类器。
+  none,
 }
 
 /// BUG-1910：游戏资源的汉化状态。值域来自 shinnku 上游 `get_game_type` 的三分类。

--- a/fushi/lib/src/media/discovery/nyaa_literature_classifier.dart
+++ b/fushi/lib/src/media/discovery/nyaa_literature_classifier.dart
@@ -1,0 +1,239 @@
+/// Nyaa Literature（`3_x`）条目的「小说 vs 漫画」启发式分类器。
+///
+/// nyaa 的 Literature 分类把轻小说、扫图漫画、同人志图包混放，站方没有
+/// 「小说 vs 漫画」维度；实测 3_1 做种榜前 75 条约 54 漫画 / 21 小说，不过滤
+/// 的话小说域发现页大半是漫画。业界没有现成分类器（Jackett/Prowlarr 一律映射
+/// 成 Books；chaptr 用出版社词表并自注「stick/lucaz 假阳性高」），这里按
+/// 设计稿 `docs/specs/2026-09-08-nyaa-novel-discovery-filters.md` 第 3 节的
+/// 规则表打分：
+///
+/// - 漫画分 M、小说分 N 各自累加（同一判据只记一次）；
+/// - `M − N ≥ 2` → manga，`N − M ≥ 2` → novel，其余 undecided（保留显示）；
+/// - `Audiobook|MP3|M4B|FLAC|M4A` → audiobook，不参与判定。
+///
+/// 关键取舍：**发布组名不是信号**——`LuCaZ / Stick / Ushi / Oak / nao` 两种都发
+/// （chaptr 语料把 `Youjo Senki v24-27 (2024-2025) (Digital) (Ushi)` 错标成 LN
+/// 正是这个反例），只能靠括号形状：wotaku 命名规范里 `()` 漫画、`[]` 轻小说。
+///
+/// 纯函数，无 IO；不做逐条 `/view/<id>` 文件列表抓取（每条一次请求，二期再说）。
+library;
+
+import 'package:html_unescape/html_unescape.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+
+/// 一条标题的打分明细。[hint] 是最终判定。
+class NyaaLiteratureScore {
+  const NyaaLiteratureScore({
+    required this.manga,
+    required this.novel,
+    required this.audiobook,
+  });
+
+  /// 漫画分 M。
+  final int manga;
+
+  /// 小说分 N。
+  final int novel;
+
+  /// 命中有声书判据（此时 [manga] / [novel] 仍会算出来，但不参与判定）。
+  final bool audiobook;
+
+  DiscoveryContentHint get hint {
+    if (audiobook) return DiscoveryContentHint.audiobook;
+    if (manga - novel >= 2) return DiscoveryContentHint.manga;
+    if (novel - manga >= 2) return DiscoveryContentHint.novel;
+    return DiscoveryContentHint.undecided;
+  }
+
+  @override
+  String toString() =>
+      'NyaaLiteratureScore(manga: $manga, novel: $novel, audiobook: $audiobook)';
+}
+
+/// 判定一条 Nyaa Literature 条目是小说还是漫画。见库注释。
+///
+/// [title] 先做 HTML 反转义（nyaa 标题里 `&amp;` 常见），正则一律不区分大小写。
+/// [sizeBytes] 参与体积规则（null 跳过）。[categoryId] 为 nyaa 分类 id：`2_x`
+/// （Audio）直接判 audiobook，其余不影响打分——`3_1/3_2/3_3` 只区分译文语言，
+/// 与「小说 vs 漫画」无关。
+DiscoveryContentHint classifyNyaaLiterature({
+  required String title,
+  int? sizeBytes,
+  String? categoryId,
+}) =>
+    scoreNyaaLiterature(
+      title: title,
+      sizeBytes: sizeBytes,
+      categoryId: categoryId,
+    ).hint;
+
+/// [classifyNyaaLiterature] 的打分版本，测试/调试看明细用。
+NyaaLiteratureScore scoreNyaaLiterature({
+  required String title,
+  int? sizeBytes,
+  String? categoryId,
+}) {
+  final String text = _unescape.convert(title).trim();
+  final bool audiobook =
+      _audiobook.hasMatch(text) || (categoryId?.startsWith('2_') ?? false);
+
+  int manga = 0;
+  int novel = 0;
+  for (final RegExp rule in _strongManga) {
+    if (rule.hasMatch(text)) manga += 3;
+  }
+  if (_hasNonYearNumberRange(text)) manga += 3;
+  for (final RegExp rule in _mediumManga) {
+    if (rule.hasMatch(text)) manga += 2;
+  }
+  for (final RegExp rule in _strongNovel) {
+    if (rule.hasMatch(text)) novel += 3;
+  }
+  for (final RegExp rule in _mediumNovel) {
+    if (rule.hasMatch(text)) novel += 2;
+  }
+  for (final RegExp rule in _weakNovel) {
+    if (rule.hasMatch(text)) novel += 1;
+  }
+
+  final (int, int) sizeScore = _sizeScore(text, sizeBytes);
+  manga += sizeScore.$1;
+  novel += sizeScore.$2;
+
+  return NyaaLiteratureScore(manga: manga, novel: novel, audiobook: audiobook);
+}
+
+final HtmlUnescape _unescape = HtmlUnescape();
+
+RegExp _ci(String source) => RegExp(source, caseSensitive: false);
+
+final RegExp _audiobook = _ci(r'\b(Audiobook|MP3|M4B|FLAC|M4A)\b');
+
+/// 强漫画 +3（每条判据独立计分）。
+final List<RegExp> _strongManga = <RegExp>[
+  // 括号源标签：(Digital) / (Digital-Compilation) / (c2c) / (Scan) / (Colored)。
+  _ci(r'\((Digital(?:-[\w ]+)?|c2c|Scans?(?:ned)?|Colou?red(?: Manga| Comics)?)\)'),
+  // 漫画容器名。
+  _ci(r'\b(cbz|cbr|cb7|cbt)\b'),
+  // 类型词（英文）。
+  _ci(r'\b(Manga|Manhwa|Manhua|Webtoon|Doujinshi?|Scanlations?|Tankobon|Omake|One-?shot)\b'),
+  // 类型词（日文：`\b` 对 CJK 无效，直接子串）。
+  _ci('一般コミック|コミック|漫画|週刊|月刊|雑誌|ジャンプ|マガジン|サンデー'),
+  // 章节编号：c12 / ch.12 / Chapter 12 / c12.5。
+  _ci(r'\b(?:c|ch|chapter)\.?\s?\d{1,4}(?:\.\d)?\b'),
+  // 「001-050 as v01」形态的章节→卷映射。
+  _ci(r'\d{3}-\d{3}\s+as\s+v\d{2}'),
+  // 周更包。
+  _ci(r'Weekly .*Chapter Updates|\bWeek \d{1,2}\b'),
+];
+
+/// 三到四位数区间（章节区间 `101-150`）。年份区间 `(2024-2025)` 形状相同，
+/// 设计稿把它单列为中漫画 +2，这里必须排除掉，否则一条 `Title (2020-2023)
+/// [Yen Press]` 会白拿 +3 强漫画分。
+final RegExp _numberRange = RegExp(r'\b(\d{3,4})\s*[-–~]\s*(\d{3,4})\b');
+
+bool _isYear(int value) => value >= 1900 && value <= 2099;
+
+bool _hasNonYearNumberRange(String text) {
+  for (final RegExpMatch m in _numberRange.allMatches(text)) {
+    final int first = int.parse(m.group(1)!);
+    final int second = int.parse(m.group(2)!);
+    if (!(_isYear(first) && _isYear(second))) return true;
+  }
+  return false;
+}
+
+/// 中漫画 +2。
+final List<RegExp> _mediumManga = <RegExp>[
+  // 年份括号后紧跟另一个括号：`(2024-2025) (Digital)` 是漫画命名规范的骨架。
+  _ci(r'\(\d{4}(?:-\d{4})?\)\s*\('),
+  // 图片格式。
+  _ci(r'\b(JXL|JPEG-?XL|WebP)\b'),
+  // 漫画专属发布组（`PapriKa+` 末尾是 `+`，`\b` 接不上，用显式非字词环视）。
+  _ci(r'(?<!\w)(1r0n|\w+-Empire|\w+-DCP|Shizu|Kaos|Rillant|Trite|0v3r|Colored Council|PapriKa\+|Chromatique|aKraa|Kileko)(?!\w)'),
+  // 版本词。
+  _ci(r'\b(Omnibus|Deluxe Edition|Perfect Edition|Master Edition|2-in-1)\b'),
+];
+
+/// 强小说 +3。
+final List<RegExp> _strongNovel = <RegExp>[
+  // 类型词（英文）。`Graphic Novel` / `Visual Novel` 不算。
+  _ci(r'\b(Light ?Novels?|LNs?|WN|Web Novel|Ranobe)\b'),
+  _ci(r'(?<!Graphic |Visual )\bNovels?\b'),
+  // 类型词（日/中文）。
+  _ci('ライトノベル|ラノベ|一般小説|小説|轻小说|輕小說'),
+  // 电子书格式。
+  _ci(r'\b(EPUB|AZW3?|MOBI)\b'),
+  // LN 专属出版社（方括号可有可无）。
+  _ci(r'(?<!\w)(Yen Press|Yen On|J-?Novel Club|Cross Infinite World|Tentai Books|Hanashi Media|One Peace Books|Sol Press|Airship)(?!\w)'),
+  // LN 专属发布者。
+  _ci(r'\b(CleanBookGuy|faratnis|Antithetical|Zaphkiel|vgperson|Skeweds|Mochiguma|SpicyEPUBs|Baka-Tsuki|LNWNCentral)\b'),
+];
+
+/// 中小说 +2。
+final List<RegExp> _mediumNovel = <RegExp>[
+  // 尾部连续 ≥2 个不含数字的方括号：`[Yen Press] [Stick]`（`[ABCD1234]` 不算）。
+  _ci(r'(\[[^\]\d]{2,}\]\s*){2,}$'),
+  // 双栖出版社只在方括号里才算小说信号（括号形状即类型）。
+  _ci(r'\[(Seven Seas(?: Siren)?|Vertical|Kodansha|Viz|Square Enix|Dark Horse)\]'),
+  // J-Novel Club 分级。
+  _ci(r'\b(Premium|Prepub)\b'),
+  // 阅读平台。
+  _ci(r'\b(Kobo|Kindle(?:HQ)?|iBooks|Google Play)\b'),
+];
+
+/// 弱小说 +1。`LuCaZ / Stick / Ushi / Oak / nao` 刻意 0 分。
+final List<RegExp> _weakNovel = <RegExp>[
+  _ci(r'\bPDF\b'),
+  _ci(r'(?<!\w)BookWalker(?!\w)'),
+];
+
+const int _mib = 1024 * 1024;
+const int _gib = 1024 * _mib;
+
+/// 合集/图包：体积与卷数无关，跳过体积规则。
+final RegExp _sizeSkip =
+    _ci(r'\b(Collection|Pack|Dump|Anthology|Bundle|SiteRip)\b');
+
+/// 单文件形态：标题以文件扩展名结尾。
+final RegExp _singleFile =
+    _ci(r'\.(cbz|cbr|cb7|cbt|epub|pdf|azw3?|mobi|zip|rar|7z)$');
+
+final RegExp _volumeRange = _ci(r'\bv(\d{1,3})\s*[-–~]\s*v?(\d{1,3})\b');
+final RegExp _jpVolumeRange = RegExp(r'第(\d{1,3})\s*[-–~]\s*(\d{1,3})巻');
+final RegExp _singleVolume = _ci(r'\bv\d{1,3}\b|第\d{1,3}巻');
+
+/// 从标题解析卷数 n；认不出返回 null。
+int? _volumeCount(String text) {
+  for (final RegExp range in <RegExp>[_volumeRange, _jpVolumeRange]) {
+    final RegExpMatch? m = range.firstMatch(text);
+    if (m == null) continue;
+    final int first = int.parse(m.group(1)!);
+    final int second = int.parse(m.group(2)!);
+    if (second >= first) return second - first + 1;
+  }
+  if (_singleVolume.hasMatch(text)) return 1;
+  return null;
+}
+
+/// 体积规则 → (漫画加分, 小说加分)。
+///
+/// LN EPUB 每卷 p50 14.8 MiB、p99 45 MiB；英文数字版漫画 70–500 MiB/卷；
+/// 日文生肉漫画 50–220；30–60 MiB 是重叠区、不给分。
+(int, int) _sizeScore(String text, int? sizeBytes) {
+  if (sizeBytes == null || sizeBytes <= 0) return (0, 0);
+  if (_sizeSkip.hasMatch(text)) return (0, 0);
+  final int? volumes = _volumeCount(text);
+  if (volumes == null) {
+    if (sizeBytes > 2 * _gib) return (0, 0);
+    if (sizeBytes > 150 * _mib && _singleFile.hasMatch(text)) return (2, 0);
+    if (sizeBytes < 30 * _mib) return (0, 1);
+    return (0, 0);
+  }
+  final double perVolume = sizeBytes / volumes;
+  if (perVolume < 25 * _mib) return (0, 2);
+  if (perVolume <= 60 * _mib) return (0, 0);
+  if (perVolume <= 150 * _mib) return (2, 0);
+  return (3, 0);
+}

--- a/fushi/lib/src/media/discovery/sources/nyaa_discovery_source.dart
+++ b/fushi/lib/src/media/discovery/sources/nyaa_discovery_source.dart
@@ -1,17 +1,29 @@
-/// nyaa 系站点的发现源 adapter：复用 `NyaaClient`（RSS 首屏 + HTML 翻页），
-/// 一个实例 = 一个站点（nyaa.si / sukebei.nyaa.si），媒体域 → 站点分类 id 的
-/// 映射由组装点给定：
+/// nyaa 系站点的发现源 adapter：复用 `NyaaClient`（HTML 搜索页，服务端按做种
+/// 降序），一个实例 = 一个站点（nyaa.si / sukebei.nyaa.si），媒体域 → 站点分类
+/// id 的映射由组装点给定：
 ///
 /// - nyaa.si：小说 `3_0`（Literature）、有声书 `2_0`（Audio）、动画 `1_0`
 /// - sukebei.nyaa.si：galgame `1_3`（Art - Games）
 ///
 /// 产出 torrent payload：UI 分流给 torrent 后端，不进 HTTP 下载队列。
+///
+/// 小说域结果经 `classifyNyaaLiterature` 打 [DiscoveryResourceItem.contentHint]
+/// （Literature 分类里漫画与小说混放，站方不区分）；其余域恒
+/// [DiscoveryContentHint.none]。
 library;
 
 import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/discovery/nyaa_literature_classifier.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/torrent/nyaa_client.dart';
+
+/// 请求时取当前 Nyaa 过滤三态的回调（偏好可随时变，源实例常驻，所以按次读）。
+typedef NyaaQualityFilterProvider = NyaaQualityFilter Function();
+
+NyaaQualityFilter _allFilter() => NyaaQualityFilter.all;
+
+NyaaQualityFilter _trustedOnlyFilter() => NyaaQualityFilter.trustedOnly;
 
 class NyaaDiscoverySource extends MediaDiscoverySource {
   NyaaDiscoverySource({
@@ -21,9 +33,12 @@ class NyaaDiscoverySource extends MediaDiscoverySource {
     required NyaaClient client,
     this.priority = 10,
     this.trustedOnly = false,
+    NyaaQualityFilterProvider? qualityFilter,
   })  : _categoryByKind =
             Map<DiscoveryMediaKind, String>.unmodifiable(categoryByKind),
-        _client = client;
+        _client = client,
+        _qualityFilter =
+            qualityFilter ?? (trustedOnly ? _trustedOnlyFilter : _allFilter);
 
   @override
   final String id;
@@ -34,11 +49,12 @@ class NyaaDiscoverySource extends MediaDiscoverySource {
   @override
   final int priority;
 
-  /// 只收 trusted 发布（nyaa `f=2`）。
+  /// 只收 trusted 发布（nyaa `f=2`）的固定档；给了 `qualityFilter` 时以后者为准。
   final bool trustedOnly;
 
   final Map<DiscoveryMediaKind, String> _categoryByKind;
   final NyaaClient _client;
+  final NyaaQualityFilterProvider _qualityFilter;
 
   @override
   DiscoveryCapabilities get capabilities => DiscoveryCapabilities(
@@ -64,9 +80,10 @@ class NyaaDiscoverySource extends MediaDiscoverySource {
     final List<NyaaTorrent> torrents = await _client.search(
       request.query!.trim(),
       category: category,
-      filter: trustedOnly ? '2' : '0',
+      filter: _qualityFilter().queryValue,
       page: request.page,
     );
+    final bool classify = request.kind == DiscoveryMediaKind.novel;
     return ProviderBatchResult<DiscoveryResultPage>.success(
       <DiscoveryResultPage>[
         DiscoveryResultPage(
@@ -86,11 +103,21 @@ class NyaaDiscoverySource extends MediaDiscoverySource {
                 seeders: torrent.seeders,
                 leechers: torrent.leechers,
                 detailUrl: torrent.pageUrl,
-                note: torrent.trusted ? 'trusted' : null,
+                category:
+                    torrent.categoryId.isEmpty ? null : torrent.categoryId,
+                trusted: torrent.trusted,
+                remake: torrent.remake,
+                contentHint: classify
+                    ? classifyNyaaLiterature(
+                        title: torrent.title,
+                        sizeBytes: torrent.sizeBytes,
+                        categoryId: torrent.categoryId,
+                      )
+                    : DiscoveryContentHint.none,
               ),
           ],
           page: request.page,
-          // 过了末页 nyaa 返回空列表（client 把 404 归一成空）；空页即到底。
+          // 过了末页 nyaa 返回空列表（client 把 404 / 越界页归一成空）；空页即到底。
           hasMore: torrents.isNotEmpty,
         ),
       ],

--- a/fushi/lib/src/media/torrent/anime_download_subscription.dart
+++ b/fushi/lib/src/media/torrent/anime_download_subscription.dart
@@ -409,6 +409,9 @@ class AnimeDownloadSubscriptionService {
             subscription.nyaaQuery,
             category: subscription.category,
             filter: subscription.trustedOnly ? '2' : '0',
+            // 订阅追的是「最新集」：一页只有 75 条，长篇（One Piece 级）按做种
+            // 排会把刚出的新集挤出首页。按发布时间倒序保住旧 RSS 语义。
+            sort: NyaaSort.date,
           )
           .timeout(kDownloadDiscoveryTimeout);
     } finally {

--- a/fushi/lib/src/media/torrent/nyaa_client.dart
+++ b/fushi/lib/src/media/torrent/nyaa_client.dart
@@ -248,12 +248,51 @@ DateTime? parseNyaaPubDate(String raw) {
 ///
 /// `nyaa:` 命名空间字段按本地名匹配（`nyaa:seeders` → `seeders`），对命名空间
 /// 前缀变化保持宽容；`<item>` 内本地名与 nyaa 扩展字段无冲突。
+///
+/// 生产搜索已改走 HTML 搜索页（见 [NyaaClient.search]：RSS 被 nyaa 后端强制按
+/// id 倒序、忽略 `s/o` 与分页）；本函数与 [parseNyaaRssStrict] 只保留给测试与
+/// 仍消费 RSS 的旧调用方。
 List<NyaaTorrent> parseNyaaRss(String body) {
   if (body.trim().isEmpty) return const <NyaaTorrent>[];
   try {
     return _parseNyaaDocument(XmlDocument.parse(body));
   } catch (_) {
     return const <NyaaTorrent>[];
+  }
+}
+
+/// 严格解析 Nyaa RSS：空 body / 非 UTF-8 XML 声明 / 坏 XML / 非 `<rss>` /
+/// 缺 `<channel>` / 缺必需字段 / 命名空间不对一律抛 [NyaaFeedFormatException]
+/// （错误码见 [NyaaFeedErrorCode]），只有结构有效、确实没有 `<item>` 才返回空。
+///
+/// 这是原 [NyaaClient.search] RSS 首屏的解析层；HTTP 层（charset 头、UTF-8
+/// 解码）不在这里。见 [parseNyaaRss] 的说明。
+List<NyaaTorrent> parseNyaaRssStrict(String body) {
+  if (body.trim().isEmpty) {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.emptyBody,
+      'response body was empty',
+    );
+  }
+  try {
+    final XmlDocument doc = XmlDocument.parse(body);
+    final String? xmlEncoding = doc.declaration?.encoding?.toLowerCase();
+    if (xmlEncoding != null &&
+        xmlEncoding != 'utf-8' &&
+        xmlEncoding != 'utf8') {
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.unsupportedEncoding,
+        'XML declared $xmlEncoding; UTF-8 is required',
+      );
+    }
+    return _parseNyaaDocumentStrict(doc);
+  } on NyaaFeedFormatException {
+    rethrow;
+  } on XmlException catch (error) {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.malformedXml,
+      error.message,
+    );
   }
 }
 
@@ -422,23 +461,125 @@ String _childText(XmlElement item, String local) {
   return '';
 }
 
+/// Nyaa HTML 搜索页的排序字段（查询参数 `s`）。
+///
+/// 只有 HTML 搜索页尊重它：nyaa 后端 `search.py` 对 RSS 两处写死按 id 倒序
+/// （ES 路径 "Only allow ID, desc if RSS"，DB 路径 "Force sort by id desc if
+/// rss"），所以排序必须走 HTML。
+enum NyaaSort {
+  /// 做种数（发现页默认：死种沉底）。
+  seeders('seeders'),
+
+  /// 发布时间（站内 id 单调递增，nyaa 用 `s=id` 表示按时间；订阅轮询用它
+  /// 保住「最新集在前 75 条里」的旧语义）。
+  date('id'),
+
+  size('size'),
+  leechers('leechers'),
+  downloads('downloads');
+
+  const NyaaSort(this.queryValue);
+
+  /// 透传给 nyaa 的 `s=` 值。
+  final String queryValue;
+}
+
+/// Nyaa 搜索排序方向（查询参数 `o`）。
+enum NyaaSortOrder {
+  desc,
+  asc;
+
+  /// 透传给 nyaa 的 `o=` 值。
+  String get queryValue => name;
+}
+
+/// Nyaa 过滤三态（查询参数 `f`）。`f=3`（仅完结批次）后端有但 UI 不露出、
+/// 无文档，刻意不暴露。
+enum NyaaQualityFilter {
+  /// 全部（与 Nyaa UI / Prowlarr / Flexget 默认一致）。
+  all('0'),
+
+  /// 排除 remake。
+  noRemakes('1'),
+
+  /// 仅 trusted 发布者。
+  trustedOnly('2');
+
+  const NyaaQualityFilter(this.queryValue);
+
+  /// 透传给 nyaa 的 `f=` 值。
+  final String queryValue;
+
+  /// 从持久化的 int（0/1/2）还原；越界值回落 [all]，不抛。
+  static NyaaQualityFilter fromIndex(int index) =>
+      index >= 0 && index < values.length ? values[index] : all;
+}
+
+/// 关键词搜索走 Elasticsearch，后端最多回 1000 条 = 14 页（每页 75）。
+const int kNyaaMaxSearchPages = 14;
+
+/// 无关键词浏览走 DB，后端最多 100 页。
+const int kNyaaMaxBrowsePages = 100;
+
+/// 同一 host 两次请求的最小间隔（对齐 Jackett/Prowlarr 的 nyaasi 定义）。
+const Duration kNyaaMinRequestInterval = Duration(seconds: 2);
+
 /// Nyaa（nyaa.si）搜索客户端。无需鉴权。
 ///
-/// 首屏端点：`GET {base}/?page=rss&q=<query>&c=<category>&f=<filter>`。
-/// 后续页使用 Nyaa 的 HTML 搜索端点 `GET {base}/?p=<page>&...`。Nyaa
-/// 上游虽然会解析 RSS 请求里的 `p`，但 RSS 查询分支只做 `limit`、不做
-/// `offset`，会重复返回首屏；因此不能用 RSS 假装分页。
+/// 端点：HTML 搜索页
+/// `GET {base}/?q=<query>&c=<category>&f=<filter>&s=<sort>&o=<order>[&p=<page>]`。
+/// **不用 RSS 作首屏**：nyaa 后端对 RSS 强制按 id 倒序、忽略 `s/o`、只回 75
+/// 条且不做 `offset` 分页；同参数实测 RSS 首条做种 34、HTML 首条 288。HTML
+/// 行 class 给出 trusted（`success`）/ remake（`danger`）；remake 行只显示红，
+/// trusted 用户发的 remake 在 HTML 里 trusted 信息被吞，与 RSS 不同。
 /// category 直接透传（常用：`1_0` 全部动画 / `1_2` 英译 / `1_3` 非英译 /
-/// `1_4` 生肉 Raw）；filter：`0` 无过滤 / `2` 仅 trusted。
+/// `1_4` 生肉 Raw / `3_0` 全部 Literature）；filter 见 [NyaaQualityFilter]。
+///
+/// 打同一站点 host 的请求按 [minRequestInterval] 节流（跨实例共用节奏，实例内串行）。
 class NyaaClient {
   NyaaClient({
     this.baseUrl = 'https://nyaa.si',
     http.Client? client,
     this.requestTimeout = kDownloadDiscoveryTimeout,
+    this.minRequestInterval = kNyaaMinRequestInterval,
   }) : _client = client ?? createAppHttpIoClient();
 
   final String baseUrl;
   final http.Client _client;
+
+  /// 同 host 两次请求**开始**之间的最小间隔；测试可注入 [Duration.zero]。
+  final Duration minRequestInterval;
+
+  /// 各站点 host 最近一次请求的开始时刻。多个实例（发现源 / 视频资源 provider /
+  /// 订阅轮询）打同一站点时共用节奏，这才是「同 host」而不只是「同实例」。
+  ///
+  /// 只存时刻、不存 Future：完成态 Future 记住创建时的 zone，测试在 setUp 里建
+  /// client、在 fake-async 测试体里 await 时，`then` 回调会被派到拿不到 pump 的
+  /// zone 里，整条搜索无声挂死（pumpAndSettle 超时、请求根本没发出）。
+  static final Map<String, DateTime> _lastRequestStartByHost =
+      <String, DateTime>{};
+
+  /// 本实例排队的尾巴；null = 没人在排。惰性创建，理由同上。
+  Future<void>? _requestQueueTail;
+
+  /// 排队等到下一个允许发请求的时刻；并发调用按到达顺序串行放行。
+  Future<void> _reserveRequestSlot() {
+    final Future<void> slot = _waitForRequestSlot(_requestQueueTail);
+    _requestQueueTail = slot;
+    return slot;
+  }
+
+  Future<void> _waitForRequestSlot(Future<void>? previous) async {
+    if (previous != null) await previous;
+    final String host = Uri.parse(baseUrl).host;
+    final DateTime? last = _lastRequestStartByHost[host];
+    if (last != null) {
+      final Duration wait =
+          minRequestInterval - DateTime.now().difference(last);
+      if (wait > Duration.zero) await Future<void>.delayed(wait);
+    }
+    _lastRequestStartByHost[host] = DateTime.now();
+  }
 
   /// 单次请求的整体超时上限。默认取发现链路的唯一真相源
   /// [kDownloadDiscoveryTimeout]；可注入只为测试能用短值跑。
@@ -462,27 +603,38 @@ class NyaaClient {
   /// 按关键词搜索种子。网络错误 / 非 200 **抛出**（`ClientException` /
   /// `SocketException` / `HandshakeException` 等），由调用方决定展示或记录：
   /// 以前这里吞错返回空列表，真实网络故障（如站点被墙、代理未配）会被
-  /// 误报成「无结果」，用户无从判断。空响应 / 损坏 RSS 同样抛
-  /// [FormatException]；只有结构有效、确实没有 `<item>` 才返回空列表。
+  /// 误报成「无结果」，用户无从判断。空响应 / 不是搜索页的 HTML 同样抛
+  /// [NyaaFeedFormatException]；只有结构有效、确实没有结果行才返回空列表。
+  ///
+  /// [sort] / [order] 默认按做种数降序。[page] 越过后端上限
+  /// （[kNyaaMaxSearchPages] / [kNyaaMaxBrowsePages]）直接返回空、不发请求
+  /// 也不抛——那是「翻到底了」，不是错误。
   Future<List<NyaaTorrent>> search(
     String query, {
     String category = '1_0',
     String filter = '0',
     int page = 1,
+    NyaaSort sort = NyaaSort.seeders,
+    NyaaSortOrder order = NyaaSortOrder.desc,
   }) async {
     if (page <= 0) throw ArgumentError.value(page, 'page');
-    final bool renderAsRss = page == 1;
+    final int maxPages =
+        query.trim().isEmpty ? kNyaaMaxBrowsePages : kNyaaMaxSearchPages;
+    if (page > maxPages) return const <NyaaTorrent>[];
     final Uri uri = Uri.parse(baseUrl).replace(
       path: '/',
       queryParameters: <String, String>{
-        if (renderAsRss) 'page': 'rss' else 'p': page.toString(),
         'q': query,
         'c': category,
         'f': filter,
+        's': sort.queryValue,
+        'o': order.queryValue,
+        if (page > 1) 'p': page.toString(),
       },
     );
+    await _reserveRequestSlot();
     final http.Response res = await _client.get(uri).timeout(requestTimeout);
-    if (!renderAsRss && res.statusCode == 404) {
+    if (page > 1 && res.statusCode == 404) {
       // Nyaa returns 404 when a valid HTML search asks past its final page.
       return const <NyaaTorrent>[];
     }
@@ -502,8 +654,9 @@ class NyaaClient {
       );
     }
 
-    // Nyaa RSS 是 UTF-8但常不声明 charset；必须严格解码，损坏字节不能被 U+FFFD
-    // 替换后继续冒充有效结果。
+    // Nyaa 响应是 UTF-8 但常不声明 charset；必须严格解码，损坏字节不能被 U+FFFD
+    // 替换后继续冒充有效结果。gzip 由 dart:io HttpClient 默认 autoUncompress
+    // 解掉（createAppHttpClient 没有关它），这里拿到的已是明文字节。
     final String body;
     try {
       body = utf8.decode(res.bodyBytes);
@@ -519,27 +672,7 @@ class NyaaClient {
         'response body was empty',
       );
     }
-    if (!renderAsRss) return _parseNyaaHtmlSearch(body, uri);
-    try {
-      final XmlDocument doc = XmlDocument.parse(body);
-      final String? xmlEncoding = doc.declaration?.encoding?.toLowerCase();
-      if (xmlEncoding != null &&
-          xmlEncoding != 'utf-8' &&
-          xmlEncoding != 'utf8') {
-        throw NyaaFeedFormatException(
-          NyaaFeedErrorCode.unsupportedEncoding,
-          'XML declared $xmlEncoding; UTF-8 is required',
-        );
-      }
-      return _parseNyaaDocumentStrict(doc);
-    } on NyaaFeedFormatException {
-      rethrow;
-    } on XmlException catch (error) {
-      throw NyaaFeedFormatException(
-        NyaaFeedErrorCode.malformedXml,
-        error.message,
-      );
-    }
+    return _parseNyaaHtmlSearch(body, uri);
   }
 
   void close() => _client.close();

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -4715,6 +4715,11 @@ class AppModel with ChangeNotifier {
           DiscoveryMediaKind.audiobook: '2_0',
         },
         client: NyaaClient(),
+        // 每次请求按当前偏好取：源实例常驻，偏好可随时改。偏好未就绪
+        // （早一帧打开发现页）时用默认「全部」。
+        qualityFilter: () => NyaaQualityFilter.fromIndex(
+          isPreferencesReady ? prefsRepo.discoveryNyaaQualityFilter : 0,
+        ),
       ),
       NyaaDiscoverySource(
         id: 'sukebei',

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -51,6 +51,14 @@ const Set<String> kKnownPreferenceKeys = <String>{
   // 发现页「全部源」聚合默认排除的源 id（逗号分隔；默认 sukebei——18+ 源
   // 只在用户显式单选时使用）。String，读写见 PreferencesRepository。
   'discovery_disabled_sources',
+  // bool（默认 true）：发现页隐藏疑似漫画（`DiscoveryContentHint.manga`）的
+  // 条目；undecided 保留。读写见 PreferencesRepository。
+  'discovery_hide_suspected_manga',
+  // bool（默认 true）：发现页隐藏 0 做种的种子条目。读写见 PreferencesRepository。
+  'discovery_hide_zero_seeders',
+  // int（0 全部 / 1 排除 remake / 2 仅 trusted，默认 0）：发现页 Nyaa 过滤三态，
+  // 透传为 nyaa `f`。读写见 PreferencesRepository。
+  'discovery_nyaa_quality_filter',
   // 用户自配的 OPDS 书目服务器清单（JSON 数组：id/name/url/username/
   // passwordB64/enabled/allowInsecureHttp）。String，读写见
   // PreferencesRepository。与 discovery_disabled_sources 的分界同 Torznab：

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -2768,6 +2768,36 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 发现页隐藏 0 做种的种子条目。**默认开**（用户 2026-09-08 拍板；调研里
+  /// 交互式 UI 的通行做法是只沉底不隐藏，记录为反对意见）。
+  bool get discoveryHideZeroSeeders =>
+      getPref('discovery_hide_zero_seeders', defaultValue: true) as bool;
+
+  Future<void> setDiscoveryHideZeroSeeders(bool value) async {
+    await setPref('discovery_hide_zero_seeders', value);
+    notifyListeners();
+  }
+
+  /// 发现页隐藏疑似漫画（只隐藏 `DiscoveryContentHint.manga` 档，undecided
+  /// 保留）。默认开。
+  bool get discoveryHideSuspectedManga =>
+      getPref('discovery_hide_suspected_manga', defaultValue: true) as bool;
+
+  Future<void> setDiscoveryHideSuspectedManga(bool value) async {
+    await setPref('discovery_hide_suspected_manga', value);
+    notifyListeners();
+  }
+
+  /// 发现页 Nyaa 过滤三态（0 全部 / 1 排除 remake / 2 仅 trusted），透传为
+  /// nyaa `f`。默认 0，与 Nyaa UI / Prowlarr / Flexget 一致。
+  int get discoveryNyaaQualityFilter =>
+      getPref('discovery_nyaa_quality_filter', defaultValue: 0) as int;
+
+  Future<void> setDiscoveryNyaaQualityFilter(int value) async {
+    await setPref('discovery_nyaa_quality_filter', value);
+    notifyListeners();
+  }
+
   /// 用户停用的**内置**视频资源索引器 id（逗号分隔，默认空 = 全部启用）。
   ///
   /// 与 [discoveryDisabledSources] 同形：都是「一组零配置内置源，按 id 记停用」。

--- a/fushi/lib/src/pages/implementations/media_discovery_page.dart
+++ b/fushi/lib/src/pages/implementations/media_discovery_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show unawaited;
 
+import 'package:collection/collection.dart' show mergeSort;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -8,9 +9,12 @@ import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/discovery/discovery_labels.dart';
 import 'package:fushi/src/media/discovery/media_discovery_service.dart';
 import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/discovery/sources/nyaa_discovery_source.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/torrent/anime_download_plan.dart';
+import 'package:fushi/src/media/torrent/nyaa_client.dart';
 import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/pages/implementations/discovery_header.dart';
 import 'package:fushi/src/pages/implementations/download_actions.dart';
 import 'package:fushi/utils.dart';
@@ -161,9 +165,9 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
       _entries.any((DiscoveryEntry e) =>
           e is DiscoveryResourceItem && e.gameLocalization != null);
 
-  /// 应用筛选后的条目。目录条目（[DiscoveryFolder]）永远保留——它们是导航结构，
-  /// 不是资源，把它们筛掉会让用户下不去。
-  List<DiscoveryEntry> get _visibleEntries {
+  /// 应用游戏汉化筛选后的条目。目录条目（[DiscoveryFolder]）永远保留——它们是
+  /// 导航结构，不是资源，把它们筛掉会让用户下不去。
+  List<DiscoveryEntry> get _gameFilteredEntries {
     if (_gameTypeFilter == _GameTypeFilter.all || !_gameTypeFilterAvailable) {
       return _entries;
     }
@@ -173,6 +177,140 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
             _gameTypeFilter.matches(e.gameLocalization))
           e,
     ];
+  }
+
+  /// 「已隐藏 N 条…」被用户点开后的临时显示态；每轮新加载重置。
+  ///
+  /// 点开**不改偏好**：用户是想看一眼这次被藏了什么，不是想永久关掉过滤。
+  bool _revealHidden = false;
+
+  /// 偏好未就绪（无 ProviderScope 的纯布局测试 / 早一帧打开）时用默认值，
+  /// 且不写盘。三个偏好的默认值只在 [PreferencesRepository] 一处定义。
+  PreferencesRepository? get _prefs {
+    final AppModel? appModel = _appModel;
+    if (appModel == null || !appModel.isPreferencesReady) return null;
+    return appModel.prefsRepo;
+  }
+
+  bool get _hideZeroSeeders => _prefs?.discoveryHideZeroSeeders ?? true;
+
+  bool get _hideSuspectedManga => _prefs?.discoveryHideSuspectedManga ?? true;
+
+  NyaaQualityFilter get _nyaaQualityFilter =>
+      NyaaQualityFilter.fromIndex(_prefs?.discoveryNyaaQualityFilter ?? 0);
+
+  /// 当前结果里有没有种子类条目（带做种数）。做种相关的 chip / 灰显只对它们
+  /// 有意义，OPDS / 直链源不该凭空多一排控件。
+  bool get _hasSeederEntries => _entries.any(
+        (DiscoveryEntry e) => e is DiscoveryResourceItem && e.seeders != null,
+      );
+
+  /// 当前结果里有没有跑过内容分类器的条目（只有 nyaa 小说域会打）。
+  bool get _hasContentHints => _entries.any(
+        (DiscoveryEntry e) =>
+            e is DiscoveryResourceItem &&
+            e.contentHint != DiscoveryContentHint.none,
+      );
+
+  /// 当前会打到 Nyaa 的来源集合里有没有 Nyaa 源：过滤三态是 nyaa 的服务端参数
+  /// （`f`），只在它真会生效时露出。
+  bool get _nyaaFilterAvailable {
+    final MediaDiscoveryService? service = _appModel?.mediaDiscoveryService;
+    if (service == null) return false;
+    if (_sourceId != kDiscoveryAllSourcesId) {
+      return service.sourceById(_sourceId) is NyaaDiscoverySource;
+    }
+    return service
+        .sourcesFor(_kind)
+        .any((MediaDiscoverySource s) => s is NyaaDiscoverySource);
+  }
+
+  static int _seedersOf(DiscoveryEntry e) =>
+      e is DiscoveryResourceItem ? (e.seeders ?? -1) : -1;
+
+  /// 源内按做种降序**稳定**排序；跨源仍按 service 给出的 priority 顺序串接。
+  ///
+  /// 服务端已经按做种排过（`s=seeders&o=desc`），这里是本地兜底：翻页追加的
+  /// 条目要能插回正确位置，多个源混排时各自内部也要有序。只对含做种数的源
+  /// 分组动手，OPDS / 直链源原序不动。`List.sort` 不稳定，用 [mergeSort]。
+  static List<DiscoveryEntry> _sortBySeedersWithinSource(
+    List<DiscoveryEntry> entries,
+  ) {
+    final Map<String, List<DiscoveryEntry>> groups =
+        <String, List<DiscoveryEntry>>{};
+    for (final DiscoveryEntry e in entries) {
+      (groups[e.sourceId] ??= <DiscoveryEntry>[]).add(e);
+    }
+    final List<DiscoveryEntry> out = <DiscoveryEntry>[];
+    for (final List<DiscoveryEntry> group in groups.values) {
+      if (group.any((DiscoveryEntry e) => _seedersOf(e) >= 0)) {
+        mergeSort<DiscoveryEntry>(
+          group,
+          compare: (DiscoveryEntry a, DiscoveryEntry b) =>
+              _seedersOf(b).compareTo(_seedersOf(a)),
+        );
+      }
+      out.addAll(group);
+    }
+    return out;
+  }
+
+  bool _isHiddenZeroSeeders(DiscoveryEntry e) =>
+      _hideZeroSeeders && e is DiscoveryResourceItem && e.seeders == 0;
+
+  bool _isHiddenSuspectedManga(DiscoveryEntry e) =>
+      _hideSuspectedManga &&
+      e is DiscoveryResourceItem &&
+      e.contentHint == DiscoveryContentHint.manga;
+
+  /// 最终渲染集合 + 两类被隐藏的计数（一条只计一次：先算无人做种，再算疑似漫画）。
+  ({List<DiscoveryEntry> entries, int hiddenZeroSeeders, int hiddenManga})
+      get _visible {
+    final List<DiscoveryEntry> sorted =
+        _sortBySeedersWithinSource(_gameFilteredEntries);
+    if (_revealHidden) {
+      return (entries: sorted, hiddenZeroSeeders: 0, hiddenManga: 0);
+    }
+    int hiddenZeroSeeders = 0;
+    int hiddenManga = 0;
+    final List<DiscoveryEntry> shown = <DiscoveryEntry>[];
+    for (final DiscoveryEntry e in sorted) {
+      if (_isHiddenZeroSeeders(e)) {
+        hiddenZeroSeeders++;
+      } else if (_isHiddenSuspectedManga(e)) {
+        hiddenManga++;
+      } else {
+        shown.add(e);
+      }
+    }
+    return (
+      entries: shown,
+      hiddenZeroSeeders: hiddenZeroSeeders,
+      hiddenManga: hiddenManga,
+    );
+  }
+
+  void _setHideZeroSeeders(bool value) {
+    final PreferencesRepository? prefs = _prefs;
+    if (prefs == null) return;
+    unawaited(prefs.setDiscoveryHideZeroSeeders(value));
+    setState(() => _revealHidden = false);
+  }
+
+  void _setHideSuspectedManga(bool value) {
+    final PreferencesRepository? prefs = _prefs;
+    if (prefs == null) return;
+    unawaited(prefs.setDiscoveryHideSuspectedManga(value));
+    setState(() => _revealHidden = false);
+  }
+
+  /// 过滤三态是服务端参数：写穿偏好后必须重新请求（源在每次请求时读偏好）。
+  void _setNyaaQualityFilter(NyaaQualityFilter value) {
+    final PreferencesRepository? prefs = _prefs;
+    if (prefs == null || value == _nyaaQualityFilter) return;
+    unawaited(prefs.setDiscoveryNyaaQualityFilter(value.index));
+    setState(() {});
+    unawaited(_load());
   }
 
   DiscoveryAggregateResult? _result;
@@ -248,6 +386,7 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
         _page = 1;
         _entries.clear();
         _result = null;
+        _revealHidden = false;
       }
     });
     try {
@@ -430,6 +569,8 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
       if (item.dateText != null) item.dateText!,
       if (item.seeders != null) '↑${item.seeders}',
       if (item.note != null) item.note!,
+      if (item.contentHint == DiscoveryContentHint.manga)
+        t.discovery_content_hint_manga,
       // BUG-1910：游戏的汉化状态走带类型的字段 + i18n 标签，不再是源里那句硬编码
       // 中文（英文用户此前看到的就是「熟肉」两个方块）。
       if (item.gameLocalization != null)
@@ -463,9 +604,55 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
     );
   }
 
-  /// header 上方插槽：媒体类型分段（多域时）+ BUG-1910 的游戏汉化状态筛选。
+  /// 种子结果的筛选条：隐藏无人做种 / 隐藏疑似漫画（客户端过滤）+ Nyaa 过滤
+  /// 三态（服务端 `f`）。三组各自只在对当前结果有意义时出现。
+  Widget? _buildTorrentFilters() {
+    final bool seederChip = _hasSeederEntries;
+    final bool mangaChip =
+        _kind == DiscoveryMediaKind.novel && _hasContentHints;
+    final bool nyaaFilter = _nyaaFilterAvailable;
+    if (!seederChip && !mangaChip && !nyaaFilter) return null;
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: <Widget>[
+        if (seederChip)
+          FilterChip(
+            key: const ValueKey<String>('discovery_filter_hide_zero_seeders'),
+            label: Text(t.discovery_filter_hide_zero_seeders),
+            selected: _hideZeroSeeders,
+            onSelected: _setHideZeroSeeders,
+          ),
+        if (mangaChip)
+          FilterChip(
+            key:
+                const ValueKey<String>('discovery_filter_hide_suspected_manga'),
+            label: Text(t.discovery_filter_hide_suspected_manga),
+            selected: _hideSuspectedManga,
+            onSelected: _setHideSuspectedManga,
+          ),
+        if (nyaaFilter)
+          for (final NyaaQualityFilter f in NyaaQualityFilter.values)
+            ChoiceChip(
+              key: ValueKey<String>('discovery_nyaa_filter_${f.index}'),
+              label: Text(switch (f) {
+                NyaaQualityFilter.all => t.discovery_nyaa_filter_all,
+                NyaaQualityFilter.noRemakes =>
+                  t.discovery_nyaa_filter_no_remakes,
+                NyaaQualityFilter.trustedOnly =>
+                  t.discovery_nyaa_filter_trusted_only,
+              }),
+              selected: _nyaaQualityFilter == f,
+              onSelected: (_) => _setNyaaQualityFilter(f),
+            ),
+      ],
+    );
+  }
+
+  /// header 上方插槽：媒体类型分段（多域时）+ BUG-1910 的游戏汉化状态筛选 +
+  /// 种子筛选条。
   ///
-  /// 两者可能同时存在（书+游戏合用一页时），所以纵向叠放而不是二选一。
+  /// 三者可能同时存在（书+游戏合用一页时），所以纵向叠放而不是二选一。
   Widget? _buildHeaderLeading() {
     final Widget? kindSelector = widget.kinds.length > 1
         ? SegmentedButton<DiscoveryMediaKind>(
@@ -501,15 +688,70 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
             ],
           )
         : null;
-    if (kindSelector == null) return typeFilter;
-    if (typeFilter == null) return kindSelector;
+    final Widget? torrentFilters = _buildTorrentFilters();
+    final List<Widget> rows = <Widget>[
+      if (kindSelector != null) kindSelector,
+      if (typeFilter != null) typeFilter,
+      if (torrentFilters != null) torrentFilters,
+    ];
+    if (rows.isEmpty) return null;
+    if (rows.length == 1) return rows.single;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        kindSelector,
-        const SizedBox(height: 8),
-        typeFilter,
+        for (int i = 0; i < rows.length; i++) ...<Widget>[
+          if (i > 0) const SizedBox(height: 8),
+          rows[i],
+        ],
+      ],
+    );
+  }
+
+  /// 「已隐藏 N 条无人做种 / M 条疑似漫画」提示行，点一下临时显示全部。
+  Widget _buildHiddenNotice(
+    BuildContext context,
+    int hiddenZeroSeeders,
+    int hiddenManga,
+  ) {
+    final String text = <String>[
+      if (hiddenZeroSeeders > 0)
+        t.discovery_hidden_zero_seeders_count(n: hiddenZeroSeeders),
+      if (hiddenManga > 0)
+        t.discovery_hidden_suspected_manga_count(n: hiddenManga),
+    ].join(' · ');
+    return FushiListItem(
+      key: const ValueKey<String>('discovery_hidden_reveal'),
+      leading: const Icon(Icons.visibility_off_outlined),
+      title: Text(text),
+      trailing: Text(t.discovery_hidden_show),
+      onTap: () => setState(() => _revealHidden = true),
+    );
+  }
+
+  /// 资源标题 + trusted 绿 / remake 红徽标（来自 nyaa HTML 行 class）。
+  Widget _buildResourceTitle(BuildContext context, DiscoveryResourceItem item) {
+    final Widget title = Text(item.title);
+    if (!item.trusted && !item.remake) return title;
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(child: title),
+        if (item.remake)
+          FushiTag(
+            key: const ValueKey<String>('discovery_badge_remake'),
+            text: t.discovery_badge_remake,
+            backgroundColor: colors.error,
+            foregroundColor: colors.onError,
+          )
+        else
+          FushiTag(
+            key: const ValueKey<String>('discovery_badge_trusted'),
+            text: t.discovery_badge_trusted,
+            backgroundColor: Colors.green.shade700,
+            foregroundColor: Colors.white,
+          ),
       ],
     );
   }
@@ -646,11 +888,22 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
       );
     }
 
+    final ({
+      List<DiscoveryEntry> entries,
+      int hiddenZeroSeeders,
+      int hiddenManga
+    }) visible = _visible;
     return AnimatedBuilder(
       animation: queue,
       builder: (BuildContext context, Widget? _) => ListView(
         padding: const EdgeInsets.all(16),
         children: <Widget>[
+          if (visible.hiddenZeroSeeders + visible.hiddenManga > 0)
+            _buildHiddenNotice(
+              context,
+              visible.hiddenZeroSeeders,
+              visible.hiddenManga,
+            ),
           if (result != null && result.hasFailures)
             Padding(
               padding: const EdgeInsets.only(bottom: 8),
@@ -661,7 +914,7 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
                     ?.copyWith(color: theme.colorScheme.error),
               ),
             ),
-          for (final DiscoveryEntry entry in _visibleEntries)
+          for (final DiscoveryEntry entry in visible.entries)
             switch (entry) {
               DiscoveryFolder() => FushiListItem(
                   leading: const Icon(Icons.folder_outlined),
@@ -679,35 +932,42 @@ class _MediaDiscoveryPageState extends State<MediaDiscoveryPage> {
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => _openFolder(entry),
                 ),
-              DiscoveryResourceItem() => FushiListItem(
-                  leading: Icon(
-                    entry.payloadKind == DiscoveryPayloadKind.torrent
-                        ? Icons.link
-                        : Icons.insert_drive_file_outlined,
+              // 未隐藏时 0 做种条目灰显：死种能看到，但一眼分得出。
+              DiscoveryResourceItem() => Opacity(
+                  key: ValueKey<String>(
+                    'discovery_item_${entry.sourceId}_${entry.id}',
                   ),
-                  title: Text(entry.title),
-                  titleMaxLines: 2,
-                  subtitle: Text(_subtitleFor(entry, service)),
-                  trailing: _resolvingTorrentIds.contains(
-                            '${entry.sourceId}\u0000${entry.id}',
-                          ) ||
-                          queue.isPending(entry)
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : entry.isDownloadable
-                          ? FushiIconButton(
-                              icon: Icons.download_outlined,
-                              tooltip: t.anime_download_generic_download,
-                              label: t.anime_download_generic_download,
-                              onTap: () => unawaited(_download(entry)),
-                            )
-                          : null,
-                  onTap: entry.isDownloadable
-                      ? () => unawaited(_download(entry))
-                      : null,
+                  opacity: entry.seeders == 0 ? 0.5 : 1,
+                  child: FushiListItem(
+                    leading: Icon(
+                      entry.payloadKind == DiscoveryPayloadKind.torrent
+                          ? Icons.link
+                          : Icons.insert_drive_file_outlined,
+                    ),
+                    title: _buildResourceTitle(context, entry),
+                    titleMaxLines: 2,
+                    subtitle: Text(_subtitleFor(entry, service)),
+                    trailing: _resolvingTorrentIds.contains(
+                              '${entry.sourceId}\u0000${entry.id}',
+                            ) ||
+                            queue.isPending(entry)
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : entry.isDownloadable
+                            ? FushiIconButton(
+                                icon: Icons.download_outlined,
+                                tooltip: t.anime_download_generic_download,
+                                label: t.anime_download_generic_download,
+                                onTap: () => unawaited(_download(entry)),
+                              )
+                            : null,
+                    onTap: entry.isDownloadable
+                        ? () => unawaited(_download(entry))
+                        : null,
+                  ),
                 ),
             },
           if (result != null && result.hasMore)

--- a/fushi/test/media/discovery/nyaa_literature_classifier_test.dart
+++ b/fushi/test/media/discovery/nyaa_literature_classifier_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/discovery/discovery_models.dart';
+import 'package:fushi/src/media/discovery/nyaa_literature_classifier.dart';
+
+/// `classifyNyaaLiterature` 的规则表语料（设计稿
+/// `docs/specs/2026-09-08-nyaa-novel-discovery-filters.md` 第 3 节）。
+///
+/// 正例/反例取自调研样本；每条都写明期望值背后的信号，改规则时先对着这张表。
+void main() {
+  const int mib = 1024 * 1024;
+
+  group('classifyNyaaLiterature 语料表', () {
+    final List<({String title, int? size, DiscoveryContentHint want})> cases =
+        <({String title, int? size, DiscoveryContentHint want})>[
+      // (Digital) 强漫画 + 1r0n 漫画专属组。
+      (
+        title: 'Sousou no Frieren v01-14 (Digital) (1r0n)',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // Yen Press 强小说 + 尾部连续方括号。
+      (
+        title: 'Re:ZERO v01-29 [Yen Press] [Stick]',
+        size: null,
+        want: DiscoveryContentHint.novel,
+      ),
+      // Stick 两种都发（0 分），只能靠 (Digital)。
+      (
+        title: 'Kemono Jihen v01-21 (Digital) (Stick)',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // chaptr 语料把它错标成 LN——发布组名不是信号，(2024-2025) (Digital) 才是。
+      (
+        title: 'Youjo Senki v24-27 (2024-2025) (Digital) (Ushi)',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // BookWalker 只是弱小说 +1，压不过 (Digital) +3。
+      (
+        title: 'Gundam The Origin v01-24 (Digital) (BookWalker) (JP)',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // 出版社 + 电子书格式。
+      (
+        title: '[Yen Press] Mushoku Tensei v01-26 EPUB',
+        size: null,
+        want: DiscoveryContentHint.novel,
+      ),
+      // 日文生肉：一般コミック。
+      (
+        title: '一般コミック [作者] 葬送のフリーレン 第01-13巻',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // 日文生肉：ライトノベル。
+      (
+        title: 'ライトノベル 薬屋のひとりごと 第01-15巻',
+        size: null,
+        want: DiscoveryContentHint.novel,
+      ),
+      // 有声书单独一档，不参与判定。
+      (
+        title: 'Title (Audiobook) [M4B]',
+        size: null,
+        want: DiscoveryContentHint.audiobook,
+      ),
+      // 没有任何信号：保留显示。
+      (
+        title: 'Some Title v01',
+        size: null,
+        want: DiscoveryContentHint.undecided,
+      ),
+      // `Graphic Novel` 不算小说词，(Digital) 判漫画。
+      (
+        title: 'Some Title Graphic Novel (Digital)',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // 三位数章节区间是强漫画；年份区间不是。
+      (
+        title: '[Group] Some Title 101-150',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      (
+        title: 'Some Title (2020-2023) [Yen Press] [Stick]',
+        size: null,
+        want: DiscoveryContentHint.novel,
+      ),
+      // 容器名 / 图片格式。
+      (
+        title: 'Some Title v01-03 cbz',
+        size: null,
+        want: DiscoveryContentHint.manga,
+      ),
+      // HTML 实体先反转义：`&amp;` 不能把 `[Yen Press]` 切坏。
+      (
+        title: 'Foo &amp; Bar v01 [Yen Press] [Stick]',
+        size: null,
+        want: DiscoveryContentHint.novel,
+      ),
+      // 体积规则：5 卷 50 MiB → 每卷 10 MiB → 小说 +2。
+      (
+        title: 'Some Title v01-05',
+        size: 50 * mib,
+        want: DiscoveryContentHint.novel,
+      ),
+      // 体积规则：5 卷 1 GiB → 每卷 200 MiB → 漫画 +3。
+      (
+        title: 'Some Title v01-05',
+        size: 1024 * mib,
+        want: DiscoveryContentHint.manga,
+      ),
+      // 重叠区 30–60 MiB/卷 不给分。
+      (
+        title: 'Some Title v01-02',
+        size: 90 * mib,
+        want: DiscoveryContentHint.undecided,
+      ),
+      // 合集跳过体积规则。
+      (
+        title: 'Some Title Collection v01-05',
+        size: 1024 * mib,
+        want: DiscoveryContentHint.undecided,
+      ),
+    ];
+
+    for (final ({String title, int? size, DiscoveryContentHint want}) c
+        in cases) {
+      test('${c.title}${c.size == null ? '' : ' @${c.size! ~/ mib} MiB'}', () {
+        final NyaaLiteratureScore score = scoreNyaaLiterature(
+          title: c.title,
+          sizeBytes: c.size,
+        );
+        expect(
+          classifyNyaaLiterature(title: c.title, sizeBytes: c.size),
+          c.want,
+          reason: '$score',
+        );
+      });
+    }
+  });
+
+  test('打分门槛：差 1 分是 undecided，差 2 分才定性', () {
+    // (Digital) +3 vs BookWalker +1 = 差 2 → manga（上表已覆盖）；
+    // 这里造一条 PDF(+1) + BookWalker(+1) vs 年份括号(+2) → 0 差 → undecided。
+    expect(
+      classifyNyaaLiterature(title: 'Some Title (2021) (BookWalker) PDF'),
+      DiscoveryContentHint.undecided,
+    );
+    final NyaaLiteratureScore score =
+        scoreNyaaLiterature(title: 'Some Title (2021) (BookWalker) PDF');
+    expect(score.manga, 2);
+    expect(score.novel, 2);
+  });
+
+  test('分类 2_x（Audio）直接判 audiobook；3_x 不影响打分', () {
+    expect(
+      classifyNyaaLiterature(title: 'Some Title v01', categoryId: '2_0'),
+      DiscoveryContentHint.audiobook,
+    );
+    expect(
+      classifyNyaaLiterature(title: 'Some Title v01', categoryId: '3_1'),
+      DiscoveryContentHint.undecided,
+    );
+    expect(
+      classifyNyaaLiterature(title: 'Some Title v01', categoryId: '3_3'),
+      DiscoveryContentHint.undecided,
+    );
+  });
+
+  test('发布组名 LuCaZ / Stick / Ushi / Oak / nao 恒 0 分', () {
+    for (final String group in <String>[
+      'LuCaZ',
+      'Stick',
+      'Ushi',
+      'Oak',
+      'nao'
+    ]) {
+      final NyaaLiteratureScore score =
+          scoreNyaaLiterature(title: 'Some Title v01 ($group)');
+      expect(score.manga, 0, reason: group);
+      expect(score.novel, 0, reason: group);
+    }
+  });
+
+  test('同一判据只记一次：两个 (Digital) 不叠加', () {
+    final NyaaLiteratureScore once =
+        scoreNyaaLiterature(title: 'Some Title v01 (Digital)');
+    final NyaaLiteratureScore twice =
+        scoreNyaaLiterature(title: 'Some Title v01 (Digital) (Digital)');
+    expect(twice.manga, once.manga);
+  });
+}

--- a/fushi/test/media/discovery/sources/nyaa_discovery_source_test.dart
+++ b/fushi/test/media/discovery/sources/nyaa_discovery_source_test.dart
@@ -9,33 +9,44 @@ import 'package:fushi/src/media/discovery/sources/nyaa_discovery_source.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/torrent/nyaa_client.dart';
 
-const String _rss = '''
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
-  <channel>
-    <title>Nyaa - "q" - Torrent File RSS</title>
-    <description>RSS Feed</description>
-    <link>https://nyaa.si/</link>
-    <item>
-      <title>Some Light Novel Vol.1-3 EPUB</title>
-      <link>https://nyaa.si/download/42.torrent</link>
-      <guid isPermaLink="true">https://nyaa.si/view/42</guid>
-      <pubDate>Fri, 03 Nov 2023 12:30:00 -0000</pubDate>
-      <nyaa:seeders>7</nyaa:seeders>
-      <nyaa:leechers>1</nyaa:leechers>
-      <nyaa:downloads>99</nyaa:downloads>
-      <nyaa:infoHash>0123456789abcdef0123456789abcdef01234567</nyaa:infoHash>
-      <nyaa:categoryId>3_1</nyaa:categoryId>
-      <nyaa:size>12.0 MiB</nyaa:size>
-      <nyaa:trusted>Yes</nyaa:trusted>
-      <nyaa:remake>No</nyaa:remake>
-    </item>
-  </channel>
-</rss>
-''';
+import '../../../torrent/nyaa_html_fixture.dart';
+
+/// 一条 Literature 英译轻小说（trusted）。
+const NyaaHtmlRow _novelRow = NyaaHtmlRow(
+  title: 'Some Light Novel Vol.1-3 EPUB',
+  infoHash: '0123456789abcdef0123456789abcdef01234567',
+  id: '42',
+  seeders: 7,
+  leechers: 1,
+  downloads: 99,
+  size: '12.0 MiB',
+  categoryId: '3_1',
+  trusted: true,
+);
+
+/// 同分类里混放的扫图漫画（remake）。
+const NyaaHtmlRow _mangaRow = NyaaHtmlRow(
+  title: 'Sousou no Frieren v01-14 (Digital) (1r0n)',
+  infoHash: 'fedcba9876543210fedcba9876543210fedcba98',
+  id: '43',
+  seeders: 80,
+  size: '2.1 GiB',
+  categoryId: '3_1',
+  remake: true,
+);
+
+NyaaClient _client(
+  Future<http.Response> Function(http.Request request) handler, {
+  String baseUrl = 'https://nyaa.si',
+}) =>
+    NyaaClient(
+      baseUrl: baseUrl,
+      minRequestInterval: Duration.zero,
+      client: MockClient(handler),
+    );
 
 void main() {
-  test('搜索映射:分类按媒体域取,条目产 torrent payload', () async {
+  test('搜索映射:分类按媒体域取,条目产 torrent payload 并透传新字段', () async {
     Uri? captured;
     final NyaaDiscoverySource source = NyaaDiscoverySource(
       id: 'nyaa',
@@ -44,27 +55,30 @@ void main() {
         DiscoveryMediaKind.novel: '3_0',
         DiscoveryMediaKind.audiobook: '2_0',
       },
-      client: NyaaClient(
-        client: MockClient((http.Request request) async {
-          captured = request.url;
-          return http.Response.bytes(
-            utf8.encode(_rss),
-            200,
-            headers: <String, String>{
-              'content-type': 'application/rss+xml; charset=utf-8',
-            },
-          );
-        }),
-      ),
+      client: _client((http.Request request) async {
+        captured = request.url;
+        return http.Response.bytes(
+          utf8.encode(nyaaSearchHtml(const <NyaaHtmlRow>[_novelRow])),
+          200,
+          headers: <String, String>{
+            'content-type': 'text/html; charset=utf-8',
+          },
+        );
+      }),
     );
 
     final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
       const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'novel'),
     );
 
+    // 分类本身不改：小说域仍是 Literature 全部。
     expect(captured!.queryParameters['c'], '3_0');
     expect(captured!.queryParameters['q'], 'novel');
-    expect(captured!.queryParameters['page'], 'rss');
+    expect(captured!.queryParameters['f'], '0');
+    // 首屏走 HTML 搜索页且服务端按做种降序，不再是 RSS。
+    expect(captured!.queryParameters.containsKey('page'), isFalse);
+    expect(captured!.queryParameters['s'], 'seeders');
+    expect(captured!.queryParameters['o'], 'desc');
 
     final DiscoveryResultPage page = result.items.single;
     expect(page.hasMore, isTrue, reason: '非空页允许翻页');
@@ -83,38 +97,68 @@ void main() {
     expect(item.seeders, 7);
     expect(item.leechers, 1);
     expect(item.sizeBytes, 12 * 1024 * 1024);
-    expect(item.note, 'trusted');
+    // 新字段：源内分类 / trusted / remake / 内容形态。
+    expect(item.category, '3_1');
+    expect(item.trusted, isTrue);
+    expect(item.remake, isFalse);
+    expect(item.contentHint, DiscoveryContentHint.novel);
+    expect(item.note, isNull, reason: 'trusted 已是带类型字段，不再塞 note');
   });
 
-  test('BUG-1946：Sukebei 源用站点自身命名空间的 RSS 也能产出条目', () async {
-    // 真实 sukebei feed 的根元素是 xmlns:nyaa="https://sukebei.nyaa.si/xmlns/nyaa"，
-    // 旧实现硬编码 nyaa.si 命名空间 → 每条 item invalidNamespace → 整源失败。
-    const String sukebeiRss = '''
-<?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:nyaa="https://sukebei.nyaa.si/xmlns/nyaa" version="2.0">
-  <channel>
-    <title>Sukebei - Home - Torrent File RSS</title>
-    <description>RSS Feed for Home</description>
-    <link>https://sukebei.nyaa.si/</link>
-    <item>
-      <title>[260826][天粋球児] 魔族ギルド 魔王の采配SLG [RJ01704616]</title>
-      <link>https://sukebei.nyaa.si/download/4697046.torrent</link>
-      <guid isPermaLink="true">https://sukebei.nyaa.si/view/4697046</guid>
-      <pubDate>Sat, 29 Aug 2026 12:57:39 -0000</pubDate>
-      <nyaa:seeders>49</nyaa:seeders>
-      <nyaa:leechers>19</nyaa:leechers>
-      <nyaa:downloads>110</nyaa:downloads>
-      <nyaa:infoHash>b5e79758ededc8b0084b5dff18c87bcf49397384</nyaa:infoHash>
-      <nyaa:categoryId>1_3</nyaa:categoryId>
-      <nyaa:category>Art - Games</nyaa:category>
-      <nyaa:size>472.7 MiB</nyaa:size>
-      <nyaa:comments>0</nyaa:comments>
-      <nyaa:trusted>No</nyaa:trusted>
-      <nyaa:remake>No</nyaa:remake>
-    </item>
-  </channel>
-</rss>
-''';
+  test('小说域结果逐条打 contentHint；remake 行 class 透传', () async {
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+      },
+      client: _client(
+        (http.Request request) async => http.Response(
+          nyaaSearchHtml(const <NyaaHtmlRow>[_novelRow, _mangaRow]),
+          200,
+        ),
+      ),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'x'),
+    );
+    final List<DiscoveryResourceItem> items =
+        result.items.single.entries.cast<DiscoveryResourceItem>();
+    expect(items, hasLength(2));
+    expect(items[0].contentHint, DiscoveryContentHint.novel);
+    expect(items[0].remake, isFalse);
+    expect(items[1].contentHint, DiscoveryContentHint.manga);
+    expect(items[1].remake, isTrue);
+    expect(items[1].trusted, isFalse, reason: 'HTML 行只有一种颜色，remake 盖掉 trusted');
+  });
+
+  test('非小说域不跑分类器：contentHint 恒 none', () async {
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+        DiscoveryMediaKind.audiobook: '2_0',
+      },
+      client: _client(
+        (http.Request request) async => http.Response(
+          nyaaSearchHtml(const <NyaaHtmlRow>[_mangaRow]),
+          200,
+        ),
+      ),
+    );
+
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.audiobook, query: 'x'),
+    );
+    final DiscoveryResourceItem item =
+        result.items.single.entries.single as DiscoveryResourceItem;
+    expect(item.contentHint, DiscoveryContentHint.none);
+    expect(item.category, '3_1', reason: '分类 id 照样透传');
+  });
+
+  test('BUG-1946：Sukebei 源按站点 baseUrl 解析详情页链接', () async {
     Uri? captured;
     final NyaaDiscoverySource source = NyaaDiscoverySource(
       id: 'sukebei',
@@ -122,16 +166,29 @@ void main() {
       categoryByKind: const <DiscoveryMediaKind, String>{
         DiscoveryMediaKind.game: '1_3',
       },
-      client: NyaaClient(
+      client: _client(
         baseUrl: 'https://sukebei.nyaa.si',
-        client: MockClient((http.Request request) async {
+        (http.Request request) async {
           captured = request.url;
           return http.Response.bytes(
-            utf8.encode(sukebeiRss),
+            utf8.encode(
+              nyaaSearchHtml(const <NyaaHtmlRow>[
+                NyaaHtmlRow(
+                  title: '[260826][天粋球児] 魔族ギルド 魔王の采配SLG [RJ01704616]',
+                  infoHash: 'b5e79758ededc8b0084b5dff18c87bcf49397384',
+                  id: '4697046',
+                  seeders: 49,
+                  leechers: 19,
+                  downloads: 110,
+                  size: '472.7 MiB',
+                  categoryId: '1_3',
+                ),
+              ]),
+            ),
             200,
-            headers: <String, String>{'content-type': 'application/xml'},
+            headers: <String, String>{'content-type': 'text/html'},
           );
-        }),
+        },
       ),
     );
 
@@ -141,7 +198,7 @@ void main() {
 
     expect(captured!.host, 'sukebei.nyaa.si');
     expect(captured!.queryParameters['c'], '1_3');
-    expect(result.failures, isEmpty, reason: '命名空间不能再被判 invalidNamespace');
+    expect(result.failures, isEmpty);
     final DiscoveryResultPage page = result.items.single;
     final DiscoveryResourceItem item =
         page.entries.single as DiscoveryResourceItem;
@@ -154,6 +211,7 @@ void main() {
     );
     expect(item.seeders, 49);
     expect(item.sizeBytes, (472.7 * 1024 * 1024).round());
+    expect(item.contentHint, DiscoveryContentHint.none);
     expect(page.hasMore, isTrue);
   });
 
@@ -164,11 +222,7 @@ void main() {
       categoryByKind: const <DiscoveryMediaKind, String>{
         DiscoveryMediaKind.novel: '3_0',
       },
-      client: NyaaClient(
-        client: MockClient(
-          (http.Request request) async => http.Response('', 500),
-        ),
-      ),
+      client: _client((http.Request request) async => http.Response('', 500)),
     );
 
     expect(
@@ -194,16 +248,62 @@ void main() {
       categoryByKind: const <DiscoveryMediaKind, String>{
         DiscoveryMediaKind.novel: '3_0',
       },
-      client: NyaaClient(
-        client: MockClient((http.Request request) async {
-          captured = request.url;
-          return http.Response.bytes(utf8.encode(_rss), 200);
-        }),
-      ),
+      client: _client((http.Request request) async {
+        captured = request.url;
+        return http.Response(kNyaaNoResultsHtml, 200);
+      }),
     );
     await source.search(
       const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'x'),
     );
     expect(captured!.queryParameters['f'], '2');
+  });
+
+  test('qualityFilter 回调每次请求现读：三态切换无需重建源', () async {
+    final List<String?> filters = <String?>[];
+    NyaaQualityFilter current = NyaaQualityFilter.all;
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      // 给了 qualityFilter 时 trustedOnly 的固定档不再生效。
+      trustedOnly: true,
+      qualityFilter: () => current,
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+      },
+      client: _client((http.Request request) async {
+        filters.add(request.url.queryParameters['f']);
+        return http.Response(kNyaaNoResultsHtml, 200);
+      }),
+    );
+    const DiscoveryRequest request =
+        DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'x');
+
+    await source.search(request);
+    current = NyaaQualityFilter.noRemakes;
+    await source.search(request);
+    current = NyaaQualityFilter.trustedOnly;
+    await source.search(request);
+
+    expect(filters, <String>['0', '1', '2']);
+  });
+
+  test('「No results found」页 → 空页且 hasMore=false，不算失败', () async {
+    final NyaaDiscoverySource source = NyaaDiscoverySource(
+      id: 'nyaa',
+      displayName: 'Nyaa',
+      categoryByKind: const <DiscoveryMediaKind, String>{
+        DiscoveryMediaKind.novel: '3_0',
+      },
+      client: _client(
+        (http.Request request) async => http.Response(kNyaaNoResultsHtml, 200),
+      ),
+    );
+    final ProviderBatchResult<DiscoveryResultPage> result = await source.search(
+      const DiscoveryRequest(kind: DiscoveryMediaKind.novel, query: 'x'),
+    );
+    expect(result.failures, isEmpty);
+    expect(result.items.single.entries, isEmpty);
+    expect(result.items.single.hasMore, isFalse);
   });
 }

--- a/fushi/test/media/video/discovery/video_discovery_service_test.dart
+++ b/fushi/test/media/video/discovery/video_discovery_service_test.dart
@@ -15,6 +15,8 @@ import 'package:fushi/src/media/video/metadata/video_metadata_transport.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 
+import '../../../torrent/nyaa_html_fixture.dart';
+
 void main() {
   group('TMDB discovery adapter', () {
     test('uses discover filters and maps a real movie response', () async {
@@ -161,19 +163,21 @@ void main() {
                 NyaaVideoResourceProvider(
                   closesClient: true,
                   client: NyaaClient(
+                    minRequestInterval: Duration.zero,
                     client: MockClient((http.Request request) async {
                       nyaaRequests.add(request.url);
                       return http.Response.bytes(
-                        utf8.encode('''
-<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
-  <channel><item>
-    <title>$title</title>
-    <link>https://nyaa.si/download/9.torrent</link>
-    <guid>https://nyaa.si/view/9</guid>
-    <nyaa:infoHash>abcdef0123456789abcdef0123456789abcdef01</nyaa:infoHash>
-    <nyaa:seeders>1</nyaa:seeders>
-  </item></channel>
-</rss>'''),
+                        utf8.encode(
+                          nyaaSearchHtml(const <NyaaHtmlRow>[
+                            NyaaHtmlRow(
+                              title: title,
+                              infoHash:
+                                  'abcdef0123456789abcdef0123456789abcdef01',
+                              id: '9',
+                              seeders: 1,
+                            ),
+                          ]),
+                        ),
                         200,
                       );
                     }),

--- a/fushi/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/fushi/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -20,6 +20,7 @@ import 'package:fushi/src/pages/implementations/jimaku_entry_picker.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
 
 import '../helpers/test_platform_services.dart';
+import '../torrent/nyaa_html_fixture.dart';
 
 /// 番剧下载「发现」流 UX 回归：
 /// - Nyaa 搜索网络故障不再吞成「无结果」/统一文案：错误态展示真实异常串 +
@@ -54,32 +55,22 @@ const NyaaTorrent _kTorrent = NyaaTorrent(
   pubDate: null,
 );
 
-String _rssItem({
-  required String title,
-  required String hash,
-  required int seeders,
-  required String size,
-}) {
-  return '''
-  <item>
-    <title>$title</title>
-    <link>https://nyaa.si/download/$hash.torrent</link>
-    <guid>https://nyaa.si/view/$hash</guid>
-    <nyaa:infoHash>$hash</nyaa:infoHash>
-    <nyaa:seeders>$seeders</nyaa:seeders>
-    <nyaa:size>$size</nyaa:size>
-  </item>''';
-}
-
-final String _kSortRss = '''
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
-  <channel>
-${_rssItem(title: 'seeders-top', hash: 'a' * 40, seeders: 300, size: '1 GiB')}
-${_rssItem(title: 'size-top', hash: 'b' * 40, seeders: 10, size: '10 GiB')}
-${_rssItem(title: 'middle', hash: 'c' * 40, seeders: 100, size: '5 GiB')}
-  </channel>
-</rss>''';
+/// 三条做种数 / 体积交错的结果（排序用例）。
+final String _kSortHtml = nyaaSearchHtml(<NyaaHtmlRow>[
+  NyaaHtmlRow(
+    title: 'seeders-top',
+    infoHash: 'a' * 40,
+    seeders: 300,
+    size: '1 GiB',
+  ),
+  NyaaHtmlRow(
+    title: 'size-top',
+    infoHash: 'b' * 40,
+    seeders: 10,
+    size: '10 GiB',
+  ),
+  NyaaHtmlRow(title: 'middle', infoHash: 'c' * 40, seeders: 100, size: '5 GiB'),
+]);
 
 /// 纯内存计划存储（widget 测试不碰真实文件）。字幕暂存目录落到临时目录，
 /// 避免推送流程往仓库工作区写字幕文件。
@@ -278,10 +269,8 @@ void main() {
   testWidgets('Nyaa 真 0 条：展示实际查询词与筛选；损坏 feed 不伪装成无结果', (
     WidgetTester tester,
   ) async {
-    const String emptyRss =
-        '<rss><channel><title>valid empty</title></channel></rss>';
     final _FakeAppModel emptyModel = _FakeAppModel(
-      (http.Request req) async => http.Response(emptyRss, 200),
+      (http.Request req) async => http.Response(kNyaaNoResultsHtml, 200),
     );
     await pumpDialog(tester, emptyModel);
     await tester.tap(find.byTooltip(t.anime_download_search).first);
@@ -297,7 +286,7 @@ void main() {
       findsOneWidget,
     );
 
-    // 损坏 RSS 必须落错误态并带真实解析原因，不能再显示「无结果」。
+    // 不是搜索页的响应必须落错误态并带真实解析原因，不能再显示「无结果」。
     await tester.pumpWidget(const SizedBox.shrink());
     final _FakeAppModel brokenModel = _FakeAppModel(
       (http.Request req) async => http.Response('not xml <<<', 200),
@@ -306,7 +295,7 @@ void main() {
     await tester.tap(find.byTooltip(t.anime_download_search).first);
     await tester.pumpAndSettle();
     expect(find.text(t.anime_download_search_failed), findsOneWidget);
-    expect(find.textContaining('malformedXml'), findsOneWidget);
+    expect(find.textContaining('missingStructure'), findsOneWidget);
     expect(find.text(t.anime_download_no_results), findsNothing);
   });
 
@@ -314,13 +303,11 @@ void main() {
     WidgetTester tester,
   ) async {
     final Completer<http.Response> oldResponse = Completer<http.Response>();
-    const String emptyRss =
-        '<rss><channel><title>valid empty</title></channel></rss>';
     final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
       if (req.url.queryParameters['q'] == 'old query') {
         return oldResponse.future;
       }
-      return http.Response(emptyRss, 200);
+      return http.Response(kNyaaNoResultsHtml, 200);
     });
     await pumpDialog(tester, appModel);
 
@@ -349,7 +336,7 @@ void main() {
     expect(find.textContaining('Query: new query;'), findsOneWidget);
     expect(find.textContaining('Query: unsent current text;'), findsNothing);
 
-    oldResponse.complete(http.Response(_kSortRss, 200));
+    oldResponse.complete(http.Response(_kSortHtml, 200));
     await tester.pumpAndSettle();
     expect(find.text(t.anime_download_no_results), findsOneWidget);
     expect(
@@ -361,7 +348,7 @@ void main() {
 
   testWidgets('选种结果排序：默认做种数降序，切「体积」就地重排', (WidgetTester tester) async {
     final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
-      return http.Response.bytes(_kSortRss.codeUnits, 200);
+      return http.Response.bytes(_kSortHtml.codeUnits, 200);
     });
     await pumpDialog(tester, appModel);
 

--- a/fushi/test/pages/anime_download_dialog_initial_context_test.dart
+++ b/fushi/test/pages/anime_download_dialog_initial_context_test.dart
@@ -13,6 +13,7 @@ import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/anime_download_dialog.dart';
 
 import '../helpers/test_platform_services.dart';
+import '../torrent/nyaa_html_fixture.dart';
 
 /// TODO-2485：AnimeDownloadDialog 初始上下文入参。
 /// ① initialMedia（合集绑 anilistId 时本地合成）→ 直达选种段：Nyaa 查询词与
@@ -37,12 +38,8 @@ void main() {
       );
     }
     if (url.contains('nyaa.si')) {
-      return http.Response(
-        '<?xml version="1.0" encoding="utf-8"?>'
-        '<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">'
-        '<channel></channel></rss>',
-        200,
-      );
+      // nyaa 无结果：HTML 搜索页的「No results found」。
+      return http.Response(kNyaaNoResultsHtml, 200);
     }
     if (url.contains('/entries/search')) {
       // 一条 Jimaku 条目：让对话框继续调 files 端点（集号过滤在那一步）。

--- a/fushi/test/pages/media_discovery_page_test.dart
+++ b/fushi/test/pages/media_discovery_page_test.dart
@@ -1,19 +1,28 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 import 'package:fushi/src/media/discovery/discovery_download_queue.dart';
 import 'package:fushi/src/media/discovery/discovery_models.dart';
 import 'package:fushi/src/media/discovery/media_discovery_service.dart';
 import 'package:fushi/src/media/discovery/media_discovery_source.dart';
+import 'package:fushi/src/media/discovery/sources/nyaa_discovery_source.dart';
 import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/nyaa_client.dart';
 import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/pages/implementations/media_discovery_page.dart';
 import 'package:fushi/utils.dart';
 
 import '../helpers/test_platform_services.dart';
+import '../torrent/nyaa_html_fixture.dart';
 
 /// 统一发现页的「不发请求」契约（BUG-1711）。
 ///
@@ -24,6 +33,10 @@ import '../helpers/test_platform_services.dart';
 /// 一块 unsupported 牌坊）。
 ///
 /// 断言点全部落在**真实行为**上：源上的调用计数必须是 0，而不是只看文案。
+///
+/// 后半部分是 Nyaa 小说源的做种排序 / 隐藏无人做种 / 隐藏疑似漫画 / 过滤三态
+/// （设计稿 `docs/specs/2026-09-08-nyaa-novel-discovery-filters.md`）：走真
+/// `NyaaDiscoverySource` + HTML fixture，偏好写穿到 Drift 内存库再回读。
 
 class _FakeSource extends MediaDiscoverySource {
   _FakeSource({
@@ -107,6 +120,56 @@ class _FakeAppModel extends AppModel {
   );
 }
 
+/// Nyaa 小说域一页结果：做种数 / 内容形态 / 行 class 交错，专供排序与过滤用例。
+const List<NyaaHtmlRow> _novelRows = <NyaaHtmlRow>[
+  // 小说，做种 50。
+  NyaaHtmlRow(
+    title: 'Re:ZERO v01-29 [Yen Press] [Stick]',
+    infoHash: 'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1',
+    id: '1',
+    seeders: 50,
+    size: '300.0 MiB',
+    categoryId: '3_1',
+  ),
+  // 疑似漫画，做种 80（默认被藏）。
+  NyaaHtmlRow(
+    title: 'Sousou no Frieren v01-14 (Digital) (1r0n)',
+    infoHash: 'b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2',
+    id: '2',
+    seeders: 80,
+    size: '2.1 GiB',
+    categoryId: '3_1',
+  ),
+  // 死种小说（默认被藏）。
+  NyaaHtmlRow(
+    title: 'Dead Novel v01 EPUB',
+    infoHash: 'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3',
+    id: '3',
+    size: '10.0 MiB',
+    categoryId: '3_1',
+  ),
+  // trusted 小说，做种 120——服务端给的顺序故意不按做种排，本地兜底得排上去。
+  NyaaHtmlRow(
+    title: 'Mushoku Tensei v01-26 [Yen Press] [Stick]',
+    infoHash: 'd4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4',
+    id: '4',
+    seeders: 120,
+    size: '350.0 MiB',
+    categoryId: '3_1',
+    trusted: true,
+  ),
+  // remake 小说，做种 5。
+  NyaaHtmlRow(
+    title: 'Remake Novel v01 EPUB',
+    infoHash: 'e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5',
+    id: '5',
+    seeders: 5,
+    size: '12.0 MiB',
+    categoryId: '3_1',
+    remake: true,
+  ),
+];
+
 void main() {
   late _FakeSource searchOnly;
   late _FakeSource browsable;
@@ -138,16 +201,17 @@ void main() {
     appModel = _FakeAppModel(service);
   });
 
-  Future<void> pumpPage(WidgetTester tester) async {
+  Future<void> pumpPage(
+    WidgetTester tester, {
+    DiscoveryMediaKind kind = DiscoveryMediaKind.game,
+  }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[appProvider.overrideWith((_) => appModel)],
         child: TranslationProvider(
           child: MaterialApp(
             home: Scaffold(
-              body: const MediaDiscoveryPage(
-                kinds: <DiscoveryMediaKind>[DiscoveryMediaKind.game],
-              ),
+              body: MediaDiscoveryPage(kinds: <DiscoveryMediaKind>[kind]),
             ),
           ),
         ),
@@ -219,6 +283,21 @@ void main() {
         matching: find.text('Browsable'),
       ),
       findsOneWidget,
+    );
+    // 非种子源：做种 / 疑似漫画 / Nyaa 过滤三组控件一个都不该凭空出现。
+    expect(
+      find.byKey(const ValueKey<String>('discovery_filter_hide_zero_seeders')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(
+        const ValueKey<String>('discovery_filter_hide_suspected_manga'),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('discovery_nyaa_filter_0')),
+      findsNothing,
     );
   });
 
@@ -314,6 +393,290 @@ void main() {
     expect(empty.browseCalls, 1);
     expect(find.text(t.discovery_empty), findsOneWidget);
     expect(find.textContaining(t.discovery_sources_unavailable), findsNothing);
+  });
+
+  group('Nyaa 小说源：做种排序 / 隐藏无人做种 / 隐藏疑似漫画 / 过滤三态', () {
+    late FushiDatabase db;
+    late PreferencesRepository prefs;
+    late Directory storeDir;
+    late List<Uri> requests;
+
+    setUp(() async {
+      db = FushiDatabase.forTesting(
+        DatabaseConnection(NativeDatabase.memory()),
+      );
+      prefs = PreferencesRepository(db);
+      await prefs.loadFromDb();
+      storeDir = Directory.systemTemp.createTempSync('fushi_discovery_nyaa');
+      requests = <Uri>[];
+      final NyaaDiscoverySource nyaa = NyaaDiscoverySource(
+        id: 'nyaa',
+        displayName: 'Nyaa',
+        categoryByKind: const <DiscoveryMediaKind, String>{
+          DiscoveryMediaKind.novel: '3_0',
+        },
+        client: NyaaClient(
+          minRequestInterval: Duration.zero,
+          client: MockClient((http.Request request) async {
+            requests.add(request.url);
+            return http.Response(nyaaSearchHtml(_novelRows), 200);
+          }),
+        ),
+        // 与 app_model.dart 的装配同形：每次请求现读偏好。
+        qualityFilter: () =>
+            NyaaQualityFilter.fromIndex(prefs.discoveryNyaaQualityFilter),
+      );
+      service = MediaDiscoveryService(sources: <MediaDiscoverySource>[nyaa]);
+      appModel = _FakeAppModel(service)
+        ..wireLocalAudioForTesting(
+          prefsRepo: prefs,
+          databaseDirectory: storeDir,
+        );
+    });
+
+    tearDown(() async {
+      // prefs 归 AppModel 处置（ProviderScope 拆除时 AppModel.dispose 会 dispose
+      // 它）；这里只关库。
+      await db.close();
+      if (storeDir.existsSync()) storeDir.deleteSync(recursive: true);
+    });
+
+    /// 选 Nyaa 源并搜一次。
+    Future<void> searchNyaa(WidgetTester tester) async {
+      await pumpPage(tester, kind: DiscoveryMediaKind.novel);
+      await tester.tap(
+        find.byKey(const ValueKey<String>('discovery_source_pick_nyaa')),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('discovery_search_field')),
+        'novel',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle();
+    }
+
+    Finder item(String title) => find.widgetWithText(FushiListItem, title);
+
+    /// 从 Drift 重新装一份仓库读回：证明是写穿到库，不是页面局部状态。
+    Future<PreferencesRepository> reloadPrefs() async {
+      final PreferencesRepository fresh = PreferencesRepository(db);
+      await fresh.loadFromDb();
+      return fresh;
+    }
+
+    testWidgets('默认藏死种与疑似漫画、源内按做种降序、徽标来自行 class', (
+      WidgetTester tester,
+    ) async {
+      await searchNyaa(tester);
+      expect(requests, hasLength(1));
+      expect(requests.single.queryParameters['c'], '3_0');
+      expect(requests.single.queryParameters['s'], 'seeders');
+      expect(requests.single.queryParameters['f'], '0');
+
+      // 三条可见：120 / 50 / 5 按做种降序（服务端给的原序是 50 在 120 前）。
+      expect(item('Mushoku Tensei v01-26 [Yen Press] [Stick]'), findsOneWidget);
+      expect(item('Re:ZERO v01-29 [Yen Press] [Stick]'), findsOneWidget);
+      expect(item('Remake Novel v01 EPUB'), findsOneWidget);
+      expect(
+        tester.getTopLeft(item('Mushoku Tensei v01-26 [Yen Press] [Stick]')).dy,
+        lessThan(tester.getTopLeft(item('Re:ZERO v01-29 [Yen Press] [Stick]')).dy),
+      );
+      expect(
+        tester.getTopLeft(item('Re:ZERO v01-29 [Yen Press] [Stick]')).dy,
+        lessThan(tester.getTopLeft(item('Remake Novel v01 EPUB')).dy),
+      );
+      // 两条被藏。
+      expect(item('Sousou no Frieren v01-14 (Digital) (1r0n)'), findsNothing);
+      expect(item('Dead Novel v01 EPUB'), findsNothing);
+      // 计数行：1 条无人做种 + 1 条疑似漫画。
+      final Finder notice =
+          find.byKey(const ValueKey<String>('discovery_hidden_reveal'));
+      expect(notice, findsOneWidget);
+      expect(
+        find.textContaining(t.discovery_hidden_zero_seeders_count(n: 1)),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining(t.discovery_hidden_suspected_manga_count(n: 1)),
+        findsOneWidget,
+      );
+      // 徽标：trusted 绿一枚、remake 红一枚。
+      expect(
+        find.byKey(const ValueKey<String>('discovery_badge_trusted')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('discovery_badge_remake')),
+        findsOneWidget,
+      );
+      // 两个 chip 默认选中；偏好默认值也是开。
+      expect(
+        tester
+            .widget<FilterChip>(
+              find.byKey(
+                const ValueKey<String>('discovery_filter_hide_zero_seeders'),
+              ),
+            )
+            .selected,
+        isTrue,
+      );
+      expect(
+        tester
+            .widget<FilterChip>(
+              find.byKey(
+                const ValueKey<String>('discovery_filter_hide_suspected_manga'),
+              ),
+            )
+            .selected,
+        isTrue,
+      );
+      expect(prefs.discoveryHideZeroSeeders, isTrue);
+      expect(prefs.discoveryHideSuspectedManga, isTrue);
+
+      // 点计数行：临时全显示，不改偏好；死种条目灰显。
+      await tester.tap(notice);
+      await tester.pumpAndSettle();
+      expect(notice, findsNothing);
+      expect(item('Sousou no Frieren v01-14 (Digital) (1r0n)'), findsOneWidget);
+      expect(item('Dead Novel v01 EPUB'), findsOneWidget);
+      expect(prefs.discoveryHideZeroSeeders, isTrue, reason: '点开不写偏好');
+      expect(prefs.discoveryHideSuspectedManga, isTrue, reason: '点开不写偏好');
+      expect(
+        tester
+            .widget<Opacity>(
+              find.byKey(
+                const ValueKey<String>(
+                  'discovery_item_nyaa_https://nyaa.si/view/3',
+                ),
+              ),
+            )
+            .opacity,
+        0.5,
+      );
+      expect(
+        tester
+            .widget<Opacity>(
+              find.byKey(
+                const ValueKey<String>(
+                  'discovery_item_nyaa_https://nyaa.si/view/4',
+                ),
+              ),
+            )
+            .opacity,
+        1,
+      );
+      // 疑似漫画条目副标题带标签。
+      expect(
+        find.descendant(
+          of: item('Sousou no Frieren v01-14 (Digital) (1r0n)'),
+          matching: find.textContaining(t.discovery_content_hint_manga),
+        ),
+        findsOneWidget,
+      );
+      expect(requests, hasLength(1), reason: '客户端过滤，不重新请求');
+    });
+
+    testWidgets('两个开关写穿偏好并即时生效，切换不重新请求', (WidgetTester tester) async {
+      await searchNyaa(tester);
+      final Finder zeroChip =
+          find.byKey(const ValueKey<String>('discovery_filter_hide_zero_seeders'));
+      final Finder mangaChip = find.byKey(
+        const ValueKey<String>('discovery_filter_hide_suspected_manga'),
+      );
+
+      // 关「隐藏无人做种」：死种出现（灰显），疑似漫画仍藏，计数行只剩漫画。
+      await tester.tap(zeroChip);
+      await tester.pumpAndSettle();
+      expect(prefs.discoveryHideZeroSeeders, isFalse);
+      expect((await reloadPrefs()).discoveryHideZeroSeeders, isFalse);
+      expect(item('Dead Novel v01 EPUB'), findsOneWidget);
+      expect(item('Sousou no Frieren v01-14 (Digital) (1r0n)'), findsNothing);
+      expect(
+        find.textContaining(t.discovery_hidden_zero_seeders_count(n: 1)),
+        findsNothing,
+      );
+      expect(
+        find.textContaining(t.discovery_hidden_suspected_manga_count(n: 1)),
+        findsOneWidget,
+      );
+
+      // 关「隐藏疑似漫画」：全部可见，计数行消失。
+      await tester.tap(mangaChip);
+      await tester.pumpAndSettle();
+      expect(prefs.discoveryHideSuspectedManga, isFalse);
+      expect((await reloadPrefs()).discoveryHideSuspectedManga, isFalse);
+      expect(item('Sousou no Frieren v01-14 (Digital) (1r0n)'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey<String>('discovery_hidden_reveal')),
+        findsNothing,
+      );
+
+      // 再开回「隐藏无人做种」：死种重新藏起。
+      await tester.tap(zeroChip);
+      await tester.pumpAndSettle();
+      expect(prefs.discoveryHideZeroSeeders, isTrue);
+      expect(item('Dead Novel v01 EPUB'), findsNothing);
+
+      expect(requests, hasLength(1), reason: '两个开关都是客户端过滤');
+    });
+
+    testWidgets('Nyaa 过滤三态写穿偏好、透传 f 并重新请求', (WidgetTester tester) async {
+      await searchNyaa(tester);
+      for (final NyaaQualityFilter f in NyaaQualityFilter.values) {
+        expect(
+          find.byKey(ValueKey<String>('discovery_nyaa_filter_${f.index}')),
+          findsOneWidget,
+        );
+      }
+      ChoiceChip chip(int index) => tester.widget<ChoiceChip>(
+            find.byKey(ValueKey<String>('discovery_nyaa_filter_$index')),
+          );
+      expect(chip(0).selected, isTrue);
+      expect(prefs.discoveryNyaaQualityFilter, 0);
+      expect(requests.last.queryParameters['f'], '0');
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('discovery_nyaa_filter_2')),
+      );
+      await tester.pumpAndSettle();
+      expect(prefs.discoveryNyaaQualityFilter, 2);
+      expect((await reloadPrefs()).discoveryNyaaQualityFilter, 2);
+      expect(chip(2).selected, isTrue);
+      expect(chip(0).selected, isFalse);
+      // 服务端参数：必须重新请求且带 f=2。
+      expect(requests, hasLength(2));
+      expect(requests.last.queryParameters['f'], '2');
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('discovery_nyaa_filter_1')),
+      );
+      await tester.pumpAndSettle();
+      expect(prefs.discoveryNyaaQualityFilter, 1);
+      expect(requests, hasLength(3));
+      expect(requests.last.queryParameters['f'], '1');
+
+      // 点已选中的档不重复请求。
+      await tester.tap(
+        find.byKey(const ValueKey<String>('discovery_nyaa_filter_1')),
+      );
+      await tester.pumpAndSettle();
+      expect(requests, hasLength(3));
+    });
+
+    test('app_model 装配：nyaa.si 源按当前偏好现读过滤三态', () {
+      final String source =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      expect(
+        source.contains('qualityFilter: () => NyaaQualityFilter.fromIndex('),
+        isTrue,
+        reason: '偏好可随时改而源实例常驻，必须按次读，不能构造时定死',
+      );
+      expect(
+        source.contains('prefsRepo.discoveryNyaaQualityFilter'),
+        isTrue,
+      );
+    });
   });
 }
 

--- a/fushi/test/torrent/external_provider_adapters_test.dart
+++ b/fushi/test/torrent/external_provider_adapters_test.dart
@@ -15,13 +15,16 @@ import 'package:fushi/src/media/video/jimaku_subtitle_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/subtitle/video_subtitle_provider.dart';
 
+import 'nyaa_html_fixture.dart';
+
 void main() {
   test('Nyaa adapter preserves release fields and resolves a magnet', () async {
     final NyaaVideoResourceProvider provider = NyaaVideoResourceProvider(
       client: NyaaClient(
+        minRequestInterval: Duration.zero,
         client: MockClient((http.Request request) async {
           expect(request.url.queryParameters['q'], 'Test Show');
-          return http.Response(_nyaaFeed, 200);
+          return http.Response(_nyaaPage, 200);
         }),
       ),
     );
@@ -46,9 +49,10 @@ void main() {
     final List<String> queries = <String>[];
     final NyaaVideoResourceProvider provider = NyaaVideoResourceProvider(
       client: NyaaClient(
+        minRequestInterval: Duration.zero,
         client: MockClient((http.Request request) async {
           queries.add(request.url.queryParameters['q']!);
-          return http.Response(_nyaaFeed, 200);
+          return http.Response(_nyaaPage, 200);
         }),
       ),
     );
@@ -84,9 +88,10 @@ void main() {
       final List<String> queries = <String>[];
       final NyaaVideoResourceProvider provider = NyaaVideoResourceProvider(
         client: NyaaClient(
+          minRequestInterval: Duration.zero,
           client: MockClient((http.Request request) async {
             queries.add(request.url.queryParameters['q']!);
-            return http.Response(_nyaaFeed, 200);
+            return http.Response(_nyaaPage, 200);
           }),
         ),
       );
@@ -188,22 +193,17 @@ void main() {
   });
 }
 
-const String _nyaaFeed = '''
-<?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
-  <channel><item>
-    <title>[Group] Test Show - 02 [1080p]</title>
-    <link>https://nyaa.si/download/1.torrent</link>
-    <guid>https://nyaa.si/view/1</guid>
-    <pubDate>Fri, 03 Nov 2023 12:30:00 -0000</pubDate>
-    <nyaa:infoHash>0123456789abcdef0123456789abcdef01234567</nyaa:infoHash>
-    <nyaa:seeders>15</nyaa:seeders>
-    <nyaa:leechers>2</nyaa:leechers>
-    <nyaa:downloads>100</nyaa:downloads>
-    <nyaa:size>1.4 GiB</nyaa:size>
-    <nyaa:categoryId>1_2</nyaa:categoryId>
-    <nyaa:trusted>Yes</nyaa:trusted>
-    <nyaa:remake>No</nyaa:remake>
-  </item></channel>
-</rss>
-''';
+/// 一条 trusted 结果的 HTML 搜索页（id `1` → pageUrl `https://nyaa.si/view/1`）。
+final String _nyaaPage = nyaaSearchHtml(const <NyaaHtmlRow>[
+  NyaaHtmlRow(
+    title: '[Group] Test Show - 02 [1080p]',
+    infoHash: '0123456789abcdef0123456789abcdef01234567',
+    id: '1',
+    seeders: 15,
+    leechers: 2,
+    downloads: 100,
+    size: '1.4 GiB',
+    categoryId: '1_2',
+    trusted: true,
+  ),
+]);

--- a/fushi/test/torrent/nyaa_client_test.dart
+++ b/fushi/test/torrent/nyaa_client_test.dart
@@ -11,6 +11,8 @@ import 'package:fushi/src/media/torrent/download_timeouts.dart';
 import 'package:fushi/src/media/torrent/nyaa_client.dart';
 import 'package:fushi/src/media/torrent/public_trackers.dart';
 
+import 'nyaa_html_fixture.dart';
+
 /// 构造只关心 [title] / [infoHash] 的最小 [NyaaTorrent]，供派生 getter 测试用。
 NyaaTorrent makeTorrent(String title, {String infoHash = ''}) {
   return NyaaTorrent(
@@ -84,6 +86,52 @@ const String sampleRss = '''
 </rss>
 ''';
 
+/// 三行 HTML 首屏：trusted / remake / 普通 各一。
+const List<NyaaHtmlRow> _sampleRows = <NyaaHtmlRow>[
+  NyaaHtmlRow(
+    title: '[SubsPlease] Sousou no Frieren - 05 (1080p) [ABCD1234].mkv',
+    infoHash: '0123456789abcdef0123456789abcdef01234567',
+    id: '1234567',
+    seeders: 120,
+    leechers: 4,
+    downloads: 2048,
+    size: '1.4 GiB',
+    categoryId: '1_2',
+    trusted: true,
+  ),
+  NyaaHtmlRow(
+    title: '[Judas] Frieren 01-12 [1080p][HEVC x265] (Batch)',
+    infoHash: 'fedcba9876543210fedcba9876543210fedcba98',
+    id: '7654321',
+    seeders: 33,
+    leechers: 2,
+    downloads: 512,
+    size: '700.5 MiB',
+    categoryId: '1_0',
+    remake: true,
+  ),
+  NyaaHtmlRow(
+    title: 'Show Raw 980 kb sample',
+    infoHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    id: '1111',
+    downloads: 7,
+    size: 'weird size',
+    categoryId: '1_4',
+  ),
+];
+
+/// 测试用 client：节流归零（节流本身单独测），其余默认。
+NyaaClient _clientWith(
+  Future<http.Response> Function(http.Request request) handler, {
+  Duration? requestTimeout,
+  Duration minRequestInterval = Duration.zero,
+}) =>
+    NyaaClient(
+      client: MockClient(handler),
+      requestTimeout: requestTimeout ?? kDownloadDiscoveryTimeout,
+      minRequestInterval: minRequestInterval,
+    );
+
 void main() {
   group('parseNyaaRss', () {
     test('解析全部字段', () {
@@ -137,6 +185,115 @@ void main() {
         parseNyaaRss('<rss><channel><title>empty</title></channel></rss>'),
         isEmpty,
       );
+    });
+  });
+
+  group('parseNyaaRssStrict（原 RSS 首屏解析层，保留给旧调用方）', () {
+    NyaaFeedErrorCode? codeOf(String body) {
+      try {
+        parseNyaaRssStrict(body);
+        return null;
+      } on NyaaFeedFormatException catch (error) {
+        return error.code;
+      }
+    }
+
+    test('严格错误矩阵：编码/XML/RSS结构/命名空间/必需字段稳定可区分', () {
+      expect(codeOf(''), NyaaFeedErrorCode.emptyBody);
+      expect(
+        codeOf(
+            '<?xml version="1.0" encoding="shift_jis"?><rss><channel/></rss>'),
+        NyaaFeedErrorCode.unsupportedEncoding,
+      );
+      expect(codeOf('<rss><channel>'), NyaaFeedErrorCode.malformedXml);
+      expect(codeOf('<html><body/></html>'), NyaaFeedErrorCode.notRss);
+      expect(codeOf('<rss/>'), NyaaFeedErrorCode.missingStructure);
+      expect(
+        codeOf(
+          '<rss><channel><item><link>x</link><guid>y</guid>'
+          '<n:infoHash xmlns:n="$_nyaaNamespaceForTest">'
+          '${'a' * 40}</n:infoHash></item></channel></rss>',
+        ),
+        NyaaFeedErrorCode.missingField,
+      );
+      expect(
+        codeOf(
+          '<rss><channel><item><title>x</title><link>x</link><guid>y</guid>'
+          '<bad:infoHash xmlns:bad="https://invalid.example/ns">'
+          '${'a' * 40}</bad:infoHash></item></channel></rss>',
+        ),
+        NyaaFeedErrorCode.invalidNamespace,
+      );
+      expect(
+        codeOf('<rss><channel><title>valid empty</title></channel></rss>'),
+        isNull,
+        reason: '结构有效、确实没有 item 才是 0 条',
+      );
+      // 严格版对坏 seeders / 坏 infoHash 抛 invalidField（宽松版 parseNyaaRss
+      // 容错保留）；把第三条修好后三条都能解析。
+      expect(codeOf(sampleRss), NyaaFeedErrorCode.invalidField);
+      expect(
+        parseNyaaRssStrict(
+          sampleRss
+              .replaceFirst(
+                '<nyaa:seeders>bad</nyaa:seeders>',
+                '<nyaa:seeders>0</nyaa:seeders>',
+              )
+              .replaceFirst(
+                '<nyaa:leechers></nyaa:leechers>',
+                '<nyaa:leechers>0</nyaa:leechers>',
+              )
+              .replaceFirst(
+                '<nyaa:infoHash>aaaa</nyaa:infoHash>',
+                '<nyaa:infoHash>${'a' * 40}</nyaa:infoHash>',
+              ),
+        ),
+        hasLength(3),
+      );
+    });
+
+    test('BUG-1946：sukebei / 镜像站 <site>/xmlns/nyaa 命名空间被接受，路径不同才拒', () {
+      String feed(String ns) => '''
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:nyaa="$ns">
+  <channel><item>
+    <title>[260825][破顔研] イモータルリコール 外伝 [RJ01660478]</title>
+    <link>https://sukebei.nyaa.si/download/4697097.torrent</link>
+    <guid isPermaLink="true">https://sukebei.nyaa.si/view/4697097</guid>
+    <nyaa:seeders>29</nyaa:seeders>
+    <nyaa:infoHash>14d40b587d2a237150b6b019e6236e93e16a1f73</nyaa:infoHash>
+    <nyaa:categoryId>1_3</nyaa:categoryId>
+    <nyaa:size>252.8 MiB</nyaa:size>
+    <nyaa:trusted>Yes</nyaa:trusted>
+  </item></channel>
+</rss>''';
+
+      for (final String ns in <String>[
+        'https://sukebei.nyaa.si/xmlns/nyaa',
+        'https://nyaa.si/xmlns/nyaa',
+        'https://nyaa.land/xmlns/nyaa',
+        'http://127.0.0.1:8080/xmlns/nyaa',
+      ]) {
+        final NyaaTorrent item = parseNyaaRssStrict(feed(ns)).single;
+        expect(item.infoHash, '14d40b587d2a237150b6b019e6236e93e16a1f73');
+        expect(item.seeders, 29, reason: '$ns：nyaa:seeders 也要按命名空间读到');
+        expect(item.categoryId, '1_3', reason: ns);
+        expect(item.trusted, isTrue, reason: ns);
+      }
+      for (final String ns in <String>[
+        'https://invalid.example/ns',
+        'https://nyaa.si/xmlns/other',
+        'https://nyaa.si/xmlns/nyaa/',
+        'nyaa',
+      ]) {
+        expect(codeOf(feed(ns)), NyaaFeedErrorCode.invalidNamespace,
+            reason: ns);
+      }
+
+      expect(isNyaaNamespace(null), isFalse);
+      expect(isNyaaNamespace(''), isFalse);
+      expect(isNyaaNamespace('/xmlns/nyaa'), isFalse, reason: '无 host 不算');
+      expect(isNyaaNamespace('https://sukebei.nyaa.si/xmlns/nyaa'), isTrue);
     });
   });
 
@@ -316,15 +473,13 @@ void main() {
     });
   });
 
-  group('NyaaClient.search', () {
+  group('NyaaClient.search（HTML 搜索页）', () {
     Future<Object?> searchResponse(
       List<int> bytes, {
       Map<String, String> headers = const <String, String>{},
     }) async {
-      final NyaaClient client = NyaaClient(
-        client: MockClient(
-          (_) async => http.Response.bytes(bytes, 200, headers: headers),
-        ),
+      final NyaaClient client = _clientWith(
+        (_) async => http.Response.bytes(bytes, 200, headers: headers),
       );
       try {
         return await client.search('show');
@@ -335,69 +490,90 @@ void main() {
       }
     }
 
-    test('拼出 page=rss&q&c&f 的查询 URL 并解析响应', () async {
+    test('首屏拼 q&c&f&s&o（默认做种降序、不带 page=rss / p）并解析 HTML', () async {
       Uri? captured;
-      final MockClient mock = MockClient((http.Request req) async {
+      final NyaaClient client = _clientWith((http.Request req) async {
         captured = req.url;
-        return http.Response(
-          sampleRss
-              .replaceFirst(
-                '<nyaa:seeders>bad</nyaa:seeders>',
-                '<nyaa:seeders>0</nyaa:seeders>',
-              )
-              .replaceFirst(
-                '<nyaa:leechers></nyaa:leechers>',
-                '<nyaa:leechers>0</nyaa:leechers>',
-              )
-              .replaceFirst(
-                '<nyaa:infoHash>aaaa</nyaa:infoHash>',
-                '<nyaa:infoHash>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-                    '</nyaa:infoHash>',
-              ),
-          200,
-        );
+        return http.Response(nyaaSearchHtml(_sampleRows), 200);
       });
-      final NyaaClient client = NyaaClient(client: mock);
       final List<NyaaTorrent> items = await client.search(
         'frieren',
         category: '1_2',
         filter: '2',
       );
-      expect(items, hasLength(3));
       expect(captured, isNotNull);
       expect(captured!.host, 'nyaa.si');
       expect(captured!.scheme, 'https');
       expect(captured!.queryParameters, <String, String>{
-        'page': 'rss',
         'q': 'frieren',
         'c': '1_2',
         'f': '2',
+        's': 'seeders',
+        'o': 'desc',
       });
+
+      expect(items, hasLength(3));
+      final NyaaTorrent first = items[0];
+      expect(
+        first.title,
+        '[SubsPlease] Sousou no Frieren - 05 (1080p) [ABCD1234].mkv',
+      );
+      expect(first.torrentUrl, 'https://nyaa.si/download/1234567.torrent');
+      expect(first.pageUrl, 'https://nyaa.si/view/1234567');
+      expect(first.infoHash, '0123456789abcdef0123456789abcdef01234567');
+      expect(first.seeders, 120);
+      expect(first.leechers, 4);
+      expect(first.downloads, 2048);
+      expect(first.sizeText, '1.4 GiB');
+      expect(first.sizeBytes, (1.4 * 1024 * 1024 * 1024).round());
+      expect(first.categoryId, '1_2');
+      expect(
+        first.pubDate,
+        DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000, isUtc: true),
+      );
+      expect(items[1].sizeBytes, (700.5 * 1024 * 1024).round());
+      expect(items[1].episodeRange, (1, 12));
+      expect(items[2].seeders, 0);
+      expect(items[2].sizeBytes, isNull, reason: '认不出的体积 → null');
       client.close();
     });
 
-    test('第二页使用 HTML p 参数并解析完整候选，不重复 RSS 首屏', () async {
+    test('行 class → trusted（success）/ remake（danger）；普通行两者皆否', () async {
+      final NyaaClient client = _clientWith(
+        (_) async => http.Response(nyaaSearchHtml(_sampleRows), 200),
+      );
+      final List<NyaaTorrent> items = await client.search('x');
+      expect(items[0].trusted, isTrue);
+      expect(items[0].remake, isFalse);
+      expect(items[1].trusted, isFalse);
+      expect(items[1].remake, isTrue);
+      expect(items[2].trusted, isFalse);
+      expect(items[2].remake, isFalse);
+      client.close();
+    });
+
+    test('sort / order 透传：订阅按发布时间用 s=id', () async {
       Uri? captured;
-      final MockClient mock = MockClient((http.Request request) async {
-        captured = request.url;
-        return http.Response('''
-<!doctype html><html><body>
-<table class="table torrent-list"><tbody>
-  <tr class="success">
-    <td><a href="/?c=1_2">Anime</a></td>
-    <td colspan="2"><a href="/view/200" title="[SubsPlease] Example - 100 [1080p]">Example</a></td>
-    <td>
-      <a href="/download/200.torrent">download</a>
-      <a href="magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&amp;dn=Example">magnet</a>
-    </td>
-    <td>1.5 GiB</td>
-    <td data-timestamp="1700000000">2023-11-14 22:13</td>
-    <td>42</td><td>3</td><td>900</td>
-  </tr>
-</tbody></table>
-</body></html>''', 200);
+      final NyaaClient client = _clientWith((http.Request req) async {
+        captured = req.url;
+        return http.Response(kNyaaNoResultsHtml, 200);
       });
-      final NyaaClient client = NyaaClient(client: mock);
+      await client.search(
+        'x',
+        sort: NyaaSort.date,
+        order: NyaaSortOrder.asc,
+      );
+      expect(captured!.queryParameters['s'], 'id');
+      expect(captured!.queryParameters['o'], 'asc');
+      client.close();
+    });
+
+    test('第二页带 p 参数，其余参数不变', () async {
+      Uri? captured;
+      final NyaaClient client = _clientWith((http.Request request) async {
+        captured = request.url;
+        return http.Response(nyaaSearchHtml(_sampleRows.take(1)), 200);
+      });
 
       final List<NyaaTorrent> items = await client.search(
         'Example',
@@ -407,38 +583,59 @@ void main() {
       );
 
       expect(captured!.queryParameters, <String, String>{
-        'p': '2',
         'q': 'Example',
         'c': '1_2',
         'f': '2',
+        's': 'seeders',
+        'o': 'desc',
+        'p': '2',
       });
       expect(items, hasLength(1));
-      final NyaaTorrent item = items.single;
-      expect(item.title, '[SubsPlease] Example - 100 [1080p]');
-      expect(item.infoHash, '0123456789abcdef0123456789abcdef01234567');
-      expect(item.torrentUrl, 'https://nyaa.si/download/200.torrent');
-      expect(item.pageUrl, 'https://nyaa.si/view/200');
-      expect(item.categoryId, '1_2');
-      expect(item.sizeBytes, (1.5 * 1024 * 1024 * 1024).round());
-      expect(item.seeders, 42);
-      expect(item.leechers, 3);
-      expect(item.downloads, 900);
-      expect(item.trusted, isTrue);
+      client.close();
+    });
+
+    test('越过后端上限的页直接返回空、不发请求：关键词 14 页 / 浏览 100 页', () async {
+      int requests = 0;
+      final NyaaClient client = _clientWith((http.Request request) async {
+        requests++;
+        return http.Response(kNyaaNoResultsHtml, 200);
+      });
+
+      expect(await client.search('x', page: kNyaaMaxSearchPages + 1), isEmpty);
+      expect(requests, 0, reason: '越界页不该打网络');
+      expect(await client.search('x', page: kNyaaMaxSearchPages), isEmpty);
+      expect(requests, 1, reason: '上限页本身仍然要请求');
+
+      expect(await client.search('', page: kNyaaMaxBrowsePages + 1), isEmpty);
+      expect(requests, 1);
       expect(
-        item.pubDate,
-        DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000, isUtc: true),
+          await client.search('   ', page: kNyaaMaxBrowsePages + 1), isEmpty);
+      expect(requests, 1, reason: '空白关键词按浏览算');
+      expect(await client.search('', page: kNyaaMaxBrowsePages), isEmpty);
+      expect(requests, 2);
+      // 浏览允许比关键词搜索翻得更深。
+      expect(await client.search('', page: kNyaaMaxSearchPages + 1), isEmpty);
+      expect(requests, 3);
+      client.close();
+
+      expect(kNyaaMaxSearchPages, 14);
+      expect(kNyaaMaxBrowsePages, 100);
+    });
+
+    test('page <= 0 仍是调用方 bug，抛 ArgumentError', () async {
+      final NyaaClient client = _clientWith(
+        (_) async => http.Response(kNyaaNoResultsHtml, 200),
       );
+      await expectLater(client.search('x', page: 0), throwsArgumentError);
       client.close();
     });
 
     test('HTML 后续页 404 表示越过末页并安全结束', () async {
       Uri? captured;
-      final NyaaClient client = NyaaClient(
-        client: MockClient((http.Request request) async {
-          captured = request.url;
-          return http.Response('not found', 404);
-        }),
-      );
+      final NyaaClient client = _clientWith((http.Request request) async {
+        captured = request.url;
+        return http.Response('not found', 404);
+      });
 
       expect(await client.search('Example', page: 3), isEmpty);
       expect(captured!.queryParameters['p'], '3');
@@ -451,11 +648,10 @@ void main() {
         // 以前吞错返回空列表，真实网络故障（站点被墙/代理未配）会被误报成
         // 「无结果」；现在必须抛出让调用方展示真实错误。
         Uri? captured;
-        final MockClient mock = MockClient((http.Request req) async {
+        final NyaaClient client = _clientWith((http.Request req) async {
           captured = req.url;
           return http.Response('server error', 500);
         });
-        final NyaaClient client = NyaaClient(client: mock);
         await expectLater(
           client.search('frieren'),
           throwsA(
@@ -477,13 +673,12 @@ void main() {
     // 代理半开时 TCP 连接能挂到操作系统重传耗尽；discovery source 与 resource
     // provider 这两条注册表路径的调用点也没有外层超时，于是一次挂死的 Nyaa
     // 请求会把整次扇出一起拖住。
-    test('永不完成的响应在 requestTimeout 后抛 TimeoutException，不是无限等待',
-        () async {
+    test('永不完成的响应在 requestTimeout 后抛 TimeoutException，不是无限等待', () async {
       // 永不完成：这个 Completer 从不 complete、也不 throw。若 search 不设超时，
       // 下面的 await 就永远不返回，只能被 flutter_test 自己的超时打死。
       final Completer<http.Response> never = Completer<http.Response>();
-      final NyaaClient client = NyaaClient(
-        client: MockClient((http.Request req) => never.future),
+      final NyaaClient client = _clientWith(
+        (http.Request req) => never.future,
         requestTimeout: const Duration(milliseconds: 50),
       );
       await expectLater(
@@ -493,12 +688,10 @@ void main() {
       client.close();
     });
 
-    test('HTML 翻页路径同样受 requestTimeout 约束', () async {
-      // 首屏走 RSS、后续页走 HTML，是 search 里两条不同的解析分支；超时必须落在
-      // 分支之前那一次 get 上，不能只对 RSS 路径成立。
+    test('翻页路径同样受 requestTimeout 约束', () async {
       final Completer<http.Response> never = Completer<http.Response>();
-      final NyaaClient client = NyaaClient(
-        client: MockClient((http.Request req) => never.future),
+      final NyaaClient client = _clientWith(
+        (http.Request req) => never.future,
         requestTimeout: const Duration(milliseconds: 50),
       );
       await expectLater(
@@ -516,14 +709,44 @@ void main() {
       final NyaaClient client =
           NyaaClient(client: MockClient((_) async => http.Response('', 200)));
       expect(client.requestTimeout, kDownloadDiscoveryTimeout);
+      expect(client.minRequestInterval, kNyaaMinRequestInterval);
+      expect(kNyaaMinRequestInterval, const Duration(seconds: 2));
+      client.close();
+    });
+
+    test('同一实例请求按 minRequestInterval 串行节流（并发调用也排队）', () async {
+      const Duration interval = Duration(milliseconds: 120);
+      final List<DateTime> startedAt = <DateTime>[];
+      final NyaaClient client = _clientWith(
+        (http.Request req) async {
+          startedAt.add(DateTime.now());
+          return http.Response(kNyaaNoResultsHtml, 200);
+        },
+        minRequestInterval: interval,
+      );
+      // 三个并发调用：不能同时打出去。
+      await Future.wait<List<NyaaTorrent>>(<Future<List<NyaaTorrent>>>[
+        client.search('a'),
+        client.search('b'),
+        client.search('c'),
+      ]);
+      expect(startedAt, hasLength(3));
+      for (int i = 1; i < startedAt.length; i++) {
+        final Duration gap = startedAt[i].difference(startedAt[i - 1]);
+        // 定时器精度留 20ms 余量；断言的是「至少隔开」，不是精确值。
+        expect(
+          gap,
+          greaterThanOrEqualTo(interval - const Duration(milliseconds: 20)),
+          reason: '第 $i 次与上一次只隔了 $gap',
+        );
+      }
       client.close();
     });
 
     test('底层网络异常（如握手失败）原样穿透，不吞成空列表', () async {
-      final MockClient mock = MockClient((http.Request req) async {
+      final NyaaClient client = _clientWith((http.Request req) async {
         throw http.ClientException('HandshakeException: 模拟被墙', req.url);
       });
-      final NyaaClient client = NyaaClient(client: mock);
       await expectLater(
         client.search('frieren'),
         throwsA(
@@ -537,12 +760,10 @@ void main() {
       client.close();
     });
 
-    test('空响应 / 损坏 RSS 抛格式错误；有效空 feed 才是 0 条结果', () async {
+    test('空响应 / 不是搜索页的 HTML 抛格式错误；「No results found」页才是 0 条', () async {
       Future<Object?> searchBody(String body) async {
-        final NyaaClient client = NyaaClient(
-          client: MockClient(
-            (http.Request req) async => http.Response(body, 200),
-          ),
+        final NyaaClient client = _clientWith(
+          (http.Request req) async => http.Response(body, 200),
         );
         try {
           return await client.search('frieren');
@@ -566,13 +787,22 @@ void main() {
         isA<NyaaFeedFormatException>().having(
           (NyaaFeedFormatException e) => e.code,
           'code',
-          NyaaFeedErrorCode.malformedXml,
+          NyaaFeedErrorCode.missingStructure,
         ),
       );
+      // 旧 RSS 空 feed 现在也不是搜索页：不能再被当成 0 条。
       expect(
         await searchBody(
           '<rss><channel><title>valid empty</title></channel></rss>',
         ),
+        isA<NyaaFeedFormatException>().having(
+          (NyaaFeedFormatException e) => e.code,
+          'code',
+          NyaaFeedErrorCode.missingStructure,
+        ),
+      );
+      expect(
+        await searchBody(kNyaaNoResultsHtml),
         isA<List<NyaaTorrent>>().having(
           (List<NyaaTorrent> items) => items,
           'items',
@@ -586,22 +816,22 @@ void main() {
       // 旧实现走 res.body(latin1) 会把「ソ・ラ・ノ・ヲ・ト」变成「Soã»...」。
       const String jpTitle =
           '[ReinForce] ソ・ラ・ノ・ヲ・ト (BDRip 1920x1080 x264 FLAC)';
-      const String rss = '''
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
-  <channel><item>
-    <title>$jpTitle</title>
-    <link>https://nyaa.si/download/9.torrent</link>
-    <guid>https://nyaa.si/view/9</guid>
-    <nyaa:infoHash>abcdef0123456789abcdef0123456789abcdef01</nyaa:infoHash>
-    <nyaa:seeders>1</nyaa:seeders>
-  </item></channel>
-</rss>''';
-      final MockClient mock = MockClient((http.Request req) async {
+      final NyaaClient client = _clientWith((http.Request req) async {
         // bytes 构造 = UTF-8 字节 + 无 charset 头（正是踩坑场景）。
-        return http.Response.bytes(utf8.encode(rss), 200);
+        return http.Response.bytes(
+          utf8.encode(
+            nyaaSearchHtml(const <NyaaHtmlRow>[
+              NyaaHtmlRow(
+                title: jpTitle,
+                infoHash: 'abcdef0123456789abcdef0123456789abcdef01',
+                id: '9',
+                seeders: 1,
+              ),
+            ]),
+          ),
+          200,
+        );
       });
-      final NyaaClient client = NyaaClient(client: mock);
       final List<NyaaTorrent> items = await client.search('sora');
       expect(items, hasLength(1));
       expect(items.single.title, jpTitle);
@@ -609,7 +839,7 @@ void main() {
       client.close();
     });
 
-    test('严格错误矩阵：编码/XML/RSS结构/命名空间/必需字段稳定可区分', () async {
+    test('严格错误矩阵：编码 / UTF-8 / 页面结构 / 必需字段稳定可区分', () async {
       Future<void> expectCode(
         List<int> bytes,
         NyaaFeedErrorCode code, {
@@ -627,123 +857,33 @@ void main() {
 
       await expectCode(const <int>[], NyaaFeedErrorCode.emptyBody);
       await expectCode(
-        utf8.encode('<rss><channel/></rss>'),
+        utf8.encode(kNyaaNoResultsHtml),
         NyaaFeedErrorCode.unsupportedEncoding,
         headers: const <String, String>{
-          'content-type': 'application/rss+xml; charset=shift_jis',
+          'content-type': 'text/html; charset=shift_jis',
         },
       );
-      await expectCode(
-        utf8.encode(
-          '<?xml version="1.0" encoding="shift_jis"?><rss><channel/></rss>',
-        ),
-        NyaaFeedErrorCode.unsupportedEncoding,
-      );
       await expectCode(<int>[
-        ...utf8.encode('<rss>'),
+        ...utf8.encode('<html>'),
         0xff,
-        ...utf8.encode('</rss>'),
+        ...utf8.encode('</html>'),
       ], NyaaFeedErrorCode.invalidUtf8);
       await expectCode(
-        utf8.encode('<rss><channel>'),
-        NyaaFeedErrorCode.malformedXml,
-      );
-      await expectCode(
         utf8.encode('<html><body/></html>'),
-        NyaaFeedErrorCode.notRss,
-      );
-      await expectCode(
-        utf8.encode('<rss/>'),
         NyaaFeedErrorCode.missingStructure,
       );
+      // infoHash 不是 40 位十六进制 → 缺必需字段。
       await expectCode(
         utf8.encode(
-          '<rss><channel><item><link>x</link><guid>y</guid>'
-          '<n:infoHash xmlns:n="$_nyaaNamespaceForTest">'
-          '${'a' * 40}</n:infoHash></item></channel></rss>',
+          nyaaSearchHtml(const <NyaaHtmlRow>[
+            NyaaHtmlRow(title: 'x', infoHash: 'aaaa', id: '1'),
+          ]),
         ),
         NyaaFeedErrorCode.missingField,
       );
-      await expectCode(
-        utf8.encode(
-          '<rss><channel><item><title>x</title><link>x</link><guid>y</guid>'
-          '<bad:infoHash xmlns:bad="https://invalid.example/ns">'
-          '${'a' * 40}</bad:infoHash></item></channel></rss>',
-        ),
-        NyaaFeedErrorCode.invalidNamespace,
-      );
     });
 
-    test('BUG-1946：sukebei / 镜像站 <site>/xmlns/nyaa 命名空间被接受，路径不同才拒', () async {
-      // 上游 nyaa 把命名空间拼成 <站点 origin>/xmlns/nyaa，sukebei 真实 feed 是
-      // https://sukebei.nyaa.si/xmlns/nyaa；硬编码 nyaa.si 会把每条 item 判成
-      // invalidNamespace，发现页 Sukebei 源恒空。
-      Future<Object?> parseWithNamespace(String ns) {
-        return searchResponse(
-          utf8.encode('''
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:nyaa="$ns">
-  <channel><item>
-    <title>[260825][破顔研] イモータルリコール 外伝 [RJ01660478]</title>
-    <link>https://sukebei.nyaa.si/download/4697097.torrent</link>
-    <guid isPermaLink="true">https://sukebei.nyaa.si/view/4697097</guid>
-    <pubDate>Sat, 29 Aug 2026 13:37:06 -0000</pubDate>
-    <nyaa:seeders>29</nyaa:seeders>
-    <nyaa:leechers>18</nyaa:leechers>
-    <nyaa:downloads>44</nyaa:downloads>
-    <nyaa:infoHash>14d40b587d2a237150b6b019e6236e93e16a1f73</nyaa:infoHash>
-    <nyaa:categoryId>1_3</nyaa:categoryId>
-    <nyaa:category>Art - Games</nyaa:category>
-    <nyaa:size>252.8 MiB</nyaa:size>
-    <nyaa:trusted>Yes</nyaa:trusted>
-    <nyaa:remake>No</nyaa:remake>
-  </item></channel>
-</rss>'''),
-        );
-      }
-
-      for (final String ns in <String>[
-        'https://sukebei.nyaa.si/xmlns/nyaa',
-        'https://nyaa.si/xmlns/nyaa',
-        'https://nyaa.land/xmlns/nyaa',
-        'http://127.0.0.1:8080/xmlns/nyaa',
-      ]) {
-        final Object? result = await parseWithNamespace(ns);
-        expect(result, isA<List<NyaaTorrent>>(), reason: ns);
-        final List<NyaaTorrent> items = result! as List<NyaaTorrent>;
-        expect(items, hasLength(1), reason: ns);
-        final NyaaTorrent item = items.single;
-        expect(item.infoHash, '14d40b587d2a237150b6b019e6236e93e16a1f73');
-        expect(item.seeders, 29, reason: '$ns：nyaa:seeders 也要按命名空间读到');
-        expect(item.categoryId, '1_3', reason: ns);
-        expect(item.sizeBytes, (252.8 * 1024 * 1024).round(), reason: ns);
-        expect(item.trusted, isTrue, reason: ns);
-      }
-
-      for (final String ns in <String>[
-        'https://invalid.example/ns',
-        'https://nyaa.si/xmlns/other',
-        'https://nyaa.si/xmlns/nyaa/',
-        'nyaa',
-      ]) {
-        expect(
-          await parseWithNamespace(ns),
-          isA<NyaaFeedFormatException>().having(
-            (NyaaFeedFormatException error) => error.code,
-            'code',
-            NyaaFeedErrorCode.invalidNamespace,
-          ),
-          reason: ns,
-        );
-      }
-
-      expect(isNyaaNamespace(null), isFalse);
-      expect(isNyaaNamespace(''), isFalse);
-      expect(isNyaaNamespace('/xmlns/nyaa'), isFalse, reason: '无 host 不算');
-      expect(isNyaaNamespace('https://sukebei.nyaa.si/xmlns/nyaa'), isTrue);
-    });
-
-    test('真实本地 HTTP：特殊字符 query/category/trusted 与任意前缀 namespace', () async {
+    test('真实本地 HTTP：特殊字符 query/category 与 gzip 响应（transport 自动解压）', () async {
       final HttpServer server = await HttpServer.bind(
         InternetAddress.loopbackIPv4,
         0,
@@ -752,25 +892,30 @@ void main() {
       Uri? captured;
       server.listen((HttpRequest request) async {
         captured = request.uri;
-        request.response.headers.contentType = ContentType(
-          'application',
-          'rss+xml',
-          charset: 'utf-8',
+        request.response.headers.contentType = ContentType.html;
+        // nyaa 真实响应是 gzip；dart:io HttpClient 默认 autoUncompress，
+        // createAppHttpClient 不能把它关掉——关了这里就拿到一坨二进制。
+        request.response.headers.set(HttpHeaders.contentEncodingHeader, 'gzip');
+        request.response.add(
+          gzip.encode(
+            utf8.encode(
+              nyaaSearchHtml(<NyaaHtmlRow>[
+                NyaaHtmlRow(
+                  title: 'ソラ & 星',
+                  infoHash: 'a' * 40,
+                  id: '1',
+                  trusted: true,
+                ),
+              ]),
+            ),
+          ),
         );
-        request.response.write('''
-<?xml version="1.0" encoding="utf-8"?>
-<rss><channel><item>
-  <title>ソラ &amp; 星</title>
-  <link>https://nyaa.si/download/1.torrent</link>
-  <guid>https://nyaa.si/view/1</guid>
-  <alt:infoHash xmlns:alt="$_nyaaNamespaceForTest">${'a' * 40}</alt:infoHash>
-  <alt:trusted xmlns:alt="$_nyaaNamespaceForTest">Yes</alt:trusted>
-</item></channel></rss>''');
         await request.response.close();
       });
 
       final NyaaClient client = NyaaClient(
         baseUrl: 'http://${server.address.address}:${server.port}',
+        minRequestInterval: Duration.zero,
       );
       addTearDown(client.close);
       final List<NyaaTorrent> items = await client.search(
@@ -780,11 +925,16 @@ void main() {
       );
       expect(items.single.title, 'ソラ & 星');
       expect(items.single.trusted, isTrue);
+      expect(
+        items.single.pageUrl,
+        'http://${server.address.address}:${server.port}/view/1',
+      );
       expect(captured!.queryParameters, <String, String>{
-        'page': 'rss',
         'q': 'ソラ & 星/空',
         'c': '1_4 special',
         'f': '2',
+        's': 'seeders',
+        'o': 'desc',
       });
     });
   });

--- a/fushi/test/torrent/nyaa_html_fixture.dart
+++ b/fushi/test/torrent/nyaa_html_fixture.dart
@@ -1,0 +1,91 @@
+/// 测试用 Nyaa HTML 搜索页构造器。
+///
+/// `NyaaClient.search` 现在只走 HTML 搜索页（RSS 被 nyaa 后端强制按 id 倒序、
+/// 忽略排序与分页），所以所有喂给 `NyaaClient` 的 mock 响应都必须长得像
+/// `table.torrent-list`。这里按真实页面结构（分类 / 标题 / 下载 / 体积 / 时间 /
+/// 做种 / 下载中 / 完成数 八列，行 class `success` = trusted、`danger` = remake）
+/// 生成，各测试只描述数据、不再各写一份 HTML。
+library;
+
+import 'dart:convert';
+
+/// 一行种子。[title] 会做 HTML 转义后写进 `title` 属性。
+class NyaaHtmlRow {
+  const NyaaHtmlRow({
+    required this.title,
+    required this.infoHash,
+    this.id,
+    this.seeders = 0,
+    this.leechers = 0,
+    this.downloads = 0,
+    this.size = '1.0 MiB',
+    this.categoryId = '1_2',
+    this.trusted = false,
+    this.remake = false,
+    this.timestampSeconds = 1700000000,
+  });
+
+  final String title;
+
+  /// 40 位十六进制 infoHash（大小写不限，页面 magnet 里原样写）。
+  final String infoHash;
+
+  /// 站内种子 id（`/view/<id>`）；null 时用 infoHash 前 8 位派生。
+  final String? id;
+  final int seeders;
+  final int leechers;
+  final int downloads;
+  final String size;
+  final String categoryId;
+  final bool trusted;
+  final bool remake;
+  final int timestampSeconds;
+}
+
+/// 「No results found」页：nyaa 对无结果的搜索返回 200 + 这个标题、没有表格。
+const String kNyaaNoResultsHtml = '''
+<!doctype html><html><body>
+<div class="container"><h3>No results found</h3></div>
+</body></html>''';
+
+/// 生成一页 HTML 搜索结果。[host] 只影响相对链接解析后的 pageUrl（测试断言
+/// `https://nyaa.si/view/<id>` 时保持默认即可，client 会用请求 URL 解析）。
+String nyaaSearchHtml(Iterable<NyaaHtmlRow> rows) {
+  final StringBuffer sb = StringBuffer()
+    ..writeln('<!doctype html><html><body>')
+    ..writeln('<table class="table table-bordered table-hover table-striped '
+        'torrent-list"><tbody>');
+  for (final NyaaHtmlRow row in rows) {
+    final String id = row.id ?? row.infoHash.substring(0, 8);
+    final String title =
+        const HtmlEscape(HtmlEscapeMode.attribute).convert(row.title);
+    // remake 盖过 trusted：nyaa 模板的行 class 优先级 deleted > hidden > remake
+    // > trusted，trusted 用户发的 remake 只显示 danger。
+    final String rowClass = row.remake
+        ? 'danger'
+        : row.trusted
+            ? 'success'
+            : 'default';
+    sb
+      ..writeln('  <tr class="$rowClass">')
+      ..writeln('    <td><a href="/?c=${row.categoryId}" title="cat">'
+          '<img src="/static/img/icons/x.png" alt="cat"></a></td>')
+      ..writeln('    <td colspan="2"><a href="/view/$id" title="$title">'
+          '$title</a></td>')
+      ..writeln('    <td class="text-center">'
+          '<a href="/download/$id.torrent"><i class="fa fa-download"></i></a>'
+          '<a href="magnet:?xt=urn:btih:${row.infoHash}&amp;dn=x">'
+          '<i class="fa fa-magnet"></i></a></td>')
+      ..writeln('    <td class="text-center">${row.size}</td>')
+      ..writeln('    <td class="text-center" '
+          'data-timestamp="${row.timestampSeconds}">2023-11-14 22:13</td>')
+      ..writeln('    <td class="text-center">${row.seeders}</td>')
+      ..writeln('    <td class="text-center">${row.leechers}</td>')
+      ..writeln('    <td class="text-center">${row.downloads}</td>')
+      ..writeln('  </tr>');
+  }
+  sb
+    ..writeln('</tbody></table>')
+    ..writeln('</body></html>');
+  return sb.toString();
+}


### PR DESCRIPTION
用户报告：在 Fushi 里下小说，nyaa 源在【发现】里找到的有些其实是漫画，而且小说的种子死种很多。

## 根因

- **混漫画**：小说域映射到 Nyaa 分类 `3_0`（Literature 整个大类，`app_model.dart` 里全应用唯一一处决策）。Nyaa 的 3_1 / 3_2 / 3_3 里轻小说与扫图漫画、同人志图包混放，站方没有「小说 vs 漫画」维度；下游映射零过滤，连 `categoryId` 都丢掉。实测 3_1 做种榜前 75 条约 54 条是漫画。
- **死种多**：查询串只有 `q / c / f`，Nyaa 默认按发布时间倒序；结果页不排序不过滤，`↑seeders` 只是一段文字。**nyaa 后端源码坐实 RSS 强制忽略排序**（`search.py` 两处「Force sort by id desc if rss」）且只返回 75 条、忽略分页；HTML 搜索页才尊重 `s=seeders&o=desc`（实测 RSS 首条做种 34、HTML 首条 288）。

## 做法

设计前调研了 Jackett/Prowlarr 的 `nyaasi.yml`、lnrelease-discord-bot、chaptr、Kavita/myne、AnimeTosho、Sonarr、qBittorrent 插件与 nyaa 官方源码。设计稿 `docs/specs/2026-09-08-nyaa-novel-discovery-filters.md`。

1. **首屏走 HTML 搜索页带 `s=seeders&o=desc`**，行 class `success` → trusted、`danger` → remake 写进模型；分页越界返回空；同 host 至少间隔 2 秒（对齐 Jackett 的 `requestDelay: 2`）；RSS 解析保留给旧调用方与测试。
2. **发现页按做种降序**，新偏好 `discovery_hide_zero_seeders` 默认开（隐藏时显示「已隐藏 N 条」一键展开）。调研结论是交互式 UI 通行做法为只沉底不隐藏、仅 Sonarr 这类自动抓取默认 `min seeders=1`，用户明确要求默认隐藏，按用户拍板。
3. **疑似漫画标记**：没有现成分类器（Jackett/Prowlarr 把 3_x 一律当 Books，lnrelease-bot 逐条抓文件列表看有没有 `.epub`）。实现成纯函数打分：括号形状（`(Digital)` 漫画 / `[Yen Press]` 小说，wotaku 命名规范）、类型词、章节编号、出版社与发布者词表、每卷体积（实测 LN EPUB p50 14.8 MiB / p99 45 MiB，漫画典型 150–350 MiB/卷）。`M − N ≥ 2` 才判漫画，默认开的开关只隐藏这一档，「未定」保留。发布组 Stick / LuCaZ / Ushi 两种都发，明确 0 分。
4. **Nyaa 过滤三态**（全部 / 排除 remake / 仅信任）默认「全部」，与 Nyaa 官方、Prowlarr、Flexget 一致；卡片加 trusted 绿 / remake 红徽标。

## 一处根因修复

`NyaaClient` 的节流门原本是字段初始化的完成态 `Future`，它记住创建时的 zone；发现页测试在 `setUp` 建 client、在 fake-async 测试体里 await，`then` 回调派到拿不到 pump 的 zone，**请求根本没发出**。改为只存时刻不存 Future，顺带把「同实例」升级成设计要求的「同 host」（发现源 / 视频 provider / 订阅轮询三处各自 new 的 client 现在共用节奏）。

## 验证

- `flutter analyze`（全量含 test）0 issue
- 定向 `test/torrent test/media/discovery test/pages/media_discovery_page_test.dart` 等 631 条 + `nyaa_client_test` 34 条通过
- 分类器语料表 19 条 + 规则边界 5 条
- 目录枚举型守卫清单 363 条通过
- 未做：Windows 真机截图对比
