### PR TITLE
fix(reader): Shift 悬停同一单词去重

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2147 条。点号进各自文件。
+> 共 2148 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-2332](bugs/BUG-2332-cloud-manga-content-sync.md) | ✅ | ✅ | 云盘同步后端完全不同步漫画（上传静默跳过、下载按 EPUB 导入失败） |
+| [BUG-2331](bugs/BUG-2331-shift-hover-dedupe.md) | ✅ | ✅ | Shift 悬停同一单词重复查词 |
 | [BUG-2330](bugs/BUG-2330-audiobook-multifile-position-no-file-index.md) | ✅ | ✅ | 多文件有声书持久化文件内毫秒无文件下标，重开恒落文件0 |
 | [BUG-2329](bugs/BUG-2329-eink-toggle-no-reader-reinject.md) | ✅ | ✅ | 墨水屏开关不通知阅读器重注入正文样式 |
 | [BUG-2328](bugs/BUG-2328-audiobook-resume-ignored-on-open.md) | ✅ | ✅ | 打开带有声书的书不按有声书进度定位，按播放才跳 |

--- a/docs/bugs/BUG-2331-shift-hover-dedupe.md
+++ b/docs/bugs/BUG-2331-shift-hover-dedupe.md
@@ -1,0 +1,6 @@
+## BUG-2331 · Shift 悬停同一单词重复查词
+- **报告**：2026-09-09（用户：按住 Shift 停在单词上会重复查询）
+- **真实性**：✅ 真 bug。`fushi/lib/src/reader/reader_selection_scripts.dart:1157` 的 `selectText` 只比较原始 hit 与 selection 起点；拉丁词首归一化发生在其后，多字日语匹配范围也未参与判断。高亮 fallback 还会拆换文本节点。
+- **[x] ① 已修复** — 悬停按 `highlightSelection` 实际匹配范围去重，兼容自己的高亮 wrapper；结果未返回时按既有拉丁词首规则去重。不把整段扫描缓冲当成词范围，保留换词和真点击 toggle。提交见本文件所在提交。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reader_hover_lookup_behavior_test.js` 执行生产 JS，覆盖 pending 拉丁词、相邻词、多字日语、跨节点、范围末端、关闭重查、真点击与 wrapper fallback；Dart wrapper 纳入 Flutter 定向测试。
+- **备注**：Node 8 个行为场景、Flutter 44 条定向测试、282 条相邻测试及完整 flutter analyze --no-pub 均通过。旧版生产脚本运行同一测试得到 5 次查询（预期 1），修复后通过。首次 PDFium 下载超时，配置代理后重跑通过。尚未在真实 Windows 阅读器复测原始悬停操作；本轮定位并修改阅读器正文路径，用户尚未确认发生位置。

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -41,8 +41,7 @@ class ReaderSelectionScripts {
     double y,
     int maxLength, {
     bool fromHover = false,
-  }) =>
-      'window.fushiSelection.selectText($x, $y, $maxLength, $fromHover)';
+  }) => 'window.fushiSelection.selectText($x, $y, $maxLength, $fromHover)';
 
   static String highlightInvocation(int count) =>
       'JSON.stringify(window.fushiSelection.highlightSelection($count))';
@@ -195,7 +194,7 @@ class ReaderSelectionScripts {
   /// 每条带 [sentence] 文本与（可选）整书归一化偏移 [normOffset]/[normLength]
   /// （供有声书裁句子音频区间）。无选区 / 解析失败时返回两个空列表。
   static ({List<SurroundingSentence> prev, List<SurroundingSentence> next})
-      surroundingSentencesFromResult(Object? raw) {
+  surroundingSentencesFromResult(Object? raw) {
     const empty = (
       prev: <SurroundingSentence>[],
       next: <SurroundingSentence>[],
@@ -1157,6 +1156,23 @@ window.fushiSelection = {
       }
       return null;
     }
+    // Hover identity uses the matched word, not the entire forward scan buffer.
+    // The latter can contain the rest of the sentence and would block new words.
+    if (fromHover && this.selection) {
+      var insideMatch = (this.selection.matchedRanges || []).some(function(r) {
+        return hit.node === r.node && hit.offset >= r.start && hit.offset < r.end;
+      });
+      var wrapper = hit.node.parentElement && hit.node.parentElement.closest('.fushi-dict-highlight');
+      if (insideMatch || (wrapper && this.highlightWrappers.indexOf(wrapper) >= 0)) return null;
+      // Before lookup finishes, normalize Latin hits just as selectFromPosition
+      // does so hovering a different letter does not enqueue the same lookup.
+      var content = hit.node.textContent;
+      var offset = hit.offset;
+      if (offset < content.length && !this.isCodePointJapanese(content.codePointAt(offset))) {
+        while (offset > 0 && !this.isScanBoundary(content[offset - 1])) offset--;
+      }
+      if (hit.node === this.selection.startNode && offset === this.selection.startOffset) return null;
+    }
     if (this.selection && hit.node === this.selection.startNode && hit.offset === this.selection.startOffset) {
       // 悬停连续查词（fromHover）命中的还是同一个词：什么都不做，保留当前选区
       // 高亮与弹窗——这是「按住 Shift 一路滑，弹窗跟着光标走」的去重基石。滑过一
@@ -1705,6 +1721,7 @@ window.fushiSelection = {
       }
       trimmedRanges.push({ node: r.node, start: r.start, end: end });
     }
+    this.selection.matchedRanges = trimmedRanges;
     var bounds = null;
     for (var i = 0; i < trimmedRanges.length; i++) {
       var seg = trimmedRanges[i];

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1269
+version: 2.3.0+1270
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/reader/reader_hover_lookup_behavior_test.dart
+++ b/fushi/test/reader/reader_hover_lookup_behavior_test.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('hover deduplicates matched words and permits the next word', () async {
+    final ProcessResult result = await Process.run(
+      Platform.isWindows ? 'node.exe' : 'node',
+      <String>['test/reader/reader_hover_lookup_behavior_test.js'],
+    );
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, contains('all assertions passed'));
+  });
+}

--- a/fushi/test/reader/reader_hover_lookup_behavior_test.js
+++ b/fushi/test/reader/reader_hover_lookup_behavior_test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const dart = fs.readFileSync(path.join(__dirname, '../../lib/src/reader/reader_selection_scripts.dart'), 'utf8');
+const source = dart.split('static String source() => r"""')[1].split('""";')[0];
+const window = { CSS: {}, getSelection: () => null };
+const document = { elementFromPoint: () => null, createRange: () => ({
+  setStart() {}, setEnd() {}, getClientRects: () => [],
+}) };
+vm.runInNewContext(source, { window, document, CSS: { highlights: { set() {}, delete() {} } }, Highlight: function() {} });
+const s = window.fushiSelection;
+const text = (textContent) => ({ textContent, parentElement: { closest: () => null } });
+let hit, lookups = 0;
+s.getCharacterAtPoint = () => hit;
+s.hideSelectionHandles = () => {};
+s.clearSelectionRubyHighlights = () => {};
+s.rubyForNode = () => null;
+s.selectFromPosition = function(node, offset) {
+  lookups++;
+  while (offset > 0 && !this.isCodePointJapanese(node.textContent.codePointAt(offset)) && !this.isScanBoundary(node.textContent[offset - 1])) offset--;
+  this.selection = {startNode: node, startOffset: offset, ranges: [{node, start: offset, end: node.textContent.length}]};
+};
+window.__fushiCssHighlightsSupported = true;
+const latin = text('hello world');
+hit = {node: latin, offset: 2};
+s.selectText(0, 0, 400, true);
+for (const offset of [2, 3, 4, 0, 1]) { hit.offset = offset; s.selectText(0, 0, 400, true); }
+assert.equal(lookups, 1, 'pending Latin lookup deduplicates normalized word');
+hit.offset = 6; s.selectText(0, 0, 400, true);
+assert.equal(lookups, 2, 'next Latin word remains queryable');
+s.clearSelection();
+const ja = text('日本語学校');
+hit = {node: ja, offset: 0}; s.selectText(0, 0, 400, true);
+s.highlightSelection(3);
+for (const offset of [0, 1, 2, 1]) { hit.offset = offset; s.selectText(0, 0, 400, true); }
+assert.equal(lookups, 3, 'matched Japanese word deduplicates every character');
+hit.offset = 3; s.selectText(0, 0, 400, true);
+assert.equal(lookups, 4, 'scan tail must not count as matched word');
+const inline = text('語学校');
+s.selection = {startNode: ja, startOffset: 0, ranges: [{node: ja, start: 0, end: 2}, {node: inline, start: 0, end: 3}]};
+s.highlightSelection(3);
+hit = {node: inline, offset: 0}; s.selectText(0, 0, 400, true);
+assert.equal(lookups, 4, 'same match spans inline nodes');
+hit.offset = 1; s.selectText(0, 0, 400, true);
+assert.equal(lookups, 5, 'end offset is exclusive');
+s.clearSelection();
+hit = {node: ja, offset: 0}; s.selectText(0, 0, 400, true);
+assert.equal(lookups, 6, 'dismiss permits looking up again');
+s.selectText(0, 0, 400, false);
+assert.equal(s.selection, null, 'real click retains toggle behavior');
+s.selectText(0, 0, 400, true);
+const wrapper = {};
+s.highlightWrappers = [wrapper];
+hit = {node: {textContent: '日本語', parentElement: {closest: () => wrapper}}, offset: 1};
+s.selectText(0, 0, 400, true);
+assert.equal(lookups, 7, 'DOM wrapper fallback preserves word identity');
+console.log('all assertions passed (8 hover scenarios)');


### PR DESCRIPTION
按住 Shift 在阅读器同一单词内移动时，旧实现只比较原始字符与词首位置，导致重复查询。本改动按实际匹配范围去重，并在查询返回前归一化拉丁词起点；移到下一个词、关闭后重查和点击取消仍保留。

兼容跨文本节点及非 CSS 高亮 wrapper，记录 BUG-2331。构建号更新为 2.3.0+1270。

验证：
- Node 8 个悬停行为场景通过；同一回归测试在旧实现得到 5 次查询，修复后为 1 次。
- 原修复分支 44 条定向测试、282 条相邻测试及完整静态分析通过。
- 最新 develop 基线上重跑 44 条定向测试和完整 flutter analyze --no-pub 均通过；BUG 编号及索引检查通过。
- 未构建安装包、未做 Windows 真实阅读器 Shift 悬停 E2E；本地未运行全量测试，交由 CI。

