### PR TITLE
fix(sync): 云盘同步后端补齐漫画内容通道（BUG-2332）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2144 条。点号进各自文件。
+> 共 2145 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2332](bugs/BUG-2332-cloud-manga-content-sync.md) | ✅ | ✅ | 云盘同步后端完全不同步漫画（上传静默跳过、下载按 EPUB 导入失败） |
 | [BUG-2330](bugs/BUG-2330-audiobook-multifile-position-no-file-index.md) | ✅ | ✅ | 多文件有声书持久化文件内毫秒无文件下标，重开恒落文件0 |
 | [BUG-2329](bugs/BUG-2329-eink-toggle-no-reader-reinject.md) | ✅ | ✅ | 墨水屏开关不通知阅读器重注入正文样式 |
 | [BUG-2328](bugs/BUG-2328-audiobook-resume-ignored-on-open.md) | ✅ | ✅ | 打开带有声书的书不按有声书进度定位，按播放才跳 |

--- a/docs/bugs/BUG-2332-cloud-manga-content-sync.md
+++ b/docs/bugs/BUG-2332-cloud-manga-content-sync.md
@@ -1,0 +1,10 @@
+## BUG-2332 · 云盘同步后端完全不同步漫画（上传静默跳过、下载按 EPUB 导入失败）
+- **报告**：2026-09-09（用户：同步后端缺少同步漫画）
+- **真实性**：✅ 真 bug。漫画的互联（局域网 host/client）通道早已完整，缺口全在**云盘**侧（Google Drive / WebDAV / OneDrive / Dropbox / FTP / SFTP 共用同一套 SyncManager + SyncOrchestrator 路径），另有一条互联域的漏网入口：
+  - 上传：`fushi/lib/src/sync/sync_manager.dart:745` `_exportContentIfMissing` 恒调 `repackageExtractedEpub`；漫画书目录没有 EPUB 根 → `resolveExtractedEpubRoot` 返回 null → `built=false` → **静默不上传**，漫画在所有云盘后端永远传不上去。
+  - 下载：`fushi/lib/src/sync/sync_orchestrator.dart:1593` `importRemoteBookFolder` 恒走 `EpubImporter.importFromPath`，即使包在云上也导不回来。
+  - 对比弹窗下载：`fushi/lib/src/sync/sync_compare_dialog.dart:857` 互联分支恒走 `EpubImporter`，缺书架页 `_importRemoteBookFile` 早有的漫画内容嗅探 → 从「同步对比」下载互联漫画必失败。
+  - 对比弹窗可下载判据：`fushi/lib/src/sync/sync_compare_dialog.dart:270` 用 `live?.hasContent`，而 host 对漫画恒 `hasContent=false`（那是 EPUB 内容树判据，漫画走 `hasMangaContent`）→ 互联漫画在对比弹窗里连下载入口都不出现。
+- **[x] ① 已修复** — 沿用互联批次既定契约（漫画包与 EPUB 共用同一个 `<title>.epub` 资产名，导入侧按**内容**嗅探 zip 根 `manga.json` 分流，扩展名不参与判定），云盘侧因此不需要第二套命名：内容探针 / `getRemoteBook` / 对比弹窗的「远端有无内容」判据全部零改。四处改动：push 按 `BookFormat` 选打包器（并显式跳过无内容通道的 PDF）、pull 与对比弹窗下载加内容嗅探、对比弹窗可下载判据并上 `hasMangaContent`。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/cloud_manga_content_sync_test.dart`（4 条：push 上传的字节确为漫画包且资产名为 `<title>.epub`；PDF 零上传；pull 按内容落库成 `format=manga` 且页图落盘、bookKey 取远端资产名不带临时时间戳；同名 `.epub` 装真 EPUB 时仍走 EPUB 导入无回归）+ `fushi/test/sync/sync_compare_live_book_test.dart` 新增「远端独有的互联漫画同样可下载」（真起 `FushiSyncServer`，host 返回 `hasContent:false, hasMangaContent:true`）。
+- **备注**：漫画阅读进度不在本缺口内——漫画与 EPUB 共用 `reader_positions`，进度/封面/标签/per-book CSS 都走格式无关的通用路径，已覆盖。向后兼容取舍与互联批次一致：旧版 client 从云盘下到漫画包会走 EPUB 导入失败、如实报错（不静默）。

--- a/fushi/lib/src/sync/sync_compare_dialog.dart
+++ b/fushi/lib/src/sync/sync_compare_dialog.dart
@@ -7,6 +7,8 @@ import 'package:fushi/src/epub/epub_importer.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+import 'package:fushi/src/sync/manga_sync_package.dart'
+    show importMangaPackageFile, isMangaPackage;
 import 'package:fushi/src/sync/fushi_library_host_service.dart';
 import 'package:fushi/src/sync/position_converter.dart';
 import 'package:fushi/src/sync/sync_auto_trigger.dart';
@@ -268,7 +270,12 @@ Future<List<SyncCompareEntry>> _fetchCompareData(
     final bool remoteHasContent = local == null
         ? (remote != null
             ? await _remoteFolderHasContent(backend, remote.id)
-            : (live?.hasContent ?? true))
+            // 互联 live 条目：host 对漫画恒 hasContent=false（那是 EPUB 内容树
+            // 判据），漫画内容走 hasMangaContent —— 只看 hasContent 会让互联漫画
+            // 在对比弹窗里连下载入口都不出现。与 _syncBooksContentLive 同判据取并。
+            : (live == null
+                ? true
+                : (live.hasContent || live.hasMangaContent)))
         : true;
 
     // 跨设备资产身份与 SyncManager 一致：sanitizeTtuFilename(title)。读共同祖先
@@ -853,11 +860,21 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
       );
       try {
         await backend.getRemoteBook(entry.remoteLiveTitle!, tmp);
-        final String localBookKey = await EpubImporter.importFromPath(
-          db: widget.db,
-          filePath: tmp.path,
-          fileName: '${entry.title}.epub',
-        );
+        // 互联 host 的书内容端点对 EPUB 与漫画共用 `.epub` 名（内容即真相），故按
+        // 内容嗅探分流——此前这里恒走 EpubImporter，从「同步对比」弹窗下载互联
+        // 漫画必然失败（书架页的下载路径早有同款嗅探，唯独这条漏了）。标题用远端
+        // raw title（bookKey 由它派生），不用本地临时文件名。
+        final String localBookKey = (await isMangaPackage(tmp))
+            ? await importMangaPackageFile(
+                db: widget.db,
+                file: tmp,
+                title: entry.remoteLiveTitle,
+              )
+            : await EpubImporter.importFromPath(
+                db: widget.db,
+                filePath: tmp.path,
+                fileName: '${entry.title}.epub',
+              );
         // 750a：EPUB 导入成功后，若该远端书带有声书则一并补下音频包（与书架
         // 互联下载同接线）。bookKeyOverride 绑定到本地刚导入 EPUB 的 bookKey。
         await _downloadLiveAudiobookFor(backend, entry, localBookKey);

--- a/fushi/lib/src/sync/sync_manager.dart
+++ b/fushi/lib/src/sync/sync_manager.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:archive/archive_io.dart';
 import 'package:drift/drift.dart';
 import 'package:flutter/foundation.dart';
+import 'package:fushi/src/sync/manga_sync_package.dart';
 import 'package:fushi/src/sync/position_converter.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_remote_listing.dart';
@@ -743,7 +744,15 @@ class SyncManager {
     // resolves to a real file, so the old `File(book.epubPath).existsSync()`
     // guard silently skipped every upload — BUG-088). Re-package the extracted
     // directory into a temp .epub and upload that.
-    if (book.extractDir.isNotEmpty && Directory(book.extractDir).existsSync()) {
+    final BookFormat format = BookFormat.parseOrEpub(book.format);
+    // PDF 无内容同步通道（与互联侧 _syncBooksContentLive 同判据）：不打包、不上传。
+    if (format != BookFormat.pdf &&
+        book.extractDir.isNotEmpty &&
+        Directory(book.extractDir).existsSync()) {
+      // 漫画包与 EPUB 共用同一个资产名 `<title>.epub`——与互联通道同契约（扩展名
+      // 不参与判定，内容即真相，导入侧 isMangaPackage 嗅探分流）。云盘侧因此不需
+      // 要第二套命名：内容探针 / getRemoteBook / 对比弹窗的「远端有无内容」判据
+      // 全部零改。
       final fileName = '${sanitizeTtuFilename(book.title)}.epub';
       final existing = await _backend.findContentFile(folderId, fileName);
       if (existing == null) {
@@ -751,8 +760,12 @@ class SyncManager {
             Directory.systemTemp.createTempSync('hibiki_epub_export');
         final File epubTmp = File(p.join(tmpDir.path, fileName));
         try {
-          final bool built =
-              await repackageExtractedEpub(book.extractDir, epubTmp.path);
+          // 漫画 → 书目录整树 zip（manga.json 标记 + 页图）；EPUB → 既有重打包。
+          // 此前恒走 repackageExtractedEpub：漫画目录无 EPUB 根 → 恒 false →
+          // 漫画在所有云盘后端静默永不上传。
+          final bool built = format == BookFormat.manga
+              ? await repackageMangaBook(book.extractDir, epubTmp.path)
+              : await repackageExtractedEpub(book.extractDir, epubTmp.path);
           if (built) {
             await _backend.uploadContentFile(
               folderId: folderId,

--- a/fushi/lib/src/sync/sync_orchestrator.dart
+++ b/fushi/lib/src/sync/sync_orchestrator.dart
@@ -8,7 +8,8 @@ import 'package:fushi/src/media/video/video_sidecar.dart'
     show listSidecarSubtitles;
 import 'package:fushi/src/models/local_audio_manager.dart';
 import 'package:fushi/src/sync/collection_manifest.dart';
-import 'package:fushi/src/sync/manga_sync_package.dart' show repackageMangaBook;
+import 'package:fushi/src/sync/manga_sync_package.dart'
+    show importMangaPackageFile, isMangaPackage, repackageMangaBook;
 import 'package:fushi/src/sync/collection_sync_engine.dart';
 import 'package:fushi/src/sync/deletion_propagation.dart';
 import 'package:fushi/src/sync/interconnect_sync_backend.dart';
@@ -1577,7 +1578,8 @@ class SyncOrchestrator {
   }
 }
 
-/// 下载远端书文件夹 [folderId] 里的 `.epub` 内容资产并导入为本地书。
+/// 下载远端书文件夹 [folderId] 里的 `.epub` 内容资产并导入为本地书。资产**内容**
+/// 可以是 EPUB，也可以是漫画书目录整树包（同名 `.epub`，见下方内容嗅探分流）。
 /// 返回 true=导入成功；false=该文件夹没有 `.epub`（发送方关了内容同步，跳过）。
 /// 传输/导入失败时抛出，交调用方决定如何提示。临时文件用后即删。
 Future<bool> importRemoteBookFolder({
@@ -1605,11 +1607,23 @@ Future<bool> importRemoteBookFolder({
   ));
   try {
     await backend.getAsset(epub.id, tmp, onProgress: onProgress);
-    final String importedBookKey = await EpubImporter.importFromPath(
-      db: db,
-      filePath: tmp.path,
-      fileName: epub.name,
-    );
+    // 漫画包与 EPUB 共用同一个 `<title>.epub` 资产名（云盘 push 侧同契约），故按
+    // **内容**嗅探分流：zip 根含 manga.json = 漫画书目录整树包，走 MangaImporter
+    // 的既有两遍式校验落库；否则按 EPUB。与互联通道（host importBookFromFile /
+    // 书架 _importRemoteBookFile）逐字同语义。标题用远端资产名去扩展名
+    // （= sanitizeTtuFilename(title)，bookKey 由它派生），不用本地临时文件名
+    // （带时间戳，会让每次下载漂成一本新书）。
+    final String importedBookKey = (await isMangaPackage(tmp))
+        ? await importMangaPackageFile(
+            db: db,
+            file: tmp,
+            title: p.basenameWithoutExtension(epub.name),
+          )
+        : await EpubImporter.importFromPath(
+            db: db,
+            filePath: tmp.path,
+            fileName: epub.name,
+          );
     // TODO-1165：按标签名重建云盘书标签映射（sidecar 由 push 侧写在同文件夹，只增
     // 不删）。复用已列出的 children，不再多发一次 listChildren。
     await _applyRemoteBookFolderTags(db, backend, children, importedBookKey);

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1267
+version: 2.3.0+1268
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/sync/cloud_manga_content_sync_test.dart
+++ b/fushi/test/sync/cloud_manga_content_sync_test.dart
@@ -1,0 +1,353 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/epub/epub_storage.dart';
+import 'package:fushi/src/sync/manga_sync_package.dart';
+import 'package:fushi/src/sync/sync_asset_store.dart';
+import 'package:fushi/src/sync/sync_backend.dart';
+import 'package:fushi/src/sync/sync_manager.dart';
+import 'package:fushi/src/sync/sync_orchestrator.dart'
+    show importRemoteBookFolder;
+import 'package:fushi/src/sync/ttu_filename.dart';
+import 'package:fushi/src/sync/sync_file_ref.dart';
+import 'package:fushi/src/sync/ttu_models.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+// 云盘同步后端的漫画内容通道（互联侧早已支持，云盘侧此前完全缺失）：
+//
+// - push：`_exportContentIfMissing` 恒调 repackageExtractedEpub，漫画书目录没有
+//   EPUB 根 → 恒返回 false → 漫画在**所有**云盘后端静默永不上传；
+// - pull：`importRemoteBookFolder` 恒走 EpubImporter，包在云上也导不回来。
+//
+// 契约与互联通道一致：漫画包与 EPUB 共用同一个 `<title>.epub` 资产名，导入侧按
+// **内容**（zip 根 manga.json）嗅探分流，扩展名不参与判定。这两条用例分别钉死
+// 上传方向「打的是漫画包」与下载方向「落库成 format=manga 的漫画」。
+
+/// 造一个真实漫画书目录（根含 manga.json + 页图），即磁盘上的漫画布局。
+Directory _mangaBookDir({int pages = 2}) {
+  final Directory dir = Directory.systemTemp.createTempSync('hbk_cloud_manga');
+  final Directory images = Directory(p.join(dir.path, 'images'))..createSync();
+  final List<Map<String, Object?>> pageJson = <Map<String, Object?>>[];
+  for (int i = 1; i <= pages; i++) {
+    File(p.join(images.path, 'p$i.jpg'))
+        .writeAsBytesSync(<int>[0xFF, 0xD8, 0xFF, i]);
+    pageJson.add(<String, Object?>{
+      'url': 'images/p$i.jpg',
+      'width': 800,
+      'height': 1200,
+      'blocks': <Object?>[],
+    });
+  }
+  File(p.join(dir.path, kMangaPackageMarker))
+      .writeAsStringSync(jsonEncode(<String, Object?>{'pages': pageJson}));
+  return dir;
+}
+
+/// 记录云盘 push 侧真正上传了什么（内容字节在回调里立刻读走——上传方在 finally
+/// 里删临时目录，晚读必然拿不到）。
+class _RecordingBackend implements SyncBackend {
+  static const String root = 'ROOT/';
+
+  /// 上传过的 (fileName, 内容字节)，顺序即上传顺序。
+  final List<({String fileName, Uint8List bytes})> uploads =
+      <({String fileName, Uint8List bytes})>[];
+
+  @override
+  Future<String> findOrCreateRootFolder() async => root;
+
+  @override
+  Future<String> ensureBookFolder({
+    required String bookTitle,
+    required String rootFolderId,
+    SyncCoverDataProvider? readCoverData,
+  }) async =>
+      '$rootFolderId${sanitizeTtuFilename(bookTitle)}/';
+
+  @override
+  Future<SyncFileTrio> listSyncFiles(String folderId) async =>
+      const SyncFileTrio();
+
+  @override
+  Future<SyncFileRef?> findContentFile(
+          String folderId, String fileName) async =>
+      null; // 远端还没有内容资产 → push 侧必须打包上传。
+
+  @override
+  Future<void> uploadContentFile({
+    required String folderId,
+    required String fileName,
+    required File file,
+    void Function(double progress)? onProgress,
+  }) async {
+    uploads.add((fileName: fileName, bytes: file.readAsBytesSync()));
+  }
+
+  @override
+  Future<void> updateProgressFile({
+    required String folderId,
+    required String? fileId,
+    required TtuProgress progress,
+  }) async {}
+
+  @override
+  Future<void> updateStatsFile({
+    required String folderId,
+    required String? fileId,
+    required List<TtuStatistics> stats,
+  }) async {}
+
+  @override
+  Future<void> updateAudioBookFile({
+    required String folderId,
+    required String? fileId,
+    required TtuAudioBook audioBook,
+  }) async {}
+
+  @override
+  Future<void> putJsonAsset(
+      String namespaceId, String name, Object? json) async {}
+
+  // ── Cache ───────────────────────────────────────────────────────────
+  @override
+  void clearCache() {}
+  @override
+  void restoreCache(
+      {String? rootFolderId, Map<String, String>? titleToFolderId}) {}
+  @override
+  String? get cachedRootFolderId => null;
+  @override
+  Map<String, String> get cachedFolderIds => const <String, String>{};
+  @override
+  void evictFolderId(String folderId) {}
+  @override
+  void cacheBookFolderIds(List<SyncFileRef> folders) {}
+
+  // ── 其余成员：走到即大声失败 ────────────────────────────────────────
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('unexpected backend call: '
+          '${invocation.memberName}');
+}
+
+/// 云盘 pull 侧：书文件夹里只有一个 `<title>.epub`，其**内容**由 [assetBytes] 决定
+/// （漫画包 or 真 EPUB）——导入侧必须按内容分流，不能看扩展名。
+class _FolderBackend implements SyncBackend {
+  _FolderBackend({required this.folderId, required this.assetName});
+
+  final String folderId;
+  final String assetName;
+  late final Uint8List assetBytes;
+
+  static const String assetId = 'content1';
+
+  @override
+  Future<List<AssetEntry>> listChildren(String id) async => id == folderId
+      ? <AssetEntry>[AssetEntry(id: assetId, name: assetName)]
+      : const <AssetEntry>[];
+
+  @override
+  Future<void> getAsset(String id, File destination,
+      {void Function(double progress)? onProgress}) async {
+    await destination.writeAsBytes(assetBytes);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('unexpected backend call: '
+          '${invocation.memberName}');
+}
+
+FushiDatabase _memDb() =>
+    FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+Future<EpubBookRow> _insertBook(
+  FushiDatabase db, {
+  required String title,
+  required String extractDir,
+  required BookFormat format,
+}) async {
+  final String bookKey = sanitizeTtuFilename(title);
+  await db.insertEpubBook(EpubBooksCompanion.insert(
+    bookKey: bookKey,
+    title: title,
+    epubPath: 'book.epub',
+    extractDir: extractDir,
+    chapterCount: 1,
+    chaptersJson: '[]',
+    importedAt: DateTime.now().millisecondsSinceEpoch,
+    format: Value(format.dbValue),
+  ));
+  return (await db.getAllEpubBooks())
+      .firstWhere((EpubBookRow b) => b.bookKey == bookKey);
+}
+
+Future<SyncBookResult> _exportBook(
+  FushiDatabase db,
+  SyncBackend backend,
+  EpubBookRow book,
+) async {
+  await db.upsertReaderPosition(ReaderPositionsCompanion(
+    bookUid: Value(book.uid),
+    sectionIndex: const Value(0),
+    normCharOffset: const Value(0),
+    updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+  ));
+  return SyncManager(db: db, backend: backend).syncBook(
+    book: book,
+    direction: SyncDirection.exportToTtu,
+    syncStats: false,
+    statsSyncMode: StatisticsSyncMode.merge,
+    syncAudioBook: false,
+    syncContent: true,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory booksRoot;
+  setUp(() {
+    // importFromMangaJson 落盘到 <books root>/<bookKey>/——钉到临时根。
+    booksRoot = Directory.systemTemp.createTempSync('hbk_cloud_manga_root');
+    EpubStorage.debugBaseDirectoryOverride = booksRoot.path;
+  });
+  tearDown(() {
+    EpubStorage.debugBaseDirectoryOverride = null;
+    try {
+      if (booksRoot.existsSync()) booksRoot.deleteSync(recursive: true);
+    } catch (_) {
+      // best-effort 清理（Windows 上偶有句柄未释放）。
+    }
+  });
+
+  test('云盘 push：漫画书上传的是漫画包，不再被 EPUB 重打包静默吞掉', () async {
+    final Directory src = _mangaBookDir(pages: 3);
+    addTearDown(() => src.deleteSync(recursive: true));
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+
+    final EpubBookRow book = await _insertBook(db,
+        title: 'ワンピース 01', extractDir: src.path, format: BookFormat.manga);
+    final _RecordingBackend backend = _RecordingBackend();
+
+    final SyncBookResult result = await _exportBook(db, backend, book);
+    expect(result.direction, SyncResult.exported);
+
+    // 修复前：repackageExtractedEpub 对漫画目录恒 false → uploads 为空。
+    expect(backend.uploads, hasLength(1), reason: '漫画必须真的上传（此前在所有云盘后端静默永不上传）');
+    expect(backend.uploads.single.fileName, 'ワンピース 01.epub',
+        reason: '与互联通道同契约：漫画包共用 `<title>.epub` 资产名');
+
+    final File uploaded = File(p.join(src.parent.path, 'uploaded_probe.zip'))
+      ..writeAsBytesSync(backend.uploads.single.bytes);
+    addTearDown(() => uploaded.deleteSync());
+    expect(await isMangaPackage(uploaded), isTrue,
+        reason: '上传的字节必须是漫画包（zip 根含 manga.json），不是 EPUB 重打包');
+  });
+
+  test('云盘 push：PDF 无内容通道，既不上传也不产生半成品', () async {
+    final Directory src = Directory.systemTemp.createTempSync('hbk_cloud_pdf');
+    addTearDown(() => src.deleteSync(recursive: true));
+    File(p.join(src.path, 'book.pdf')).writeAsBytesSync(<int>[0x25, 0x50]);
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+
+    final EpubBookRow book = await _insertBook(db,
+        title: 'Some PDF', extractDir: src.path, format: BookFormat.pdf);
+    final _RecordingBackend backend = _RecordingBackend();
+
+    await _exportBook(db, backend, book);
+    expect(backend.uploads, isEmpty);
+  });
+
+  test('云盘 pull：`<title>.epub` 里装的是漫画包时，按内容落库成 format=manga', () async {
+    final Directory src = _mangaBookDir(pages: 3);
+    addTearDown(() => src.deleteSync(recursive: true));
+    final Directory out = Directory.systemTemp.createTempSync('hbk_cloud_pull');
+    addTearDown(() => out.deleteSync(recursive: true));
+    final String zipPath = p.join(out.path, 'pkg.epub');
+    expect(await repackageMangaBook(src.path, zipPath), isTrue);
+
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+    final _FolderBackend backend =
+        _FolderBackend(folderId: 'f1', assetName: 'ワンピース 01.epub')
+          ..assetBytes = File(zipPath).readAsBytesSync();
+
+    final bool imported = await importRemoteBookFolder(
+      db: db,
+      backend: backend,
+      folderId: 'f1',
+      tempDir: Directory(p.join(out.path, 'tmp')),
+    );
+    expect(imported, isTrue, reason: '修复前恒走 EpubImporter → 抛错，导不回来');
+
+    final List<EpubBookRow> rows = await db.getAllEpubBooks();
+    expect(rows, hasLength(1));
+    expect(rows.single.format, BookFormat.manga.dbValue,
+        reason: '漫画身份必须落地，而不是变成一本夹带页图的「文字书」');
+    // 身份取远端资产名去扩展名，不含临时文件的时间戳（否则每次下载漂成新书）。
+    expect(rows.single.bookKey, sanitizeTtuFilename('ワンピース 01'));
+    expect(
+        File(p.join(rows.single.extractDir, kMangaPackageMarker)).existsSync(),
+        isTrue,
+        reason: '页图与 manga.json 必须真的落盘');
+  });
+
+  test('云盘 pull：同名 `.epub` 里装的是真 EPUB 时仍走 EPUB 导入（无回归）', () async {
+    final Archive archive = Archive();
+    void add(String name, String content) {
+      final List<int> bytes = utf8.encode(content);
+      archive.addFile(ArchiveFile(name, bytes.length, bytes));
+    }
+
+    add('mimetype', 'application/epub+zip');
+    add(
+        'META-INF/container.xml',
+        '<?xml version="1.0"?><container version="1.0" '
+            'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+            '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+            'media-type="application/oebps-package+xml"/></rootfiles>'
+            '</container>');
+    add(
+        'OEBPS/content.opf',
+        '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+            '<dc:title>Plain Book</dc:title></metadata>'
+            '<manifest><item id="c" href="chapter.xhtml" '
+            'media-type="application/xhtml+xml"/></manifest>'
+            '<spine><itemref idref="c"/></spine></package>');
+    add(
+        'OEBPS/chapter.xhtml',
+        '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml">'
+            '<head><title>C</title></head><body><p>Hello.</p></body></html>');
+
+    final Directory out = Directory.systemTemp.createTempSync('hbk_cloud_epub');
+    addTearDown(() => out.deleteSync(recursive: true));
+
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+    final _FolderBackend backend =
+        _FolderBackend(folderId: 'f1', assetName: 'Plain Book.epub')
+          ..assetBytes = Uint8List.fromList(ZipEncoder().encode(archive)!);
+
+    expect(
+      await importRemoteBookFolder(
+        db: db,
+        backend: backend,
+        folderId: 'f1',
+        tempDir: Directory(p.join(out.path, 'tmp')),
+      ),
+      isTrue,
+    );
+    final List<EpubBookRow> rows = await db.getAllEpubBooks();
+    expect(rows, hasLength(1));
+    expect(rows.single.format, BookFormat.epub.dbValue);
+  });
+}

--- a/fushi/test/sync/sync_compare_live_book_test.dart
+++ b/fushi/test/sync/sync_compare_live_book_test.dart
@@ -64,13 +64,23 @@ class _LiveBookLibraryService implements FushiLibraryHostService {
           CollectionManifest incoming) async =>
       incoming;
 
-  const _LiveBookLibraryService(this.bookTitle);
+  const _LiveBookLibraryService(this.bookTitle, {this.manga = false});
 
   final String bookTitle;
 
+  /// true = 该 host 书是漫画：host 对漫画恒 `hasContent: false`（那是 EPUB 内容树
+  /// 判据），内容可下载性走 `hasMangaContent`。
+  final bool manga;
+
   @override
-  Future<List<RemoteBookInfo>> listBooks() async =>
-      <RemoteBookInfo>[RemoteBookInfo(title: bookTitle, hasContent: true)];
+  Future<List<RemoteBookInfo>> listBooks() async => <RemoteBookInfo>[
+        RemoteBookInfo(
+          title: bookTitle,
+          hasContent: !manga,
+          hasMangaContent: manga,
+          format: manga ? 'manga' : 'epub',
+        ),
+      ];
 
   @override
   Future<File> exportBook(String title) async {
@@ -261,5 +271,45 @@ void main() {
         reason: 'live library book does not live in the WebDAV book folder');
     expect(liveEntry.isDownloadableRemoteOnly, isTrue,
         reason: 'Hibiki 互联 compare 必须读取 live /api/library/books');
+  });
+
+  test('远端独有的互联漫画同样可下载（hasContent 恒 false，判据须并上 hasMangaContent）', () async {
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_compare_live_manga');
+    addTearDown(() {
+      try {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+
+    final FushiSyncServer server = FushiSyncServer(
+      syncDataDir: '${tempDir.path}/server',
+      port: 0,
+      token: 'compare-live-manga',
+      allowLan: false,
+      libraryService:
+          const _LiveBookLibraryService('MangaOnlyBook', manga: true),
+    );
+    await server.start();
+    addTearDown(server.stop);
+
+    final InterconnectSyncBackend backend = await _buildLiveBackend(
+      db: db,
+      base: 'http://127.0.0.1:${server.port}',
+      token: 'compare-live-manga',
+    );
+    addTearDown(backend.clearCache);
+
+    final List<SyncCompareEntry> entries =
+        await fetchCompareDataForTest(db, backend);
+    final SyncCompareEntry liveEntry =
+        entries.singleWhere((SyncCompareEntry e) => e.title == 'MangaOnlyBook');
+
+    // 修复前判据只看 live.hasContent（漫画恒 false）→ 互联漫画在对比弹窗里
+    // 连下载入口都不出现。
+    expect(liveEntry.isDownloadableRemoteOnly, isTrue,
+        reason: '漫画内容走 hasMangaContent，判据必须取并');
   });
 }


### PR DESCRIPTION
用户报「同步后端缺少同步漫画」。查下来漫画的**互联**（局域网 host/client）通道早已完整，缺口全在**云盘**侧，另有一条互联域的漏网入口。

## 缺口（4 处）

| # | 位置 | 症状 |
|---|---|---|
| 1 | `sync_manager.dart` `_exportContentIfMissing` | 恒调 `repackageExtractedEpub`，漫画目录没有 EPUB 根 → `built=false` → **静默不上传**。漫画在 Drive/WebDAV/OneDrive/Dropbox/FTP/SFTP 全部后端永远传不上去。 |
| 2 | `sync_orchestrator.dart` `importRemoteBookFolder` | 恒走 `EpubImporter.importFromPath`，包在云上也导不回来。 |
| 3 | `sync_compare_dialog.dart` `_downloadRemoteOnlyBook` 互联分支 | 恒走 `EpubImporter`，缺书架页 `_importRemoteBookFile` 早有的漫画内容嗅探 → 从「同步对比」下载互联漫画必失败。 |
| 4 | `sync_compare_dialog.dart` 可下载判据 | 只看 `live.hasContent`，而 host 对漫画恒 `false`（那是 EPUB 内容树判据，漫画走 `hasMangaContent`）→ 互联漫画在对比弹窗里连下载入口都不出现。 |

## 修法

沿用互联批次已定的契约：**漫画包与 EPUB 共用同一个 `<title>.epub` 资产名，导入侧按内容（zip 根 `manga.json`）嗅探分流，扩展名不参与判定**。云盘侧因此不需要第二套命名——内容探针 / `getRemoteBook` / 对比弹窗的「远端有无内容」判据全部零改。push 侧同时显式跳过无内容通道的 PDF（此前靠 `repackage` 返回 false 兜着）。

## 已核实不缺

漫画阅读进度（与 EPUB 共用 `reader_positions`，走格式无关的通用路径）、封面、标签 sidecar、per-book CSS、书架远端页下载（早有嗅探）。

## 向后兼容

与互联批次同一既定取舍：旧版 client 从云盘下到漫画包会走 EPUB 导入失败、**如实报错**（不静默）。旧 client 的上传/下载 EPUB 行为逐字不变。

## 验证

- `flutter analyze lib test`：No issues found
- `flutter test test/sync/cloud_manga_content_sync_test.dart test/sync/sync_compare_live_book_test.dart test/sync/manga_sync_package_test.dart test/sync/cloud_book_folder_tags_test.dart test/sync/epub_content_repackage_test.dart --no-pub`：全绿（退出码 0）

新增测试 `fushi/test/sync/cloud_manga_content_sync_test.dart`（4 条）：push 上传的字节确为漫画包且资产名为 `<title>.epub`（修复前 uploads 为空）；PDF 零上传；pull 按内容落库成 `format=manga`、页图落盘、bookKey 取远端资产名不带临时时间戳；同名 `.epub` 装真 EPUB 时仍走 EPUB 导入（无回归）。`sync_compare_live_book_test.dart` 新增「远端独有的互联漫画同样可下载」（真起 `FushiSyncServer`）。

BUG-2332

https://claude.ai/code/session_01RSroTiRjNDox2shndhH44r
