### PR TITLE
fix(reader): 修复收藏高亮偏移及阅读器音频坐标混用

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2112 条。点号进各自文件。
+> 共 2113 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2333](bugs/BUG-2333-reader-favorite-coordinate-contract.md) | ✅ | ✅ | 收藏拖选范围与高亮及音频坐标混用 |
 | [BUG-2281](bugs/BUG-2281-dashboard-hover-frame.md) | ✅ | ✅ | 首页继续卡片悬停放大被列表裁剪 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-2281](bugs/BUG-2281-dashboard-hover-frame.md) | ✅ | ✅ | 首页继续卡片悬停缺少边框 |
+| [BUG-2281](bugs/BUG-2281-dashboard-hover-frame.md) | ✅ | ✅ | 首页继续卡片悬停放大被列表裁剪 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2111 条。点号进各自文件。
+> 共 2112 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2281](bugs/BUG-2281-dashboard-hover-frame.md) | ✅ | ✅ | 首页继续卡片悬停缺少边框 |
 | [BUG-2253](bugs/BUG-2253-gal-japanese-locale-auto-by-default.md) | ✅ | ✅ | 游戏日文转区默认自动，没选过就替用户改了启动方式 |
 | [BUG-2252](bugs/BUG-2252-opensubtitles-key-stub-double-quotes.md) | ✅ | ✅ | CI 注入 OpenSubtitles key 生成双引号字面量，analyze 门必红 |
 | [BUG-2251](bugs/BUG-2251-video-tracker-dispose-unawaited-write.md) | 🚧 | 🚧 | VideoWatchTracker.dispose 在 dispose 里发起无人 await 的 DB 写 |

--- a/docs/bugs/BUG-2281-dashboard-hover-frame.md
+++ b/docs/bugs/BUG-2281-dashboard-hover-frame.md
@@ -1,6 +1,6 @@
-## BUG-2281 · 首页继续卡片悬停缺少边框
-- **报告**：2026-09-08（用户：首页「继续」卡片鼠标移入应该出框）
-- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_dashboard_page.dart:1499` 的 `_buildContinueCard` 忽略 `FushiHoverLift.builder` 的悬停状态，只缩放，不绘制边框。
-- **[x] ① 已修复** — 消费已有悬停状态，以 foreground DecoratedBox 绘制 2px 主题色圆角框，移出透明；不会增加布局尺寸，封面不会遮挡描边。「继续」与「最近添加」复用同一修复。提交见本文件所属提交。
-- **[x] ② 已加自动化测试** — `fushi/test/pages/home_dashboard_page_test.dart` 在真实首页书卡上验证鼠标移入显框、移出复位、尺寸不变；与 `fushi_hover_lift_test.dart` 合跑 34 passed，7 个既有 Bangumi 测试 skipped。`flutter analyze --no-pub` 通过。
+## BUG-2281 · 首页继续卡片悬停放大被列表裁剪
+- **报告**：2026-09-08（用户：首页「继续」卡片放大应该能显示在框外，而不是增加描边）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_dashboard_page.dart:1280` 的 `_continueCardsRow` 只给视口加高，没有给列表加 padding，横向 ListView 将卡片拉伸到整个视口高度，悬停缩放仍被截平；首尾两端也没有横向放大余量。
+- **[x] ① 已修复** — 列表增加真实上下 padding，使卡体保持原始高度；首尾按最宽横卡计算横向余量。放大绘制可以超出卡片原始边界，仍在视口可见范围内，不会放出缓存中的屏外卡片。「继续」与「最近添加」共用修复。撤销 `418c331c8b` 中因误解需求添加的描边，修复提交见本文件所属提交。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_dashboard_page_test.dart` 验证真实书卡鼠标移入后绘制超出原始边界、四边未超出视口、布局尺寸不变、移出复位；两行横版视频卡也验证放大及四边可见。临时移除修复时书卡测试失败（顶部 432.59 < 视口顶部 438），恢复后与 hover 组件合跑 34 passed、7 个既有 Bangumi 用例 skipped。
 - **备注**：未构建/运行真实 Windows 应用，原始截图路径设备肉眼复测待补。未运行全量测试。

--- a/docs/bugs/BUG-2281-dashboard-hover-frame.md
+++ b/docs/bugs/BUG-2281-dashboard-hover-frame.md
@@ -1,0 +1,6 @@
+## BUG-2281 · 首页继续卡片悬停缺少边框
+- **报告**：2026-09-08（用户：首页「继续」卡片鼠标移入应该出框）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_dashboard_page.dart:1499` 的 `_buildContinueCard` 忽略 `FushiHoverLift.builder` 的悬停状态，只缩放，不绘制边框。
+- **[x] ① 已修复** — 消费已有悬停状态，以 foreground DecoratedBox 绘制 2px 主题色圆角框，移出透明；不会增加布局尺寸，封面不会遮挡描边。「继续」与「最近添加」复用同一修复。提交见本文件所属提交。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_dashboard_page_test.dart` 在真实首页书卡上验证鼠标移入显框、移出复位、尺寸不变；与 `fushi_hover_lift_test.dart` 合跑 34 passed，7 个既有 Bangumi 测试 skipped。`flutter analyze --no-pub` 通过。
+- **备注**：未构建/运行真实 Windows 应用，原始截图路径设备肉眼复测待补。未运行全量测试。

--- a/docs/bugs/BUG-2333-reader-favorite-coordinate-contract.md
+++ b/docs/bugs/BUG-2333-reader-favorite-coordinate-contract.md
@@ -1,0 +1,16 @@
+## BUG-2333 · 收藏拖选范围与高亮及音频坐标混用
+- **报告**：2026-09-09（用户：拖选灰底文字后右键收藏，黄色高亮落到前文）
+- **真实性**：✅ 真 bug；使用生产 JS 在真实 Chrome DOM 复现并回归。
+- **根因**：
+  - `fushi/lib/src/reader/reader_selection_scripts.dart:1814` 的 `getNormalizedOffset` 已按学习单位计数，`fushi/lib/src/media/audiobook/highlight_bridge.dart:166` 却按可匹配字符计数；收藏位置直接跨坐标使用。
+  - `fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart:2712` 的右键收藏读取菜单失焦后的原生选区，并优先使用扩展句子及上次查词收藏状态；原生元素边界下钻首子节点还会改变真实选区。
+  - 查词 cue、句子音频、插图归属和上下文句导出也消费学习单位作为音频 UTF-16 字符坐标；音频恢复/跨章/歌词保存把音频字符位置除以学习单位总数。
+- **[x] ① 已实现根因修复** — 提交 `1ec221380c`（`fix(reader): separate favorite and audio coordinate contracts`）。
+  - 收藏操作捕获选区及章号，严格保存选中文字，并按本轮内容查询精确删除 ID。
+  - 收藏高亮使用正文文本锚，持久位置仅用于区分重复内容；旧记录同样验证文本，歧义/失配不画到别处。CSS Highlight 与旧 WebView span 路径共用解析。
+  - 原生选区按真实 DOM Range 剪裁可见文本，排除 ruby 注音，正确处理元素子节点边界。
+  - 保留历史学习单位字段供导航；新增明确的音频匹配字段，缺失时不跨坐标回退。
+  - 音频 fragment 经章节 DOM 文本节点映射为学习范围，覆盖恢复、跨章与歌词收藏/退出保存；保留合法近似匹配，拒绝越界和半个代理对。索引最多缓存三章。
+- **[x] ② 自动化测试** — `reader_favorite_coordinates_test.dart/.js`（21 个真实 Chrome DOM 场景）、`reader_audio_coordinate_contract_test.dart`、`reader_audio_position_test.dart`，更新收藏入口和跨章契约守卫。
+- **验证**：`flutter test test/reader test/media/audiobook/cross_chapter_no_zero_test.dart test/media/audiobook/mining_audio_clip_test.dart test/pages/favorited_sentence_stats_bug893_test.dart test/pages/reader_text_context_menu_scale_guard_test.dart --no-pub`：1,616 项通过，退出 0（含 21 个 Chrome DOM 场景）。`flutter analyze --no-pub`：No issues found，退出 0。`bug.dart check`：2113 条，号唯一，索引同步。
+- **备注**：未取得截图对应的原书与用户运行设备，尚未复测真实 App 的“拖选→右键收藏”原始路径；未运行全平台构建和本地全量 Flutter 测试。旧对齐 fragment 没有正文版本指纹，合法范围内的历史失效对齐无法仅凭范围识别，本次不搜索或猜测其它 cue。

--- a/fushi/lib/src/media/audiobook/highlight_bridge.dart
+++ b/fushi/lib/src/media/audiobook/highlight_bridge.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:fushi/src/reader/reader_content_styles.dart';
-import 'package:fushi/src/utils/misc/error_log_service.dart';
 import 'package:fushi_audio/fushi_audio.dart';
 
 class HighlightBridge {
@@ -159,33 +157,61 @@ class HighlightBridge {
     });
   }
 
-  function _skip(c) {
-    if (typeof __fushiIsSkippable === 'function') return __fushiIsSkippable(c);
-    if (window.fushiReader && window.fushiReader.isMatchableChar) {
-      return !window.fushiReader.isMatchableChar(String.fromCodePoint(c));
-    }
-    return false;
+  // Text anchors retain punctuation and every script. Only layout whitespace
+  // is ignored; audio's character whitelist is not a favorite-text coordinate.
+  function _anchorText(text) {
+    return Array.from(text || '').filter(function(ch) { return ch.trim() !== ''; }).join('');
   }
 
   function _buildOffsetMap() {
-    var root = _root();
-    var walker = _walker(root);
+    var walker = _walker(_root());
     var map = [];
-    var normCount = 0;
+    var normCount = 0, studyCount = 0;
     var node;
     while ((node = walker.nextNode()) != null) {
       var txt = node.textContent || '';
       for (var i = 0; i < txt.length;) {
         var cp = txt.codePointAt(i);
-        var charLen = cp > 0xFFFF ? 2 : 1;
-        if (!_skip(cp)) {
-          map.push({ node: node, rawIdx: i, normIdx: normCount, rawLen: charLen });
-          normCount++;
+        var ch = String.fromCodePoint(cp);
+        if (_anchorText(ch)) {
+          map.push({ node: node, rawIdx: i, normIdx: normCount,
+            rawLen: ch.length, text: ch, studyIdx: studyCount });
+          normCount += ch.length;
         }
-        i += charLen;
+        if (window.fushiStudyUnits && window.fushiStudyUnits.isUnitEnd(txt, i)) studyCount++;
+        i += ch.length;
       }
     }
     return map;
+  }
+
+  function _resolveTextRange(map, text, studyHint) {
+    var needle = _anchorText(text);
+    if (!needle) return null;
+    var haystack = map.map(function(entry) { return entry.text; }).join('');
+    var best = null, distance = Infinity, tied = false;
+    for (var at = haystack.indexOf(needle); at >= 0;
+         at = haystack.indexOf(needle, at + 1)) {
+      var entry = map[_bisect(map, at)];
+      if (!entry || entry.normIdx !== at) continue;
+      var d = typeof studyHint === 'number' ? Math.abs(entry.studyIdx - studyHint) : 0;
+      if (d < distance) {
+        best = { offset: at, length: needle.length };
+        distance = d;
+        tied = false;
+      } else if (d === distance) tied = true;
+    }
+    // A stale offset may narrow repeated text, but cannot invent a text match.
+    // Ambiguous matches remain unpainted rather than highlighting another copy.
+    return tied ? null : best;
+  }
+
+  function _resolveHighlights(map, highlights) {
+    return (highlights || []).map(function(hl) {
+      var range = _resolveTextRange(map, hl.text, hl.offset);
+      return range ? { id: hl.id, color: hl.color,
+        offset: range.offset, length: range.length } : null;
+    }).filter(function(hl) { return hl !== null; });
   }
 
   function _bisect(map, target) {
@@ -258,45 +284,10 @@ class HighlightBridge {
 
   // ── 从 selection 计算 normCharOffset + length ──
   window.__fushiGetSelectionNormRange = function() {
-    var sel = window.getSelection();
-    if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
-    var range = sel.getRangeAt(0);
-    var text = sel.toString().trim();
-    if (!text) return null;
-
-    var root = _root();
-    var walker = _walker(root);
-
-    var normCount = 0;
-    var startNorm = -1;
-    var endNorm = -1;
-    var node;
-
-    while ((node = walker.nextNode()) != null) {
-      var nodeText = node.textContent || '';
-      for (var i = 0; i < nodeText.length;) {
-        var cp = nodeText.codePointAt(i);
-        var charLen = cp > 0xFFFF ? 2 : 1;
-        var inRange;
-        try {
-          var pt = document.createRange();
-          pt.setStart(node, i);
-          pt.setEnd(node, Math.min(i + charLen, node.length));
-          inRange = (range.compareBoundaryPoints(Range.START_TO_END, pt) > 0 &&
-                     range.compareBoundaryPoints(Range.END_TO_START, pt) < 0);
-        } catch(e) { inRange = false; }
-
-        if (!_skip(cp)) {
-          if (inRange && startNorm < 0) startNorm = normCount;
-          if (inRange) endNorm = normCount + 1;
-          normCount++;
-        }
-        i += charLen;
-      }
-    }
-
-    if (startNorm < 0) return null;
-    return { offset: startNorm, length: endNorm - startNorm, text: text };
+    var data = window.fushiSelection && window.fushiSelection.nativeSelectionSentenceRange();
+    return data && data.normalizedOffset !== null && data.normalizedLength !== null
+      ? { offset: data.normalizedOffset, length: data.normalizedLength, text: data.text }
+      : null;
   };
 
   // ── 应用高亮 ──
@@ -312,6 +303,7 @@ class HighlightBridge {
         return;
       }
       var map = _buildOffsetMap();
+      highlightsJson = _resolveHighlights(map, highlightsJson);
       for (var h = 0; h < highlightsJson.length; h++) {
         var hl = highlightsJson[h];
         var color = hl.color || 'yellow';
@@ -350,10 +342,10 @@ class HighlightBridge {
       var root = _root();
       root.normalize();
       if (!highlightsJson || highlightsJson.length === 0) return;
-      var sorted = highlightsJson.slice().sort(function(a, b) {
+      var map = _buildOffsetMap();
+      var sorted = _resolveHighlights(map, highlightsJson).sort(function(a, b) {
         return a.offset - b.offset;
       });
-      var map = _buildOffsetMap();
       for (var h = sorted.length - 1; h >= 0; h--) {
         var hl = sorted[h];
         var groups = _buildGroups(map, hl.offset, hl.length);
@@ -396,38 +388,8 @@ class HighlightBridge {
   };
 
   // ── 文本搜索回退：为没有偏移量的收藏查找位置 ──
-  window.__fushiFindTextNormRange = function(text) {
-    if (!text) return null;
-    var root = _root();
-    var walker = _walker(root);
-    var normChars = [];
-    var node;
-    while ((node = walker.nextNode()) != null) {
-      var txt = node.textContent || '';
-      for (var i = 0; i < txt.length;) {
-        var cp = txt.codePointAt(i);
-        var charLen = cp > 0xFFFF ? 2 : 1;
-        if (!_skip(cp)) {
-          normChars.push(String.fromCodePoint(cp));
-        }
-        i += charLen;
-      }
-    }
-    var haystack = normChars.join('');
-    var needleChars = [];
-    for (var i = 0; i < text.length;) {
-      var cp = text.codePointAt(i);
-      var charLen = cp > 0xFFFF ? 2 : 1;
-      if (!_skip(cp)) {
-        needleChars.push(String.fromCodePoint(cp));
-      }
-      i += charLen;
-    }
-    var needle = needleChars.join('');
-    if (!needle) return null;
-    var idx = haystack.indexOf(needle);
-    if (idx < 0) return null;
-    return { offset: idx, length: needle.length };
+  window.__fushiFindTextNormRange = function(text, studyHint) {
+    return _resolveTextRange(_buildOffsetMap(), text, studyHint);
   };
 
   // ── 移除单条高亮 ──
@@ -482,56 +444,24 @@ class HighlightBridge {
     List<FavoriteSentence> highlights, {
     String backgroundHex = '#ffffff',
   }) async {
-    final List<Map<String, dynamic>> payload = [];
-    int backfillCount = 0;
-    for (final FavoriteSentence h in highlights) {
-      if (h.normCharOffset != null && h.normCharLength != null) {
-        payload.add(<String, dynamic>{
-          'id': h.id,
-          'offset': h.normCharOffset,
-          'length': h.normCharLength,
-          'color': h.color ?? 'yellow',
-        });
-        continue;
-      }
-      if (h.text.isEmpty) continue;
-      final String escapedText = jsonEncode(h.text);
-      final Object? raw = await controller.evaluateJavascript(
-        source:
-            '(function(){try{var r=window.__fushiFindTextNormRange($escapedText);'
-            'return r?JSON.stringify(r):"null";}catch(e){return "null";}})();',
-      );
-      if (raw is String && raw != 'null' && raw.isNotEmpty) {
-        try {
-          final Map<String, dynamic> found =
-              jsonDecode(raw) as Map<String, dynamic>;
-          final int? offset = (found['offset'] as num?)?.toInt();
-          final int? length = (found['length'] as num?)?.toInt();
-          if (offset != null && length != null) {
-            payload.add(<String, dynamic>{
-              'id': h.id,
-              'offset': offset,
-              'length': length,
-              'color': h.color ?? 'yellow',
-            });
-            backfillCount++;
-          }
-        } catch (e, stack) {
-          ErrorLogService.instance
-              .log('HighlightBridge.backfillDecode', e, stack);
-        }
-      }
-    }
-    if (backfillCount > 0) {
-      debugPrint(
-          '[fushi-hl] backfilled $backfillCount favorites via text search');
-    }
+    // Stored offsets are navigation hints, not highlight character indexes.
+    // Always send the text, including for old favorites with a non-null offset.
+    final List<Map<String, dynamic>> payload = highlights
+        .where((FavoriteSentence h) => h.text.isNotEmpty)
+        .map(
+          (FavoriteSentence h) => <String, dynamic>{
+            'id': h.id,
+            'text': h.text,
+            'offset': h.normCharOffset,
+            'length': h.normCharLength,
+            'color': h.color ?? 'yellow',
+          },
+        )
+        .toList();
     final String json = jsonEncode(payload);
-    // G14：深/浅判定在 Dart 侧用与原生滚动条同一个单一真相
-    // （ReaderContentStyles.isDarkBackground，Rec.601/0.5）算好，注入 bool；
-    // JS 侧不再持有第二套亮度公式。
-    final bool backgroundIsDark =
-        ReaderContentStyles.isDarkBackground(backgroundHex);
+    final bool backgroundIsDark = ReaderContentStyles.isDarkBackground(
+      backgroundHex,
+    );
     await controller.evaluateJavascript(
       source: 'window.__fushiHighlightBgDark=$backgroundIsDark;'
           'window.__fushiApplyHighlights && window.__fushiApplyHighlights($json);',

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1497,11 +1497,21 @@ class _HomeDashboardPageState
     bool videoLandscape = false,
   }) {
     return FushiHoverLift(
-      builder: (BuildContext _, bool __) => _buildContinueCardForOrientation(
-        tokens,
-        appModel,
-        entry,
-        videoLandscape: videoLandscape,
+      builder: (BuildContext _, bool hovering) => DecoratedBox(
+        position: DecorationPosition.foreground,
+        decoration: BoxDecoration(
+          borderRadius: FushiBorderRadius.card,
+          border: Border.all(
+            color: hovering ? tokens.surfaces.primary : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: _buildContinueCardForOrientation(
+          tokens,
+          appModel,
+          entry,
+          videoLandscape: videoLandscape,
+        ),
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1279,6 +1279,8 @@ class _HomeDashboardPageState
     // 不能改用 Clip.none：懒加载 cacheExtent 里已构建的卡会画到行外。
     final double rowHeight = _continueRowHeight(context, tokens);
     final double liftHeadroom = rowHeight * (kFushiHoverLiftScale - 1) / 2;
+    const double liftSideRoom =
+        _kContinueCoverHeight * 16 / 9 * (kFushiHoverLiftScale - 1) / 2;
     return SizedBox(
       height: rowHeight + liftHeadroom * 2,
       // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
@@ -1287,6 +1289,12 @@ class _HomeDashboardPageState
       child: HorizontalDragScrollable(
         child: ListView.separated(
           scrollDirection: Axis.horizontal,
+          // 卡片不能占满加高后的视口，否则会把放大余量也拉进卡体。
+          // 两端按最宽横卡留量，首尾卡放大时也能完整显示。
+          padding: EdgeInsets.symmetric(
+            vertical: liftHeadroom,
+            horizontal: liftSideRoom,
+          ),
           physics: desktopAwareScrollPhysics(),
           itemCount: entries.length,
           separatorBuilder: (BuildContext _, int __) =>
@@ -1497,21 +1505,11 @@ class _HomeDashboardPageState
     bool videoLandscape = false,
   }) {
     return FushiHoverLift(
-      builder: (BuildContext _, bool hovering) => DecoratedBox(
-        position: DecorationPosition.foreground,
-        decoration: BoxDecoration(
-          borderRadius: FushiBorderRadius.card,
-          border: Border.all(
-            color: hovering ? tokens.surfaces.primary : Colors.transparent,
-            width: 2,
-          ),
-        ),
-        child: _buildContinueCardForOrientation(
-          tokens,
-          appModel,
-          entry,
-          videoLandscape: videoLandscape,
-        ),
+      builder: (BuildContext _, bool __) => _buildContinueCardForOrientation(
+        tokens,
+        appModel,
+        entry,
+        videoLandscape: videoLandscape,
       ),
     );
   }

--- a/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
@@ -20,14 +20,15 @@ double? audiobookSrtCrossChapterProgress({
 /// TODO-746　sasayaki cue cross-chapter in-chapter progress (0..1). When
 /// `chapterChars <= 0` (chapter char count unknown / empty chapter) returns
 /// null — callers must then preserve the current scroll and never zero.
-/// Reuses the restore-path formula `normCharStart / chapterChars`.
+/// Both values use learning units; audio character positions must be converted
+/// with ReaderAudioPositionIndex before calling this helper.
 @visibleForTesting
 double? audiobookSentenceAudioCrossChapterProgress({
-  required int normCharStart,
+  required int studyCharOffset,
   required int chapterChars,
 }) {
   if (chapterChars <= 0) return null;
-  return (normCharStart / chapterChars).clamp(0.0, 1.0);
+  return (studyCharOffset / chapterChars).clamp(0.0, 1.0);
 }
 
 /// 普通 EPUB + SRT 音频在 matcher 未能落到 EPUB 章节时，cue 仍保留
@@ -441,6 +442,33 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     return (map, ranges);
   }
 
+  ({int offset, int length})? _studyRangeForAudioFragment(
+    SubtitleRematchFragment frag,
+  ) {
+    final EpubBook? book = _book;
+    if (book == null ||
+        frag.sectionIndex < 0 ||
+        frag.sectionIndex >= book.chapters.length) {
+      return null;
+    }
+    final String html = book.chapters[frag.sectionIndex].html;
+    final ({String html, ReaderAudioPositionIndex index})? cached =
+        _audioPositionIndices.remove(frag.sectionIndex);
+    final ReaderAudioPositionIndex index = cached?.html == html
+        ? cached!.index
+        : ReaderAudioPositionIndex.fromChapterHtml(html);
+    _audioPositionIndices[frag.sectionIndex] = (html: html, index: index);
+    // The current and adjacent chapters suffice; avoid retaining a whole-book
+    // per-character index when playback moves through a long audiobook.
+    while (_audioPositionIndices.length > 3) {
+      _audioPositionIndices.remove(_audioPositionIndices.keys.first);
+    }
+    return index.studyRangeForFragment(
+      matchableStart: frag.normCharStart,
+      matchableEnd: frag.normCharEnd,
+    );
+  }
+
   void _restoreFromCurrentAudioCue() {
     final AudioCue? cue = _audiobookController?.cueAtCurrentPositionInBook();
     if (cue == null || _book == null) return;
@@ -451,18 +479,20 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     if (frag != null &&
         frag.sectionIndex >= 0 &&
         frag.sectionIndex < _book!.chapters.length) {
+      final int? studyOffset = _studyRangeForAudioFragment(frag)?.offset;
+      if (studyOffset == null) return;
       _currentChapter = frag.sectionIndex;
-      // TODO-746: reuse the shared in-chapter progress helper (DRY). On initial
-      // open a null (unknown char count) falls back to 0.0 = chapter start,
-      // which is a sane initial anchor and preserves the original behaviour.
+      _initialCharOffset = studyOffset;
+      _initialCharOffsetEnd = -1;
       _initialProgress =
           audiobookSentenceAudioCrossChapterProgress(
-            normCharStart: frag.normCharStart,
+            studyCharOffset: studyOffset,
             chapterChars: _chapterCharCounts[frag.sectionIndex],
           ) ??
           0.0;
       _lastProgressSection = _currentChapter;
       _lastProgressValue = _initialProgress;
+      _lastProgressCharOffset = studyOffset;
       debugPrint(
         '[ReaderFushi] restore from audio cue: '
         'chapter=$_currentChapter progress=$_initialProgress',
@@ -719,27 +749,18 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
       _audiobookController?.cancelChapterTransition();
       return;
     }
-    // TODO-746: reuse the same sasayaki in-chapter progress formula the restore
-    // path already uses, so cross-chapter playback lands on the cue's real
-    // in-chapter position instead of _navigateToChapter's default progress=0.0
-    // → restoreProgress(0) → scrollToChapterStart six-fold clear (the "slides to
-    // chapter 1" symptom). newSection here is the matched cue's own declared
-    // section (frag.sectionIndex; a text-missing cue has a null/cleared fragment
-    // and never reaches this path), so it legitimately belongs in newSection —
-    // we only need its offset, not a chapter switch. A null progress (chapter
-    // char count transiently 0 before the lazy recompute lands) falls back to
-    // 0.0 = that chapter's own start, which is the original behaviour for a
-    // matched cue and is NOT a zero-to-chapter-1 (it is its real chapter).
+    // Validate the matched fragment against the target chapter and convert its audio
+    // coordinate to a learning-unit anchor before entering the restore chain.
     final AudioCue? cue = _audiobookController?.currentCue;
     final SubtitleRematchFragment? frag = cue == null
         ? null
         : SubtitleRematchCodec.tryDecode(cue.textFragmentId);
-    double? progress;
-    if (frag != null && newSection < _chapterCharCounts.length) {
-      progress = audiobookSentenceAudioCrossChapterProgress(
-        normCharStart: frag.normCharStart,
-        chapterChars: _chapterCharCounts[newSection],
-      );
+    final int? studyOffset = cue != null && frag?.sectionIndex == newSection
+        ? _studyRangeForAudioFragment(frag!)?.offset
+        : null;
+    if (studyOffset == null) {
+      _audiobookController?.cancelChapterTransition();
+      return;
     }
     // TODO-1037：cue 驱动的跨章会一步跳过「独立成章的纯图片页」（无 cue 故从不
     // 被推进看见），图片等待对它彻底失效。跨章落定前先把中间纯图片章逐个导航过去
@@ -753,7 +774,7 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
       _audiobookController?.cancelChapterTransition();
       return;
     }
-    await _navigateToChapter(newSection, progress: progress ?? 0.0);
+    await _navigateToChapter(newSection, charOffset: studyOffset);
   }
 
   /// TODO-1037：跨章推进若跨过「独立成章的纯图片章」，且图片等待开启
@@ -892,7 +913,26 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     return _currentChapter;
   }
 
-  AudioCue? _findCueForOffset(int normalizedOffset) {
+  void _cacheMatchableSelection(ReaderSelectionData data) {
+    _cachedMatchableSelectionRange =
+        data.matchableOffset != null && data.matchableLength != null
+        ? (
+            offset: data.matchableOffset!,
+            length: data.matchableLength!,
+            text: data.text,
+          )
+        : null;
+    _cachedMatchableSentenceRange =
+        data.sentenceMatchableOffset != null &&
+            data.sentenceMatchableLength != null
+        ? (
+            offset: data.sentenceMatchableOffset!,
+            length: data.sentenceMatchableLength!,
+          )
+        : null;
+  }
+
+  AudioCue? _findCueForOffset(int matchableOffset) {
     final AudiobookPlayerController? ctrl = _audiobookController;
     if (ctrl == null) return null;
     final List<AudioCue> cues = ctrl.sentenceAudioCuesForSection(
@@ -903,8 +943,8 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
         cue.textFragmentId,
       );
       if (frag == null) continue;
-      if (frag.normCharStart <= normalizedOffset &&
-          frag.normCharEnd > normalizedOffset) {
+      if (frag.normCharStart <= matchableOffset &&
+          frag.normCharEnd > matchableOffset) {
         return cue;
       }
     }
@@ -1005,25 +1045,17 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     );
   }
 
-  /// 归一化选区 span 的单一真相源（TODO-1278）：优先句级 span（[_cachedSentenceRange]），
-  /// 句级缺失时回退到词/选区级 span（[_cachedSelectionRange]）。
-  ///
-  /// 片段导出 / Anki 句子音频的位置锚点**必须**和收藏、制卡历史
-  /// （[_checkFavoriteStatus] / [_recordMinedSentence] / lookup.part / chrome.part）
-  /// 用同一套回退——否则句级 span 偶发缺失（拖选跨 block / ruby / 图片相邻节点未进归一化
-  /// 索引 → JS `sentenceNormalizedOffset` 为 null，见 reader_selection_scripts）时，导出
-  /// 侧独自丢掉位置锚点：[miningSentenceAudioRange] 拿不到 sectionIndex+offset+length，
-  /// 对 gap word（`_lookupCue==null`、currentSentence 为空）解析出 null 区间，被
-  /// [classifyAudiobookClipSelection] 归成 `unsupportedRange`，弹出误导的「跨章或跨音频
-  /// 文件」toast——而选区其实同章、Anki 收藏路径能正常定位。回退到选区级 span 后，位置
-  /// 匹配重新生效，同章选区正常进入导出管线。
+  /// 音频使用匹配字符坐标：优先整句，缺失时用选区。学习单位范围不能
+  /// 与字幕的 normCharStart/End 比较；旧 payload 没有匹配坐标时保留 null，
+  /// 由音频匹配器使用 cue 身份或文本。
   ({int offset, int length})? _miningSpanRange() {
-    final ({int offset, int length})? sentenceRange = _cachedSentenceRange;
+    final ({int offset, int length})? sentenceRange =
+        _cachedMatchableSentenceRange;
     if (sentenceRange != null) {
       return sentenceRange;
     }
     final ({int offset, int length, String text})? selectionRange =
-        _cachedSelectionRange;
+        _cachedMatchableSelectionRange;
     if (selectionRange != null) {
       return (offset: selectionRange.offset, length: selectionRange.length);
     }
@@ -1275,14 +1307,14 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
     final AudiobookPlayerController? ctrl = _audiobookController;
     if (ctrl == null) return (plan: null, range: null);
     final ({int offset, int length, String text})? selection =
-        _cachedSelectionRange;
+        _cachedMatchableSelectionRange;
     // BUG-1243：导出入口的主锚是用户真实选区；只有没有原生选区（普通点词导出）时
     // 才回退 currentSentence。不能复用 _miningSpanRange 的「句级优先」规则——那是
     // 单句制卡语义，会把跨多句 selection 收窄回当前句。
     final ({int offset, int length})? fallbackRange = _miningSpanRange();
     final AudiobookClipSelectionSpan resolvedSelection =
         resolveAudiobookClipSelectionSpan(
-          selectedText: selection?.text,
+          selectedText: _cachedSelectionRange?.text,
           selectedOffset: selection?.offset,
           selectedLength: selection?.length,
           fallbackText: appModel.currentMediaSource?.currentSentence.text ?? '',

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -277,13 +277,23 @@ extension _ReaderChrome on _ReaderFushiPageState {
           source: ReaderSelectionScripts.nativeSelectionTextInvocation(),
         );
       } catch (e, stack) {
-        ErrorLogService.instance
-            .log('ReaderFushi.showReaderTextContextMenu', e, stack);
+        ErrorLogService.instance.log(
+          'ReaderFushi.showReaderTextContextMenu',
+          e,
+          stack,
+        );
         return;
       }
       final String selectedText =
           ReaderSelectionScripts.nativeSelectionTextFromResult(rawText);
       if (selectedText.isEmpty) return;
+      if (!mounted) return;
+
+      // Capture before the Flutter menu takes focus. Favorite must consume
+      // this immutable selection, never a later WebView selection or lookup cache.
+      final int favoriteSection = _lookupSectionIndex;
+      final ReaderSelectionData? favoriteSelection =
+          await _fillLookupStateFromNativeSelection();
       if (!mounted) return;
 
       // A native WebView2 popup surface is above Flutter routes on Windows. Move
@@ -395,31 +405,33 @@ extension _ReaderChrome on _ReaderFushiPageState {
           await _clearReaderAppSelection();
           if (!mounted) return;
           await searchDictionaryResult(
-              searchTerm: selectedText, selectionRect: rect);
+            searchTerm: selectedText,
+            selectionRect: rect,
+          );
           if (mounted) _checkFavoriteStatus();
           return;
         case 'copy':
           await Clipboard.setData(ClipboardData(text: selectedText));
           FushiToast.show(
-              msg: t.copied_to_clipboard, severity: ToastSeverity.success);
+            msg: t.copied_to_clipboard,
+            severity: ToastSeverity.success,
+          );
           // 复制是终结动作：清掉刻意保留的原生选区，和移动端拖选菜单的 'copy'
           // （_clearReaderAppSelection）对齐。否则残留的原生蓝色选区会一直卡住后续
           // 查词（见 webview.part.dart pointerup 里对 nativeMoved 的处理）。BUG-927。
           await _clearReaderAppSelection();
           return;
         case 'favorite':
-          // BUG-854：右键收藏也走「原生选区 → 查词状态」补写（与 search 同源），确保
-          // _toggleFavoriteSentence 读到的 currentSentence / 句级区间非空；解析失败退回
-          // 选中文本本身满足非空契约。
-          final ReaderSelectionData? favSel =
-              await _fillLookupStateFromNativeSelection();
-          if (!mounted) return;
-          if (favSel == null) {
-            appModel.currentMediaSource?.setCurrentSentence(
-              selection: FushiTextSelection(text: selectedText),
+          if (favoriteSelection == null) {
+            FushiToast.show(
+              msg: t.no_sentence_selected,
+              severity: ToastSeverity.error,
             );
+            return;
           }
-          await _toggleFavoriteSentence();
+          await _toggleFavoriteSentence(
+              selection: favoriteSelection, selectionSection: favoriteSection);
+          await _clearReaderAppSelection();
           return;
         case 'export':
           await _exportAudiobookClipFromSelection();
@@ -450,6 +462,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
     // BUG-1236：这里必须是非模态 OverlayEntry。showMenu 会 push 带全屏
     // ModalBarrier 的 PopupRoute，菜单在场时 WebView 里的选区手柄收不到触摸。
     _selectionActionData = data;
+    _selectionActionSectionIndex = _lookupSectionIndex;
     if (_selectionActionBarEntry != null) {
       _selectionActionBarEntry!.markNeedsBuild();
       return;
@@ -470,6 +483,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
       ..dispose();
     _selectionActionBarEntry = null;
     _selectionActionData = null;
+    _selectionActionSectionIndex = null;
   }
 
   Widget _buildSelectionActionBar(BuildContext overlayContext) {
@@ -583,6 +597,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
 
   Future<void> _runSelectionAction(String action) async {
     final ReaderSelectionData? data = _selectionActionData;
+    final int? selectionSection = _selectionActionSectionIndex;
     if (data == null) return;
     _removeSelectionActionBar();
     if (!mounted) return;
@@ -600,35 +615,38 @@ extension _ReaderChrome on _ReaderFushiPageState {
       case 'copy':
         await Clipboard.setData(ClipboardData(text: data.text));
         FushiToast.show(
-            msg: t.copied_to_clipboard, severity: ToastSeverity.success);
+          msg: t.copied_to_clipboard,
+          severity: ToastSeverity.success,
+        );
         await _clearReaderAppSelection();
         return;
       case 'share':
-        final bool shared =
-            await SelectionExternalActions.instance.shareText(data.text);
+        final bool shared = await SelectionExternalActions.instance.shareText(
+          data.text,
+        );
         if (mounted && !shared) {
           FushiToast.show(
-              msg: t.selection_share_failed, severity: ToastSeverity.error);
+            msg: t.selection_share_failed,
+            severity: ToastSeverity.error,
+          );
         }
         await _clearReaderAppSelection();
         return;
       case 'webSearch':
-        final bool opened =
-            await SelectionExternalActions.instance.searchWeb(data.text);
+        final bool opened = await SelectionExternalActions.instance.searchWeb(
+          data.text,
+        );
         if (mounted && !opened) {
           FushiToast.show(
-              msg: t.selection_web_search_unavailable,
-              severity: ToastSeverity.error);
+            msg: t.selection_web_search_unavailable,
+            severity: ToastSeverity.error,
+          );
         }
         await _clearReaderAppSelection();
         return;
       case 'favorite':
-        // BUG-854：拖选是 app 自绘选区（无原生选区），从菜单 payload 填查词状态
-        // （currentSentence 非空契约 + 句级区间），与「导出片段」共用
-        // _fillLookupStateFromSelectionData，再走既有收藏句子后端；收藏完清掉选区高亮。
-        await _fillLookupStateFromSelectionData(data,
-            extractNativeImages: false);
-        await _toggleFavoriteSentence();
+        await _toggleFavoriteSentence(
+            selection: data, selectionSection: selectionSection);
         await _clearReaderAppSelection();
         return;
       case 'export':
@@ -735,8 +753,9 @@ extension _ReaderChrome on _ReaderFushiPageState {
       ),
     );
     _cachedSentenceOffset = data.sentenceOffset;
-    _lookupCue = data.normalizedOffset != null
-        ? _findCueForOffset(data.normalizedOffset!)
+    _cacheMatchableSelection(data);
+    _lookupCue = data.matchableOffset != null
+        ? _findCueForOffset(data.matchableOffset!)
         : null;
     if (_lookupCue == null && _srtBookUid != null) {
       _lookupCue = _findCueForSentence(data.sentence);
@@ -2678,57 +2697,71 @@ extension _ReaderChrome on _ReaderFushiPageState {
     }
     final List<FavoriteSentence> chapterFavs =
         await _favoriteSentencesForSection(section);
-    await HighlightBridge.applyHighlights(_controller!, chapterFavs,
-        backgroundHex: _readerBackgroundHex);
+    if (!mounted || _controller == null || section != _lookupSectionIndex) return;
+    await HighlightBridge.applyHighlights(
+      _controller!,
+      chapterFavs,
+      backgroundHex: _readerBackgroundHex,
+    );
     await _controller!.evaluateJavascript(
       source:
           'if (!window.__fushiCssHighlightsSupported) { window.fushiReader && window.fushiReader.buildNodeOffsets(); }',
     );
   }
 
-  Future<void> _toggleFavoriteSentence() async {
+  Future<void> _toggleFavoriteSentence(
+      {ReaderSelectionData? selection, int? selectionSection}) async {
     if (_controller == null || _book == null) return;
-    final String sentence =
-        appModel.currentMediaSource?.currentSentence.text ?? '';
+    final String sentence = selection?.text ??
+        appModel.currentMediaSource?.currentSentence.text ??
+        '';
     if (sentence.isEmpty) {
       FushiToast.show(
-          msg: t.no_sentence_selected, severity: ToastSeverity.error);
+        msg: t.no_sentence_selected,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
-    final int section = _favoriteSectionIndex;
-    final sentenceRange = _cachedSentenceRange ??
-        (_cachedSelectionRange != null
+    final int section = selectionSection ?? _favoriteSectionIndex;
+    final sentenceRange = selection != null
+        ? (selection.normalizedOffset != null &&
+                selection.normalizedLength != null
             ? (
-                offset: _cachedSelectionRange!.offset,
-                length: _cachedSelectionRange!.length
+                offset: selection.normalizedOffset!,
+                length: selection.normalizedLength!,
               )
-            : null);
-    debugPrint('[fushi-hl] toggleFavorite: '
-        'sentenceRange=${sentenceRange != null ? "(${sentenceRange.offset},${sentenceRange.length})" : "null"} '
-        'cachedSentence=${_cachedSentenceRange != null} '
-        'cachedSelection=${_cachedSelectionRange != null}');
-    final FavoriteSentenceRepository repo =
-        FavoriteSentenceRepository(appModel.database);
+            : null)
+        : _cachedSentenceRange ??
+            (_cachedSelectionRange != null
+                ? (
+                    offset: _cachedSelectionRange!.offset,
+                    length: _cachedSelectionRange!.length,
+                  )
+                : null);
+    debugPrint(
+      '[fushi-hl] toggleFavorite: '
+      'sentenceRange=${sentenceRange != null ? "(${sentenceRange.offset},${sentenceRange.length})" : "null"} '
+      'cachedSentence=${_cachedSentenceRange != null} '
+      'cachedSelection=${_cachedSelectionRange != null}',
+    );
+    final FavoriteSentenceRepository repo = FavoriteSentenceRepository(
+      appModel.database,
+    );
 
-    if (_currentSentenceIsFavorited) {
-      // BUG-494：优先按 _checkFavoriteStatus 缓存的精确条目 id 删单条（身份键坍缩下不连坐
-      // 误删同内容的另一条）；无缓存 id（老路径 / 未经 checkFavoriteStatus）回退内容键删单条。
-      final String? favId = _currentFavoriteId;
-      if (favId != null) {
-        await repo.removeById(favId);
-      } else {
-        await repo.removeByContent(
-          text: sentence,
-          bookKey: widget.bookKey,
-          sectionIndex: section,
-          normCharOffset: sentenceRange?.offset,
-        );
-      }
-      _currentFavoriteId = null;
+    // Resolve identity for this action; cached lookup favorite state can belong
+    // to another sentence, including when a right-click selection is used.
+    final String? matchedId = await repo.matchedFavoriteId(
+      text: sentence,
+      bookKey: widget.bookKey,
+      sectionIndex: section,
+      normCharOffset: sentenceRange?.offset,
+    );
+    if (matchedId != null) {
+      await repo.removeById(matchedId);
       _invalidateFavoriteSentenceCache();
       _rebuild(() => _currentSentenceIsFavorited = false);
-      if (sentenceRange != null || _lyricsMode) {
+      if (mounted) {
         await _refreshSectionHighlights(section);
       }
       FushiToast.show(msg: t.favorite_removed, severity: ToastSeverity.success);
@@ -2749,11 +2782,9 @@ extension _ReaderChrome on _ReaderFushiPageState {
       dateKey: statTodayKey(),
     );
     await repo.add(fav);
-    // BUG-494：记住刚写入条目的精确 id，供随后取消收藏 removeById 精确删单条。
-    _currentFavoriteId = fav.id;
     _invalidateFavoriteSentenceCache();
     _rebuild(() => _currentSentenceIsFavorited = true);
-    if (sentenceRange != null || _lyricsMode) {
+    if (mounted) {
       await _refreshSectionHighlights(section);
     }
     FushiToast.show(msg: t.favorite_added, severity: ToastSeverity.success);
@@ -2766,7 +2797,7 @@ extension _ReaderChrome on _ReaderFushiPageState {
     final int? normCharOffset = fav.normCharOffset;
     // TODO-1308 问题②（BUG-696 根因①）：fav.normCharOffset 是写入端
     // （lookup.part / mining.part 的 sentenceNormalizedOffset，即 JS
-    // getNormalizedOffset）产的**章内绝对可匹配字符索引**（0..数千），不是书签的
+    // getNormalizedOffset）产的**章内绝对学习单位索引**（0..数千），不是书签的
     // 0-10000 进度分数。旧代码把它 /10000.0 当分数还原 → 0.0x 分数恒落章节开头。
     // BUG-459 只修了收藏页冷启动入口（charAnchor 绝对锚），书内收藏面板这条
     // 从未修到；TODO-1309 重写 handler 时又原样保留了 /10000。改走与冷启动

--- a/fushi/lib/src/pages/implementations/reader_fushi/lookup.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/lookup.part.dart
@@ -58,12 +58,14 @@ extension _ReaderLookup on _ReaderFushiPageState {
     try {
       controller
           .evaluateJavascript(
-              source: 'window.__fushiTapGate = '
-                  '{ chrome: $_showChrome, lookup: $lookup, maxLen: 400 };')
+            source:
+                'window.__fushiTapGate = '
+                '{ chrome: $_showChrome, lookup: $lookup, maxLen: 400 };',
+          )
           .catchError((Object e, StackTrace s) {
-        ErrorLogService.instance.log('ReaderFushi.syncTapGate', e, s);
-        return null;
-      });
+            ErrorLogService.instance.log('ReaderFushi.syncTapGate', e, s);
+            return null;
+          });
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderFushi.syncTapGate', e, stack);
     }
@@ -88,8 +90,11 @@ extension _ReaderLookup on _ReaderFushiPageState {
         source: ReaderSelectionScripts.clearInvocation(),
       );
     } catch (e, stack) {
-      ErrorLogService.instance
-          .log('ReaderFushi.clearLookupState.eval', e, stack);
+      ErrorLogService.instance.log(
+        'ReaderFushi.clearLookupState.eval',
+        e,
+        stack,
+      );
     }
   }
 
@@ -126,8 +131,11 @@ extension _ReaderLookup on _ReaderFushiPageState {
       // evaluateJavascript 抛 MissingPluginException。`_controller != null` 守卫只防
       // null，防不了通道已废 —— 必须 try/catch 兜底。弹窗已显示，重锚失败仅停在选区
       // rect（查词弹窗不中断）。
-      ErrorLogService.instance
-          .log('ReaderFushi.highlightAndShowPopup.eval', e, stack);
+      ErrorLogService.instance.log(
+        'ReaderFushi.highlightAndShowPopup.eval',
+        e,
+        stack,
+      );
     }
   }
 
@@ -171,15 +179,19 @@ extension _ReaderLookup on _ReaderFushiPageState {
     // 时退回选中的词，杜绝收藏读点（chrome.part.dart）误报「未选择句子」。
     final String sentenceText =
         ReaderSelectionScripts.resolveCurrentSentenceText(
-      data.sentence,
-      data.text,
-    );
+          data.sentence,
+          data.text,
+        );
     appModel.currentMediaSource?.setCurrentSentence(
       selection: FushiTextSelection(text: sentenceText),
     );
     _cachedSentenceOffset = data.sentenceOffset;
 
     if (_lyricsMode) {
+      _cacheMatchableSelection(data);
+      _cachedSelectionRange = null;
+      _cachedSentenceRange = null;
+      _cachedSelectionSectionIndex = null;
       _lookupCue = null;
       try {
         // TODO-678（BUG-005 同根因）：把歌词 cue context 的 evaluateJavascript 纳入
@@ -198,15 +210,25 @@ extension _ReaderLookup on _ReaderFushiPageState {
             final SubtitleRematchFragment? frag =
                 SubtitleRematchCodec.tryDecode(fragId);
             if (frag != null) {
-              _cachedSelectionRange = (
+              _cachedMatchableSelectionRange = (
                 offset: frag.normCharStart,
                 length: frag.normCharEnd - frag.normCharStart,
                 text: data.text,
               );
-              _cachedSentenceRange = (
+              _cachedMatchableSentenceRange = (
                 offset: frag.normCharStart,
                 length: frag.normCharEnd - frag.normCharStart,
               );
+              final ({int offset, int length})? studyRange =
+                  _studyRangeForAudioFragment(frag);
+              _cachedSelectionRange = studyRange == null
+                  ? null
+                  : (
+                      offset: studyRange.offset,
+                      length: studyRange.length,
+                      text: data.text,
+                    );
+              _cachedSentenceRange = studyRange;
               // BUG-492：歌词 cue 选区所属章号取自 fragment（与 _lookupSectionIndex 同源）。
               _cachedSelectionSectionIndex = frag.sectionIndex;
             }
@@ -225,8 +247,8 @@ extension _ReaderLookup on _ReaderFushiPageState {
       return;
     }
 
-    _lookupCue = data.normalizedOffset != null
-        ? _findCueForOffset(data.normalizedOffset!)
+    _lookupCue = data.matchableOffset != null
+        ? _findCueForOffset(data.matchableOffset!)
         : null;
     if (_lookupCue == null && _srtBookUid != null) {
       _lookupCue = _findCueForSentence(data.sentence);
@@ -234,6 +256,7 @@ extension _ReaderLookup on _ReaderFushiPageState {
     _syncCueSentence();
 
     await _runLookupAndHighlight(data.text, selectionRect);
+    _cacheMatchableSelection(data);
     if (data.normalizedOffset != null && data.normalizedLength != null) {
       _cachedSelectionRange = (
         offset: data.normalizedOffset!,
@@ -261,28 +284,27 @@ extension _ReaderLookup on _ReaderFushiPageState {
     final String sentence =
         appModel.currentMediaSource?.currentSentence.text ?? '';
     if (sentence.isEmpty) {
-      _currentFavoriteId = null;
       if (_currentSentenceIsFavorited) {
         _rebuild(() => _currentSentenceIsFavorited = false);
       }
       return;
     }
-    final sentenceRange = _cachedSentenceRange ??
+    final sentenceRange =
+        _cachedSentenceRange ??
         (_cachedSelectionRange != null
             ? (
                 offset: _cachedSelectionRange!.offset,
-                length: _cachedSelectionRange!.length
+                length: _cachedSelectionRange!.length,
               )
             : null);
     // BUG-494：拿匹配条目的精确 id（未收藏 → null），供 toggle 用 removeById 精确删单条。
     final String? matchedId =
         await FavoriteSentenceRepository(appModel.database).matchedFavoriteId(
-      text: sentence,
-      bookKey: widget.bookKey,
-      sectionIndex: _favoriteSectionIndex,
-      normCharOffset: sentenceRange?.offset,
-    );
-    _currentFavoriteId = matchedId;
+          text: sentence,
+          bookKey: widget.bookKey,
+          sectionIndex: _favoriteSectionIndex,
+          normCharOffset: sentenceRange?.offset,
+        );
     final bool favorited = matchedId != null;
     if (mounted && favorited != _currentSentenceIsFavorited) {
       _rebuild(() => _currentSentenceIsFavorited = favorited);

--- a/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
@@ -1402,20 +1402,22 @@ extension _ReaderNavigation on _ReaderFushiPageState {
       cue.textFragmentId,
     );
     if (frag != null) {
+      final int? studyOffset = _studyRangeForAudioFragment(frag)?.offset;
+      if (studyOffset == null) return;
       _lastProgressSection = frag.sectionIndex;
       if (frag.sectionIndex >= 0 &&
           frag.sectionIndex < _chapterCharCounts.length &&
           _chapterCharCounts[frag.sectionIndex] > 0) {
         _lastProgressValue =
-            frag.normCharStart / _chapterCharCounts[frag.sectionIndex];
+            studyOffset / _chapterCharCounts[frag.sectionIndex];
         _lastProgressValue = _lastProgressValue.clamp(0.0, 1.0);
-        // BUG-162: cue 派生位置无 WebView 精确偏移 → -1（恢复走 cue 的 normChar 分数），
-        // 并清陈旧锚，避免后续 flush 把别 section 的偏移误写进来。
-        _lastProgressCharOffset = -1;
+        // The validated XHTML mapping gives the same learning-unit anchor as
+        // the reader, including when exiting lyrics mode without a WebView.
+        _lastProgressCharOffset = studyOffset;
         _debouncedSaveReaderPosition(
           _lastProgressSection,
           _lastProgressValue,
-          -1,
+          studyOffset,
         );
       }
       return;

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -60,6 +60,7 @@ import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart'
 import 'package:fushi/src/pages/implementations/stat_activity.dart';
 import 'package:fushi/src/profile/profile_view_model.dart';
 import 'package:fushi/src/reader/reader_caret_scripts.dart';
+import 'package:fushi/src/reader/reader_audio_position.dart';
 import 'package:fushi/src/reader/reader_chapter_perf_trace.dart';
 import 'package:fushi/src/reader/reader_engine_config.dart';
 import 'package:fushi/src/reader/reader_script_compactor.dart';
@@ -415,7 +416,8 @@ ReaderThemeColors applyReaderThemeOverrides(
   final bool dark = overrides.bg == null
       ? base.dark
       : ThemeData.estimateBrightnessForColor(bg) == Brightness.dark;
-  final Color fg = overrides.fg ??
+  final Color fg =
+      overrides.fg ??
       (overrides.bg == null
           ? base.fg
           : (dark ? const Color(0xDEFFFFFF) : const Color(0xDE000000)));
@@ -1448,6 +1450,7 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   // ModalBarrier 会截断 WebView 手柄触摸；OverlayEntry 只让按钮区域命中。
   OverlayEntry? _selectionActionBarEntry;
   ReaderSelectionData? _selectionActionData;
+  int? _selectionActionSectionIndex;
   bool _restoreInFlight = false;
   bool _isNavigatingToChapter = false;
   // TODO-1037：跨章推进经过的「纯图片章逐个停留」序列在途时为真，防重入跨章导航。
@@ -1975,12 +1978,12 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   /// 悬浮态恒 0，挤压且占位时占 [_readerChromeHeight]。占位判据与
   /// [_buildBottomChrome] 的可见条件（_hasEverLoaded && _showChrome）一致。
   double get _bottomChromeReserve => bottomChromeReserve(
-        barOccupiesLayout: _hasEverLoaded && _showChrome,
-        floating: _bottomBarFloating,
-        chromeHeight: _desktopChromeEnabled && _audiobookController == null
-            ? 0
-            : _readerChromeHeight,
-      );
+    barOccupiesLayout: _hasEverLoaded && _showChrome,
+    floating: _bottomBarFloating,
+    chromeHeight: _desktopChromeEnabled && _audiobookController == null
+        ? 0
+        : _readerChromeHeight,
+  );
 
   /// 宽屏把阅读状态并入播放条；窄屏保留独立状态行，避免文本挤占触控按钮。
   double get _readerControlsWidth =>
@@ -3590,8 +3593,16 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   void onExplicitCueJump(AudioCue cue) => _handleExplicitCueJump(cue);
 
   AudioCue? _lookupCue;
+  final LinkedHashMap<int, ({String html, ReaderAudioPositionIndex index})>
+  _audioPositionIndices =
+      LinkedHashMap<int, ({String html, ReaderAudioPositionIndex index})>();
   ({int offset, int length, String text})? _cachedSelectionRange;
   ({int offset, int length})? _cachedSentenceRange;
+
+  /// Audio alignment uses normalized UTF-16 characters, independent of the
+  /// learning-unit ranges used by reading progress and persisted favorites.
+  ({int offset, int length, String text})? _cachedMatchableSelectionRange;
+  ({int offset, int length})? _cachedMatchableSentenceRange;
   int? _cachedSentenceOffset;
 
   /// TODO-1127：选区那一刻抽取到的、夹在选区里的 EPUB 插图（`normOffset` = 图在整书归一化
@@ -3610,12 +3621,6 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   /// 无缓存选区，消费点 [_favoriteSectionIndex] 回退当前 [_lookupSectionIndex]（旧行为）。
   int? _cachedSelectionSectionIndex;
   bool _currentSentenceIsFavorited = false;
-
-  /// BUG-494 (TODO-1053 Bug C)：当前句若已收藏，缓存其**精确条目 id**（未收藏 → null）。
-  /// 取消收藏走 [FavoriteSentenceRepository.removeById]（按此 id 删单条），杜绝身份键坍缩下
-  /// 的连坐误删——同章重复短句 normCharOffset 均 null 时内容键相同，若按内容删会把另一条
-  /// 同内容记录一起删掉。由 [_checkFavoriteStatus] 与收藏 toggle 同步维护。
-  String? _currentFavoriteId;
 
   /// 收藏 / 制卡写入与「是否已收藏」判定统一取的 section 来源：优先用选区时刻快照的
   /// [_cachedSelectionSectionIndex]（绑定到选中句所在真实章），无快照时回退当前
@@ -3647,11 +3652,12 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
     _lookupCue = null;
     _cachedSelectionRange = null;
     _cachedSentenceRange = null;
+    _cachedMatchableSelectionRange = null;
+    _cachedMatchableSentenceRange = null;
     _cachedSentenceOffset = null;
     _cachedSelectionImages = const <({int normOffset, Uint8List bytes})>[];
     _cachedSelectionSectionIndex = null;
     _currentSentenceIsFavorited = false;
-    _currentFavoriteId = null;
     appModel.currentMediaSource?.clearCurrentCueSentence();
     super.clearDictionaryResult();
   }
@@ -3735,8 +3741,9 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   Future<bool> onPreviewSentenceAudio() async {
     final AudiobookPlayerController? controller = _audiobookController;
     if (controller == null) return false;
-    final AudioPlaybackRange? clip =
-        _miningDraft.composeAudioRange(_currentSentenceAudioRange());
+    final AudioPlaybackRange? clip = _miningDraft.composeAudioRange(
+      _currentSentenceAudioRange(),
+    );
     if (clip == null || clip.endMs <= clip.startMs) return false;
     await controller.playRange(clip);
     return true;

--- a/fushi/lib/src/reader/reader_audio_position.dart
+++ b/fushi/lib/src/reader/reader_audio_position.dart
@@ -1,0 +1,99 @@
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:html/dom.dart' as dom;
+
+import 'package:fushi/src/epub/epub_book.dart';
+import 'package:fushi/src/stats/study_char_count.dart';
+
+/// Converts audio UTF-16 positions to the reader's completed learning units.
+/// Each original DOM text node retains its own word boundary, matching
+/// fushiReader.buildNodeOffsets and fushiStudyUnits.isUnitEnd.
+class ReaderAudioPositionIndex {
+  ReaderAudioPositionIndex._(this._text, this._studyOffsets, this._studyEnds);
+
+  factory ReaderAudioPositionIndex.fromChapterHtml(String html) {
+    final dom.Document document = EpubBook.parseChapterHtml(html);
+    final StringBuffer normalized = StringBuffer();
+    final List<int> offsets = <int>[];
+    final List<int> studyEnds = <int>[];
+    int studyOffset = 0;
+
+    void visit(dom.Node node) {
+      if (node is dom.Element &&
+          const <String>{'rt', 'rp', 'rtc'}.contains(node.localName)) {
+        return;
+      }
+      if (node is dom.Text) {
+        final List<int> runes = node.data.runes.toList(growable: false);
+        final List<int> kinds = runes.map(_classify).toList(growable: false);
+        final List<bool> ends = List<bool>.filled(runes.length, false);
+        int nextKind = 3;
+        for (int i = runes.length - 1; i >= 0; i--) {
+          final int kind = kinds[i];
+          ends[i] = kind == 1 || (kind == 2 && nextKind != 2);
+          if (kind != 0) nextKind = kind;
+        }
+        for (int i = 0; i < runes.length; i++) {
+          final int folded = AudioTextNormalizer.foldCodePoint(runes[i]);
+          final int studyEnd = studyOffset + (ends[i] ? 1 : 0);
+          if (folded >= 0) {
+            normalized.writeCharCode(folded);
+            offsets.add(studyOffset);
+            studyEnds.add(studyEnd);
+            if (folded > 0xffff) {
+              offsets.add(studyOffset);
+              studyEnds.add(studyEnd);
+            }
+          }
+          if (ends[i]) studyOffset++;
+        }
+        return;
+      }
+      for (final dom.Node child in node.nodes) {
+        visit(child);
+      }
+    }
+
+    final dom.Element? body = document.body;
+    if (body != null) visit(body);
+    offsets.add(studyOffset);
+    return ReaderAudioPositionIndex._(
+      normalized.toString(),
+      offsets,
+      studyEnds,
+    );
+  }
+
+  final String _text;
+  final List<int> _studyOffsets;
+  final List<int> _studyEnds;
+
+  /// The persisted fragment identifies an upstream-matched EPUB span. Subtitle
+  /// text may intentionally differ (fuzzy matching / ASR), so this conversion
+  /// validates coordinates rather than redoing matching or searching by text.
+  ({int offset, int length})? studyRangeForFragment({
+    required int matchableStart,
+    required int matchableEnd,
+  }) {
+    if (matchableStart < 0 ||
+        matchableEnd <= matchableStart ||
+        matchableEnd > _text.length ||
+        !_isCodePointBoundary(matchableStart) ||
+        !_isCodePointBoundary(matchableEnd)) {
+      return null;
+    }
+    final int start = _studyOffsets[matchableStart];
+    return (offset: start, length: _studyEnds[matchableEnd - 1] - start);
+  }
+
+  bool _isCodePointBoundary(int offset) =>
+      offset == _text.length ||
+      _text.codeUnitAt(offset) < 0xdc00 ||
+      _text.codeUnitAt(offset) > 0xdfff;
+
+  static int _classify(int rune) {
+    final String char = String.fromCharCode(rune);
+    if (kStudyTransparentPattern.hasMatch(char)) return 0;
+    if (!kStudyLetterOrNumberPattern.hasMatch(char)) return 3;
+    return kStudyNoSpaceScriptPattern.hasMatch(char) ? 1 : 2;
+  }
+}

--- a/fushi/lib/src/reader/reader_selection_data.dart
+++ b/fushi/lib/src/reader/reader_selection_data.dart
@@ -8,6 +8,10 @@ class ReaderSelectionData {
     this.sentenceOffset = 0,
     this.sentenceNormalizedOffset,
     this.sentenceNormalizedLength,
+    this.matchableOffset,
+    this.matchableLength,
+    this.sentenceMatchableOffset,
+    this.sentenceMatchableLength,
     this.verticalWriting = false,
     this.mangaPageIndex,
   });
@@ -34,6 +38,12 @@ class ReaderSelectionData {
           (json['sentenceNormalizedOffset'] as num?)?.toInt(),
       sentenceNormalizedLength:
           (json['sentenceNormalizedLength'] as num?)?.toInt(),
+      matchableOffset: (json['matchableOffset'] as num?)?.toInt(),
+      matchableLength: (json['matchableLength'] as num?)?.toInt(),
+      sentenceMatchableOffset:
+          (json['sentenceMatchableOffset'] as num?)?.toInt(),
+      sentenceMatchableLength:
+          (json['sentenceMatchableLength'] as num?)?.toInt(),
       verticalWriting: json['verticalWriting'] as bool? ?? false,
       mangaPageIndex: (json['mangaPageIndex'] as num?)?.toInt(),
     );
@@ -42,11 +52,20 @@ class ReaderSelectionData {
   final String text;
   final String sentence;
   final Map<String, double>? rect;
+
+  /// Chapter learning-unit coordinates for navigation and persisted favorites.
   final int? normalizedOffset;
   final int? normalizedLength;
   final int sentenceOffset;
   final int? sentenceNormalizedOffset;
   final int? sentenceNormalizedLength;
+
+  /// Audio matching coordinates, measured in normalized UTF-16 code units.
+  /// Never substitute learning-unit offsets when these are unavailable.
+  final int? matchableOffset;
+  final int? matchableLength;
+  final int? sentenceMatchableOffset;
+  final int? sentenceMatchableLength;
 
   /// Whether the source glyph belongs to a vertical writing run.
   ///

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -872,8 +872,8 @@ window.fushiSelection = {
     var describe = function(ctx) {
       var entry = { sentence: ctx.sentence };
       if (window.fushiReader) {
-        var s = self.getNormalizedOffset(ctx.sStartNode, ctx.sStartOffset);
-        var e = self.getNormalizedOffset(ctx.sEndNode, ctx.sEndOffset);
+        var s = self.getMatchableOffset(ctx.sStartNode, ctx.sStartOffset);
+        var e = self.getMatchableOffset(ctx.sEndNode, ctx.sEndOffset);
         if (s !== null && e !== null) {
           entry.normOffset = s;
           entry.normLength = Math.max(0, e - s);
@@ -937,23 +937,25 @@ window.fushiSelection = {
     var text = sel.toString();
     if (!text) return null;
     var range = sel.getRangeAt(0);
-    var startNode = range.startContainer;
-    var startOffset = range.startOffset;
-    // 选区起点可能落在元素节点上（如 <p> 的子节点边界）；下钻到其首个文本节点，
-    // 与 getNormalizedOffset / getSentenceContext 的「文本节点 + 字符偏移」契约对齐。
-    if (startNode.nodeType !== Node.TEXT_NODE) {
-      var firstText = this.firstTextNode(startNode);
-      if (!firstText) return null;
-      startNode = firstText.node;
-      startOffset = firstText.offset;
+    // Clip against the actual Range. Element offsets are child indexes, not
+    // text offsets; descending to the element's first child shifts selections.
+    // Use the same visible-text walker as lookup, excluding ruby annotations.
+    var walker = this.createWalker(document.body);
+    var selected = [];
+    var node;
+    while ((node = walker.nextNode()) != null) {
+      if (!range.intersectsNode(node)) continue;
+      var start = node === range.startContainer ? range.startOffset : 0;
+      var end = node === range.endContainer ? range.endOffset : node.textContent.length;
+      if (end > start) selected.push({ node: node, start: start, end: end });
     }
-    var endNode = range.endContainer;
-    var endOffset = range.endOffset;
-    if (endNode.nodeType !== Node.TEXT_NODE) {
-      var firstEnd = this.firstTextNode(endNode);
-      if (firstEnd) { endNode = firstEnd.node; endOffset = firstEnd.offset; }
-      else { endNode = startNode; endOffset = startOffset; }
-    }
+    if (!selected.length) return null;
+    var first = selected[0], last = selected[selected.length - 1];
+    var startNode = first.node, startOffset = first.start;
+    var endNode = last.node, endOffset = last.end;
+    text = selected.map(function(part) {
+      return part.node.textContent.slice(part.start, part.end);
+    }).join('');
     var sentenceContext = this.getSentenceContext(startNode, startOffset);
     var normalizedOffset = window.fushiReader
       ? this.getNormalizedOffset(startNode, startOffset) : null;
@@ -1007,7 +1009,16 @@ window.fushiSelection = {
         }
       }
     }
+    var match = this.matchableRange(startNode, startOffset, endNode, endOffset);
+    var matchSentence = this.matchableRange(
+      sentenceContext.sStartNode, sentenceContext.sStartOffset,
+      span && span.merged ? span.sEndNode : sentenceContext.sEndNode,
+      span && span.merged ? span.sEndOffset : sentenceContext.sEndOffset);
     return {
+      matchableOffset: match.offset,
+      matchableLength: match.length,
+      sentenceMatchableOffset: matchSentence.offset,
+      sentenceMatchableLength: matchSentence.length,
       text: text,
       sentence: sentence,
       normalizedOffset: normalizedOffset,
@@ -1078,14 +1089,14 @@ window.fushiSelection = {
     w.currentNode = el;
     var after = w.nextNode();
     if (after) {
-      var o = this.getNormalizedOffset(after, 0);
+      var o = this.getMatchableOffset(after, 0);
       if (o !== null) return o;
     }
     var w2 = this.createWalker(document.body);
     w2.currentNode = el;
     var before = w2.previousNode();
     if (before) {
-      var o2 = this.getNormalizedOffset(before, before.textContent.length);
+      var o2 = this.getMatchableOffset(before, before.textContent.length);
       if (o2 !== null) return o2;
     }
     return null;
@@ -1311,7 +1322,18 @@ window.fushiSelection = {
         sentenceNormalizedLength = Math.max(0, snEnd - snStart);
       }
     }
+    var lastSelectedRange = ranges.length ? ranges[ranges.length - 1] : null;
+    var match = lastSelectedRange
+      ? this.matchableRange(startNode, startOffset, lastSelectedRange.node, lastSelectedRange.end)
+      : { offset: null, length: null };
+    var matchSentence = this.matchableRange(
+      sentenceContext.sStartNode, sentenceContext.sStartOffset,
+      sentenceContext.sEndNode, sentenceContext.sEndOffset);
     return {
+      matchableOffset: match.offset,
+      matchableLength: match.length,
+      sentenceMatchableOffset: matchSentence.offset,
+      sentenceMatchableLength: matchSentence.length,
       text: text,
       sentence: mangaSentence !== null && mangaSentence !== ''
         ? mangaSentence : sentenceContext.sentence,
@@ -1762,6 +1784,33 @@ window.fushiSelection = {
     }
     return bounds ? { x: bounds.left, y: bounds.top, width: bounds.right - bounds.left, height: bounds.bottom - bounds.top } : null;
   },
+  // Audio coordinates use normalized UTF-16 units, independently of study
+  // counts. Do not read nodeStartOffsets: that index belongs to navigation.
+  getMatchableOffset: function(targetNode, offset) {
+    if (!window.fushiReader || !targetNode) return null;
+    var walker = this.createWalker(document.body);
+    var count = 0;
+    var node;
+    while ((node = walker.nextNode()) != null) {
+      var text = node.textContent || '';
+      var limit = node === targetNode ? offset : text.length;
+      for (var i = 0; i < limit;) {
+        var ch = String.fromCodePoint(text.codePointAt(i));
+        if (window.fushiReader.isMatchableChar(ch)) count += ch.length;
+        i += ch.length;
+      }
+      if (node === targetNode) return count;
+    }
+    return null;
+  },
+  matchableRange: function(startNode, startOffset, endNode, endOffset) {
+    var start = this.getMatchableOffset(startNode, startOffset);
+    var end = this.getMatchableOffset(endNode, endOffset);
+    return { offset: start, length: start !== null && end !== null && end >= start
+      ? end - start : null };
+  },
+  // Historical API name: this is a learning-unit offset for navigation, not
+  // an audio matching or DOM text index. Keep persisted navigation compatible.
   getNormalizedOffset: function(targetNode, offset) {
     if (!window.fushiReader) return null;
     var base = window.fushiReader.nodeStartOffsets

--- a/fushi/test/media/audiobook/cross_chapter_no_zero_test.dart
+++ b/fushi/test/media/audiobook/cross_chapter_no_zero_test.dart
@@ -18,59 +18,80 @@ void main() {
       // 第 N 章 sentenceIndex 范围 10..20，cue=15 → (15-10)/(20-10)=0.5
       expect(
         audiobookSrtCrossChapterProgress(
-            sentenceIndex: 15, first: 10, last: 20),
+          sentenceIndex: 15,
+          first: 10,
+          last: 20,
+        ),
         0.5,
       );
     });
     test('cue 是该章首句 → 0.0 (章首是真实位置，非归零哨兵)', () {
       expect(
         audiobookSrtCrossChapterProgress(
-            sentenceIndex: 10, first: 10, last: 20),
+          sentenceIndex: 10,
+          first: 10,
+          last: 20,
+        ),
         0.0,
       );
     });
     test('cue 是该章末句 → 1.0', () {
       expect(
         audiobookSrtCrossChapterProgress(
-            sentenceIndex: 20, first: 10, last: 20),
+          sentenceIndex: 20,
+          first: 10,
+          last: 20,
+        ),
         1.0,
       );
     });
     test('单句章 span=0 → null (拿不到句内偏移，调用方保位)', () {
       expect(
         audiobookSrtCrossChapterProgress(
-            sentenceIndex: 10, first: 10, last: 10),
+          sentenceIndex: 10,
+          first: 10,
+          last: 10,
+        ),
         isNull,
       );
     });
     test('越界保护：cue 超出范围 → clamp 不溢出', () {
       expect(
         audiobookSrtCrossChapterProgress(
-            sentenceIndex: 99, first: 10, last: 20),
+          sentenceIndex: 99,
+          first: 10,
+          last: 20,
+        ),
         1.0,
       );
     });
   });
 
   group('sentenceAudioHighlight 跨章章内进度 (TODO-746)', () {
-    test('frag 落在该章中段 → normCharStart/chapterChars，不归 0', () {
+    test('转换后的学习单位锚落在章中段 → studyOffset/chapterChars', () {
       expect(
         audiobookSentenceAudioCrossChapterProgress(
-            normCharStart: 250, chapterChars: 1000),
+          studyCharOffset: 250,
+          chapterChars: 1000,
+        ),
         0.25,
       );
     });
     test('章字符数为 0 (未知/空章) → null (调用方退回该章章首 0.0，非归到第一章)', () {
       expect(
         audiobookSentenceAudioCrossChapterProgress(
-            normCharStart: 250, chapterChars: 0),
+          studyCharOffset: 250,
+          chapterChars: 0,
+        ),
         isNull,
       );
     });
-    test('clamp 上界：normCharStart 超章字符 → 1.0 不溢出', () {
+    test('clamp 上界：学习单位锚超章总单位 → 1.0 不溢出', () {
       expect(
         audiobookSentenceAudioCrossChapterProgress(
-            normCharStart: 2000, chapterChars: 1000),
+          studyCharOffset: 2000,
+          chapterChars: 1000,
+        ),
         1.0,
       );
     });
@@ -84,11 +105,11 @@ void main() {
       ).readAsStringSync();
     });
 
-    test('sentenceAudioHighlight 跨章 (_handleCueCrossChapter) 复用章内进度纯函数', () {
+    test('sentenceAudioHighlight 跨章使用转换后的精确学习单位锚', () {
       expect(
-        src.contains('audiobookSentenceAudioCrossChapterProgress('),
+        src.contains('_navigateToChapter(newSection, charOffset: studyOffset)'),
         isTrue,
-        reason: '跨章必须复用进度公式落到 cue 真实位置，不得走缺省 progress=0.0',
+        reason: '跨章必须转换字符坐标，不得把音频字符直接除以学习单位',
       );
     });
 

--- a/fushi/test/pages/home_dashboard_page_test.dart
+++ b/fushi/test/pages/home_dashboard_page_test.dart
@@ -393,34 +393,35 @@ void main() {
     expect(find.text('横滑测试书'), findsOneWidget);
     expect(find.text('${t.home_filter_read} · 50%'), findsOneWidget);
 
-    // 悬停边框须画在封面和文字前景；移出恢复，且不改变布局尺寸。
-    final Finder frame = find
-        .ancestor(
-          of: find.text('横滑测试书'),
-          matching: find.byWidgetPredicate(
-            (Widget widget) =>
-                widget is DecoratedBox &&
-                widget.position == DecorationPosition.foreground,
-          ),
-        )
-        .first;
-    Border frameBorder() =>
-        (tester.widget<DecoratedBox>(frame).decoration as BoxDecoration).border!
-            as Border;
-    final Size originalSize = tester.getSize(frame);
-    expect(frameBorder().top.color, Colors.transparent);
+    // 悬停绘制须超出卡片原始边界，同时完整落在列表视口内，不被截平。
+    final Finder card = find.ancestor(
+      of: find.text('横滑测试书'),
+      matching: find.byType(InkWell),
+    ).first;
+    final Finder row = find.ancestor(
+      of: card,
+      matching: find.byType(ListView),
+    ).first;
+    final Rect viewport = tester.getRect(row);
+    final Rect originalRect = tester.getRect(card);
+    final Size originalSize = tester.getSize(card);
     final TestGesture mouse = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
     await mouse.addPointer(location: Offset.zero);
     await mouse.moveTo(tester.getCenter(find.text('横滑测试书')));
     await pumpDashboard(tester);
-    expect(frameBorder().top.color, isNot(Colors.transparent));
-    expect(frameBorder().top.width, 2);
-    expect(tester.getSize(frame), originalSize);
+    final Rect liftedRect = tester.getRect(card);
+    expect(liftedRect.top, lessThan(originalRect.top));
+    expect(liftedRect.left, lessThan(originalRect.left));
+    expect(liftedRect.top, greaterThanOrEqualTo(viewport.top - 0.01));
+    expect(liftedRect.left, greaterThanOrEqualTo(viewport.left - 0.01));
+    expect(liftedRect.bottom, lessThanOrEqualTo(viewport.bottom + 0.01));
+    expect(liftedRect.right, lessThanOrEqualTo(viewport.right + 0.01));
+    expect(tester.getSize(card), originalSize);
     await mouse.moveTo(Offset.zero);
     await pumpDashboard(tester);
-    expect(frameBorder().top.color, Colors.transparent);
+    expect(tester.getRect(card), originalRect);
     await mouse.removePointer();
   });
 
@@ -682,6 +683,27 @@ void main() {
         reason: '${row.$1} 行的视频卡应随横版封面自适应成 16:9 横槽，'
             '恒竖槽会把 16:9 抽帧模糊垫底成白条',
       );
+      await tester.ensureVisible(card);
+      await pumpDashboard(tester);
+      final Finder list = find.ancestor(
+        of: card,
+        matching: find.byType(ListView),
+      ).first;
+      final Rect viewport = tester.getRect(list);
+      final Rect original = tester.getRect(card);
+      final TestGesture mouse =
+          await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(card));
+      await pumpDashboard(tester);
+      final Rect lifted = tester.getRect(card);
+      expect(lifted.width, greaterThan(original.width));
+      expect(lifted.top, greaterThanOrEqualTo(viewport.top - 0.01));
+      expect(lifted.left, greaterThanOrEqualTo(viewport.left - 0.01));
+      expect(lifted.bottom, lessThanOrEqualTo(viewport.bottom + 0.01));
+      expect(lifted.right, lessThanOrEqualTo(viewport.right + 0.01));
+      await mouse.removePointer();
+      await pumpDashboard(tester);
     }
   });
 

--- a/fushi/test/pages/home_dashboard_page_test.dart
+++ b/fushi/test/pages/home_dashboard_page_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:ui' show PointerDeviceKind;
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
@@ -391,6 +392,36 @@ void main() {
     // 散卡：标题=书名，副标题=「阅读 · 50%」。
     expect(find.text('横滑测试书'), findsOneWidget);
     expect(find.text('${t.home_filter_read} · 50%'), findsOneWidget);
+
+    // 悬停边框须画在封面和文字前景；移出恢复，且不改变布局尺寸。
+    final Finder frame = find
+        .ancestor(
+          of: find.text('横滑测试书'),
+          matching: find.byWidgetPredicate(
+            (Widget widget) =>
+                widget is DecoratedBox &&
+                widget.position == DecorationPosition.foreground,
+          ),
+        )
+        .first;
+    Border frameBorder() =>
+        (tester.widget<DecoratedBox>(frame).decoration as BoxDecoration).border!
+            as Border;
+    final Size originalSize = tester.getSize(frame);
+    expect(frameBorder().top.color, Colors.transparent);
+    final TestGesture mouse = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+    );
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(find.text('横滑测试书')));
+    await pumpDashboard(tester);
+    expect(frameBorder().top.color, isNot(Colors.transparent));
+    expect(frameBorder().top.width, 2);
+    expect(tester.getSize(frame), originalSize);
+    await mouse.moveTo(Offset.zero);
+    await pumpDashboard(tester);
+    expect(frameBorder().top.color, Colors.transparent);
+    await mouse.removePointer();
   });
 
   testWidgets('显示名统一：合集成员的继续卡标题=合集名，活动时间轴拼「合集名 - 名字」',

--- a/fushi/test/reader/background_dark_single_truth_test.dart
+++ b/fushi/test/reader/background_dark_single_truth_test.dart
@@ -64,8 +64,8 @@ void main() {
       expect(bridgeSrc.contains('__fushiHighlightBgDark'), isTrue,
           reason: 'JS 读 Dart 注入的 __fushiHighlightBgDark');
       expect(
-          bridgeSrc
-              .contains('ReaderContentStyles.isDarkBackground(backgroundHex)'),
+          RegExp(r'ReaderContentStyles\.isDarkBackground\(\s*backgroundHex\s*,?\s*\)')
+              .hasMatch(bridgeSrc),
           isTrue,
           reason: 'applyHighlights 必须用滚动条同款单一真相计算深浅');
     });

--- a/fushi/test/reader/book_open_perf_wiring_guard_test.dart
+++ b/fushi/test/reader/book_open_perf_wiring_guard_test.dart
@@ -172,7 +172,7 @@ void main() {
     );
     final String toggleBody = methodBody(
       src,
-      'Future<void> _toggleFavoriteSentence()',
+      'Future<void> _toggleFavoriteSentence(',
     );
     // 这两条锚点是**跨行**的相邻语句对（「删完紧接着失效缓存」），containsCodeLine 逐行
     // 匹配表达不了，故保留整段 contains——窗口已掩码，注释满足不了它。
@@ -183,19 +183,22 @@ void main() {
       ),
       reason: '设置面板删除收藏后，当前 reader 缓存必须失效',
     );
-    // BUG-494：取消收藏优先按缓存的精确条目 id removeById 删单条，无 id 时才回退内容键
-    // removeByContent（包在 else 分支里，故内容键删单条这段多缩进一层，text: 现为 10 空格
-    // 缩进）。守卫更新到当前缩进，不变量强度不变：内容键删除仍走 removeByContent 单条删。
+    // 每次操作按实际选区解析精确收藏 ID，不能采用另一句的查词缓存。
     expect(
       toggleBody,
-      contains('await repo.removeByContent(\n          text: sentence,'),
+      contains('await repo.matchedFavoriteId('),
+    );
+    expect(
+      toggleBody,
+      contains('await repo.removeById(matchedId);'),
     );
     expect(
       containsCodeLine(toggleBody, '_invalidateFavoriteSentenceCache();'),
       isTrue,
     );
-    // 删除路径（内容键回退分支）删后必失效缓存。
-    final int removeIdx = toggleBody.indexOf('await repo.removeByContent(');
+    // 精确删除后必失效缓存。
+    final int removeIdx =
+        toggleBody.indexOf('await repo.removeById(matchedId);');
     final int removeInvalidateIdx = toggleBody.indexOf(
       '_invalidateFavoriteSentenceCache();',
       removeIdx,
@@ -203,12 +206,10 @@ void main() {
     expect(
       removeInvalidateIdx,
       greaterThan(removeIdx),
-      reason: '删除收藏（内容键回退）后当前 reader 缓存必须失效',
+      reason: '删除本次选区对应收藏后当前 reader 缓存必须失效',
     );
-    // 新增收藏：repo.add(fav) 后必记住精确 id（BUG-494 removeById 用）并失效缓存再刷新
-    // 高亮。BUG-494 在 add 与 invalidate 之间插入 _currentFavoriteId = fav.id;，故不再是
-    // 紧邻两行——改为「add 之后、rebuild 之前必有 _currentFavoriteId 记账 + 缓存失效」，
-    // 不变量强度不变（新增后缓存必失效）。
+    // 新增后先失效缓存再刷新高亮。后续删除重新按本次文本与章号解析 ID，
+    // 不依赖可能属于其他查词选区的 _currentFavoriteId。
     final int addIdx = toggleBody.indexOf('await repo.add(fav);');
     expect(addIdx, greaterThan(0), reason: '新增收藏必须 repo.add(fav)');
     final int rebuildAfterAddIdx = toggleBody.indexOf(
@@ -221,11 +222,12 @@ void main() {
       reason: '新增收藏后必须 rebuild 星标态',
     );
     final String addBody = toggleBody.substring(addIdx, rebuildAfterAddIdx);
-    expect(
-      containsCodeLine(addBody, '_currentFavoriteId = fav.id;'),
-      isTrue,
-      reason: 'BUG-494：新增后记住精确 id，供随后 removeById 精确删单条',
-    );
+    final int matchIdx = toggleBody.indexOf('await repo.matchedFavoriteId(');
+    expect(matchIdx, lessThan(removeIdx));
+    final String matchBody = toggleBody.substring(matchIdx, removeIdx);
+    expect(matchBody, contains('text: sentence,'));
+    expect(matchBody, contains('sectionIndex: section,'));
+    expect(matchBody, contains('if (matchedId != null)'));
     expect(
       containsCodeLine(addBody, '_invalidateFavoriteSentenceCache();'),
       isTrue,

--- a/fushi/test/reader/favorite_write_section_source_guard_test.dart
+++ b/fushi/test/reader/favorite_write_section_source_guard_test.dart
@@ -36,8 +36,17 @@ void main() {
         read('lib/src/pages/implementations/reader_fushi/chrome.part.dart');
     final String mining =
         read('lib/src/pages/implementations/reader_fushi/mining.part.dart');
-    expect(chrome, contains('final int section = _favoriteSectionIndex;'),
-        reason: '收藏 toggle 的 section 必须来自选区快照 getter');
+    expect(
+        chrome,
+        contains(
+            'final int section = selectionSection ?? _favoriteSectionIndex;'),
+        reason: '显式拖选必须使用菜单捕获的章号，查词收藏消费选区快照 getter');
+    expect(chrome, contains('final int favoriteSection = _lookupSectionIndex;'),
+        reason: '桌面右键必须在菜单接管焦点前捕获章号');
+    expect(chrome, contains('selectionSection: favoriteSection'),
+        reason: '桌面右键收藏传递本次捕获的章号');
+    expect(chrome, contains('selectionSection: selectionSection'),
+        reason: '移动端收藏传递菜单创建时的选区章号');
     expect(mining, contains('final int section = _favoriteSectionIndex;'),
         reason: '制卡历史落库的 section 必须来自选区快照 getter');
     // 不得再在这两处直接用裸 _lookupSectionIndex 当 section 写入。

--- a/fushi/test/reader/reader_audio_coordinate_contract_test.dart
+++ b/fushi/test/reader/reader_audio_coordinate_contract_test.dart
@@ -1,0 +1,106 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/audiobook/mining_audio_clip.dart';
+import 'package:fushi/src/reader/reader_selection_data.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+void main() {
+  test('audio resolves the second repeated sentence after a Latin prefix', () {
+    // Learning units collapse ABC to one unit, whereas audio retains ABC.
+    final ReaderSelectionData data =
+        ReaderSelectionData.fromJson(<String, dynamic>{
+          'text': '猫だ',
+          'sentence': '猫だ',
+          'normalizedOffset': 3,
+          'normalizedLength': 2,
+          'matchableOffset': 5,
+          'matchableLength': 2,
+          'sentenceMatchableOffset': 5,
+          'sentenceMatchableLength': 2,
+        });
+    final List<AudioCue> cues = <AudioCue>[
+      _cue('ABC', 0, 3),
+      _cue('猫だ', 3, 5),
+      _cue('猫だ', 5, 7),
+    ];
+    final List<AudioCue> hits = miningSentenceCueSpan(
+      cues: cues,
+      cue: null,
+      sentence: data.sentence,
+      sectionIndex: 0,
+      sentenceNormCharOffset: data.sentenceMatchableOffset,
+      sentenceNormCharLength: data.sentenceMatchableLength,
+    );
+    expect(hits, <AudioCue>[cues.last]);
+    expect(data.normalizedOffset, 3);
+  });
+
+  test(
+    'legacy selection does not promote learning units into audio positions',
+    () {
+      final ReaderSelectionData data =
+          ReaderSelectionData.fromJson(<String, dynamic>{
+            'text': '猫だ',
+            'sentence': '猫だ',
+            'normalizedOffset': 3,
+            'normalizedLength': 2,
+            'sentenceNormalizedOffset': 3,
+            'sentenceNormalizedLength': 2,
+          });
+      expect(data.matchableOffset, isNull);
+      expect(data.matchableLength, isNull);
+      expect(data.sentenceMatchableOffset, isNull);
+      expect(data.sentenceMatchableLength, isNull);
+    },
+  );
+
+  test(
+    'lookup, context menu and audio export keep coordinate domains separate',
+    () {
+      const String directory = 'lib/src/pages/implementations/reader_fushi/';
+      for (final String file in <String>[
+        'lookup.part.dart',
+        'chrome.part.dart',
+      ]) {
+        final String source = File('$directory$file').readAsStringSync();
+        expect(
+          source,
+          isNot(contains('_findCueForOffset(data.normalizedOffset!')),
+        );
+        expect(source, contains('_findCueForOffset(data.matchableOffset!'));
+        expect(source, contains('_cacheMatchableSelection(data)'));
+      }
+      final String audio = File(
+        '${directory}audiobook.part.dart',
+      ).readAsStringSync();
+      final String span = audio.substring(
+        audio.indexOf('  ({int offset, int length})? _miningSpanRange()'),
+        audio.indexOf('  AudioPlaybackRange? _sentenceAudioRangeFor('),
+      );
+      expect(span, contains('_cachedMatchableSentenceRange'));
+      expect(span, contains('_cachedMatchableSelectionRange'));
+      expect(span, isNot(contains('_cachedSentenceRange')));
+      expect(span, isNot(contains('_cachedSelectionRange')));
+      final String export = audio.substring(
+        audio.indexOf('  _buildAudiobookClipPlan('),
+        audio.indexOf('    final String sentence = resolvedSelection.text;'),
+      );
+      expect(export, contains('_cachedMatchableSelectionRange'));
+    },
+  );
+}
+
+AudioCue _cue(String text, int start, int end) => AudioCue()
+  ..bookKey = 'book'
+  ..chapterHref = 'chapter.xhtml'
+  ..sentenceIndex = start
+  ..textFragmentId = SubtitleRematchCodec.encodeHit(
+    sectionIndex: 0,
+    normCharStart: start,
+    normCharEnd: end,
+  )
+  ..text = text
+  ..startMs = start * 1000
+  ..endMs = end * 1000
+  ..audioFileIndex = 0;

--- a/fushi/test/reader/reader_audio_position_test.dart
+++ b/fushi/test/reader/reader_audio_position_test.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_audio_position.dart';
+
+void main() {
+  test('Latin and astral CJK audio coordinates convert to study range', () {
+    final ReaderAudioPositionIndex index =
+        ReaderAudioPositionIndex.fromChapterHtml(
+          '<body>ABC 123𠮷<ruby>猫<rt>ねこ</rt></ruby>だ。</body>',
+        );
+    expect(index.studyRangeForFragment(matchableStart: 8, matchableEnd: 10), (
+      offset: 3,
+      length: 2,
+    ));
+  });
+
+  test('node boundaries preserve reader word accounting', () {
+    final ReaderAudioPositionIndex index =
+        ReaderAudioPositionIndex.fromChapterHtml(
+          '<body><span>ab</span><em>cd</em><p>猫</p></body>',
+        );
+    expect(index.studyRangeForFragment(matchableStart: 4, matchableEnd: 5), (
+      offset: 2,
+      length: 1,
+    ));
+  });
+
+  test('word prefixes do not count unfinished study units', () {
+    final ReaderAudioPositionIndex index =
+        ReaderAudioPositionIndex.fromChapterHtml('<body>ABC 猫</body>');
+    expect(index.studyRangeForFragment(matchableStart: 1, matchableEnd: 2), (
+      offset: 0,
+      length: 0,
+    ));
+    expect(index.studyRangeForFragment(matchableStart: 1, matchableEnd: 3), (
+      offset: 0,
+      length: 1,
+    ));
+  });
+
+  test(
+    'nonmatchable study units and transparent apostrophes are accounted for',
+    () {
+      final ReaderAudioPositionIndex index =
+          ReaderAudioPositionIndex.fromChapterHtml(
+            '<body>don\'t café русский 𠮷猫</body>',
+          );
+      expect(index.studyRangeForFragment(matchableStart: 9, matchableEnd: 10), (
+        offset: 4,
+        length: 1,
+      ));
+      expect(index.studyRangeForFragment(matchableStart: 4, matchableEnd: 7), (
+        offset: 1,
+        length: 0,
+      ));
+    },
+  );
+
+  test('matched EPUB fragment does not require verbatim subtitle equality', () {
+    // A fuzzy SRT match can pair "猫なんだ" with the EPUB fragment "猫だ".
+    // Its persisted position is authoritative; no text-search replacement is used.
+    final ReaderAudioPositionIndex index =
+        ReaderAudioPositionIndex.fromChapterHtml('<body>ABC猫だ犬猫だ</body>');
+    expect(index.studyRangeForFragment(matchableStart: 6, matchableEnd: 8), (
+      offset: 4,
+      length: 2,
+    ));
+  });
+
+  test('invalid ranges and split surrogate boundaries are rejected', () {
+    final ReaderAudioPositionIndex index =
+        ReaderAudioPositionIndex.fromChapterHtml('<body>ABC𠮷猫</body>');
+    for (final (int start, int end) in <(int, int)>[
+      (-1, 0),
+      (6, 7),
+      (4, 5),
+      (3, 4),
+      (3, 3),
+    ]) {
+      expect(
+        index.studyRangeForFragment(matchableStart: start, matchableEnd: end),
+        isNull,
+      );
+    }
+    expect(index.studyRangeForFragment(matchableStart: 3, matchableEnd: 5), (
+      offset: 1,
+      length: 1,
+    ));
+  });
+
+  test(
+    'restore, cross chapter, lyrics persistence and favorites convert positions',
+    () {
+      const String base = 'lib/src/pages/implementations/reader_fushi/';
+      final String audio = File(
+        '${base}audiobook.part.dart',
+      ).readAsStringSync();
+      final String navigation = File(
+        '${base}navigation.part.dart',
+      ).readAsStringSync();
+      final String lookup = File('${base}lookup.part.dart').readAsStringSync();
+      expect(audio, contains('_initialCharOffset = studyOffset'));
+      expect(
+        audio,
+        contains('_navigateToChapter(newSection, charOffset: studyOffset)'),
+      );
+      expect(navigation, contains('_lastProgressCharOffset = studyOffset'));
+      expect(
+        navigation,
+        isNot(contains('frag.normCharStart / _chapterCharCounts')),
+      );
+      expect(audio, isNot(contains('normCharStart: frag.normCharStart')));
+      expect(lookup, contains('_cachedSentenceRange = studyRange'));
+      expect(lookup, contains('_studyRangeForAudioFragment(frag)'));
+    },
+  );
+}

--- a/fushi/test/reader/reader_chrome_floating_test.dart
+++ b/fushi/test/reader/reader_chrome_floating_test.dart
@@ -297,7 +297,7 @@ void main() {
             'WebView 往返（BUG-969 根因），必须经合并执行器收敛',
       );
       expect(
-        src.contains('CoalescedAsyncRunner(() async {'),
+        RegExp(r'CoalescedAsyncRunner\(\s*\(\)\s*async\s*\{').hasMatch(src),
         isTrue,
         reason: '合并动作本体（错误处理/tap-gate/setState）必须收在 runner 内',
       );

--- a/fushi/test/reader/reader_favorite_coordinates_test.dart
+++ b/fushi/test/reader/reader_favorite_coordinates_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/reader/reader_selection_scripts.dart';
+import 'package:fushi/src/reader/reader_study_unit_script.dart';
+
+/// Runs production scripts against real DOM Range and CSS Highlight APIs.
+/// Set CHROME_EXECUTABLE on machines where Chromium is not in a standard path.
+void main() {
+  final String? chrome = <String?>[
+    Platform.environment['CHROME_EXECUTABLE'],
+    r'C:\Program Files\Google\Chrome\Application\chrome.exe',
+    r'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe',
+    '/usr/bin/google-chrome',
+    '/usr/bin/chromium',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ]
+      .whereType<String>()
+      .where((String path) => File(path).existsSync())
+      .firstOrNull;
+
+  test(
+    'favorite anchors and native selections preserve actual DOM text',
+    () async {
+      final String bridgeSource = File(
+        'lib/src/media/audiobook/highlight_bridge.dart',
+      ).readAsStringSync();
+      final String bridge = bridgeSource
+          .split("_js = '''")[1]
+          .split("''';")[0]
+          .replaceAll(r'\\', r'\');
+      final String visualNovelSource = File(
+        'lib/src/reader/reader_visual_novel_scripts.dart',
+      ).readAsStringSync();
+      final String matchableRegex = RegExp(
+        r'var readerRegex = (.+);',
+      ).firstMatch(visualNovelSource)!.group(1)!.replaceAll(r'\\', r'\');
+      final String cases = File(
+        'test/reader/reader_favorite_coordinates_test.js',
+      ).readAsStringSync();
+      final Directory temp = Directory.systemTemp.createTempSync(
+        'favorite-dom-',
+      );
+      try {
+        final File html = File('${temp.path}/test.html');
+        html.writeAsStringSync('''<!doctype html><meta charset="utf-8"><head>
+<script>$kStudyUnitJs</script>
+<script>${ReaderSelectionScripts.source()}</script>
+<script>$bridge</script>
+</head><body><script>
+window.fushiReader = {isMatchableChar: ch => $matchableRegex.test(ch)};
+$cases
+</script></body>''');
+        final ProcessResult result = await Process.run(chrome!, <String>[
+          '--headless',
+          '--no-sandbox',
+          '--disable-gpu',
+          '--no-first-run',
+          '--disable-background-networking',
+          '--dump-dom',
+          '--user-data-dir=${temp.path}/profile',
+          html.uri.toString(),
+        ]).timeout(const Duration(seconds: 45));
+        expect(result.exitCode, 0, reason: '${result.stderr}');
+        final RegExpMatch? payload = RegExp(
+          r'<pre id="results">([^<]+)</pre>',
+        ).firstMatch(result.stdout as String);
+        expect(
+          payload,
+          isNotNull,
+          reason: '${result.stdout}\n${result.stderr}',
+        );
+        final Map<String, dynamic> report =
+            jsonDecode(utf8.decode(base64Decode(payload!.group(1)!)))
+                as Map<String, dynamic>;
+        expect(report['failures'], isEmpty, reason: '${report['failures']}');
+        expect(report['passed'], 21);
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+    },
+    skip: chrome == null ? 'Chromium required; set CHROME_EXECUTABLE' : false,
+  );
+}

--- a/fushi/test/reader/reader_favorite_coordinates_test.js
+++ b/fushi/test/reader/reader_favorite_coordinates_test.js
@@ -1,0 +1,93 @@
+(() => {
+  const failures = [];
+  let passed = 0;
+  function test(name, action) {
+    try { action(); passed++; }
+    catch (error) { failures.push(name + ': ' + error.stack); }
+  }
+  function equal(actual, expected) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw Error(JSON.stringify({actual, expected}));
+    }
+  }
+  function fixture(html) {
+    window.getSelection().removeAllRanges();
+    document.body.innerHTML = html;
+  }
+  function select(start, startOffset, end, endOffset) {
+    const range = document.createRange();
+    range.setStart(start, startOffset);
+    range.setEnd(end, endOffset);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+    return window.fushiSelection.nativeSelectionSentenceRange();
+  }
+  function paint(text, offset, css) {
+    window.__fushiCssHighlightsSupported = css;
+    window.__fushiApplyHighlights([{id: 'favorite', text, offset, length: 1, color: 'yellow'}]);
+    return css
+      ? Array.from(CSS.highlights.get('fushi-hl-yellow') || []).map(r => r.toString()).join('')
+      : Array.from(document.querySelectorAll('[data-highlight-id="favorite"]')).map(n => n.textContent).join('');
+  }
+  for (const css of [true, false]) {
+    const mode = css ? 'CSS Highlight' : 'fallback span';
+    for (const [name, html, needle, hint] of [
+      ['Latin and digits before selection', '<p>ABC 123日本語選択した文章です。</p>', '選択した文章', 5],
+      ['Japanese only', '<p>これは選択した文章です。</p>', '選択した文章', 3],
+      ['middle of Latin word', '<p>before alphabet after</p>', 'phab', 1],
+      ['punctuation', '<p>前文。選択、した！文章。</p>', '選択、した！', 2],
+      ['non BMP and other scripts', '<p>before 𠮷🙂 café Ελληνικά العربية after</p>', '𠮷🙂 café Ελληνικά العربية', 1],
+      ['cross-node whitespace', '<p>前文。<b>選択 </b><i>した文章</i>です。</p>', '選択 した文章', 2],
+    ]) {
+      test(mode + ': ' + name, () => {
+        fixture(html);
+        const painted = paint(needle, hint, css);
+        // Layout whitespace at a node boundary has no glyph to paint.
+        equal(painted.replace(/\s/g, ''), needle.replace(/\s/g, ''));
+      });
+    }
+    test(mode + ': repeated text uses study hint', () => {
+      fixture('<p>ABC 同文。後。同文。</p>');
+      equal(paint('同文', 4, css), '同文');
+      if (css) equal(window.__fushiHighlightRangeMap.favorite.ranges[0].startOffset, 9);
+      else equal(document.querySelector('[data-highlight-id]').previousSibling.textContent, 'ABC 同文。後。');
+    });
+    test(mode + ': ambiguous repeat stays unpainted', () => {
+      fixture('<p>同文。同文。</p>');
+      equal(paint('同文', 1, css), '');
+    });
+    test(mode + ': missing text cannot paint stale offset', () => {
+      fixture('<p>別の文章。</p>');
+      equal(paint('保存時の文章', 0, css), '');
+    });
+  }
+  test('native drag keeps substring independent of expanded sentence', () => {
+    fixture('<p>ABC 123日本語選択した文章です。</p>');
+    const node = document.querySelector('p').firstChild;
+    const data = select(node, 10, node, 17);
+    equal(data.text, '選択した文章で');
+    equal(data.normalizedOffset, 5);
+    equal(data.matchableOffset, 9);
+    equal(window.__fushiGetSelectionNormRange().text, data.text);
+    equal(paint(data.text, data.normalizedOffset, true), data.text);
+  });
+  test('native range element child indexes exclude adjacent text', () => {
+    fixture('<p><span>前</span><b>選択</b><i>文章</i><span>後</span></p>');
+    const p = document.querySelector('p');
+    const data = select(p, 1, p, 3);
+    equal(data.text, '選択文章');
+    equal(data.normalizedOffset, 1);
+    equal(data.normalizedLength, 4);
+  });
+  test('native ruby range excludes pronunciation and respects cross-node ends', () => {
+    fixture('<p>前<ruby>漢<rt>かん</rt></ruby><b>字と文章</b>後</p>');
+    const p = document.querySelector('p');
+    const b = document.querySelector('b').firstChild;
+    const data = select(p, 1, b, 2);
+    equal(data.text, '漢字と');
+    equal(data.normalizedOffset, 1);
+    equal(data.normalizedLength, 3);
+  });
+  document.body.innerHTML = '<pre id="results"></pre>';
+  document.querySelector('#results').textContent = btoa(unescape(encodeURIComponent(JSON.stringify({passed, failures}))));
+})();

--- a/fushi/test/reader/reader_image_lazy_pipeline_guard_test.dart
+++ b/fushi/test/reader/reader_image_lazy_pipeline_guard_test.dart
@@ -125,8 +125,8 @@ void main() {
       final String src =
           navFile.readAsStringSync().replaceAll(RegExp(r'\s+'), ' ');
       expect(
-          src.contains(
-              '_prefetchAdjacentChapterImages( _currentChapter + _chapterAdvanceDirection)'),
+          RegExp(r'_prefetchAdjacentChapterImages\(\s*_currentChapter\s*\+\s*_chapterAdvanceDirection\s*,?\s*\)')
+              .hasMatch(src),
           isTrue,
           reason: '倒着读时必须预热上一章，而不是刚离开的那一章');
       expect(

--- a/fushi/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
+++ b/fushi/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
@@ -55,10 +55,14 @@ void main() {
       expect(bar, contains('t.selection_web_search'));
       expect(bar, contains("case 'share':"));
       expect(bar, contains("case 'webSearch':"));
-      expect(bar,
-          contains('SelectionExternalActions.instance.shareText(data.text)'));
-      expect(bar,
-          contains('SelectionExternalActions.instance.searchWeb(data.text)'));
+      expect(
+          RegExp(r'SelectionExternalActions\.instance\.shareText\(\s*data\.text\s*,?\s*\)')
+              .hasMatch(bar),
+          isTrue);
+      expect(
+          RegExp(r'SelectionExternalActions\.instance\.searchWeb\(\s*data\.text\s*,?\s*\)')
+              .hasMatch(bar),
+          isTrue);
       expect(bar, contains('t.selection_web_search_unavailable'));
       expect(bar, contains('await _clearReaderAppSelection()'));
     });

--- a/fushi/test/reader/reader_selection_favorite_menu_guard_test.dart
+++ b/fushi/test/reader/reader_selection_favorite_menu_guard_test.dart
@@ -8,13 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 /// （`_toggleFavoriteSentence`，桌面底栏 / 查词弹窗顶栏用），但选区菜单从没接进去。
 /// 触屏拖选是 **app 自绘选区**（`_handleSelectionMenu`），桌面是 **原生选区右键**
 /// （`_showReaderTextContextMenu`），两条选区入口此前都无收藏项。本守卫钉死两处都补上
-/// 「收藏」，且各自按选区类型正确填「查词状态」（`currentSentence` / 句级区间非空契约）
-/// 后复用同一后端 `_toggleFavoriteSentence`：
+/// 「收藏」，且各自将实际拖选快照传入同一后端 `_toggleFavoriteSentence`：
 ///   ① 手机拖选菜单：非模态条的 `'favorite'` + `t.action_favorite`，switch 分支经
-///      `_fillLookupStateFromSelectionData(..., extractNativeImages: false)`（无原生选区）
-///      填状态后 `_toggleFavoriteSentence()`；
-///   ② 桌面右键菜单：同项，switch 分支经 `_fillLookupStateFromNativeSelection()`
-///      （原生选区）填状态后 `_toggleFavoriteSentence()`；
+///      直接传递自绘选区 data，不把查词整句范围当作收藏范围；
+///   ② 桌面右键菜单：菜单抢焦点前快照原生选区，选择收藏后传递该快照；
 ///   ③ 查词 / 复制两条老出口零回归。
 ///
 /// 真机触屏 WebView 才能跑真手势 + 菜单，故用 Dart 源码扫描钉死契约（与既有
@@ -28,43 +25,59 @@ String _between(String src, String startMarker, String endMarker) {
 }
 
 void main() {
-  final String chrome =
-      File('lib/src/pages/implementations/reader_fushi/chrome.part.dart')
-          .readAsStringSync();
+  final String chrome = File(
+    'lib/src/pages/implementations/reader_fushi/chrome.part.dart',
+  ).readAsStringSync();
 
   String selectionMenuBody() => _between(
-      chrome,
-      'Future<void> _handleSelectionMenu(',
-      'Future<void> _clearReaderAppSelection(');
+        chrome,
+        'Future<void> _handleSelectionMenu(',
+        'Future<void> _clearReaderAppSelection(',
+      );
   String desktopMenuBody() => _between(
-      chrome,
-      'Future<void> _showReaderTextContextMenu(',
-      'Future<void> _handleSelectionMenu(');
+        chrome,
+        'Future<void> _showReaderTextContextMenu(',
+        'Future<void> _handleSelectionMenu(',
+      );
 
   group('① 手机拖选菜单补「收藏」（自绘选区，无原生选区）', () {
     test('菜单项含 favorite + 复用 action_favorite i18n key', () {
       final String body = selectionMenuBody();
       expect(body, contains("'favorite'"), reason: '缺「收藏」操作项');
-      expect(body, contains('t.action_favorite'),
-          reason: '收藏项必须复用既有 action_favorite i18n key（勿新增重复 key）');
+      expect(
+        body,
+        contains('t.action_favorite'),
+        reason: '收藏项必须复用既有 action_favorite i18n key（勿新增重复 key）',
+      );
       // 查词 / 复制两条老出口仍在（共存，不回退）。
       expect(body, contains('t.search'));
       expect(body, contains('t.copy'));
     });
 
-    test('switch favorite 分支从自绘选区 payload 填状态后走收藏后端', () {
+    test('switch favorite 分支直接消费自绘选区 payload', () {
       // 折叠空白，容忍 dart format 把长调用换行折行（断言不依赖具体换行）。
-      final String body = selectionMenuBody().replaceAll(RegExp(r'\s+'), ' ');
+      final String body = _between(
+        selectionMenuBody(),
+        "case 'favorite':",
+        "case 'export':",
+      ).replaceAll(RegExp(r'\s+'), ' ');
       expect(body, contains("case 'favorite':"));
       expect(
-          body,
-          contains(
-              '_fillLookupStateFromSelectionData(data, extractNativeImages: false)'),
-          reason: '触屏自绘选区无原生选区，须从 payload 填 currentSentence / 句级区间');
-      expect(body, contains('_toggleFavoriteSentence()'),
-          reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence');
-      expect(body, contains('_clearReaderAppSelection()'),
-          reason: '收藏完清掉 app 选区高亮');
+        body,
+        contains('selection: data'),
+        reason: '触屏收藏须直接使用实际拖选 payload，不能被扩展后的查词整句替换',
+      );
+      expect(body, isNot(contains('_fillLookupStateFromSelectionData')));
+      expect(
+        body,
+        contains('_toggleFavoriteSentence('),
+        reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence',
+      );
+      expect(
+        body,
+        contains('_clearReaderAppSelection()'),
+        reason: '收藏完清掉 app 选区高亮',
+      );
     });
   });
 
@@ -77,13 +90,34 @@ void main() {
       expect(body, contains('isWindowsPlatform'), reason: '桌面右键菜单门控不得回退');
     });
 
-    test('switch favorite 分支从原生选区填状态后走收藏后端', () {
+    test('菜单获取焦点前捕获原生选区，收藏消费快照', () {
       final String body = desktopMenuBody();
       expect(body, contains("case 'favorite':"));
-      expect(body, contains('_fillLookupStateFromNativeSelection()'),
-          reason: '桌面走原生选区路径填 currentSentence（与 search 同源）');
-      expect(body, contains('_toggleFavoriteSentence()'),
-          reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence');
+      final int capture = body.indexOf(
+        'await _fillLookupStateFromNativeSelection()',
+      );
+      expect(capture, greaterThanOrEqualTo(0));
+      expect(
+        capture,
+        lessThan(body.indexOf('await showMenu<String>(')),
+        reason: '菜单抢焦点前必须快照原生拖选范围',
+      );
+      final String favorite = _between(
+        body,
+        "case 'favorite':",
+        "case 'export':",
+      );
+      expect(favorite, contains('selection: favoriteSelection'));
+      expect(
+        favorite,
+        isNot(contains('_fillLookupStateFromNativeSelection()')),
+        reason: '菜单关闭后不得重读可能已经丢失的原生选区',
+      );
+      expect(
+        favorite,
+        contains('_toggleFavoriteSentence('),
+        reason: '收藏必须复用桌面同一后端 _toggleFavoriteSentence',
+      );
     });
   });
 }

--- a/fushi/test/reader/tap_gate_mirror_guard_test.dart
+++ b/fushi/test/reader/tap_gate_mirror_guard_test.dart
@@ -74,7 +74,11 @@ void main() {
     // BUG-969：highlightOnTap 镜像同步随实时预览合并进 _liveSettingsRunner 动作体；
     // onSettingsChangedLive 只负责 trigger 该 runner（拖 slider 风暴收敛为背靠背串行趟）。
     // runner 定义在 hook 之前，故同步点必须落在 runner 动作内、且 hook 经 trigger 触发。
-    final int runnerDef = mainShell.indexOf('CoalescedAsyncRunner(() async {');
+    final RegExpMatch? runner = RegExp(
+      r'CoalescedAsyncRunner\(\s*\(\)\s*async\s*\{',
+    ).firstMatch(mainShell);
+    expect(runner, isNotNull, reason: '实时设置合并执行器必须存在');
+    final int runnerDef = runner!.start;
     final int syncCall = mainShell.indexOf('_syncTapGateJs();', runnerDef);
     expect(runnerDef, greaterThan(-1),
         reason: '实时设置合并执行器 _liveSettingsRunner 必须存在');


### PR DESCRIPTION
拖选文字后右键收藏，保存位置使用学习单位，高亮却按字符解释，导致黄色高亮落到前文。右键收藏还会扩大到整句，并可能读取菜单失焦后的选区或旧查词状态。

本次按原始选区和捕获章号收藏，以保存正文解析高亮位置；同时分开阅读导航与音频匹配坐标，修复查词音频定位、制卡/导出范围、插图归属、音频跨章恢复和歌词模式中的同类混用。旧收藏也验证正文，歧义或失配不会画到其它文字。

验证：
- 1,616 项阅读器、音频及相关页面定向测试全部通过，包含 21 个真实 Chrome DOM 场景（CSS Highlight 与 span fallback、跨节点、ruby、元素边界、英文及非 BMP 文本）。
- flutter analyze --no-pub：无问题。
- bug.dart check：通过。对应 BUG-2333。

待验证：截图对应原书的真实 App“拖选→右键收藏”路径尚未复测；未跑全平台构建或本地全量 Flutter 测试。历史音频 fragment 没有正文版本指纹，无法仅凭合法范围识别旧对齐失效。
