### PR TITLE
fix(reader): 分页落页列号补 column-gap 下侧容差，治有声书跟随退回前一页（BUG-2325）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2135 条。点号进各自文件。
+> 共 2136 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-2326](bugs/BUG-2326-lyrics-mode-top-chrome.md) | ✅ | ✅ | 歌词模式没有顶栏，也没有回到阅读模式的入口 |
+| [BUG-2325](bugs/BUG-2325-audiobook-follow-flips-back-one-page.md) | ✅ | ✅ | 有声书跟随播放时视口自己退回前一页，下一句又翻回来 |
 | [BUG-2286](bugs/BUG-2286-episode-only-filenames-split-into-cards.md) | ✅ | ✅ | 文件名只剩集号时每集各成一张卡，整部番被拆成一堆分开的条目 |
 | [BUG-2285](bugs/BUG-2285-fribb-tmdb-id-shape-misparsed.md) | ✅ | ✅ | Fribb 映射表的 themoviedb_id 是对象不是裸数字、TVDB 键是 tvdb_id，解析用错形状导致 TMDB id 恒为 null |
 | [BUG-2284](bugs/BUG-2284-lookup-popup-instant-scroll.md) | ✅ | ✅ | 查词弹窗「瞬时滚动」开关对滚轮完全无效 |

--- a/docs/bugs/BUG-2325-audiobook-follow-flips-back-one-page.md
+++ b/docs/bugs/BUG-2325-audiobook-follow-flips-back-one-page.md
@@ -1,0 +1,71 @@
+## BUG-2325 · 有声书跟随播放时视口自己退回前一页，下一句又翻回来
+
+- **报告**：2026-09-09（用户录屏 `ee86b45ffce1fd7add2efba0022bff58.mp4` + 当晚 adb 现场复现一次；设备 HiBreak 墨水屏 Android 14，824x1648 @300dpi，app 2.3.0-debug.13961，书=無職転生 21 第 10 节，竖排分页 + 有声书跟随）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/reader/reader_pagination_scripts.dart` 的 `alignToPage`（落页列号函数在列边界上是**零余量**的等号判据）+ `getScrollContext` 的 `pageStep` 与浏览器真实列周期之间**每页累积**的亚像素差。
+- **[x] ① 已修复** — `alignToPage` 补**下侧容差 column-gap**（`getScrollContext` 把 gap 挂进 context）；`scrollToCharOffset` 的 `charPage` 改走同一个列号函数（旧实现连相位都没减）；章首落点 `alignContentStartToPage` 刻意不吃容差。见本 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reveal_column_grid_drift_test.dart`（真机几何漂移率下第 1~1900 页列顶首字不得退页 + 去掉容差立刻复现症状 + BUG-1764/875 双向回归锁 + JS 源码三段守卫）。
+- **备注**：修复在**真机几何的 headless 真渲染**里验证（修前 30~112 次/章 → 修后 0），**未在物理设备上验证**——本机没有 release 签名 keystore，自建包签名不同，装上去必须先卸载，会连同用户阅读进度一起清掉，故不做。真机复验需等一个带签名的 CI 包。
+
+### 症状（用户可见）
+
+竖排分页 + 有声书跟随播放，读到某一句时**没有任何操作**，视口自己退回上一页；约 1~2 秒后下一句又把它翻回来。退回的那一句无一例外是**句首恰好落在列顶**的句子。
+
+### 真机证据（2026-09-09 现场 adb 抓取）
+
+logcat 里 13 秒窗口内只有两类应用日志，**一一配对、间隔恒定 ~0.9 秒**（reveal → 250ms settle 补刷 → 500ms 去抖落库）：
+
+| 时刻 | 日志 | 视口首字 |
+|---|---|---|
+| 38.939 / 39.848 | `highlightCue` → `save position … charOffset=5126` | A 页（`しかし、`） |
+| 41.142 / 42.035 | `highlightCue` → `save … charOffset=5157` | B 页（`「それで納得されないのであれば、`） |
+| 42.762 / 43.655 | `highlightCue` → `save … charOffset=5126` | **退回 A 页** |
+| 44.560 / 45.456 | `highlightCue` → `save … charOffset=5157` | 又翻回 B 页 |
+| 48.302 / 49.187 | `highlightCue` → `save … charOffset=5218` | 继续前进 |
+
+- `charOffset` 是 `fushiProgressDetails` 第三段 = `getFirstVisibleCharOffset()`（视口首字），所以 5126→5157→5126→5157 是**视口真的在两页之间来回**，不是只有落库数字回退。
+- 窗口内**没有** `[FushiInit]`（无章节重载）、**没有** `_syncPageSize`（无重分页），无任何 Dart 异常 —— 能动视口的只剩 JS 落页。
+- 本机库 `audio_cues` 实证该段坐标（sentence_index 3255..3262）：`しかし、`5126..5129 / … / `「それで納得されないのであれば、`5157..5171 / `せっかく仲良くなりかけた友人と、`5171..5186 / …。三个落库 charOffset（5126/5157/5233）**恰好等于** cue 的 `ns` 起点，两套坐标同一量纲。退回发生在 B 页**首句**（其首字恰在列顶）那次跟随上。
+
+### 根因
+
+分页落页的唯一列号函数是 `alignToPage`：`floor((anchor − contentStart) / pageStep)`。BUG-875 / BUG-1764 已经给它补过**相位** `contentStart`，但它在列边界上仍是**零余量的等号判据**——而 `pageStep` 与浏览器真实列周期之间存在**每页累积**的亚像素差：
+
+- `getScrollContext` 的 `pageStep` 由 `parseFloat(getComputedStyle(body).columnWidth)` 推出，CSSOM 把 used 值**序列化成 3 位小数字符串**；
+- 浏览器排版时把 used 列宽**量化到 LayoutUnit（1/64 px）**。
+
+两者只有在列宽恰好是 1/64 的整数倍时才相等。真机 824x1648 @300dpi → Flutter DPR = 300/160 = **1.875** → CSS 视口高 `1648/1.875 = 878.9333…px`（**小数**）→ used 列宽 `878.9333… − 46 = 832.9333…px` 被量化成 **832.921875px**，而 JS 读到的是 `"832.933px"`：
+
+```
+pageStep(JS)   = 832.933    + 22 = 854.933
+真实列周期      = 832.921875 + 22 = 854.921875
+δ = 0.011125 px / 页（累积）
+```
+
+于是第 j 列的真实起始坐标比网格线 `j·pageStep` **低 j·δ**：第 9 页低过 0.1px，第 89 页低近 1px。**列顶首字**的 reveal 锚恰好等于该列真实起始坐标，裸 floor 就把它判进**前一列** → 视口退回上一页；下一句 cue 不在列顶、锚离网格线远，于是又翻回来。整数 CSS 视口（列宽本就是 1/64 倍数）δ=0，所以这条**只在小数 DPR 的设备上现形**——也解释了为什么既有用例、既有探针（都用整数几何）一直全绿。
+
+同一个漂移也打在 `scrollToCharOffset` 上（精确锚恢复 / 样式重锚 commit 落到「页首字」时同样退回前一列），而且那里连相位 `contentStart` 都没减，是独立于本 bug 的旧漏。
+
+### 修复
+
+- `getScrollContext` 把 `column-gap` 挂进 context（`columnGap`）。
+- `alignToPage` 改成 `floor((offset − contentStart + gap) / pageSize)`：网格线之前那一段恰好是 column-gap，**里面没有任何内容**（前一列内容盒在 gap 之前就结束了），落进 gap 带的锚只可能是后一列被漂移带下来的列顶字，按「gap 归属后一列」定义列号即可。容差是几何真值 22px（按上面的漂移率能兜约 1900 页），不是拍脑袋的 ε；列内任意位置（含列末最后一像素）仍落本列，BUG-875 / BUG-1764 两个方向都不受影响。
+- `scrollToCharOffset` 的 `charPage` 改走 `alignToPage`（同时补上它缺的相位）。
+- `alignContentStartToPage`（章首 `minScroll`）**刻意不吃**这条容差：那里的语义是「绝不跳过首行」，吃了容差反而会把首行内容边推进下一列（TODO-1179）。
+
+**没有**去改 `pageStep` 本身：把它量化到 1/64 是 Blink 实现细节、跨引擎不成立；改列周期口径会动到 `paginate` / `minScroll` / 全部恢复落页路径（TODO-753/792 的历史）。漂移在渲染上的另一面（第 845 页时页对齐差约 9.4px）属于那条更深的账，本次不动。
+
+### 验证
+
+真渲染探针：`test/reader/reader_headless_shell_dump_test.dart` 产出的**真引擎** shell + 该章**真实 xhtml 正文**（`p-003.xhtml`，1695 段 / 57697 字）+ 从本机库导出的**该节全部 4026 条真实 cue**（含真实 `ns/ne`），按**真机几何**（DPR 1.875、小数 CSS 视口、column-width 用 calc + CSS 变量让浏览器全精度算）逐句走真 `scrollToRange`：
+
+| 配置（字号 / chrome inset） | 修前退回次数 | 修后 |
+|---|---|---|
+| 22 / 0 | 30 | 0 |
+| 40 / 0 | 81 | 0 |
+| 46 / 0 | 81 | 0 |
+| 52 / 0 | 101 | 0 |
+| 46 / 上18 下56（挤压态，contentStart=18） | 112 | 0 |
+
+对照：同一套数据换成**整数** CSS 视口（824x824、DPR 1~3、字号 42~50、行高 1.5~1.9、含高精度小数边距共 20 组、约 8 万次 reveal）修前修后都是 0 —— 与「δ 只在小数视口下非零」的推导一致。
+
+另：本 PR 分支（基于 upstream/develop）上 `flutter analyze` 全绿，分页相关 14 个测试文件共 150 例全绿。

--- a/fushi/lib/src/reader/reader_pagination_scripts.dart
+++ b/fushi/lib/src/reader/reader_pagination_scripts.dart
@@ -282,15 +282,23 @@ class ReaderPaginationScripts {
   /// 横排 `padding-left`）。滚动坐标原点是 body 的 padding box，列内容却从 content box
   /// 起始边开始，故列 j 的起始滚动坐标 = `contentStart + j*pageSize`。不减相位就等于把
   /// 网格整体平移了 contentStart，见 `alignToPage` 注释与 BUG-1764/BUG-875。
+  ///
+  /// [columnGap] 是 BUG-2325 的落页下侧容差：`pageSize` 由 CSSOM 序列化的列宽（3 位小数）
+  /// 推出，浏览器排版却把 used 列宽量化到 1/64 px，两者每页差一点点并**累积**，于是第 j 列
+  /// 的真实起始坐标比网格线 `j*pageSize` 低 j·δ —— 列顶首字的 anchor 就被 floor 判进前一列
+  /// （用户可见：有声书跟随读到列顶那句时视口退回上一页）。网格线之前的 column-gap 带没有
+  /// 任何内容，落进去的锚只可能是后一列的列顶字，故按「gap 归属后一列」定义列号。默认 0 =
+  /// 旧语义（既有相位契约用例口径不变）；JS `alignToPage` 恒传 `context.columnGap`。
   @visibleForTesting
   static double revealAnchorTargetScrollForTesting({
     required double rectStart,
     required double currentScroll,
     required double pageSize,
     double contentStart = 0,
+    double columnGap = 0,
   }) {
     if (pageSize <= 0) return currentScroll;
-    final double anchor = rectStart + currentScroll - contentStart;
+    final double anchor = rectStart + currentScroll - contentStart + columnGap;
     final double safe = anchor < 0 ? 0 : anchor;
     return (safe / pageSize).floorToDouble() * pageSize;
   }
@@ -312,6 +320,7 @@ class ReaderPaginationScripts {
     required double currentScroll,
     required double pageSize,
     double contentStart = 0,
+    double columnGap = 0,
   }) {
     if (pageSize <= 0) return null;
     final double target = revealAnchorTargetScrollForTesting(
@@ -319,6 +328,7 @@ class ReaderPaginationScripts {
       currentScroll: currentScroll,
       pageSize: pageSize,
       contentStart: contentStart,
+      columnGap: columnGap,
     );
     if (target == currentScroll) return null;
     return target;
@@ -2209,7 +2219,10 @@ $_sharedJs
       maxScroll: maxScroll,
       physicalMaxScroll: physicalMaxScroll,
       viewportExtent: viewportExtent,
-      contentStart: contentStart
+      contentStart: contentStart,
+      // BUG-2325：列间距。alignToPage 拿它当「落页网格的下侧容差」——gap 带里没有任何
+      // 内容，落进去的锚只可能是后一列列顶被网格漂移带到线下的字。见 alignToPage。
+      columnGap: gap
     };
   },
   getPagePosition: function(context) {
@@ -2280,8 +2293,30 @@ $_sharedJs
     // 减相位后 alignToPage 就是精确的列号函数，两个方向的错判同时消失，不需要任何可见性特例。
     // 返回值仍落在 j*pageSize 的滚动网格上（页对齐后内容起始边露出 contentStart 的页边距，
     // 与 paginate / pageStepPosition / minScroll 的网格严格同源，网格本身零变化）。
+    //
+    // BUG-2325（真机 HiBreak 竖排：有声书跟随读到「句首恰在列顶」的句子时退回前一页，下
+    // 一句又翻回来）：列号函数还必须带**下侧容差**，否则它在列边界上是零余量的等号判据。
+    // 根因是 pageStep 与浏览器真实列周期之间存在**每页累积**的亚像素差：
+    //   · pageStep 由 `parseFloat(getComputedStyle(body).columnWidth)` 推出，而 CSSOM 把
+    //     used 值序列化成 3 位小数字符串；
+    //   · 浏览器内部把 used 列宽量化到 LayoutUnit（1/64 px）再排版。
+    //   两者只有在列宽恰好是 1/64 的整数倍时才相等。真机 824x1648@300dpi → DPR 1.875 →
+    //   CSS 视口高 878.9333…px（小数！）→ used 列宽 832.9333…px 被量化成 832.921875px，
+    //   而 JS 读到 "832.933px" → pageStep 每页比真实列周期大 0.0111px。第 j 列的真实起始
+    //   坐标因此比网格线 j*pageStep 低 j*0.0111px：第 9 页起就低过 0.1px，第 89 页低近 1px。
+    //   列顶首字的 anchor 恰好等于该列真实起始坐标，于是 floor 把它判进**前一列** → 视口
+    //   退回上一页；下一句 cue 不在列顶，anchor 远离网格线，又翻回来。整数 CSS 视口（列宽
+    //   本就是 1/64 倍数）零漂移，所以这条只在小数 DPR 设备上现形。
+    // 网格线之前恰好是 column-gap 那一段，**没有任何内容**（前一列内容盒在 gap 之前就结束
+    // 了），所以落进 gap 带的锚只可能是后一列被漂移带下来的列顶字。列号按「gap 归属后一列」
+    // 定义即可，容差用的是几何真值 gap(22px)，不是拍脑袋的 ε：按上面的漂移率能兜住约 1900
+    // 页，且列内任意位置（含列末最后一像素，anchor−phase+gap < (j+1)*pageSize）仍落本列，
+    // BUG-875 / BUG-1764 两个方向都不受影响。
+    // 不去改 pageStep 本身（把它量化到 1/64 是 Blink 实现细节、跨引擎不成立；改列周期口径
+    // 会动到 paginate/minScroll/restore 全部落页路径，见 TODO-753/792 的历史）。
     var phase = context.contentStart || 0;
-    return Math.floor(Math.max(0, offset - phase) / context.pageSize) * context.pageSize;
+    var gapTolerance = context.columnGap || 0;
+    return Math.floor(Math.max(0, offset - phase + gapTolerance) / context.pageSize) * context.pageSize;
   },
   alignContentStartToPage: function(context, offset) {
     // TODO-1179：章首落点只能向下偏置到「包含首行内容边」的那一页。firstContentEdge
@@ -2291,7 +2326,11 @@ $_sharedJs
     // 「含首行」那页，绝不跳过首行（宁可多显示半列 padding）。与 scrollToCharOffset /
     // scrollToProgressPaged 的 floor(alignToPage) 落页锚同量纲；此函数只被 minScroll
     // 一处调用，无其它场景受影响。
-    return this.alignToPage(context, offset);
+    // BUG-2325：alignToPage 起带 gap 下侧容差（列顶字不再被网格漂移判进前一列）；章首落点
+    // **不吃**这条容差——这里的语义是「绝不跳过首行」，首行内容边真落在前一列末时必须留在
+    // 前一列，吃了容差反而会把它推进下一列、跳过首行。故保留裸相位 floor。
+    var phase = context.contentStart || 0;
+    return Math.floor(Math.max(0, offset - phase) / context.pageSize) * context.pageSize;
   },
   pageStepPosition: function(currentScroll, pitch) {
     if (pitch <= 0) return currentScroll;
@@ -2817,7 +2856,10 @@ $_sharedJs
     var scrollOffset = context.vertical
       ? (context.scrollEl.scrollTop + rect.top)
       : (context.scrollEl.scrollLeft + rect.left);
-    var charPage = Math.floor(Math.max(0, scrollOffset) / context.pageSize);
+    // BUG-2325：字符落页走同一个列号函数 alignToPage（减相位 + gap 下侧容差）。旧的裸
+    // floor(scrollOffset/pageSize) 既漏了相位 contentStart，也吃不住上面那条每页累积的
+    // 网格漂移：精确锚恢复 / 样式重锚 commit 落到「页首字」时同样会退回前一列。
+    var charPage = Math.round(this.alignToPage(context, scrollOffset) / context.pageSize);
     var aligned;
     if (hintScroll !== undefined) {
       // Page-stable hint: if the target char is within one page of where we

--- a/fushi/test/reader/reveal_column_grid_drift_test.dart
+++ b/fushi/test/reader/reveal_column_grid_drift_test.dart
@@ -1,0 +1,221 @@
+// BUG-2325 · 分页落页网格的**累积漂移**容差契约。
+//
+// 症状（真机 HiBreak 墨水屏，竖排分页 + 有声书跟随）：读到某一句时视口自己退回上一页，
+// 下一句又翻回来。退回的那句无一例外是**句首恰好落在列顶**的句子。
+//
+// 根因不是相位（BUG-875/1764 那条已修），而是 `pageStep` 与浏览器真实列周期之间存在
+// **每页累积**的亚像素差：
+//   · `getScrollContext` 的 pageStep 由 `parseFloat(getComputedStyle(body).columnWidth)`
+//     推出，而 CSSOM 把 used 值序列化成 3 位小数字符串；
+//   · 浏览器排版时把 used 列宽量化到 LayoutUnit（1/64 px）。
+//   两者只有在列宽恰好是 1/64 的整数倍时才相等。真机 824x1648 @300dpi → DPR 1.875 →
+//   CSS 视口高 878.9333…px（小数）→ used 列宽 832.9333…px 被量化成 832.921875px，JS 却
+//   读到 "832.933px"：pageStep 每页比真实列周期大约 0.0111px。
+//
+// 于是第 j 列的真实起始坐标比网格线 `j*pageStep` **低** j·δ。列顶首字的 reveal 锚恰好等于
+// 该列真实起始坐标，裸 floor 就把它判进**前一列** → 视口退回上一页；下一句不在列顶、锚离
+// 网格线远，又翻回来。整数 CSS 视口（列宽本就是 1/64 倍数）δ=0，所以这条只在小数 DPR 设备
+// 上现形——也解释了为什么整数几何的既有用例与探针一直是绿的。
+//
+// 修复：列号函数带**下侧容差** gap —— 网格线之前那一段恰好是 column-gap，里面没有任何内容
+// （前一列内容盒在 gap 之前就结束了），落进去的锚只可能是后一列被漂移带下来的列顶字。
+//
+// 真渲染证据（headless Chrome + 真引擎 shell + 该章真实正文 + 该节 4026 条真实 cue，按真机
+// 几何 DPR 1.875 逐句走 scrollToRange）：修前退回 30~112 次/章（字号 22/40/46/52 与挤压态
+// chrome inset 各一组），修后全部为 0。
+//
+// 本文件是那条决策的纯 Dart 影子（headless WebView 不可用，按项目测试范式：纯函数单测 +
+// 源码守卫）。相位本身（BUG-875 / BUG-1764）由 reveal_viewport_visible_no_flip_test.dart 守。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_pagination_scripts.dart';
+
+void main() {
+  // 真机实测几何（HiBreak 824x1648 @300dpi，DPR 1.875，字号 46）：
+  //   CSS 视口高 V = 1648/1.875 = 878.9333…；used 列宽 = V − F = 832.9333…
+  //   CSSOM 序列化 "832.933px" → pageStep = 832.933 + 22 = 854.933
+  //   浏览器量化 832.921875 → 真实列周期 = 854.921875
+  const double gap = 22.0;
+  const double pageSize = 854.933; // JS 侧网格步长（读序列化列宽推出）
+  const double realPitch = 854.921875; // 浏览器真实列周期（LayoutUnit 量化后）
+  const double drift = pageSize - realPitch; // ≈ 0.011125 px/页，累积
+  const double contentStart = 0.0; // 真机默认上下页边距 0% + 悬浮 chrome
+
+  /// 第 j 列列顶首字的 reveal 锚（= 该列真实起始坐标，绝对文档坐标）。
+  double columnTopAnchor(int column) => contentStart + column * realPitch;
+
+  /// 停在第 j 页时，列顶首字相对视口的起始边（reveal 拿到的 rect 起始边）。
+  double rectStartAt(int column) =>
+      columnTopAnchor(column) - column * pageSize + contentStart;
+
+  double? revealTarget({
+    required double rectStart,
+    required double currentScroll,
+    double columnGap = gap,
+  }) =>
+      ReaderPaginationScripts.revealScrollTargetForTesting(
+        rectStart: rectStart,
+        currentScroll: currentScroll,
+        pageSize: pageSize,
+        contentStart: contentStart,
+        columnGap: columnGap,
+      );
+
+  group('BUG-2325 累积网格漂移下，列顶首字不得被判进前一列', () {
+    test('漂移是真的：真机几何下每页差 ~0.0111px，第 9 页起就超过 0.1px', () {
+      expect(drift, greaterThan(0));
+      expect(drift * 9, greaterThan(0.1));
+      expect(drift * 89, greaterThan(0.98));
+      // 容差必须远大于整章累积量：本章最深 845 页。
+      expect(drift * 845, lessThan(gap));
+    });
+
+    test('症状复现：不带容差时，列顶首字从第 9 页起就退回前一页', () {
+      // 第 9 页：锚比网格线低 9·δ ≈ 0.1px，裸 floor 掉进第 8 页。
+      final double? bare = revealTarget(
+        rectStart: rectStartAt(9),
+        currentScroll: 9 * pageSize,
+        columnGap: 0,
+      );
+      expect(bare, isNotNull, reason: '裸网格判定要翻页 = 症状');
+      expect((bare! / pageSize).round(), 8, reason: '列顶首字被判进前一列 → 用户看到视口退回上一页');
+    });
+
+    test('修复后：第 1~1900 页的列顶首字一律留在本页（不翻页）', () {
+      for (int column = 1; column <= 1900; column++) {
+        expect(
+          revealTarget(
+            rectStart: rectStartAt(column),
+            currentScroll: column * pageSize,
+          ),
+          isNull,
+          reason: '第 $column 页列顶首字仍属本页，reveal 不得移动视口',
+        );
+      }
+    });
+
+    test('容差是几何真值 gap，不是随手的 ε：漂移吃满 gap 之后才退化', () {
+      // 漂移超过一个 gap（约 1978 页）后容差耗尽，如实退回——这是可预期的边界，
+      // 不是静默错误；真实章节远达不到（本章 845 页，drift·845 ≈ 9.4px）。
+      const int beyond = 2100;
+      expect(drift * beyond, greaterThan(gap));
+      expect(
+        revealTarget(
+          rectStart: rectStartAt(beyond),
+          currentScroll: beyond * pageSize,
+        ),
+        isNotNull,
+      );
+    });
+  });
+
+  group('容差不得破坏既有两个方向（BUG-1764 / BUG-875 回归锁）', () {
+    // 用一组干净的整数几何，避免与漂移量纠缠。
+    const double cleanPage = 1000.0;
+    const double cleanBox = cleanPage - gap; // 978
+    const double phase = 60.0;
+    const double font = 22.0;
+    const double current = 2 * cleanPage;
+
+    double? clean(double rectStart) =>
+        ReaderPaginationScripts.revealScrollTargetForTesting(
+          rectStart: rectStart,
+          currentScroll: current,
+          pageSize: cleanPage,
+          contentStart: phase,
+          columnGap: gap,
+        );
+
+    test('BUG-1764：下一页第一句仍然必须翻页', () {
+      expect(clean(phase + cleanPage), current + cleanPage);
+    });
+
+    test('BUG-875：本页行尾单字仍然不得前翻', () {
+      expect(clean(phase + cleanBox - font), isNull);
+    });
+
+    test('列末最后一像素仍属本页（容差恰好不越界）', () {
+      // 列内最大锚 = contentStart + contentBox（不含），加 gap 恰好等于 pageSize。
+      expect(clean(phase + cleanBox - 0.001), isNull);
+    });
+
+    test('句首已滚出视口首边：仍回翻到句首所在页', () {
+      expect(clean(phase - cleanPage + cleanBox - 200), current - cleanPage);
+    });
+  });
+
+  group('源码守卫：JS 侧容差三段线（读 gap → 挂 context → 用进 floor）', () {
+    final String scripts = File(
+      'lib/src/reader/reader_pagination_scripts.dart',
+    ).readAsStringSync();
+
+    String functionBody(String startMarker, String endMarker) {
+      final int start = scripts.indexOf(startMarker);
+      expect(start, greaterThanOrEqualTo(0), reason: '找不到 $startMarker');
+      final int end = scripts.indexOf(endMarker, start);
+      return scripts.substring(start, end >= 0 ? end : scripts.length);
+    }
+
+    test('getScrollContext 把 column-gap 挂进 context', () {
+      final String body = functionBody(
+        'getScrollContext: function()',
+        'getPagePosition: function(context)',
+      );
+      expect(
+        RegExp(r'columnGap\s*:\s*gap').hasMatch(body),
+        isTrue,
+        reason: '容差取自真实 column-gap；不挂进 context 就静默塌成 0',
+      );
+    });
+
+    test('alignToPage 用 context.columnGap 做下侧容差', () {
+      final String body = functionBody(
+        'alignToPage: function(context, offset)',
+        'alignContentStartToPage: function',
+      );
+      expect(
+        RegExp(r'gapTolerance\s*=\s*context\.columnGap').hasMatch(body),
+        isTrue,
+        reason: '写死 0 = 容差失效，BUG-2325 静默回归',
+      );
+      expect(
+        RegExp(r'offset\s*-\s*phase\s*\+\s*gapTolerance').hasMatch(body),
+        isTrue,
+        reason: '容差必须真的进 floor 的被除数',
+      );
+    });
+
+    test('alignContentStartToPage 不吃容差（章首落点绝不跳过首行）', () {
+      final String body = functionBody(
+        'alignContentStartToPage: function',
+        'pageStepPosition: function',
+      );
+      expect(
+        body.contains('gapTolerance'),
+        isFalse,
+        reason: '章首 minScroll 吃了容差会把首行内容边推进下一列 → 跳过首行（TODO-1179）',
+      );
+      expect(
+        RegExp(r'offset\s*-\s*phase').hasMatch(body),
+        isTrue,
+        reason: '章首落点仍必须减相位',
+      );
+    });
+
+    test('scrollToCharOffset 的 charPage 走同一个列号函数', () {
+      final String body = functionBody(
+        'scrollToCharOffset: function(charOffset, hintScroll)',
+        'notifyRestoreComplete: function',
+      );
+      expect(
+        RegExp(
+          r'charPage\s*=\s*Math\.round\(\s*this\.alignToPage\(',
+        ).hasMatch(body),
+        isTrue,
+        reason: '裸 floor(scrollOffset/pageSize) 既漏相位也吃不住漂移，'
+            '精确锚恢复 / 样式重锚落到页首字时同样退回前一列',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 症状

竖排分页 + 有声书跟随播放，读到某一句时**没有任何操作**，视口自己退回上一页；约 1~2 秒后下一句又把它翻回来。退回的那一句无一例外是**句首恰好落在列顶**的句子。

真机 HiBreak 墨水屏（Android 14，824x1648 @300dpi）现场 adb 复现，logcat 里 reveal 与落库一一配对、间隔恒定 ~0.9 秒：

| 时刻 | 日志 | 视口首字 |
|---|---|---|
| 41.142 / 42.035 | `highlightCue` → `save position … charOffset=5157` | B 页（`「それで納得されないのであれば、`） |
| 42.762 / 43.655 | `highlightCue` → `save … charOffset=5126` | **退回 A 页** |
| 44.560 / 45.456 | `highlightCue` → `save … charOffset=5157` | 又翻回 B 页 |

`charOffset` 是 `fushiProgressDetails` 第三段 = `getFirstVisibleCharOffset()`，所以是**视口真的在两页之间来回**，不是只有落库数字回退。窗口内没有 `[FushiInit]`（无章节重载）、没有 `_syncPageSize`（无重分页）。

## 根因

分页落页的唯一列号函数是 `alignToPage`：`floor((anchor − contentStart) / pageStep)`。BUG-875 / BUG-1764 已经给它补过**相位**，但它在列边界上仍是**零余量的等号判据**——而 `pageStep` 与浏览器真实列周期之间存在**每页累积**的亚像素差：

- `pageStep` 由 `parseFloat(getComputedStyle(body).columnWidth)` 推出，CSSOM 把 used 值**序列化成 3 位小数字符串**；
- 浏览器排版时把 used 列宽**量化到 LayoutUnit（1/64 px）**。

两者只有在列宽恰好是 1/64 的整数倍时才相等。真机 300dpi → Flutter DPR = 1.875 → CSS 视口高 `1648/1.875 = 878.9333…px`（**小数**）→ used 列宽 `832.9333…px` 被量化成 **832.921875px**，而 JS 读到 `"832.933px"`：

```
pageStep(JS)   = 832.933    + 22 = 854.933
真实列周期      = 832.921875 + 22 = 854.921875
δ = 0.011125 px / 页（累积）
```

第 j 列的真实起始坐标因此比网格线 `j·pageStep` **低 j·δ**：第 9 页低过 0.1px，第 89 页低近 1px。**列顶首字**的 reveal 锚恰好等于该列真实起始坐标，裸 floor 把它判进**前一列** → 视口退回上一页；下一句 cue 不在列顶、锚离网格线远，于是又翻回来。

整数 CSS 视口（列宽本就是 1/64 倍数）δ=0，所以这条**只在小数 DPR 的设备上现形**——也解释了为什么既有用例与既有 headless 探针（都用整数几何）一直全绿。

同一个漂移也打在 `scrollToCharOffset` 上（精确锚恢复 / 样式重锚 commit 落到「页首字」时同样退回前一列），而且那里连相位 `contentStart` 都没减，是独立于本 bug 的旧漏。

## 修复

- `getScrollContext` 把 `column-gap` 挂进 context（`columnGap`）。
- `alignToPage` 改成 `floor((offset − contentStart + gap) / pageSize)`：网格线之前那一段恰好是 column-gap，**里面没有任何内容**（前一列内容盒在 gap 之前就结束了），落进 gap 带的锚只可能是后一列被漂移带下来的列顶字。容差是几何真值 22px（按上面的漂移率能兜约 1900 页），不是拍脑袋的 ε；列内任意位置（含列末最后一像素）仍落本列，BUG-875 / BUG-1764 两个方向都不受影响。
- `scrollToCharOffset` 的 `charPage` 改走 `alignToPage`（同时补上它缺的相位）。
- `alignContentStartToPage`（章首 `minScroll`）**刻意不吃**这条容差：那里的语义是「绝不跳过首行」，吃了容差反而会把首行内容边推进下一列（TODO-1179）。

**没有**去改 `pageStep` 本身：把它量化到 1/64 是 Blink 实现细节、跨引擎不成立；改列周期口径会动到 `paginate` / `minScroll` / 全部恢复落页路径（TODO-753/792 的历史）。漂移在渲染上的另一面（第 845 页时页对齐差约 9.4px）属于那条更深的账，本次不动。

## 验证

真渲染探针：`test/reader/reader_headless_shell_dump_test.dart` 产出的**真引擎** shell + 该章**真实 xhtml 正文**（1695 段 / 57697 字）+ 该节**全部 4026 条真实 cue**（含真实 `ns/ne`），按**真机几何**（DPR 1.875、小数 CSS 视口、column-width 用 calc + CSS 变量让浏览器全精度算）逐句走真 `scrollToRange`：

| 配置（字号 / chrome inset） | 修前退回次数 | 修后 |
|---|---|---|
| 22 / 0 | 30 | 0 |
| 40 / 0 | 81 | 0 |
| 46 / 0 | 81 | 0 |
| 52 / 0 | 101 | 0 |
| 46 / 上18 下56（挤压态，contentStart=18） | 112 | 0 |

对照：同一套数据换成**整数** CSS 视口（DPR 1~3、字号 42~50、行高 1.5~1.9、含高精度小数边距共 20 组、约 8 万次 reveal）修前修后都是 0 —— 与「δ 只在小数视口下非零」的推导一致。

新增 `fushi/test/reader/reveal_column_grid_drift_test.dart`（12 例：真机漂移率下第 1~1900 页列顶首字不得退页、**去掉容差立刻复现症状**、BUG-1764/875 双向回归锁、JS 源码三段守卫）。

`flutter analyze` 全绿；分页相关 14 个测试文件 + bug 守卫共 153 例全绿。

## 未做

**没有在物理设备上复验**：本机没有 release 签名 keystore，自建包签名不同，装上去必须先卸载，会连同用户阅读进度一起清掉。真机复验需要一个带签名的 CI 包。

https://claude.ai/code/session_01Xu7QnKaq1apsSiwEVKrzGR
