### PR TITLE
fix(reader): 歌词模式恢复顶栏，并给它一颗回到阅读模式的键（BUG-2326）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2129 条。点号进各自文件。
+> 共 2130 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2326](bugs/BUG-2326-lyrics-mode-top-chrome.md) | ✅ | ✅ | 歌词模式没有顶栏，也没有回到阅读模式的入口 |
 | [BUG-2284](bugs/BUG-2284-lookup-popup-instant-scroll.md) | ✅ | ✅ | 查词弹窗「瞬时滚动」开关对滚轮完全无效 |
 | [BUG-2283](bugs/BUG-2283-eink-swipe-dismiss-animation.md) | ✅ | ✅ | 墨水屏模式：查词弹窗滑动关闭仍有滑出/弹回补间动画 |
 | [BUG-2278](bugs/BUG-2278-ankidroid-live-target.md) | ✅ | ✅ | AnkiDroid识别与API实例缓存导致安装或启用后仍无法连接 |

--- a/docs/bugs/BUG-2326-lyrics-mode-top-chrome.md
+++ b/docs/bugs/BUG-2326-lyrics-mode-top-chrome.md
@@ -27,6 +27,16 @@
   行为断言）、`fushi/test/reader/reader_desktop_chrome_test.dart`（pinned 动作在紧凑形态
   仍是可见按钮）、`fushi/integration_test/reader_lyrics_mode_entry_itest.dart`（真 app：
   进歌词模式 → 唤出 chrome → 顶栏与模式键在场 → 按下去真切回正文）。
-- **备注**：`reader_desktop_chrome_test.dart` 里那条「顶栏自带 RepaintBoundary」的守卫
-  原来切「方法签名后 900 字符」的定长窗口，往方法开头加几行就会假红；一并改成取整个
-  方法体（`methodBody`）。
+- **真机证据**：Windows 离屏 runner（`fushi/tool/run_windows_itest.ps1`）跑
+  `reader_lyrics_mode_entry_itest.dart` 通过（exit 0，`All tests passed`）：种一本有声书 →
+  进歌词模式 → 走生产唤出路径（歌词页空白点击桥 `onLyricsTapEmpty`）→ 顶栏
+  `fushi_desktop_header` 与播放条 `fushi_play_bar` 同时在场 → 顶栏模式键按下去后
+  `lyricsMode` 落回 false、正文重新就绪。
+- **备注**：三处顺带修的既有问题（都会让上面那条真机验证跑不到本 bug 的断言）：
+  ① `reader_desktop_chrome_test.dart` 里「顶栏自带 RepaintBoundary」的守卫原来切「方法
+  签名后 900 字符」的定长窗口，往方法开头加几行就假红，改成取整个方法体（`methodBody`）；
+  ② 该集成测试按 focus-id 前缀 `reader-action` 找歌词开关，而设置面改成右侧抽屉后那颗
+  开关的焦点目标前缀已是 `settings-row`——**修本 bug 之前该测试就卡在这一步**（已在
+  upstream/develop 基线上复现），改成不钉前缀、只要求「是个能接 ActivateIntent 的具体
+  焦点停靠点」；③ 首次进歌词模式的一次性提示对话框是一层吃指针的模态，会把对顶栏的
+  点击吸走，测试里把 `lyrics_mode_hint_shown` 预置成已看过。

--- a/docs/bugs/BUG-2326-lyrics-mode-top-chrome.md
+++ b/docs/bugs/BUG-2326-lyrics-mode-top-chrome.md
@@ -1,0 +1,32 @@
+## BUG-2326 · 歌词模式没有顶栏，也没有回到阅读模式的入口
+- **报告**：2026-09-09（用户：hajisensai）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/reader/reader_desktop_chrome.dart:39`（旧
+  `readerDesktopChromeEnabled` 直接委托给 `readerStatusFooterEnabled`，判据 `!lyricsMode`）
+  → `fushi/lib/src/pages/implementations/reader_fushi_page.dart:1941` 的
+  `_desktopChromeEnabled` 在歌词模式恒 false → `chrome.part.dart:2115` 的
+  `_buildDesktopHeader` 整条早返回。
+  两个后果连在一起：
+  1. 顶栏（返回 / 目录 / 插图 / 统计 / 有声书 / 全屏 / 设置）在歌词模式整条不画；
+  2. 「切回阅读模式」的开关只住在这套 chrome 的设置抽屉里
+     （`reader_quick_settings_sheet.dart` 的排版页），顶栏一没，歌词模式就没有任何
+     可见的回正文入口——只剩播放条上的齿轮那一条隐蔽路径。
+  另有一笔几何差：歌词页是独立 HTML（`LyricsModeHtml`），`_applyChromeInsets` 对它
+  整体早返回，留白只能由 Flutter 侧给；`independentDocumentInsets` 当时只给底部留白，
+  顶部恒 0 → 文档从 y=0 起画，系统状态栏 / 刘海直接压在首行歌词上。
+- **[x] ① 已修复** — `_desktopChromeEnabled` 不再随 `_lyricsMode` 翻转（顶栏两种模式都
+  在场，动作按模式取舍：导航 / 插图只在正文模式挂，歌词模式换成一颗 pinned 的
+  「歌词 ⇄ 阅读」模式键）；`independentDocumentInsets` 增加 `topReserve`，由
+  `_lyricsTopReserve`（系统顶 inset + 顶栏预留，不含歌词模式不画的进度 pill 预留）喂入。
+  底部状态行仍留在歌词模式之外——`_refreshProgress` 在歌词模式整体早返回，画出来会是
+  冻住的旧数；并进播放条右端的那份状态文字（`_playbackStatusInline` /
+  `_separatePlaybackStatus`）同理改挂 `_statusFooterEnabled`。
+- **[x] ② 已加自动化测试** —
+  `fushi/test/pages/reader_lyrics_top_chrome_static_test.dart`（顶栏判据不再随歌词模式
+  翻转 / 顶栏挂 pinned 模式键 / 留白接线）、
+  `fushi/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart`（顶部留白的
+  行为断言）、`fushi/test/reader/reader_desktop_chrome_test.dart`（pinned 动作在紧凑形态
+  仍是可见按钮）、`fushi/integration_test/reader_lyrics_mode_entry_itest.dart`（真 app：
+  进歌词模式 → 唤出 chrome → 顶栏与模式键在场 → 按下去真切回正文）。
+- **备注**：`reader_desktop_chrome_test.dart` 里那条「顶栏自带 RepaintBoundary」的守卫
+  原来切「方法签名后 900 字符」的定长窗口，往方法开头加几行就会假红；一并改成取整个
+  方法体（`methodBody`）。

--- a/fushi/integration_test/reader_lyrics_mode_entry_itest.dart
+++ b/fushi/integration_test/reader_lyrics_mode_entry_itest.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -86,6 +85,12 @@ void main() {
             await ReaderFushiSource.instance.setLyricsMode(originalLyricsMode);
           });
           await ReaderFushiSource.instance.setLyricsMode(false);
+          // 首次进入歌词模式会弹一次性提示对话框（`lyrics_mode_hint_shown`）。它是
+          // 一层吃掉指针的模态路由：留着它，后面对顶栏那颗模式键的点击会被它吸走
+          // （hit test 落在 AbsorbPointer 上）。本用例测的不是这条提示，直接把一次性
+          // 旗预置成「已看过」，与真机上第二次进歌词模式的状态一致。
+          ReaderFushiSource.instance
+              .setPreference<bool>(key: 'lyrics_mode_hint_shown', value: true);
 
           final String bookKey = await seedAudiobook(
             tester,
@@ -142,17 +147,19 @@ void main() {
               find.byKey(const ValueKey<String>('fushi_lyrics_mode_toggle'));
           expect(lyricsToggle, findsOneWidget,
               reason: 'quick settings must expose the lyrics-mode action');
+          // 不再按 `reader-action` 这个 focus-id 前缀过滤：设置面改成右侧抽屉后，
+          // 这颗开关由 AdaptiveSettingsNavigationRow 渲染，焦点目标的 id 前缀是
+          // `settings-row`；钉死旧前缀会让这一步在真机上恒 false（本条修复前该
+          // 集成测试就卡在这里，与歌词模式本身无关）。断言的意图不变：这颗开关
+          // 必须是一个**具体的、能接 ActivateIntent 的焦点停靠点**，而不是裸 InkWell。
           expect(
-            await driver.requestFocusInside(
-              lyricsToggle,
-              debugLabelContains: 'reader-action',
-            ),
+            await driver.requestFocusInside(lyricsToggle),
             isTrue,
-            reason:
-                'lyrics-mode action must expose a concrete reader-action focus node',
+            reason: 'lyrics-mode action must expose a concrete focus node',
           );
           expect(await driver.activateIntent(), isTrue,
-              reason: 'lyrics-mode reader-action must handle ActivateIntent');
+              reason:
+                  'the focused lyrics-mode action must handle ActivateIntent');
           await tester.pump(const Duration(seconds: 1));
           expect(lyricsToggle, findsNothing,
               reason: 'activating lyrics mode must dismiss quick settings');
@@ -183,15 +190,20 @@ void main() {
           );
 
           // 歌词模式的顶栏必须与阅读模式一样在场，并挂着回正文的模式键。
-          // 默认底栏是悬浮态（点空白唤出 / 3 秒自动收起），所以先按 chrome 开关键
-          // （readerToggleChrome，默认 M）把 chrome 唤出来，再断言——这与用户在真机上
-          // 点一下空白处看到的是同一台状态机。
-          await tester.sendKeyEvent(LogicalKeyboardKey.keyM);
-          await tester.pump(const Duration(milliseconds: 300));
+          // 默认 chrome 是悬浮态（点空白唤出 / 计时自动收起），所以先走用户在歌词页
+          // 唤出 chrome 的**生产路径**：歌词文档空白点击 → `onLyricsTapEmpty` 桥
+          // （lyrics_mode_html.dart 里就是这么调的）。顶栏与底栏是同一台状态机，
+          // 所以两者一起断言——只出一个才说明顶栏那半边被漏掉了。
+          await ReaderFushiPage.debugEvaluateJavascript?.call(
+            "window.flutter_inappwebview.callHandler('onLyricsTapEmpty');true",
+          );
           final Finder header =
               find.byKey(const ValueKey<String>('fushi_desktop_header'));
-          expect(header, findsOneWidget,
-              reason: '歌词模式必须和阅读模式一样有顶栏（它是这里唯一的返回 / 设置面）');
+          await _pumpUntil(tester, () => header.evaluate().isNotEmpty,
+              reason: '歌词模式必须和阅读模式一样有顶栏（它是这里唯一的返回 / 设置面）', polls: 20);
+          expect(find.byKey(const ValueKey<String>('fushi_play_bar')),
+              findsOneWidget,
+              reason: '底栏与顶栏同一台显隐状态机，唤出后两条都该在');
           final Finder modeButton = find.byKey(
             const ValueKey<String>('fushi_reader_lyrics_mode_button'),
           );

--- a/fushi/integration_test/reader_lyrics_mode_entry_itest.dart
+++ b/fushi/integration_test/reader_lyrics_mode_entry_itest.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -181,7 +182,37 @@ void main() {
             reason: 'the live WebView document must be LyricsModeHtml',
           );
 
+          // 歌词模式的顶栏必须与阅读模式一样在场，并挂着回正文的模式键。
+          // 默认底栏是悬浮态（点空白唤出 / 3 秒自动收起），所以先按 chrome 开关键
+          // （readerToggleChrome，默认 M）把 chrome 唤出来，再断言——这与用户在真机上
+          // 点一下空白处看到的是同一台状态机。
+          await tester.sendKeyEvent(LogicalKeyboardKey.keyM);
+          await tester.pump(const Duration(milliseconds: 300));
+          final Finder header =
+              find.byKey(const ValueKey<String>('fushi_desktop_header'));
+          expect(header, findsOneWidget,
+              reason: '歌词模式必须和阅读模式一样有顶栏（它是这里唯一的返回 / 设置面）');
+          final Finder modeButton = find.byKey(
+            const ValueKey<String>('fushi_reader_lyrics_mode_button'),
+          );
+          expect(modeButton, findsOneWidget,
+              reason: '歌词模式顶栏必须有一颗看得见的「回到阅读模式」键');
+
           await takeScreenshot(binding, 'reader_lyrics_mode_entry_ready');
+
+          // 那颗键真的能把文档换回正文（回路闭合，不只是画出来）。顶栏整体包在
+          // ExcludeFocus 里（TODO-700 不变式：焦点只住在正文），是纯指针面，没有
+          // 焦点等价物，故此处按豁免通道①用一次坐标点击。
+          await tester.tap(
+              modeButton); // itest-tap-allow: 顶栏是 ExcludeFocus 的纯指针面，无焦点等价路径
+          await _pumpUntil(
+            tester,
+            () => !ReaderFushiSource.instance.lyricsMode,
+            reason: '顶栏模式键必须真把歌词模式关掉',
+            polls: 20,
+          );
+          await _pumpUntil(tester, _readerContentReady,
+              reason: '退出歌词模式后正文必须重新就绪');
         },
       );
     },

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -2096,10 +2096,16 @@ extension _ReaderChrome on _ReaderFushiPageState {
 
   // ── Desktop header (ッツ / Hoshi Reader 形态) ──────────────────────
 
-  /// 桌面端顶部工具栏：左「← 返回 / 导航 / 插图 / 统计」，居中书名，右「有声书导入 /
-  /// 全屏 / 外观设置」。取代桌面端的底部设置栏，与底栏同一台显隐状态机
-  /// （[_bottomBarShouldPaint]：悬浮态点空白唤出 + 自动收起；挤压态常驻并占
-  /// [_desktopHeaderReserve]）。歌词模式 / 移动端不启用（[_desktopChromeEnabled]）。
+  /// 各平台顶部工具栏：左「← 返回 /（歌词⇄阅读）/ 导航 / 插图 / 统计」，居中书名，
+  /// 右「有声书导入 / 全屏 / 外观设置」。取代桌面端的底部设置栏，与底栏同一台显隐
+  /// 状态机（[_bottomBarShouldPaint]：悬浮态点空白唤出 + 自动收起；挤压态常驻并占
+  /// [_desktopHeaderReserve]）。
+  ///
+  /// **歌词模式同样在场**（[_desktopChromeEnabled]），但动作按模式取舍：导航与插图
+  /// 在歌词页是空转——翻章会把歌词文档换成 EPUB 章节（[_paginate] 为此专门早返回），
+  /// 画廊也没有对应的正文位置——故只在正文模式挂；换来的是「歌词 ⇄ 阅读」这颗模式键，
+  /// 歌词模式下它是**唯一**可见的回正文入口（另一处在设置抽屉的排版页里），所以那时
+  /// 强制 `pinned`，窄窗也不许折进 ⋮ 溢出菜单。
   ///
   /// 纯指针面：包 ExcludeFocus，不进焦点遍历池（与 [_wrapBottomChromeBar] 同一规则，
   /// TODO-700 不变式）。BUG-1692：排在 WebView 之后绘制，必须自带 RepaintBoundary。
@@ -2116,6 +2122,19 @@ extension _ReaderChrome on _ReaderFushiPageState {
       return const SizedBox.shrink();
     }
     final Color fg = _themeTextColor();
+    // 歌词模式必须挂着有声书控制器（[_toggleLyricsMode] 进入分支的前置），没有控制器
+    // 就没有可切的歌词，这颗键整个不出现。
+    final bool lyrics = _lyricsMode;
+    final ReaderHeaderAction? modeToggle = _audiobookController == null
+        ? null
+        : ReaderHeaderAction(
+            key: const ValueKey<String>('fushi_reader_lyrics_mode_button'),
+            icon: lyrics ? Icons.auto_stories_outlined : Icons.lyrics_outlined,
+            label: lyrics ? t.book_mode : t.lyrics_mode,
+            pinned: lyrics,
+            semanticsId: 'hibiki.reader.header.lyrics_mode',
+            onPressed: () => unawaited(_toggleLyricsMode()),
+          );
     return Positioned(
       top: _stableTopInset,
       left: MediaQuery.viewPaddingOf(context).left,
@@ -2147,25 +2166,28 @@ extension _ReaderChrome on _ReaderFushiPageState {
                 // （落位置 flush / closeMedia / 关书同步，BUG-782）。
                 onPressed: () => unawaited(Navigator.of(context).maybePop()),
               ),
-              ReaderHeaderAction(
-                icon: Icons.format_list_bulleted,
-                label: _labelWithShortcut(
-                  t.section_navigation,
-                  ShortcutAction.readerOpenNavigation,
+              if (modeToggle != null) modeToggle,
+              if (!lyrics)
+                ReaderHeaderAction(
+                  icon: Icons.format_list_bulleted,
+                  label: _labelWithShortcut(
+                    t.section_navigation,
+                    ShortcutAction.readerOpenNavigation,
+                  ),
+                  pinned: true,
+                  semanticsId: 'hibiki.reader.header.navigation',
+                  onPressed: () => unawaited(
+                      _showAppearanceSheet(initialSubPage: 'location')),
                 ),
-                pinned: true,
-                semanticsId: 'hibiki.reader.header.navigation',
-                onPressed: () =>
-                    unawaited(_showAppearanceSheet(initialSubPage: 'location')),
-              ),
-              ReaderHeaderAction(
-                icon: Icons.collections_outlined,
-                label: _labelWithShortcut(
-                  t.reader_gallery_tooltip,
-                  ShortcutAction.readerOpenGallery,
+              if (!lyrics)
+                ReaderHeaderAction(
+                  icon: Icons.collections_outlined,
+                  label: _labelWithShortcut(
+                    t.reader_gallery_tooltip,
+                    ShortcutAction.readerOpenGallery,
+                  ),
+                  onPressed: _openGallery,
                 ),
-                onPressed: _openGallery,
-              ),
               ReaderHeaderAction(
                 icon: Icons.insights_outlined,
                 label: _labelWithShortcut(

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -1936,12 +1936,18 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     footerHeight: kReaderStatusFooterHeight,
   );
 
-  /// 桌面端 ッツ 形态 chrome（顶部工具栏 + 右侧抽屉）是否启用：与状态行同判据
-  /// （各平台非歌词模式），单一真相源 [readerDesktopChromeEnabled]。
-  bool get _desktopChromeEnabled => readerDesktopChromeEnabled(
-    desktop: isDesktopPlatform,
-    lyricsMode: _lyricsMode,
-  );
+  /// ッツ 形态共用 chrome（顶部工具栏 + 右侧抽屉）是否启用：**所有平台、两种模式**。
+  ///
+  /// 歌词模式曾与状态行共用 `!lyricsMode` 判据整块关掉它。后果不是「少一条装饰」：
+  /// 顶栏是歌词页（独立 HTML，页内没有任何 chrome）唯一的返回 / 设置面，而「切回
+  /// 阅读模式」的开关本身就住在这套 chrome 的设置抽屉里——歌词模式因此既没有顶栏，
+  /// 也没有回正文的入口。现在顶栏与正文模式对齐（动作按模式取舍见
+  /// [_buildDesktopHeader]，留白见 [_lyricsTopReserve]）。
+  ///
+  /// 仍留在歌词模式之外的只有底部状态行 [_statusFooterEnabled]：它画字数进度 /
+  /// 阅读追踪，而 `_refreshProgress` 在歌词模式整体早返回，画出来的会是进歌词那一刻
+  /// 冻住的旧数。
+  bool get _desktopChromeEnabled => true;
 
   /// 顶部工具栏的顶部预留高：悬浮态（默认）恒 0；挤压态且底栏占位时占工具栏高
   /// （与 [_bottomChromeReserve] 同一台状态机的上端），并入 [_readerTopOffset]。
@@ -1992,11 +1998,16 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
           MediaQuery.viewPaddingOf(context).horizontal) /
       _readerChromeScale;
 
+  /// 两者都以状态行**本身**启用为前提（[_statusFooterEnabled]，而不再是整套 chrome
+  /// 的 [_desktopChromeEnabled]——顶栏在歌词模式已恢复在场，这两条不能跟着它一起
+  /// 在歌词模式翻真）：状态行画的是字数进度 / 阅读追踪，歌词模式不刷新进度，
+  /// 并进播放条右端的那一份同样不能画，否则只是把同一批冻住的旧数字换个位置。
+  /// 正文模式两个判据恒等（非歌词 ⇒ 状态行启用 ⇒ chrome 启用），行为逐字不变。
   bool get _playbackStatusInline =>
-      _desktopChromeEnabled && !readerHeaderCompact(_readerControlsWidth);
+      _statusFooterEnabled && !readerHeaderCompact(_readerControlsWidth);
 
   bool get _separatePlaybackStatus =>
-      _desktopChromeEnabled && !_playbackStatusInline;
+      _statusFooterEnabled && !_playbackStatusInline;
 
   double get _statusFooterBottomOffset =>
       _stableBottomInset + (_separatePlaybackStatus ? 0 : _bottomChromeReserve);
@@ -2033,6 +2044,15 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   // 阅读器不再需要自己让位或自绘拖拽带——留着就是顶栏下面又压一条 28pt 空白。
   double get _readerTopOffset =>
       _stableTopInset + _topProgressReserve + _desktopHeaderReserve;
+
+  /// 歌词模式（独立 HTML 文档）此刻真正被顶部 chrome 占掉的高度：系统顶 inset +
+  /// 顶栏预留（悬浮态顶栏不占正文位置，[_desktopHeaderReserve] 那时本就是 0）。
+  ///
+  /// 与 [_readerTopOffset] 的唯一差别是**不含** [_topProgressReserve]：歌词模式不画
+  /// 顶部进度 pill（[_buildTopProgressBar] 对歌词早返回），把它的预留算进来就是在
+  /// 歌词首行上方留一条谁也不占的空带。正文那条走 `setChromeInsets` 下发给
+  /// WebView，歌词这条走 [independentDocumentInsets] 的 Flutter 侧 Padding。
+  double get _lyricsTopReserve => _stableTopInset + _desktopHeaderReserve;
 
   double get _readerBottomReserve =>
       _bottomChromeReserve + _statusFooterReserve + _stableBottomInset;
@@ -3226,6 +3246,9 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
       lyricsMode: _lyricsMode,
       // 底栏占位条件与 _buildBottomChrome / popupBottomReserve 一致。
       chromeOccupiesLayout: _hasEverLoaded && _showChrome,
+      // 顶栏在歌词模式同样在场（[_desktopChromeEnabled]），文档要给它让位，
+      // 否则首行歌词被顶栏 / 系统状态栏压住。
+      topReserve: _lyricsTopReserve,
       bottomReserve: _readerBottomReserve,
     );
     if (independentDocumentPadding == EdgeInsets.zero) return webView;

--- a/fushi/lib/src/reader/reader_chrome_floating.dart
+++ b/fushi/lib/src/reader/reader_chrome_floating.dart
@@ -104,22 +104,28 @@ double bottomChromeReserve({
 ///    （`_hasEverLoaded && _showChrome`，与 [bottomChromeReserve] 同一门控），
 ///    [bottomReserve] 已含悬浮态恒 0 的语义（悬浮不占正文位置）。
 ///    spread 不需要底部留白：它没有文档级滚动条，底栏叠在整页图上是既有可接受形态。
-///  * **顶部**：曾有一笔 `titlebarInset`（BUG-1343：macOS 阅读器自绘的 28pt
-///    DragToMoveArea 叠在 WebView 之上，独立文档不缩进就会把首行歌词 / 整页图压到
-///    拖拽区下面）。macOS 改用自绘 MD3 顶栏（`FushiDesktopTitleBar`，在整个
-///    Navigator 之上）后那条带子已删除，页内不再有任何叠在 WebView 上的顶部 chrome
-///    需要独立文档让位，这笔留白随之取消。
+///  * **顶部**（歌词顶栏对齐）：歌词模式过去整块关掉顶部工具栏，文档从 y=0 起画，
+///    连系统状态栏 / 刘海都压在歌词首行上。顶栏在歌词模式恢复在场后，独立文档必须
+///    像正文一样给它让位：[topReserve] 由调用方喂「此刻顶部 chrome 真占掉多少」
+///    （系统顶 inset + 挤压态顶栏高；悬浮态顶栏不占正文位置，那笔本就是 0）。
+///    它**不含**顶部进度 pill 的预留——歌词模式不画那颗 pill（`_buildTopProgressBar`
+///    对歌词早返回），算进来就是在文档顶上留一条谁也不占的空带。
+///    （更早还有一笔 `titlebarInset`（BUG-1343，macOS 自绘 28pt DragToMoveArea），
+///    macOS 改用 `FushiDesktopTitleBar` 后那条带子连同这笔留白一起删了。）
+///    spread 不需要顶部留白：它是整页图，顶栏叠在图上与底栏叠在图上是同一形态。
 ///
 /// 返回 [EdgeInsets.zero] 表示「无需任何留白」，调用方据此跳过 `Padding` 包装。
-/// 顶部那笔取消后，spread 与「完全没有独立文档」在留白上已不可区分（两者都是
-/// 零），所以 `spreadDocumentLoaded` 也一并从签名里去掉——留一个不影响任何返回值的
-/// 必填参数只会让调用方以为它还有作用。
+/// 判据只认 [lyricsMode]：spread 与「完全没有独立文档」在留白上不可区分（两者都是
+/// 零），所以 `spreadDocumentLoaded` 不在签名里——留一个不影响任何返回值的必填参数
+/// 只会让调用方以为它还有作用。
 EdgeInsets independentDocumentInsets({
   required bool lyricsMode,
   required bool chromeOccupiesLayout,
+  required double topReserve,
   required double bottomReserve,
 }) {
   return EdgeInsets.only(
+    top: lyricsMode ? topReserve : 0,
     bottom: lyricsMode && chromeOccupiesLayout ? bottomReserve : 0,
   );
 }

--- a/fushi/lib/src/reader/reader_desktop_chrome.dart
+++ b/fushi/lib/src/reader/reader_desktop_chrome.dart
@@ -1,6 +1,6 @@
 /// 跨平台阅读器 chrome（ッツ / Hoshi Reader 形态）的纯函数与外壳组件。
 ///
-/// 非歌词模式下各平台阅读器的控制面由三块组成：
+/// 各平台阅读器的控制面由三块组成：
 ///  * **顶部工具栏** [ReaderDesktopHeader]：左「← 返回 / 目录 / 插图 / 统计」，居中书名，
 ///    右「有声书导入 / 全屏 / 外观设置」。它取代桌面端的底部设置栏，显隐与底栏同一
 ///    台状态机（点空白唤出、自动收起 / 挤压常驻）。
@@ -8,13 +8,17 @@
 ///    一条纵向面板（[showReaderSideSheet]），点面板外空白即关。
 ///  * **底部状态行**（reader_status_footer.dart）：常驻挤压式。
 ///
-/// 窄屏折叠次要操作，导航和设置共用侧栏；歌词模式仍走旧底栏（独立文档，正文 chrome 不适用）。
+/// 窄屏折叠次要操作，导航和设置共用侧栏。
+///
+/// 顶部工具栏在**歌词模式下同样在场**：歌词页是独立 HTML 文档，页内没有任何 chrome，
+/// 顶栏是它唯一的返回 / 设置面，而「切回阅读模式」的开关本身就住在这套 chrome 的设置
+/// 抽屉里——关掉顶栏等于把歌词模式关成一间没有门的房间。只有底部状态行仍留在歌词模式
+/// 之外（它画字数进度 / 阅读追踪，歌词模式不刷新进度，见 reader_status_footer.dart 的
+/// `readerStatusFooterEnabled`）。
 library;
 
 import 'package:flutter/material.dart';
 
-import 'package:fushi/src/reader/reader_status_footer.dart'
-    show readerStatusFooterEnabled;
 import 'package:fushi/src/utils/misc/platform_utils.dart'
     show kFushiSettingsWideMinHeight, kFushiSettingsWideThreshold;
 
@@ -35,14 +39,6 @@ const double kReaderDesktopHeaderTitleFontSize = 14;
 /// 右侧抽屉宽度（逻辑 px）。窄窗口下由 [showReaderSideSheet] 收窄到留出 48px 空白。
 const double kReaderSideSheetWidth = 400;
 
-/// 共用 chrome（顶部工具栏 + 右侧抽屉）是否启用：与底部状态行同一判据——非
-/// 歌词模式。沿用既有符号名，页面的 `_desktopChromeEnabled` 委托到这里。
-bool readerDesktopChromeEnabled({
-  required bool desktop,
-  required bool lyricsMode,
-}) =>
-    readerStatusFooterEnabled(desktop: desktop, lyricsMode: lyricsMode);
-
 /// 有声书面板的容器按可用空间选择：桌面/宽窗居中，手机保留全高底部面板。
 /// 此判断独立于导航和设置，两者在所有平台均使用侧栏。
 bool readerAudiobookUsesDialog({required bool desktop, required Size window}) =>
@@ -52,7 +48,7 @@ bool readerAudiobookUsesDialog({required bool desktop, required Size window}) =>
 
 /// 顶部工具栏的顶部预留高。
 ///
-///  * 未启用（歌词模式）→ 0；
+///  * 未启用 → 0；
 ///  * 悬浮态（默认：点空白唤出、自动收起）→ 0，工具栏盖在正文之上；
 ///  * 挤压态且底栏占位（`_hasEverLoaded && _showChrome`）→ [headerHeight]。
 ///

--- a/fushi/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
+++ b/fushi/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
@@ -29,14 +29,18 @@ void main() {
   group('independentDocumentInsets（独立 HTML 文档留白契约）', () {
     const double reserve = 72;
 
+    const double topReserve = 60;
+
     EdgeInsets insets({
       required bool lyricsMode,
       required bool chromeOccupiesLayout,
       double bottomReserve = reserve,
+      double top = topReserve,
     }) {
       return independentDocumentInsets(
         lyricsMode: lyricsMode,
         chromeOccupiesLayout: chromeOccupiesLayout,
+        topReserve: top,
         bottomReserve: bottomReserve,
       );
     }
@@ -76,12 +80,26 @@ void main() {
       // ——判据只认 lyricsMode，所以 spread 与「没有独立文档」在这里同为 0。
     });
 
-    test('顶部恒不留白（macOS 拖拽带随自绘顶栏一并删除）', () {
-      // BUG-1343 曾让独立文档顶部缩进 macOS 阅读器自绘的 28pt 拖拽带。macOS 改用
-      // 应用级 MD3 顶栏（FushiDesktopTitleBar，在整个 Navigator 之上）后，页内不再
-      // 有任何叠在 WebView 上的顶部 chrome，这笔留白必须消失，否则歌词/整页图会在
-      // 顶栏下面再空一条。
-      expect(insets(lyricsMode: true, chromeOccupiesLayout: true).top, 0);
+    test('歌词模式：顶部留白 == 调用方给的顶部 chrome 占高（顶栏在歌词模式在场）', () {
+      // 顶栏过去在歌词模式整块不启用，歌词文档因此从 y=0 起画，系统状态栏 / 刘海
+      // 直接压在首行歌词上；顶栏恢复在场后，独立文档必须像正文一样给它让位。
+      expect(
+          insets(lyricsMode: true, chromeOccupiesLayout: true).top, topReserve);
+      expect(insets(lyricsMode: true, chromeOccupiesLayout: true, top: 12).top,
+          12);
+    });
+
+    test('顶部留白不受底栏占位门控（顶栏是否占位已由调用方算进 topReserve）', () {
+      // 悬浮顶栏不占正文位置时调用方喂进来的就是「只剩系统 inset」的那个值，
+      // 这里不能再叠一道底栏的门 —— 底栏收起并不会让状态栏不压歌词。
+      expect(
+        insets(lyricsMode: true, chromeOccupiesLayout: false).top,
+        topReserve,
+      );
+    });
+
+    test('正文 / spread 模式不留顶部（正文走 setChromeInsets，重复留白会挖掉一条空白）', () {
+      expect(insets(lyricsMode: false, chromeOccupiesLayout: true).top, 0);
       expect(insets(lyricsMode: false, chromeOccupiesLayout: false).top, 0);
     });
 
@@ -91,7 +109,12 @@ void main() {
         EdgeInsets.zero,
       );
       expect(
-        insets(lyricsMode: true, chromeOccupiesLayout: true, bottomReserve: 0),
+        insets(
+          lyricsMode: true,
+          chromeOccupiesLayout: true,
+          bottomReserve: 0,
+          top: 0,
+        ),
         EdgeInsets.zero,
       );
     });

--- a/fushi/test/pages/reader_lyrics_top_chrome_static_test.dart
+++ b/fushi/test/pages/reader_lyrics_top_chrome_static_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+import 'reader_fushi_page_source_corpus.dart';
+
+/// 歌词模式顶栏缺席回归的守卫。
+///
+/// 症状（用户报）：进歌词模式后顶栏整条不见，而且**没有任何回到阅读模式的入口**。
+/// 根因：`_desktopChromeEnabled` 与底部状态行共用同一个 `!lyricsMode` 判据，歌词模式
+/// 把「顶部工具栏 + 右侧抽屉」整套 chrome 一起关掉；而「切回阅读模式」的开关正住在
+/// 这套 chrome 的设置抽屉里 —— 关掉顶栏等于把歌词模式关成一间没有门的房间。
+///
+/// 修复的三件事各有一条钉子：
+///  * 顶栏在歌词模式在场（本文件第一组）；
+///  * 顶栏挂着一颗回正文的模式键，且在歌词模式强制 pinned（第二组）；
+///  * 歌词文档给顶栏让位（第三组接线 + `reader_lyrics_progress_bottom_reserve_static_test`
+///    里 `independentDocumentInsets` 的顶部留白行为断言）。
+///
+/// 端到端那一层在 `integration_test/reader_lyrics_mode_entry_itest.dart`：真 app 进歌词
+/// 模式 → 唤出 chrome → 顶栏与模式键在场 → 按下去真能切回正文。
+void main() {
+  final String src = readReaderPageSource();
+
+  /// 取 `bool get <name> =>` 到语句末尾 `;` 的初始化表达式。
+  String getterExpression(String name) {
+    final int start = src.indexOf('bool get $name =>');
+    expect(start, greaterThanOrEqualTo(0), reason: '$name 必须仍是页面的 getter');
+    final int end = maskComments(src).indexOf(';', start);
+    expect(end, greaterThan(start));
+    return src.substring(start, end);
+  }
+
+  group('顶栏在歌词模式在场', () {
+    test('_desktopChromeEnabled 不再随 _lyricsMode 翻转', () {
+      expect(
+        getterExpression('_desktopChromeEnabled'),
+        isNot(contains('_lyricsMode')),
+        reason: '顶栏一旦跟着歌词模式关掉，歌词模式就没有返回 / 设置面，也没有回正文的入口',
+      );
+    });
+
+    test('底部状态行仍留在歌词模式之外（进度在歌词模式不刷新，画出来是冻住的旧数）', () {
+      expect(getterExpression('_statusFooterEnabled'), contains('_lyricsMode'));
+    });
+
+    test('并进播放条右端的状态文字跟状态行同真值，不跟整套 chrome', () {
+      // 否则顶栏在歌词模式恢复在场会顺手把那批冻住的进度数字搬进播放条。
+      expect(
+        getterExpression('_playbackStatusInline'),
+        contains('_statusFooterEnabled'),
+      );
+      expect(
+        getterExpression('_separatePlaybackStatus'),
+        contains('_statusFooterEnabled'),
+      );
+    });
+  });
+
+  group('顶栏上的模式键', () {
+    final String header = methodBody(src, '  Widget _buildDesktopHeader()');
+
+    test('歌词模式下顶栏有一颗回正文的键，且强制 pinned（窄窗不许折进溢出菜单）', () {
+      expect(
+        containsIdentifierCall(header, '_toggleLyricsMode'),
+        isTrue,
+        reason: '顶栏必须能切模式，这是歌词模式里唯一看得见的回正文入口',
+      );
+      expect(header, contains('pinned: lyrics'),
+          reason: '折进 ⋮ 溢出菜单的入口对「顶栏上找不到回去的路」这个症状等于不存在');
+      expect(header, contains("'fushi_reader_lyrics_mode_button'"),
+          reason: '集成测试按 key 找这颗键');
+    });
+
+    test('导航 / 插图只在正文模式挂（歌词页翻章会把歌词文档换成 EPUB 章节）', () {
+      expect(header, contains('if (!lyrics)'));
+    });
+  });
+
+  group('歌词文档给顶栏让位', () {
+    test('_buildBody 的顶部留白来自 _lyricsTopReserve', () {
+      final String body = methodBody(src, '  Widget _buildBody()');
+      expect(body, contains('topReserve: _lyricsTopReserve'));
+    });
+
+    test('_lyricsTopReserve 不含顶部进度预留（歌词模式不画那颗 pill）', () {
+      final int start = src.indexOf('double get _lyricsTopReserve =>');
+      expect(start, greaterThanOrEqualTo(0));
+      final String expr =
+          src.substring(start, maskComments(src).indexOf(';', start));
+      expect(expr, contains('_stableTopInset'));
+      expect(expr, contains('_desktopHeaderReserve'));
+      expect(expr, isNot(contains('_topProgressReserve')),
+          reason: '算进来就是在歌词首行上方留一条谁也不占的空带');
+    });
+  });
+}

--- a/fushi/test/reader/reader_desktop_chrome_test.dart
+++ b/fushi/test/reader/reader_desktop_chrome_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/reader/reader_desktop_chrome.dart';
 
+import '../helpers/source_guard.dart';
+
 void main() {
   test('compact playback leaves footer and system inset outside its surface',
       () {
@@ -69,21 +71,45 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  group('readerDesktopChromeEnabled', () {
-    test('各平台非歌词模式均启用', () {
-      expect(
-        readerDesktopChromeEnabled(desktop: true, lyricsMode: false),
-        isTrue,
-      );
-      expect(
-        readerDesktopChromeEnabled(desktop: true, lyricsMode: true),
-        isFalse,
-      );
-      expect(
-        readerDesktopChromeEnabled(desktop: false, lyricsMode: false),
-        isTrue,
-      );
-    });
+  testWidgets('pinned 动作在紧凑形态下仍是可见按钮（歌词模式回正文的入口靠它）',
+      (WidgetTester tester) async {
+    // 歌词模式里「切回阅读模式」是顶栏上唯一可见的回正文入口，页面为此把那颗键
+    // 标成 pinned。这里钉的是 pinned 的**行为**：窄到进紧凑形态时它不进溢出菜单，
+    // 仍是一颗按得着的图标按钮。
+    await tester.binding.setSurfaceSize(const Size(320, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    int toggled = 0;
+    await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+            body: ReaderDesktopHeader(
+      title: 'lyrics mode',
+      textColor: Colors.black,
+      backgroundColor: Colors.white,
+      leading: <ReaderHeaderAction>[
+        ReaderHeaderAction(
+            icon: Icons.arrow_back,
+            label: 'Back',
+            pinned: true,
+            onPressed: () {}),
+        ReaderHeaderAction(
+            icon: Icons.auto_stories_outlined,
+            label: 'Book mode',
+            pinned: true,
+            onPressed: () => toggled++),
+      ],
+      trailing: <ReaderHeaderAction>[
+        ReaderHeaderAction(
+            icon: Icons.tune,
+            label: 'Settings',
+            pinned: true,
+            onPressed: () {}),
+      ],
+    ))));
+    expect(find.byIcon(Icons.auto_stories_outlined), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.auto_stories_outlined));
+    await tester.pumpAndSettle();
+    expect(toggled, 1);
+    expect(tester.takeException(), isNull);
   });
 
   group('readerDesktopHeaderReserve', () {
@@ -177,10 +203,14 @@ void main() {
     final String page = File(
       'lib/src/pages/implementations/reader_fushi_page.dart',
     ).readAsStringSync();
-    final int at = chrome.indexOf('Widget _buildDesktopHeader() {');
-    expect(at, greaterThan(-1));
+    // 取整个方法体，而不是「方法签名后 900 个字符」：那种定长窗口是 B 类要求型
+    // 锚点——往方法开头加几行（比如歌词模式那颗模式键）就会把 RepaintBoundary 挤出
+    // 窗口，行为分毫未变而守卫变红。
     expect(
-      chrome.substring(at, at + 900).contains('RepaintBoundary('),
+      containsIdentifierCall(
+        methodBody(chrome, '  Widget _buildDesktopHeader()'),
+        'RepaintBoundary',
+      ),
       isTrue,
       reason: 'BUG-1692：排在 WebView 之后的 chrome 必须自带 RepaintBoundary',
     );


### PR DESCRIPTION
## 症状（用户报）

歌词模式下**顶栏整条不可见**，而且**没有任何回到阅读模式的入口**。

## 根因

`readerDesktopChromeEnabled` 直接委托给 `readerStatusFooterEnabled`（判据 `!lyricsMode`），
于是 `_desktopChromeEnabled` 在歌词模式恒 false，`_buildDesktopHeader` 整条早返回。

两个后果连在一起：顶栏（返回 / 目录 / 插图 / 统计 / 有声书 / 全屏 / 设置）在歌词模式不画；
而「切回阅读模式」的开关本身就住在这套 chrome 的设置抽屉里——顶栏一没，歌词模式就成了
一间没有门的房间（只剩播放条齿轮那条隐蔽路径）。

另有一笔几何差：歌词页是独立 HTML（`LyricsModeHtml`），`_applyChromeInsets` 对它整体早返回，
留白只能由 Flutter 侧给，而 `independentDocumentInsets` 当时只给底部留白、顶部恒 0 →
文档从 y=0 起画，系统状态栏 / 刘海直接压在首行歌词上。

## 改动

- **顶栏两种模式都在场**（`_desktopChromeEnabled` 不再随 `_lyricsMode` 翻转），动作按模式取舍：
  导航与插图在歌词页是空转（翻章会把歌词文档换成 EPUB 章节，`_paginate` 为此专门早返回），
  只在正文模式挂；换来一颗「歌词 ⇄ 阅读」模式键——歌词模式下强制 `pinned`，窄窗也不折进
  ⋮ 溢出菜单（它是那里唯一可见的回正文入口）。有声书控制器不存在时这颗键整个不出现。
- **歌词文档给顶栏让位**：`independentDocumentInsets` 增加 `topReserve`，由新的
  `_lyricsTopReserve`（系统顶 inset + 顶栏预留）喂入。它**不含**顶部进度 pill 的预留——
  歌词模式不画那颗 pill，算进来就是在首行歌词上方留一条谁也不占的空带。
- **底部状态行仍留在歌词模式之外**：`_refreshProgress` 在歌词模式整体早返回，画出来会是
  进歌词那一刻冻住的旧数。并进播放条右端的那份状态文字（`_playbackStatusInline` /
  `_separatePlaybackStatus`）同理改挂 `_statusFooterEnabled` 而不是整套 chrome，
  否则会跟着顶栏一起在歌词模式翻真。正文模式下两个判据恒等，行为逐字不变。

## 测试

- 新增 `fushi/test/pages/reader_lyrics_top_chrome_static_test.dart`：顶栏判据不再随歌词模式
  翻转 / 状态行仍在歌词模式外 / 顶栏挂 pinned 模式键 / 留白接线。
- `reader_lyrics_progress_bottom_reserve_static_test.dart`：`independentDocumentInsets`
  顶部留白的行为断言（歌词 == 调用方给的顶部占高；正文与 spread 恒 0）。
- `reader_desktop_chrome_test.dart`：pinned 动作在紧凑形态仍是可见按钮；并把「顶栏自带
  RepaintBoundary」的守卫从「方法签名后 900 字符」的定长窗口改成取整个方法体
  （往方法开头加几行就假红，是典型的要求型锚点失效）。
- **真机**：Windows 离屏 runner 跑 `reader_lyrics_mode_entry_itest.dart` 通过（exit 0，
  `All tests passed`）：种一本有声书 → 进歌词模式 → 走生产唤出路径（歌词页空白点击桥
  `onLyricsTapEmpty`）→ 顶栏 `fushi_desktop_header` 与播放条 `fushi_play_bar` 同时在场 →
  按顶栏模式键后 `lyricsMode` 落回 false、正文重新就绪。
- `flutter analyze` 全绿；`test/reader/` + 歌词/chrome 相邻域约 2700 条定向测试通过
  （唯一一条红 `popup_dict_masonry_guard_test.dart` 在 `upstream/develop` 基线上同样红，
  与本 PR 无关）。

## 顺带修的两处既有拦路（都会让上面那条真机验证跑不到本 PR 的断言）

1. 该集成测试按 focus-id 前缀 `reader-action` 找快速设置里的歌词开关，设置面改成右侧
   抽屉后那颗开关的焦点目标前缀已是 `settings-row` → 恒 false。**已在 upstream/develop
   基线上复现同一条红**，与本改动无关。改成不钉前缀，只要求它是个能接 `ActivateIntent`
   的具体焦点停靠点。
2. 首次进歌词模式的一次性提示对话框是一层吃指针的模态，会把对顶栏模式键的点击吸走
   （hit test 落在 `AbsorbPointer` 上）。测试里把 `lyrics_mode_hint_shown` 预置成已看过。

记录：`docs/bugs/BUG-2326-lyrics-mode-top-chrome.md`。

https://claude.ai/code/session_01T9d4asGfG6CT1uhTH6TsHB
