### PR TITLE
feat(reader): 移动端阅读器底栏右端加大号「阅读统计」直达键

### DIFF
--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -1632,6 +1632,41 @@ extension _ReaderChrome on _ReaderFushiPageState {
             onPressed: () => unawaited(_changeReaderWindowFullscreen()),
           ),
         ),
+      // 阅读统计直达键。移动端此前**没有**底栏统计入口：唯一的路是齿轮 → 快速设置
+      // sheet → 「阅读统计」行（三步），而手动计时开关又只活在浮层里，于是「现在有没有
+      // 在计时」在正文界面上没有任何指示。桌面端那条状态行（左 14px 计时图标 / 右进度
+      // 数字）只在 isDesktopPlatform 渲染，手机上根本不存在，所以这里是新增一颗、而不是
+      // 搬运一颗。
+      //
+      // 规格与底栏其余键同级：iconSize 22 + IconButton 默认 48dp 命中区（底栏基高 56
+      // 容得下），不是紧凑小图标——与统计浮层里那颗整宽计时开关同一条口径（触摸目标不
+      // 得低于 48dp）。位置在底栏右端、设置齿轮左侧：齿轮仍是最右那颗（移动端唯一的
+      // 面板入口，肌肉记忆不动），统计落在右下角这一片。底栏整体反转（
+      // reverseReaderBottomBar）时随 barItems.reversed 一起镜像，与其它键同待遇。
+      //
+      // 图标随**手动停表**状态切换（timer_off = 用户按过暂停），只作状态指示；点击语义
+      // 恒为「打开统计浮层」，停表 / 继续仍在浮层底部那颗整宽按钮上做，不给同一颗键塞
+      // 两种动作。
+      //
+      // 歌词模式不画：那是独立 HTML 文档，进度与阅读追踪都不适用（桌面状态行在歌词模式
+      // 同样不画，见 readerStatusFooterEnabled），浮层里的「预计读完本章 / 全书」在那儿
+      // 没有意义。
+      if (!_lyricsMode)
+        Semantics(
+          identifier: 'hibiki.reader.bottom.statistics',
+          child: IconButton(
+            key: const ValueKey<String>('fushi_reader_statistics_button'),
+            icon: Icon(
+              _studyClockManualPause
+                  ? Icons.timer_off_outlined
+                  : Icons.insights_outlined,
+              color: _themeTextColor(),
+            ),
+            iconSize: 22,
+            tooltip: t.reading_statistics,
+            onPressed: _openReadingStatistics,
+          ),
+        ),
       Semantics(
         identifier: 'hibiki.reader.bottom.settings',
         child: IconButton(

--- a/fushi/test/pages/reader_bottom_bar_statistics_static_test.dart
+++ b/fushi/test/pages/reader_bottom_bar_statistics_static_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reader_fushi_page_source_corpus.dart';
+
+/// 守卫：移动端阅读器底栏（`_buildSettingsBar`，桌面 ッツ 形态不画）右端必须有一颗
+/// 「阅读统计」直达键，且是底栏级规格的按钮，不是紧凑小图标。
+///
+/// 由来：移动端此前唯一的统计入口是「齿轮 → 快速设置 sheet → 阅读统计行」三步，
+/// 手动计时开关只活在浮层里，正文界面上没有任何「在不在计时」的指示；桌面那条状态行
+/// （左 14px 计时图标 / 右进度数字）只在 `isDesktopPlatform` 渲染，手机上不存在。
+///
+/// 静态守卫而非 widget 测试：这颗键长在 `_ReaderFushiPageState` 的私有 build 方法里，
+/// 渲染它要整页起 WebView（真 InAppWebView 平台视图），测试环境跑不动；能落地的最强层
+/// 就是对合并语料切 `_buildSettingsBar` 方法体做结构断言。
+///
+/// 提取方法体：从签名起，到下一个 2 空格缩进的成员声明为止。签名/邻接方法改名时窗口
+/// 只会变大，断言更保守，不会漏。
+String _settingsBarBody(String src) {
+  const String signature = 'Widget _buildSettingsBar() {';
+  final int start = src.indexOf(signature);
+  expect(
+    start,
+    greaterThanOrEqualTo(0),
+    reason: '找不到 `_buildSettingsBar`——移动端底栏被改名了？请更新守卫。',
+  );
+  final int bodyStart = start + signature.length;
+  final RegExp nextMember = RegExp(
+    r'\n  (Future<|void |bool |String |int |double |Widget )',
+  );
+  final Match? next = nextMember.firstMatch(src.substring(bodyStart));
+  final int end = next == null ? src.length : bodyStart + next.start;
+  return src.substring(start, end);
+}
+
+void main() {
+  group('移动端阅读器底栏统计键守卫', () {
+    test('底栏右端有阅读统计直达键，点击开统计浮层', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+
+      expect(
+        body,
+        contains("ValueKey<String>('fushi_reader_statistics_button')"),
+        reason: '移动端底栏必须有一颗统计直达键',
+      );
+      expect(
+        body,
+        contains("identifier: 'hibiki.reader.bottom.statistics'"),
+        reason: '统计键要有稳定的 semantics identifier（集成测试按它找控件）',
+      );
+      expect(
+        body,
+        contains('onPressed: _openReadingStatistics'),
+        reason: '统计键点击必须开阅读统计浮层',
+      );
+      expect(
+        body,
+        contains('tooltip: t.reading_statistics'),
+        reason: '统计键沿用既有 i18n key，不新造',
+      );
+    });
+
+    test('统计键在 Spacer 之后（右端）且排在设置齿轮之前', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+
+      final int spacer = body.indexOf('const Spacer(),');
+      final int stats = body.indexOf('fushi_reader_statistics_button');
+      final int settings = body.indexOf('fushi_reader_settings_button');
+
+      expect(spacer, greaterThanOrEqualTo(0), reason: '底栏左右分区的 Spacer 没了？');
+      expect(
+        stats,
+        greaterThan(spacer),
+        reason: '统计键必须落在 Spacer 之后，也就是底栏右端（用户要的右下角）',
+      );
+      expect(stats, lessThan(settings), reason: '设置齿轮仍是最右那颗（移动端唯一面板入口，肌肉记忆不动）');
+    });
+
+    test('统计键是底栏级规格：iconSize 22，不套紧凑 visualDensity', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+      final int stats = body.indexOf('fushi_reader_statistics_button');
+      final int settings = body.indexOf('fushi_reader_settings_button');
+      final String statsButton = body.substring(stats, settings);
+
+      // 旧的「统计开关太小」正是 18px + visualDensity.compact 的紧凑 IconButton
+      // （触摸目标约 40dp，低于 48dp 下限）。这里钉住底栏级规格：iconSize 22 +
+      // IconButton 默认 48dp 命中区（底栏基高 56 容得下）。
+      expect(
+        statsButton,
+        contains('iconSize: 22'),
+        reason: '统计键要和底栏其余键同规格（22），不能缩成小图标',
+      );
+      expect(
+        statsButton,
+        isNot(contains('visualDensity')),
+        reason: '统计键不得套紧凑 visualDensity，那会把触摸目标压到 48dp 以下',
+      );
+    });
+
+    test('统计键图标随手动停表状态切换，但点击语义不双关', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+      final int stats = body.indexOf('fushi_reader_statistics_button');
+      final int settings = body.indexOf('fushi_reader_settings_button');
+      final String statsButton = body.substring(stats, settings);
+
+      expect(
+        statsButton,
+        contains('_studyClockManualPause'),
+        reason: '移动端要有「计时被手动暂停」的常驻指示',
+      );
+      expect(
+        statsButton,
+        contains('Icons.timer_off_outlined'),
+        reason: '停表态用 timer_off 图标',
+      );
+      expect(
+        statsButton,
+        isNot(contains('_toggleStudyClockManualPause')),
+        reason: '停表 / 继续留在浮层底部那颗整宽按钮上，底栏键不塞第二种动作',
+      );
+    });
+
+    test('统计键活在 barItems 里，跟随底栏反转镜像', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+      final int listStart = body.indexOf('final List<Widget> barItems');
+      final int listEnd = body.indexOf('\n    ];', listStart);
+      expect(listStart, greaterThanOrEqualTo(0));
+      expect(listEnd, greaterThan(listStart));
+
+      final String barItems = body.substring(listStart, listEnd);
+      expect(
+        barItems,
+        contains('fushi_reader_statistics_button'),
+        reason: '统计键必须是 barItems 的一员，否则 reverseReaderBottomBar 反转时它不跟着镜像',
+      );
+      expect(
+        body,
+        contains('reversed ? barItems.reversed.toList() : barItems'),
+        reason: '底栏反转仍由 barItems 统一处理',
+      );
+    });
+
+    test('歌词模式不画统计键（进度/阅读追踪都不适用）', () {
+      final String body = _settingsBarBody(readReaderPageSource());
+      final int stats = body.indexOf('fushi_reader_statistics_button');
+      final String before = body.substring(0, stats);
+
+      expect(
+        before.contains('if (!_lyricsMode)'),
+        isTrue,
+        reason: '歌词模式是独立 HTML 文档，桌面状态行同样不画，底栏统计键也不该出现',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 背景与事实纠正

诉求是「移动端左下角统计开关太小，挪到底部 bar 的右下角」。沿真实代码路径核实后，移动端**不存在**左下角统计开关：那条「左计时图标 / 右进度数字」的状态行 `ReaderStatusFooter`（计时图标只有 14px）门控是 `readerStatusFooterEnabled = isDesktopPlatform && !lyricsMode`，手机上根本不渲染。

移动端底栏 `_buildSettingsBar` 此前只有耳机 / 图库 / 齿轮三颗（桌面另有全屏键），统计的唯一路径是「齿轮 → 快速设置 sheet → 阅读统计行」三步；而正文界面上没有任何「在不在计时」的指示。

所以本 PR 是按诉求指定的落点**新增一颗**，而不是搬运一颗。

## 改动

`fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart`（+35）

- **位置**：底栏 `Spacer()` 之后的右端、设置齿轮左侧（齿轮仍是最右那颗——移动端唯一的面板入口，肌肉记忆不动）。作为 `barItems` 的一员，`reverseReaderBottomBar` 反转时跟着一起镜像。
- **规格**：`iconSize: 22` + IconButton 默认 48dp 命中区（底栏基高 56 容得下），与底栏其余键同级；不是 18px + `visualDensity.compact` 那种紧凑小图标（≈40dp，低于可点击下限）。
- **语义**：点击恒为「打开统计浮层」（`_openReadingStatistics`），不给同一颗键塞两种动作。图标随 `_studyClockManualPause` 在 `insights_outlined` / `timer_off_outlined` 之间切换，纯状态指示，补上移动端此前缺失的「计时被暂停」提示。
- **歌词模式不画**：独立 HTML 文档，进度与阅读追踪都不适用（桌面状态行在歌词模式同样不画）。
- 文案沿用既有 `t.reading_statistics`，不新造 i18n key。

## 测试

新增 `fushi/test/pages/reader_bottom_bar_statistics_static_test.dart`（+154，源码扫描层：这颗键长在 `_ReaderFushiPageState` 的私有 build 方法里，渲染它要整页起真 WebView，widget 层落不了地）：统计键存在且带稳定 semantics identifier `hibiki.reader.bottom.statistics`、点击开浮层、排在 Spacer 之后且在齿轮之前、`iconSize 22` 且不套 `visualDensity`、图标随 `_studyClockManualPause` 切换但不绑 `_toggleStudyClockManualPause`、活在 `barItems` 里跟随反转、歌词模式受 `!_lyricsMode` 门控。

## 验证

基于 `develop` tip `6abb3099` 的干净 worktree：

- `flutter analyze`：`No issues found!`
- 定向 `flutter test --no-pub`：本守卫 6 条 + `reader_status_footer_test`（18 条，含 BUG-1692 平台视图守卫）+ `reader_bottom_bar_reverse_static_test` → **25/25 绿，退出码 0**；再跑底栏 chrome 门控 / focus 排除 / 歌词顶栏 / 歌词底部留白 / 统计目标卡 → **29 条全绿**。
- 未 bump `fushi/pubspec.yaml`（与近期 PR 一致，版本由合并后的 `chore(version)` 统一打）。

https://claude.ai/code/session_01LbPhJQ7bkCdcaHKT1x71MX
