### PR TITLE
fix(test): 修 develop 单测门红——降级保护守卫把「未来版本」写死成 99，schema 升到 99 后失效

### DIFF
--- a/packages/fushi_core/test/migration_downgrade_test.dart
+++ b/packages/fushi_core/test/migration_downgrade_test.dart
@@ -2,6 +2,13 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+/// 比当前代码 schema 高一级的版本号，用来伪造「未来版本的库」。
+///
+/// **必须从代码派生，不能写死。** 读 `schemaVersion` 只是取一个常量 getter，
+/// 不会触发 lazy open，所以这个探针实例不建表、不落盘。
+final int kFutureSchemaVersion =
+    FushiDatabase.forTesting(NativeDatabase.memory()).schemaVersion + 1;
+
 /// Regression guard for the DOWNGRADE-PROTECTION branch in
 /// FushiDatabase.migration (database.dart `if (from > to)`).
 ///
@@ -14,15 +21,20 @@ import 'package:fushi_core/fushi_core.dart';
 /// app layer catches it and shows an "update your app" notice.
 ///
 /// These tests therefore assert the OPPOSITE of the old ones: the open must be
-/// REFUSED (throw), never silently rebuilt. Seeds user_version = 99 (well above
-/// the current schema) to force the `from > to` path regardless of how high the
-/// real [FushiDatabase.schemaVersion] climbs, so the guard never goes stale on a
-/// schema bump.
+/// REFUSED (throw), never silently rebuilt.
+///
+/// The seeded "future" version is **derived from the code** ([kFutureSchemaVersion]),
+/// not a hand-picked constant. It used to be a literal 99 with a comment claiming
+/// 99 "never goes stale on a schema bump" — that held right up until the schema
+/// actually reached 99 (v98 → v99, per-source metadata locale + scrape field
+/// locks), at which point 99 stopped being a future version, the `from > to`
+/// branch never ran, and these guards went green-by-vacuum on develop's package
+/// test gate. Derive it and the assumption cannot rot.
 Future<FushiDatabase> _openDowngradedFromFuture() async {
   return FushiDatabase.forTesting(
     NativeDatabase.memory(
       setup: (rawDb) {
-        // Seed a DB that claims to be a FUTURE version (99 > current) with a
+        // Seed a DB that claims to be a FUTURE version (schemaVersion + 1) with a
         // real row, so a destructive rebuild (if it ever regressed back) would
         // be observable as data loss.
         rawDb.execute('''
@@ -45,7 +57,7 @@ CREATE TABLE epub_books (
           "(book_key, title, epub_path, extract_dir, chapter_count, chapters_json, imported_at) "
           "VALUES ('stale future row', 'stale future row', '/x.epub', '/x', 0, '[]', 0)",
         );
-        rawDb.execute('PRAGMA user_version = 99');
+        rawDb.execute('PRAGMA user_version = $kFutureSchemaVersion');
       },
     ),
   );
@@ -93,7 +105,7 @@ CREATE TABLE book_tag_mappings (
         rawDb.execute(
           "INSERT INTO book_tag_mappings (book_key, tag_id) VALUES ('b', 1)",
         );
-        rawDb.execute('PRAGMA user_version = 99');
+        rawDb.execute('PRAGMA user_version = $kFutureSchemaVersion');
       },
     ),
   );
@@ -105,13 +117,13 @@ void main() {
     final FushiDatabase db = await _openDowngradedFromFuture();
     addTearDown(db.close);
 
-    // Reading forces the lazy DB to open, which triggers onUpgrade(99 -> current)
+    // Reading forces the lazy DB to open, which triggers onUpgrade(future -> current)
     // and must throw the protection exception instead of dropping/rebuilding.
     await expectLater(
       db.customSelect('PRAGMA user_version').getSingle(),
       throwsA(isA<FushiDatabaseDowngradeException>()
           .having((FushiDatabaseDowngradeException e) => e.dbVersion,
-              'dbVersion', 99)
+              'dbVersion', kFutureSchemaVersion)
           .having((FushiDatabaseDowngradeException e) => e.appSchemaVersion,
               'appSchemaVersion', db.schemaVersion)),
       reason: 'a newer-schema DB must be refused to protect user data, '

--- a/packages/fushi_core/test/migration_paired_peers_v31_test.dart
+++ b/packages/fushi_core/test/migration_paired_peers_v31_test.dart
@@ -3,6 +3,11 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
 
+/// 比当前代码 schema 高一级的版本号，用来伪造「未来版本的库」。读 `schemaVersion`
+/// 只是取常量 getter，不触发 lazy open，探针实例不建表、不落盘。
+final int kFutureSchemaVersion =
+    FushiDatabase.forTesting(NativeDatabase.memory()).schemaVersion + 1;
+
 /// TODO-1017 阶段1：互联 per-peer 授权凭据表 fushi_paired_peers 的建表迁移
 /// （v30 -> v31；历史上以旧名 hibiki_paired_peers 建出，v69 起统一新名）与
 /// DB 方法的守护测试。
@@ -51,8 +56,12 @@ CREATE TABLE epub_books (
   );
 }
 
-/// 手写一个「未来版本」库（user_version = 99 > 代码 schemaVersion）以强制走降级
-/// 保护分支，且 99 恒大于任何未来 bump 不会 stale。
+/// 手写一个「未来版本」库以强制走降级保护分支。
+///
+/// 版本号**从代码派生**（[kFutureSchemaVersion] = 当前 schemaVersion + 1），不写死。
+/// 这里原本是字面量 99，注释还写着「99 恒大于任何未来 bump 不会 stale」——直到
+/// schema 真的升到 99（v98 → v99：每来源资料语言 + 刮削字段锁），99 就不再是未来
+/// 版本，`from > to` 分支根本不进，这条守卫在 develop 的 package 测试门上空转。
 FushiDatabase _openDowngradedFromFuture() {
   return FushiDatabase.forTesting(
     NativeDatabase.memory(
@@ -70,7 +79,7 @@ CREATE TABLE fushi_paired_peers (
           "INSERT INTO fushi_paired_peers "
           "(peer_id, token, paired_at_ms) VALUES ('p-future', 'tok', 1)",
         );
-        raw.execute('PRAGMA user_version = 99');
+        raw.execute('PRAGMA user_version = $kFutureSchemaVersion');
       },
     ),
   );
@@ -182,7 +191,7 @@ void main() {
       db.customSelect('PRAGMA user_version').getSingle(),
       throwsA(isA<FushiDatabaseDowngradeException>()
           .having((FushiDatabaseDowngradeException e) => e.dbVersion,
-              'dbVersion', 99)
+              'dbVersion', kFutureSchemaVersion)
           .having((FushiDatabaseDowngradeException e) => e.appSchemaVersion,
               'appSchemaVersion', db.schemaVersion)),
       reason: 'a newer-schema DB must be refused, never destructively rebuilt',


### PR DESCRIPTION
**develop 现在的 Build Release APK 是红的**（`2.3.0+1262`，run [34295332459](https://github.com/hajisensai/Fushi/actions/runs/34295332459)），红在 `Run package tests`。这条修它。

## 根因

`packages/fushi_core/test/` 里三条降级保护守卫造「未来版本的库」时把 `user_version` 写死成 **99**：

- `migration_downgrade_test.dart` — `opening a future-version DB is refused, not destructively rebuilt`、`BUG-075: future-version refusal is clean under foreign_keys=ON`
- `migration_paired_peers_v31_test.dart` — `opening a future-version DB is refused with the downgrade exception`

两处注释还都写着「99 恒大于任何未来 bump 不会 stale」。这个假设在 schema 升到 99（v98 → v99，每来源资料语言 + 刮削字段锁）那一刻失效：99 不再大于当前版本，`database.dart` 的 `if (from > to)` 降级保护分支根本不进，`expectLater(..., throwsA(FushiDatabaseDowngradeException))` 拿到的是正常返回的 `QueryRow`。

三条守卫护的是 **BUG-075 家族**——历史上打开高版本库会 DROP 掉所有表重建，把用户书库抹掉过两次。守卫失效意味着这条数据保护回归不再有人看着。

## 修法

不换一个更大的硬编码数字（那只是把腐烂推迟），改成**从代码派生**：

```dart
final int kFutureSchemaVersion =
    FushiDatabase.forTesting(NativeDatabase.memory()).schemaVersion + 1;
```

读 `schemaVersion` 只是取常量 getter，不触发 drift 的 lazy open，所以这个探针实例不建表、不落盘。此后任何 schema bump 都不会让这三条守卫 stale。

其余 `expect(db.schemaVersion, 99)` 是**钉当前版本**的正确断言（bump 时本来就该改），不动；`fushi/test/database/downgrade_protection_test.dart` 之前已被改成 999，语义正确，本条也不动它。

## 我的责任

这是那次 schema bump 的漏网：连带断言我只扫了 `fushi/test`，没扫 `packages/*/test`。后者只有 CI 的 `Run package tests` 会跑 —— 本地按爆炸半径挑的定向测试结构上碰不到它，`flutter analyze` 也不覆盖 `packages/*`。

## 验证

| 项 | 结果 |
|---|---|
| `packages/fushi_core` 全量 `flutter test` | **82 passed**，exit 0（改前 3 红） |
| `packages/fushi_core` `dart analyze --fatal-infos` | No issues found |
| 全仓扫描其它 `user_version = 99` / `'dbVersion', 99` | 无残留 |

https://claude.ai/code/session_01MHXgvA2egBwp6S9iQSWTNH
