### PR TITLE
feat(video): 字幕模型重定时（逐句对轴，产出新字幕档）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 76466 (4498 per locale)
+/// Strings: 76585 (4505 per locale)
 ///
-/// Built on 2026-09-08 at 19:22 UTC
+/// Built on 2026-09-08 at 19:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6234,6 +6234,21 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get discovery_badge_trusted => 'Trusted';
   String get discovery_badge_remake => 'Remake';
   String get discovery_content_hint_manga => 'Suspected manga';
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -16794,6 +16809,28 @@ class _StringsAr extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -27581,6 +27618,28 @@ class _StringsDe extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -38421,6 +38480,28 @@ class _StringsEs extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -49295,6 +49376,28 @@ class _StringsFr extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -59972,6 +60075,28 @@ class _StringsId extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -70740,6 +70865,28 @@ class _StringsIt extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -80888,6 +81035,28 @@ class _StringsJa extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -91046,6 +91215,28 @@ class _StringsKo extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -101772,6 +101963,28 @@ class _StringsNl extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -112550,6 +112763,28 @@ class _StringsPtBr extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -123306,6 +123541,28 @@ class _StringsRu extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -133860,6 +134117,28 @@ class _StringsTh extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -144532,6 +144811,28 @@ class _StringsTr extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -155175,6 +155476,28 @@ class _StringsVi extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 // Path: <root>
@@ -164951,6 +165274,27 @@ class _StringsZhCn extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => '疑似漫画';
+  @override
+  String get video_subtitle_retime_action => '用语音模型重定时';
+  @override
+  String get video_subtitle_retime_no_track => '先选一条字幕轨';
+  @override
+  String get video_subtitle_retime_running => '正在用语音模型重定时字幕…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      '已重定时 ${matched}/${total} 句（${percent}%），中位偏移 ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      '只有 ${percent}% 的句子对上了。检查语音语言是否选对、这份字幕是不是这一集的。';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '已剔除 ${count} 条格式异常的字幕';
+  @override
+  String get video_subtitle_retime_failed => '字幕重定时失败';
 }
 
 // Path: <root>
@@ -174787,6 +175131,28 @@ class _StringsZhHk extends _StringsEn {
   String get discovery_badge_remake => 'Remake';
   @override
   String get discovery_content_hint_manga => 'Suspected manga';
+  @override
+  String get video_subtitle_retime_action => 'Retime with speech model';
+  @override
+  String get video_subtitle_retime_no_track => 'Load a subtitle track first';
+  @override
+  String get video_subtitle_retime_running =>
+      'Retiming subtitles with the speech model…';
+  @override
+  String video_subtitle_retime_done(
+          {required Object matched,
+          required Object total,
+          required Object percent,
+          required Object ms}) =>
+      'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+  @override
+  String video_subtitle_retime_low_match({required Object percent}) =>
+      'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+  @override
+  String video_subtitle_retime_dropped({required Object count}) =>
+      '${count} malformed lines were left out';
+  @override
+  String get video_subtitle_retime_failed => 'Subtitle retiming failed';
 }
 
 /// Flat map(s) containing all translations.
@@ -184036,6 +184402,27 @@ extension on _StringsEn {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -193280,6 +193667,27 @@ extension on _StringsAr {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -202569,6 +202977,27 @@ extension on _StringsDe {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -211849,6 +212278,27 @@ extension on _StringsEs {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -221138,6 +221588,27 @@ extension on _StringsFr {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -230398,6 +230869,27 @@ extension on _StringsId {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -239680,6 +240172,27 @@ extension on _StringsIt {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -248889,6 +249402,27 @@ extension on _StringsJa {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -258102,6 +258636,27 @@ extension on _StringsKo {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -267377,6 +267932,27 @@ extension on _StringsNl {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -276647,6 +277223,27 @@ extension on _StringsPtBr {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -285924,6 +286521,27 @@ extension on _StringsRu {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -295173,6 +295791,27 @@ extension on _StringsTh {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -304437,6 +305076,27 @@ extension on _StringsTr {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -313695,6 +314355,27 @@ extension on _StringsVi {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }
@@ -322873,6 +323554,26 @@ extension on _StringsZhCn {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return '疑似漫画';
+      case 'video_subtitle_retime_action':
+        return '用语音模型重定时';
+      case 'video_subtitle_retime_no_track':
+        return '先选一条字幕轨';
+      case 'video_subtitle_retime_running':
+        return '正在用语音模型重定时字幕…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            '已重定时 ${matched}/${total} 句（${percent}%），中位偏移 ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            '只有 ${percent}% 的句子对上了。检查语音语言是否选对、这份字幕是不是这一集的。';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) => '已剔除 ${count} 条格式异常的字幕';
+      case 'video_subtitle_retime_failed':
+        return '字幕重定时失败';
       default:
         return null;
     }
@@ -332060,6 +332761,27 @@ extension on _StringsZhHk {
         return 'Remake';
       case 'discovery_content_hint_manga':
         return 'Suspected manga';
+      case 'video_subtitle_retime_action':
+        return 'Retime with speech model';
+      case 'video_subtitle_retime_no_track':
+        return 'Load a subtitle track first';
+      case 'video_subtitle_retime_running':
+        return 'Retiming subtitles with the speech model…';
+      case 'video_subtitle_retime_done':
+        return (
+                {required Object matched,
+                required Object total,
+                required Object percent,
+                required Object ms}) =>
+            'Retimed ${matched}/${total} lines (${percent}%), median shift ${ms} ms';
+      case 'video_subtitle_retime_low_match':
+        return ({required Object percent}) =>
+            'Only ${percent}% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.';
+      case 'video_subtitle_retime_dropped':
+        return ({required Object count}) =>
+            '${count} malformed lines were left out';
+      case 'video_subtitle_retime_failed':
+        return 'Subtitle retiming failed';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "仅信任发布者",
   "discovery_badge_trusted": "信任发布者",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "疑似漫画"
+  "discovery_content_hint_manga": "疑似漫画",
+  "video_subtitle_retime_action": "用语音模型重定时",
+  "video_subtitle_retime_no_track": "先选一条字幕轨",
+  "video_subtitle_retime_running": "正在用语音模型重定时字幕…",
+  "video_subtitle_retime_done": "已重定时 $matched/$total 句（$percent%），中位偏移 $ms ms",
+  "video_subtitle_retime_low_match": "只有 $percent% 的句子对上了。检查语音语言是否选对、这份字幕是不是这一集的。",
+  "video_subtitle_retime_dropped": "已剔除 $count 条格式异常的字幕",
+  "video_subtitle_retime_failed": "字幕重定时失败"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4496,5 +4496,12 @@
   "discovery_nyaa_filter_trusted_only": "Trusted only",
   "discovery_badge_trusted": "Trusted",
   "discovery_badge_remake": "Remake",
-  "discovery_content_hint_manga": "Suspected manga"
+  "discovery_content_hint_manga": "Suspected manga",
+  "video_subtitle_retime_action": "Retime with speech model",
+  "video_subtitle_retime_no_track": "Load a subtitle track first",
+  "video_subtitle_retime_running": "Retiming subtitles with the speech model…",
+  "video_subtitle_retime_done": "Retimed $matched/$total lines ($percent%), median shift $ms ms",
+  "video_subtitle_retime_low_match": "Only $percent% of lines matched. Check the spoken language and whether this subtitle belongs to this episode.",
+  "video_subtitle_retime_dropped": "$count malformed lines were left out",
+  "video_subtitle_retime_failed": "Subtitle retiming failed"
 }

--- a/fushi/lib/src/media/video/subtitle_retiming_service.dart
+++ b/fushi/lib/src/media/video/subtitle_retiming_service.dart
@@ -1,0 +1,253 @@
+/// 视频字幕**模型重定时**的装配层。
+///
+/// 算法住在 `fushi_asr_subtitles`（上游 fushi-subtitles 仓库）：拿一份设备端 ASR
+/// 转录当参照，只认「归一化后唯一且单调」的文本锚点，锚点之间按分区域时钟模型推，
+/// 推不出来的段原样保留——**正文与顺序一个字都不动**。
+///
+/// 与既有的三条调轴路径是不同的东西，别混：手动延迟 / 跳到相邻 cue / 波形自动对轴
+/// 都只能整体平移一个 `delayMs`，修不了帧率漂移（越往后偏得越多）和分段偏移
+/// （片头剪切、版本差异）。重定时逐句给时间，因此产出的是**一份新的字幕档**而不是
+/// 一个偏移量。
+///
+/// 本层只做三件「只有本仓知道」的事：
+/// 1. 把播放器的 [AudioCue] 换成算法要的 [SubtitleCue]（[retimingCuesFromAudioCues]）；
+/// 2. 把本仓转录产物（SRT + 同序 token 时间 sidecar）包成 [RetimingTranscription]；
+/// 3. 把结果写成一个新的外挂字幕档，交给视频页既有的外挂字幕导入路径去应用。
+library;
+
+import 'dart:io';
+
+import 'package:fushi_asr_core/asr_core.dart'
+    show AsrCueTokenTiming, AsrTranscriptionService;
+import 'package:fushi_asr_subtitles/asr_subtitles.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:path/path.dart' as p;
+
+/// [RetimingTranscription] 的本仓实现：一次设备端转录的产物。
+///
+/// 只带算法真正要的两样——cue 列表与逐 token 发射时间。**不要**换成
+/// `AsrTranscribeResult`：那是「任务落了哪些盘」的记录，与对轴无关。
+class AsrRetimingTranscription implements RetimingTranscription {
+  const AsrRetimingTranscription({
+    required this.cues,
+    required this.tokenTimings,
+  });
+
+  @override
+  final List<SubtitleCue> cues;
+
+  @override
+  final List<AsrCueTokenTiming>? tokenTimings;
+
+  /// 从转录落盘的 SRT（[AsrTranscribeResult.srtPath]）读一份参照转录。
+  ///
+  /// 文件不存在、读不动或不是合法 SRT 时返回 null（调用方据此提示失败，不要拿空
+  /// 转录去跑对轴——那只会把所有 cue 判成「无锚点」再原样写回，白跑一趟）。
+  ///
+  /// 逐 token 发射时间是 SRT 旁边的 sidecar，**行数与 cue 数不符时整份丢掉**：
+  /// 错位的 token 时间会把锚点钉到别的句子上，比没有更糟（与
+  /// `attachAsrCueTokenTiming` 同一条纪律）。丢掉之后算法自动退回按 cue 边界取锚点。
+  static Future<AsrRetimingTranscription?> fromTranscriptSrt(
+    String srtPath,
+  ) async {
+    final File file = File(srtPath);
+    if (!await file.exists()) return null;
+    final List<SubtitleCue> cues;
+    try {
+      cues = parseRetimingSubtitles(await file.readAsString());
+    } on FormatException {
+      return null;
+    } on FileSystemException {
+      return null;
+    }
+    final List<AsrCueTokenTiming>? rows =
+        await AsrTranscriptionService.readCueTokenTimings(
+      srtPath,
+      expectedCount: cues.length,
+    );
+    return AsrRetimingTranscription(
+      cues: cues,
+      tokenTimings: (rows != null && rows.length == cues.length) ? rows : null,
+    );
+  }
+}
+
+/// [retimingCuesFromAudioCues] 的产物：可送进算法的 cue，加上被剔掉的条数。
+class RetimingInputCues {
+  const RetimingInputCues({required this.cues, required this.droppedCount});
+
+  /// 按原顺序编号（1-based）的可用 cue。
+  final List<SubtitleCue> cues;
+
+  /// 被剔掉的退化 cue 条数（空正文 / 起止时间非递增 / 负起点）。
+  final int droppedCount;
+
+  bool get isEmpty => cues.isEmpty;
+}
+
+/// **纯函数**：播放器 cue → 重定时输入。
+///
+/// 剔掉算法层会直接判非法的退化 cue（空正文、`endMs <= startMs`、负起点）——ASS
+/// 转来的字幕里零长度 cue 并不罕见，让它们把整趟对轴炸成一个 FormatException 不
+/// 合算。剔掉多少条如实回报（[RetimingInputCues.droppedCount]），由调用方告诉用户
+/// 「新档比原档少了几句」，**不要**悄悄补一个 1ms 的假时间窗糊过去。
+///
+/// [SubtitleCue.index] 按剔除后的次序重编（1-based），与算法输出的 SRT 序号一致。
+RetimingInputCues retimingCuesFromAudioCues(List<AudioCue> cues) {
+  final List<SubtitleCue> out = <SubtitleCue>[];
+  int dropped = 0;
+  for (final AudioCue cue in cues) {
+    if (cue.startMs < 0 ||
+        cue.endMs <= cue.startMs ||
+        cue.text.trim().isEmpty) {
+      dropped++;
+      continue;
+    }
+    out.add(SubtitleCue(
+      index: out.length + 1,
+      startMs: cue.startMs,
+      endMs: cue.endMs,
+      text: cue.text,
+    ));
+  }
+  return RetimingInputCues(cues: out, droppedCount: dropped);
+}
+
+/// **纯函数**：重定时产物的档名。
+///
+/// `<原名>.retimed.srt`；[taken] 里已被占用时补 `-2`、`-3`…（重定时可以对同一部
+/// 片跑很多次——换语言、换模型、改用另一版原始字幕——每次都该留下自己的档，
+/// 覆盖掉上一次的结果等于让用户没法回头比较）。
+///
+/// [baseName] 可以带扩展名（`ep01.zh.ass`）也可以不带，一律先去掉扩展名。
+String retimedSubtitleFileName(String baseName,
+    {Set<String> taken = const <String>{}}) {
+  final String stem = p.basenameWithoutExtension(baseName).trim();
+  // 前导点要剥掉：`basenameWithoutExtension('.srt')` 原样返回 `.srt`（点开头被当成
+  // 隐藏文件、不是扩展名），拼出来的 `.srt.retimed.srt` 在类 Unix 上是隐藏档，
+  // 用户在文件管理器里根本看不见自己刚生成的字幕。
+  final String stripped = stem.replaceFirst(RegExp(r'^\.+'), '');
+  final String safe = stripped.isEmpty ? 'subtitle' : stripped;
+  String candidate = '$safe.retimed.srt';
+  int serial = 2;
+  while (taken.contains(candidate)) {
+    candidate = '$safe.retimed-$serial.srt';
+    serial++;
+  }
+  return candidate;
+}
+
+/// 一次重定时的完整结果：新档路径 + 算法统计 + 输入侧剔除数。
+class RetimedSubtitleFile {
+  const RetimedSubtitleFile({
+    required this.path,
+    required this.cueCount,
+    required this.droppedInputCues,
+    required this.stats,
+  });
+
+  /// 落盘的新外挂字幕档（SRT，UTF-8）。
+  final String path;
+
+  /// 新档里的 cue 条数。
+  final int cueCount;
+
+  /// 输入侧被剔掉的退化 cue 条数（见 [retimingCuesFromAudioCues]）。
+  final int droppedInputCues;
+
+  /// 算法统计原样透传（`matchedCues` / `inputCues` / `medianShiftMs` /
+  /// `timingMode` / `warnings` …），UI 摘要走 [retimedSubtitleSummary]。
+  final Map<String, Object?> stats;
+
+  /// 命中锚点的 cue 条数（算法未给或类型不对时 0）。
+  int get matchedCues => _intStat('matchedCues');
+
+  /// 送进算法的 cue 条数。
+  int get inputCues => _intStat('inputCues');
+
+  /// 命中 cue 的时间修正量中位数（毫秒，可正可负）。
+  int get medianShiftMs => _intStat('medianShiftMs');
+
+  int _intStat(String key) {
+    final Object? value = stats[key];
+    return value is int ? value : 0;
+  }
+}
+
+/// **纯函数**：给 UI 用的一行摘要（命中率 + 中位偏移）。
+///
+/// 不做 i18n 拼装——调用方拿这三个数去填 i18n 模板；这里只负责把「命中率」算成
+/// 整数百分比，免得每个调用点各算一遍还算得不一样。
+({int matched, int total, int percent, int medianShiftMs})
+    retimedSubtitleSummary(
+  RetimedSubtitleFile file,
+) {
+  final int total = file.inputCues;
+  final int matched = file.matchedCues;
+  final int percent = total <= 0 ? 0 : ((matched * 100) / total).round();
+  return (
+    matched: matched,
+    total: total,
+    percent: percent,
+    medianShiftMs: file.medianShiftMs,
+  );
+}
+
+/// 命中率低于此值时**不该**直接把结果当成功用：锚点太少意味着这份转录和这份字幕
+/// 很可能不是同一段内容（语言选错、字幕对不上这一集、片源版本不同）。
+///
+/// 算法本身在没锚点时会老实把 cue 原样写回，所以低命中不会毁字幕；但让用户在
+/// 「已经切换到一份几乎没修过的新档」之后自己发现，比当场说清楚要糟。
+const double kRetimedSubtitleLowMatchRate = 0.4;
+
+/// 跑一次重定时并把结果写成新的外挂字幕档。
+///
+/// [subtitleCues] 是**当前正在放的那条字幕轨**的 cue（内嵌轨与外挂档都行——播放器
+/// 侧已经把两者都解析成了 [AudioCue]，所以重定时不挑字幕来源）；
+/// [transcriptSrtPath] 是设备端转录刚落盘的 SRT；[outputDirectory] 一般是
+/// `AppPaths.videoSubtitlesDirectory()`。
+///
+/// 返回 null 的三种情况：输入 cue 全被剔光、转录读不出来、算法判输入非法。
+/// 取消（[cancellation]）会以 [TranscribeCancelled] 抛出，由调用方吞掉。
+Future<RetimedSubtitleFile?> retimeVideoSubtitleToFile({
+  required List<AudioCue> subtitleCues,
+  required String transcriptSrtPath,
+  required Directory outputDirectory,
+  required String baseName,
+  TranscribeCancellation? cancellation,
+}) async {
+  final RetimingInputCues input = retimingCuesFromAudioCues(subtitleCues);
+  if (input.isEmpty) return null;
+  final AsrRetimingTranscription? transcription =
+      await AsrRetimingTranscription.fromTranscriptSrt(transcriptSrtPath);
+  if (transcription == null || transcription.cues.isEmpty) return null;
+
+  final RetimedSubtitles retimed;
+  try {
+    retimed = await retimeSubtitles(
+      input.cues,
+      transcription,
+      SubtitleFormat.srt,
+      cancellation: cancellation,
+    );
+  } on FormatException {
+    return null;
+  }
+
+  await outputDirectory.create(recursive: true);
+  final Set<String> taken = <String>{
+    for (final FileSystemEntity entity in outputDirectory.listSync())
+      p.basename(entity.path),
+  };
+  final String dest = p.join(
+    outputDirectory.path,
+    retimedSubtitleFileName(baseName, taken: taken),
+  );
+  await File(dest).writeAsString(retimed.text);
+  return RetimedSubtitleFile(
+    path: dest,
+    cueCount: retimed.cueCount,
+    droppedInputCues: input.droppedCount,
+    stats: retimed.stats,
+  );
+}

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -212,6 +212,18 @@ extension _VideoSubtitle on _VideoFushiPageState {
                       : _pickAndImportSubtitle(controller),
                 ),
       ),
+      // 模型重定时：与上面两行同属「拿到 / 修好一份字幕」，所以并在同一组。
+      // 只对本地视频出现——它要把整条音轨喂给设备端转录，远端模式手里只有一条流。
+      // 空 cue 时也显示（点了会说「先选一条字幕轨」），不显示反而更像功能坏了。
+      if (!_isRemote && _currentVideoPath != null && isAsrSupported)
+        ListTile(
+          leading: const Icon(Icons.model_training_outlined),
+          title: Text(t.video_subtitle_retime_action),
+          enabled: !_subtitleLoadingShown,
+          onTap: _subtitleLoadingShown
+              ? null
+              : () => unawaited(_retimeSubtitleWithSpeechModel(controller)),
+        ),
       const Divider(height: 1),
       ListTile(
         leading: const Icon(Icons.subtitles_off),
@@ -1618,6 +1630,95 @@ extension _VideoSubtitle on _VideoFushiPageState {
         t.video_subtitle_switched(label: _youtubeCaptionTrackLabel(track)),
       );
     }
+  }
+
+  /// 用设备端语音模型**重定时**当前字幕轨：跑一遍 ASR 转录当参照，逐句修正时间，
+  /// 结果写成一份新的外挂字幕档并当场切过去。
+  ///
+  /// 与「自动对轴」（[_autoAlignSubtitle]）的分工：那条只算一个整体平移量写进
+  /// `delayMs`，修不了帧率漂移与分段偏移；这条逐句给时间，所以产出是**新档**而不是
+  /// 一个偏移量——原档一个字节都不动，用户随时能在字幕轨列表里切回去比较。
+  ///
+  /// 转录整段复用有声书那个弹层（[showAsrTranscribeSheet]）：模型下载、进度、暂停 /
+  /// 取消、语音语言选择全在里面，视频侧一行 UI 都不用重写。它返回落盘的 SRT 路径，
+  /// 用户中途取消则返回 null，这里直接安静收工。
+  ///
+  /// 算法在 `fushi_asr_subtitles`（见 [retimeVideoSubtitleToFile]），只认唯一且单调
+  /// 的文本锚点、推不出来的段原样保留，所以**低命中率不会毁字幕**——但会得到一份
+  /// 几乎没改过的新档，那种情况下明确告诉用户去查语言 / 集数，别让他自己发现。
+  Future<void> _retimeSubtitleWithSpeechModel(
+    VideoPlayerController controller,
+  ) async {
+    final String? videoPath = _currentVideoPath;
+    if (videoPath == null || videoPath.isEmpty) return;
+    final List<AudioCue> cues = List<AudioCue>.of(controller.cues);
+    if (cues.isEmpty) {
+      _showOsd(
+        t.video_subtitle_retime_no_track,
+        severity: ToastSeverity.warning,
+      );
+      return;
+    }
+    final String? transcriptSrt = await showAsrTranscribeSheet(
+      context: context,
+      audioPaths: <String>[videoPath],
+    );
+    if (transcriptSrt == null || !mounted) return;
+    _showOsd(
+      t.video_subtitle_retime_running,
+      icon: Icons.model_training_outlined,
+      severity: ToastSeverity.info,
+    );
+    RetimedSubtitleFile? retimed;
+    try {
+      retimed = await retimeVideoSubtitleToFile(
+        subtitleCues: cues,
+        transcriptSrtPath: transcriptSrt,
+        outputDirectory: await AppPaths.videoSubtitlesDirectory(),
+        baseName: p.basename(videoPath),
+      );
+    } catch (error) {
+      debugPrint('[fushi-video] subtitle retiming failed: $error');
+      retimed = null;
+    }
+    if (!mounted) return;
+    if (retimed == null) {
+      _showOsd(
+        t.video_subtitle_retime_failed,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    // 落盘的新档走既有外挂字幕链路：拷进字幕目录（同目录时跳过）、选中、并入字幕轨
+    // 列表。这条路径已经处理好持久化与「当场出现在列表里」（BUG-1329 / BUG-1861）。
+    await _importExternalSubtitle(controller, retimed.path);
+    if (!mounted) return;
+    final ({int matched, int total, int percent, int medianShiftMs}) summary =
+        retimedSubtitleSummary(retimed);
+    if (retimed.droppedInputCues > 0) {
+      _showOsd(
+        t.video_subtitle_retime_dropped(count: retimed.droppedInputCues),
+        severity: ToastSeverity.warning,
+      );
+    }
+    if (summary.total > 0 &&
+        summary.matched / summary.total < kRetimedSubtitleLowMatchRate) {
+      _showOsd(
+        t.video_subtitle_retime_low_match(percent: summary.percent),
+        severity: ToastSeverity.warning,
+      );
+      return;
+    }
+    _showOsd(
+      t.video_subtitle_retime_done(
+        matched: summary.matched,
+        total: summary.total,
+        percent: summary.percent,
+        ms: summary.medianShiftMs,
+      ),
+      icon: Icons.model_training_outlined,
+      severity: ToastSeverity.success,
+    );
   }
 
   Future<void> _importExternalSubtitle(

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -43,7 +43,11 @@ import 'package:fushi/src/media/video/dandanplay_client.dart';
 import 'package:fushi/src/media/video/danmaku_manual_match_panel.dart';
 import 'package:fushi/src/media/source_library/source_stream_headers.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
+import 'package:fushi/src/asr_host/asr_host.dart' show isAsrSupported;
+import 'package:fushi/src/media/audiobook/asr_transcribe_sheet.dart'
+    show showAsrTranscribeSheet;
 import 'package:fushi/src/media/video/subtitle_embedded_fonts.dart';
+import 'package:fushi/src/media/video/subtitle_retiming_service.dart';
 import 'package:fushi/src/media/video/video_display_claim.dart';
 import 'package:fushi/src/media/video/video_episode_start_policy.dart';
 import 'package:fushi/src/media/video/video_exit_flush.dart';

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1258
+version: 2.3.0+1259
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"
@@ -18,7 +18,17 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: ac67a2e92800a334f46124f4b4461ce04f8283a2
+      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+  # 字幕重定时（拿 ASR 转录当参照修好已有字幕的时间轴）。与 fushi_asr_core 同仓同 sha。
+  #
+  # 只依赖 fushi_asr_core，**不含** ONNX 后端：算法那半边住在 fushi_asr 包里的话会
+  # 拖上 fushi_asr_onnx_ffi（archive ^4），而本仓钉 archive ^3.6.1，引进来等于强制一次
+  # archive 4 迁移。上游 PR #7 因此把它拆成了这个零重依赖的包。
+  fushi_asr_subtitles:
+    git:
+      url: https://github.com/hajisensai/fushi-subtitles.git
+      path: packages/asr_subtitles
+      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
   archive: ^3.6.1
   async_zip: ^0.1.0
   basic_utils: ^5.7.0

--- a/fushi/test/media/video/subtitle_retiming_service_test.dart
+++ b/fushi/test/media/video/subtitle_retiming_service_test.dart
@@ -1,0 +1,303 @@
+import 'dart:io';
+
+import 'package:fushi/src/media/video/subtitle_retiming_service.dart';
+import 'package:fushi_asr_subtitles/asr_subtitles.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+AudioCue _cue(String text, int startMs, int endMs) {
+  final AudioCue cue = AudioCue();
+  cue.bookKey = 'video';
+  cue.chapterHref = '';
+  cue.sentenceIndex = 0;
+  cue.textFragmentId = '';
+  cue.text = text;
+  cue.startMs = startMs;
+  cue.endMs = endMs;
+  cue.audioFileIndex = 0;
+  return cue;
+}
+
+/// 造一份 SRT 文本（当 ASR 转录产物用）。
+String _srt(List<(String, int, int)> rows) {
+  String stamp(int ms) {
+    final int h = ms ~/ 3600000;
+    final int m = (ms % 3600000) ~/ 60000;
+    final int s = (ms % 60000) ~/ 1000;
+    final int rest = ms % 1000;
+    return '${h.toString().padLeft(2, '0')}:${m.toString().padLeft(2, '0')}:'
+        '${s.toString().padLeft(2, '0')},${rest.toString().padLeft(3, '0')}';
+  }
+
+  final StringBuffer buf = StringBuffer();
+  for (int i = 0; i < rows.length; i++) {
+    final (String text, int start, int end) = rows[i];
+    buf.writeln('${i + 1}');
+    buf.writeln('${stamp(start)} --> ${stamp(end)}');
+    buf.writeln(text);
+    buf.writeln();
+  }
+  return buf.toString();
+}
+
+void main() {
+  group('retimingCuesFromAudioCues', () {
+    test('保留正常 cue 并按剔除后的次序重编 1-based 序号', () {
+      final RetimingInputCues input = retimingCuesFromAudioCues(<AudioCue>[
+        _cue('первый', 0, 1000),
+        _cue('second', 2000, 3000),
+      ]);
+
+      expect(input.droppedCount, 0);
+      expect(input.cues.map((SubtitleCue c) => c.index), <int>[1, 2]);
+      expect(input.cues.first.text, 'первый');
+      expect(input.cues.last.startMs, 2000);
+    });
+
+    test('剔掉退化 cue：空正文 / 零长 / 逆序 / 负起点，并如实计数', () {
+      final RetimingInputCues input = retimingCuesFromAudioCues(<AudioCue>[
+        _cue('keep', 0, 1000),
+        _cue('   ', 1000, 2000), // 空白正文
+        _cue('zero', 2000, 2000), // 零长
+        _cue('reversed', 4000, 3000), // 逆序
+        _cue('negative', -5, 100), // 负起点
+        _cue('tail', 5000, 6000),
+      ]);
+
+      expect(input.droppedCount, 4);
+      expect(
+          input.cues.map((SubtitleCue c) => c.text), <String>['keep', 'tail']);
+      // 序号必须连续，否则渲染出的 SRT 序号会有洞。
+      expect(input.cues.map((SubtitleCue c) => c.index), <int>[1, 2]);
+    });
+
+    test('全部退化时判空，调用方据此不跑对轴', () {
+      expect(retimingCuesFromAudioCues(<AudioCue>[_cue('', 0, 0)]).isEmpty,
+          isTrue);
+      expect(retimingCuesFromAudioCues(<AudioCue>[]).isEmpty, isTrue);
+    });
+  });
+
+  group('retimedSubtitleFileName', () {
+    test('剥掉原扩展名，产出 .retimed.srt', () {
+      expect(retimedSubtitleFileName('ep01.zh.ass'), 'ep01.zh.retimed.srt');
+      expect(retimedSubtitleFileName('movie.mkv'), 'movie.retimed.srt');
+      expect(retimedSubtitleFileName('nodots'), 'nodots.retimed.srt');
+    });
+
+    test('档名被占用时补序号，不覆盖上一次的结果', () {
+      expect(
+        retimedSubtitleFileName('ep01.mkv',
+            taken: <String>{'ep01.retimed.srt'}),
+        'ep01.retimed-2.srt',
+      );
+      expect(
+        retimedSubtitleFileName(
+          'ep01.mkv',
+          taken: <String>{'ep01.retimed.srt', 'ep01.retimed-2.srt'},
+        ),
+        'ep01.retimed-3.srt',
+      );
+    });
+
+    test('空名兜底，不产出以点开头的档名', () {
+      expect(retimedSubtitleFileName('   '), 'subtitle.retimed.srt');
+      expect(retimedSubtitleFileName('.srt'), 'srt.retimed.srt');
+    });
+  });
+
+  group('retimedSubtitleSummary', () {
+    RetimedSubtitleFile file(Map<String, Object?> stats) => RetimedSubtitleFile(
+          path: 'x.srt',
+          cueCount: 0,
+          droppedInputCues: 0,
+          stats: stats,
+        );
+
+    test('命中率取整成百分比', () {
+      final summary = retimedSubtitleSummary(
+        file(<String, Object?>{
+          'inputCues': 8,
+          'matchedCues': 3,
+          'medianShiftMs': -420,
+        }),
+      );
+      expect(summary.matched, 3);
+      expect(summary.total, 8);
+      expect(summary.percent, 38); // 37.5 -> 38
+      expect(summary.medianShiftMs, -420);
+    });
+
+    test('缺失或类型不对的统计按 0 处理，不抛也不除零', () {
+      final summary = retimedSubtitleSummary(
+        file(<String, Object?>{'inputCues': 'oops'}),
+      );
+      expect(summary.total, 0);
+      expect(summary.percent, 0);
+      expect(summary.medianShiftMs, 0);
+    });
+  });
+
+  group('AsrRetimingTranscription.fromTranscriptSrt', () {
+    late Directory dir;
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp('fushi_retime_');
+    });
+
+    tearDown(() async {
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    });
+
+    test('文件不存在返回 null', () async {
+      expect(
+        await AsrRetimingTranscription.fromTranscriptSrt(
+          p.join(dir.path, 'missing.srt'),
+        ),
+        isNull,
+      );
+    });
+
+    test('非法 SRT 返回 null 而不是抛', () async {
+      final File file = File(p.join(dir.path, 'bad.srt'));
+      await file.writeAsString('这不是字幕');
+      expect(
+        await AsrRetimingTranscription.fromTranscriptSrt(file.path),
+        isNull,
+      );
+    });
+
+    test('合法 SRT 读出 cue；没有 sidecar 时 tokenTimings 为 null', () async {
+      final File file = File(p.join(dir.path, 'ok.srt'));
+      await file.writeAsString(_srt(<(String, int, int)>[
+        ('hello there', 1200, 2200),
+        ('second line', 3200, 4200),
+      ]));
+
+      final AsrRetimingTranscription? transcription =
+          await AsrRetimingTranscription.fromTranscriptSrt(file.path);
+
+      expect(transcription, isNotNull);
+      expect(transcription!.cues.length, 2);
+      expect(transcription.cues.first.startMs, 1200);
+      expect(transcription.tokenTimings, isNull);
+    });
+  });
+
+  group('retimeVideoSubtitleToFile', () {
+    late Directory dir;
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp('fushi_retime_out_');
+    });
+
+    tearDown(() async {
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    });
+
+    Future<String> writeTranscript(List<(String, int, int)> rows) async {
+      final File file = File(p.join(dir.path, 'transcript.srt'));
+      await file.writeAsString(_srt(rows));
+      return file.path;
+    }
+
+    test('按 ASR 锚点把整体偏掉的字幕拉回来，并落一份新档', () async {
+      // 字幕整体早了 2 秒；ASR 转录给出真实时间。
+      const List<String> lines = <String>[
+        'the quick brown fox jumps',
+        'over the lazy dog again',
+        'pack my box with five dozen',
+      ];
+      final String transcript = await writeTranscript(<(String, int, int)>[
+        (lines[0], 10000, 12000),
+        (lines[1], 14000, 16000),
+        (lines[2], 18000, 20000),
+      ]);
+
+      final RetimedSubtitleFile? out = await retimeVideoSubtitleToFile(
+        subtitleCues: <AudioCue>[
+          _cue(lines[0], 8000, 10000),
+          _cue(lines[1], 12000, 14000),
+          _cue(lines[2], 16000, 18000),
+        ],
+        transcriptSrtPath: transcript,
+        outputDirectory: dir,
+        baseName: 'ep01.mkv',
+      );
+
+      expect(out, isNotNull);
+      expect(p.basename(out!.path), 'ep01.retimed.srt');
+      expect(File(out.path).existsSync(), isTrue);
+      expect(out.droppedInputCues, 0);
+      expect(out.matchedCues, greaterThan(0));
+
+      final List<SubtitleCue> written =
+          parseRetimingSubtitles(await File(out.path).readAsString());
+      expect(written.length, 3);
+      // 正文一个字都不许动。
+      expect(written.map((SubtitleCue c) => c.text), lines);
+      // 时间被拉到了转录给的位置（允许算法在锚点上留少量余量）。
+      expect((written.first.startMs - 10000).abs(), lessThan(500));
+      expect((written.last.startMs - 18000).abs(), lessThan(500));
+    });
+
+    test('转录读不出来时返回 null，不留半份档', () async {
+      final File bad = File(p.join(dir.path, 'bad.srt'));
+      await bad.writeAsString('nonsense');
+
+      final RetimedSubtitleFile? out = await retimeVideoSubtitleToFile(
+        subtitleCues: <AudioCue>[_cue('hello there', 0, 1000)],
+        transcriptSrtPath: bad.path,
+        outputDirectory: dir,
+        baseName: 'ep01.mkv',
+      );
+
+      expect(out, isNull);
+      expect(
+        dir.listSync().where(
+            (FileSystemEntity e) => p.basename(e.path).contains('retimed')),
+        isEmpty,
+      );
+    });
+
+    test('输入 cue 全退化时不跑对轴', () async {
+      final String transcript = await writeTranscript(
+          <(String, int, int)>[('anything at all', 0, 1000)]);
+
+      expect(
+        await retimeVideoSubtitleToFile(
+          subtitleCues: <AudioCue>[_cue('  ', 0, 1000)],
+          transcriptSrtPath: transcript,
+          outputDirectory: dir,
+          baseName: 'ep01.mkv',
+        ),
+        isNull,
+      );
+    });
+
+    test('同一部片跑两次留下两份档，不覆盖上一次', () async {
+      const String line = 'the quick brown fox jumps';
+      final String transcript =
+          await writeTranscript(<(String, int, int)>[(line, 10000, 12000)]);
+      final List<AudioCue> cues = <AudioCue>[_cue(line, 8000, 10000)];
+
+      final RetimedSubtitleFile? first = await retimeVideoSubtitleToFile(
+        subtitleCues: cues,
+        transcriptSrtPath: transcript,
+        outputDirectory: dir,
+        baseName: 'ep01.mkv',
+      );
+      final RetimedSubtitleFile? second = await retimeVideoSubtitleToFile(
+        subtitleCues: cues,
+        transcriptSrtPath: transcript,
+        outputDirectory: dir,
+        baseName: 'ep01.mkv',
+      );
+
+      expect(p.basename(first!.path), 'ep01.retimed.srt');
+      expect(p.basename(second!.path), 'ep01.retimed-2.srt');
+      expect(File(first.path).existsSync(), isTrue);
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -882,11 +882,20 @@ packages:
     source: sdk
     version: "0.0.0"
   fushi_asr_core:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "packages/asr_core"
-      ref: ac67a2e92800a334f46124f4b4461ce04f8283a2
-      resolved-ref: ac67a2e92800a334f46124f4b4461ce04f8283a2
+      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      url: "https://github.com/hajisensai/fushi-subtitles.git"
+    source: git
+    version: "0.1.0"
+  fushi_asr_subtitles:
+    dependency: transitive
+    description:
+      path: "packages/asr_subtitles"
+      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -136,6 +136,16 @@ dependency_overrides:
   # See third_party/flutter_onnxruntime/PATCHES.md.
   flutter_onnxruntime:
     path: third_party/flutter_onnxruntime
+  # fushi_asr_subtitles 的 pubspec 把 fushi_asr_core 写成 `^0.1.0`（上游 workspace 里
+  # 靠 workspace 解析），我们从 git 单包引进来时 pub 会把它当 hosted 去 pub.dev 找 ——
+  # 那儿没有这个包（publish_to: none），于是 "fushi_asr_subtitles from git is forbidden"。
+  # 这条 override 把它钉回同仓同 sha 的 git 源；ref 必须与 fushi/pubspec.yaml 里那两条
+  # 逐字一致，否则同一份算法会被解析成两个副本。
+  fushi_asr_core:
+    git:
+      url: https://github.com/hajisensai/fushi-subtitles.git
+      path: packages/asr_core
+      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
 
 # Melos 7 的配置位置就是这里（7.0 起 melos.yaml 被废弃）。包列表不再重复声明：
 # 成员由上面的 workspace: 决定，melos 直接读它。


### PR DESCRIPTION
## 做了什么

视频页新增**字幕模型重定时**：拿设备端 ASR 转录当参照，逐句修正已有字幕的时间轴，结果落成一份新的外挂字幕档并当场切过去。

现有四条调轴路径（手动延迟 / 跳到相邻 cue / 波形自动对轴 / 波形面板）**全部只能整体平移一个 `delayMs`**，修不了：

- **帧率漂移**（23.976↔25 / PAL 拉伸）——越往后偏得越多，一个 offset 按下葫芦起瓢；
- **分段偏移**——片头 OP/CM 剪切、BD/TV 版本差异，前半段对了后半段全崩。

重定时逐句给时间，所以产出是**新档**而不是偏移量：原档一个字节不动，用户随时能在字幕轨列表里切回去比较。

## 算法不在本仓

住在 `fushi-subtitles` 的 `fushi_asr_subtitles`：

- 上游 PR #7 把重定时从 `fushi_asr` 拆成零重依赖的独立包。原来它为了拿 `TranscribeOutcome` 而 import `transcribe_runner`，顺带拖上 `fushi_asr_onnx_ffi`（要 `archive ^4`），而本仓钉 `archive ^3.6.1` —— 引进来等于强制一次 archive 4 大迁移。现在签名换成窄接口 `RetimingTranscription`。
- 上游 PR #8 把归一化原语挪进 `fushi_asr_core/text.dart` 而不是主入口 —— 否则 `AudioTextNormalizer` 会与本仓 `fushi_audio` 的同名类撞成 `ambiguous_import`（实测炸了 `asr_realdata_match_test` 5 处）。

算法本身很克制：只认归一化后**唯一且单调**的文本锚点，锚点之间按分区域时钟模型推（`fitSubtitleClock`，中位数鲁棒估计 + 外推上限），推不出来的段原样保留，**正文与顺序一个字不动**。

## 本仓只加装配与 UI

- `lib/src/media/video/subtitle_retiming_service.dart`：`AudioCue` → `SubtitleCue`、转录产物（SRT + 同序 token 时间 sidecar）包成 `RetimingTranscription`、结果落成新外挂字幕档。sidecar 行数与 cue 数不符时**整份丢弃**（与 `attachAsrCueTokenTiming` 同一条纪律：错位的 token 时间比没有更糟）。
- 视频页「字幕」分类新增「用语音模型重定时」一行，本地视频 + 本机支持 ASR 才出现。转录整段复用有声书那个弹层（模型下载 / 进度 / 暂停取消 / 语音语言选择都在里面），结果走既有外挂字幕导入链路（`_importExternalSubtitle`）应用。
- 命中率 < 40% 不当成功报，明确提示去查语音语言与集数。
- 退化 cue（空正文 / 零长 / 逆序 / 负起点）先剔掉再送算法，剔了几条如实告诉用户，**不悄悄补假时间窗**。
- 重复跑不覆盖上一次的结果（`ep01.retimed.srt` → `ep01.retimed-2.srt`）。

顺带白送的能力：视频页此前**一个 ASR 入口都没有**（三个入口全在有声书 / 阅读器），这条链路接上之后「无字幕视频一键生成字幕」也在同一处了。

## 依赖

`fushi_asr_core` 升 pin 到 `78a5241`，新增 `fushi_asr_subtitles`（同仓同 sha）。根 pubspec 加一条 `fushi_asr_core` 的 git override —— 新包的 pubspec 写的是 `fushi_asr_core: ^0.1.0`（上游靠 workspace 解析），单包从 git 引进来时 pub 会当 hosted 去 pub.dev 找，解析会直接失败。

## 验证

- `dart analyze --fatal-infos` 全仓（含 test）：`No issues found!`
- 新测试 15 条全绿，含端到端「整体偏 2 秒的字幕被拉回转录给的时间」，并断言正文逐字不变。
- 定向：`test/asr` 47、`test/i18n` 24、`test/media/audiobook` 1049 全绿。
- `test/media/video` 批量跑时 `anidb_udp_file_client_test` 红一条；单跑该文件 16 条全绿 —— 真 UDP 绑端口的并发抢占伪红，与本改动无逻辑关联。
- rebase 到最新 develop 后重跑 analyze + 上述定向，全绿。

## 已知缺口

- 15 种非中英语言暂为英文占位（`i18n_sync --add` 的既有欠账）。
- 未做真机验证（用户已明确取消真机验证要求）。图形字幕轨（PGS/VobSub）没有文本 cue，入口对它不可用——这是算法前提，不是缺陷。

https://claude.ai/code/session_01BGF3mZNHAd7TN643Yso7uD
