### PR TITLE
fix(video): 手机端画质档位改用「只修复不放大」的着色器链（BUG-2334）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2144 条。点号进各自文件。
+> 共 2145 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2334](bugs/BUG-2334-mobile-shader-tier-desktop-chain.md) | ✅ | ✅ | mobile-shader-tier-desktop-chain |
 | [BUG-2330](bugs/BUG-2330-audiobook-multifile-position-no-file-index.md) | ✅ | ✅ | 多文件有声书持久化文件内毫秒无文件下标，重开恒落文件0 |
 | [BUG-2329](bugs/BUG-2329-eink-toggle-no-reader-reinject.md) | ✅ | ✅ | 墨水屏开关不通知阅读器重注入正文样式 |
 | [BUG-2328](bugs/BUG-2328-audiobook-resume-ignored-on-open.md) | ✅ | ✅ | 打开带有声书的书不按有声书进度定位，按播放才跳 |

--- a/docs/bugs/BUG-2334-mobile-shader-tier-desktop-chain.md
+++ b/docs/bugs/BUG-2334-mobile-shader-tier-desktop-chain.md
@@ -1,0 +1,33 @@
+## BUG-2334 · mobile-shader-tier-desktop-chain
+
+- **报告**：2026-09-09（用户）
+  > "If I set the video quality to anything higher than 'Low,' both the playback and the entire app start lagging severely."（追问后确认：**手机上**）
+
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/video_shader_tier.dart:57`（`kVideoShaderTiers`，改前是**唯一一张桌面档位表**）。
+
+  「视频画质」= 画质增强档位（无/低/中/高/极高），它不是连续强度旋钮，而是把档位投影到两套正交状态：mpv 内置缩放开关 + GLSL 启用集。**低**=内置缩放 on + 零 GLSL；**中/高/极高**=额外叠 Anime4K 链。用户报的分界线（「高于低就卡」）与「有没有 GLSL」这条线一字不差。
+
+  改前这张表没有移动端投影：中/高/极高 在手机上拿到的是为「1080p 片源 → 4K 桌面显示器」设计的桌面链——
+  `Clamp_Highlights → Restore_CNN_M → Upscale_CNN_x2_M → AutoDownscalePre_x2 → AutoDownscalePre_x4 → Upscale_CNN_x2_S`
+  （6~7 个 pass，含 2x/4x 中间帧缓冲），而档位说明文案写的门槛是「NVIDIA GTX 1660 / RX 6600」这类桌面显卡。手机屏幕不高于片源分辨率，放大出来的中间帧最终仍被压回屏幕尺寸——**GPU 代价全额付，收益被显示分辨率截断**。
+
+  「连整个 app 一起卡」不是第二个 bug：移动端 libmpv 的 `vo=gpu` 与 Flutter 的 raster 共用同一块 GPU 与 EGL 驱动，CNN pass 占满 GPU 时 Flutter 合成排队等待，全局掉帧；持续满载再叠发热降频。
+
+  **同一判断此前只做了一半**：`fushi/lib/src/media/video/video_mpv_config.dart:492` 的 `resolveScaleProperties` 早就为移动端把 EWA polar 降级成 spline36（"移动中端 GPU 扛不住"，TODO-1196 realme8 闪烁）。那次只改了「内置缩放」这一半，**GLSL 这一半一直漏着**。改前代码里唯一的应对是 `video_shader_dialog.dart` 加了一句「高档位可能掉帧或发热」的提示文案——那是补丁式绕过，不是修复：档位说明照旧写着桌面显卡型号，用户按说明选，然后卡死。
+
+- **[x] ① 已修复** — 档位表改成**按平台投影**，与 `resolveScaleProperties` 同签名范式。
+  - `video_shader_tier.dart`：新增 `kMobileVideoShaderTiers` + `shaderTiersFor({bool? isMobile})`；`shaderTierSpec` / `shaderFilesForTier` / `tierFromState` / `orderedEnabledForTier` 四个纯函数统一接 `isMobile`，保证「选档写入」与「反查回读」取同一张表（取不同表会让刚选的档立刻显示成「自定义」）。
+  - `video_shader_downloader.dart`：新增三个**只修复、不放大**的移动端预设 `kAnime4kMobileRestoreSPreset` / `MPreset` / `MSoftPreset`，并登记进 `anime4kManifestFileNames()`（漏登记会让存储页删不掉这几个文件）。移动 中/高/极高 = `Clamp_Highlights` + `Restore_CNN_S` / `Restore_CNN_M` / `Restore_CNN_M + Restore_CNN_Soft_M`：pass 数 6~7 → 2~3，中间帧缓冲 2x/4x → 1x。1:1 观看时真正改善观感的本来就是修复 pass。
+  - `video_shader_dialog.dart` / `web_video_fushi_page.dart`：档位选择器与对照表改走 `shaderTiersFor()`；`shaderTierLabelDescription` 按平台分文案（移动端不再显示 RTX 4060 这类桌面门槛）。
+  - i18n：新增 4 个 `*_hint_mobile` key（经 `tool/i18n_sync.dart --add`），并改写 17 语言的 `video_shader_mobile_perf_hint`（旧文案「建议先用低/中档」已与新行为不符）。
+  - **档位语义零变化**（无→极高，越高越强），持久化键与已启用集格式不动，桌面链一字未改；老用户手工勾选的自定义集仍走「自定义」通路。
+
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_shader_tier_test.dart` 新增 group「移动端档位投影」8 条：
+  - `shaderTiersFor` 按平台取表；移动表五档同序同 id（档位语义不变）；无/低 两端完全相同；
+  - **核心不变式**：移动 中/高/极高 一个 `Upscale` / `AutoDownscale` 文件都不含，且同一断言对桌面档取反（`isNotEmpty`）作对照组——**防止写成恒真的空壳守卫**；
+  - 移动档以 `Clamp_Highlights` 开头且 pass ≤ 3；移动五档文件集两两互异 → `tierFromState(isMobile: true)` 反查无歧义；`orderedEnabledForTier` 缺文件时保序过滤；移动档文件全部登记进 manifest。
+
+- **备注**：
+  - **未做真机复测**（该步骤按用户 2026-07-29 决定已取消）。因此有一种情形本次区分不了：除了上述纯 GPU 成本，是否还叠加了 **fp16 FBO 回落**——Anime4K 需要 `rgba16f` 中间缓冲，移动 GPU 上 mpv `fbo-format` 协商若回落，代价会再翻几倍。这条线有前科（BUG-465 因 Mali 16-bit 纹理 OOM 强制过 `vf=format=yuv420p`）。判据现成：`FUSHI_TEST_MPV_LOG_FILE` + `msg-level=all=v`（`video_player_controller.dart:1449`）会打出 VO / FBO 协商。
+  - 移动三档的绝对开销未在真机量化。若某机型连「中」都吃不消，用户退回「低」（纯 mpv 内置 spline36，零 GLSL）即可——阶梯是可往下调的，这是保留三档而非直接封顶的理由。
+  - `video_shader_mobile_copy_consistency_test.dart` 的英文文案守卫用子串 `vary` 判断，`varies` 不命中——改文案时容易撞。本次按守卫要求把限定词写成 `vary`，未动守卫。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 76976 (4528 per locale)
+/// Strings: 77044 (4532 per locale)
 ///
-/// Built on 2026-09-09 at 05:27 UTC
+/// Built on 2026-09-09 at 06:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5829,7 +5829,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_shader_import_from_mpv_hint =>
       'Search local mpv automatically, or choose an mpv folder when none is found.';
   String get video_shader_mobile_perf_hint =>
-      'On phones, shaders apply only on the standard GPU render path and effectiveness varies by device GPU; higher tiers may drop frames or heat up. Try Low/Medium first and check the result on your device.';
+      'On phones, Medium/High/Ultra use deblur-only Anime4K chains: the upscaling passes are left out, because your screen is no larger than the source, so they would cost a lot of GPU for little gain and slow the whole app down. Results still vary by device GPU, and shaders only apply on the standard GPU render path — drop a tier if you see dropped frames or heat.';
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv folder: ${path}';
   String get video_shader_mpv_dir_empty => 'No shaders found in that folder';
@@ -6281,6 +6281,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The source returned invalid torrent data. Retry later or choose another source.';
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -16154,7 +16162,7 @@ class _StringsAr extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'على الهواتف، تُطبَّق المظلِّلات فقط على مسار العرض الرسومي القياسي وتختلف الفعالية بحسب معالج الجهاز الرسومي؛ قد تسبب المستويات الأعلى تساقط الإطارات أو ارتفاع الحرارة. جرّب منخفض/متوسط أولًا وتحقق من النتيجة على جهازك.';
+      'على الهواتف، تستخدم المستويات المتوسط/العالي/الفائق سلاسل Anime4K لإزالة الضبابية فقط: تُحذف مراحل التكبير لأن الشاشة ليست أكبر من المصدر — فهي تستهلك المعالج الرسومي وتُبطئ التطبيق كله. والتأثير يختلف حسب معالج الجهاز؛ انزل مستوى عند تقطع الإطارات أو الحرارة.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'مجلد mpv: ${path}';
@@ -16918,6 +16926,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -26998,7 +27018,7 @@ class _StringsDe extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Auf Handys werden Shader nur über den Standard-GPU-Renderpfad angewendet und die Wirkung variiert je nach Geräte-GPU; höhere Stufen können Frames verwerfen oder das Gerät erhitzen. Probiere zuerst Niedrig/Mittel und prüfe das Ergebnis auf deinem Gerät.';
+      'Auf Telefonen nutzen Mittel/Hoch/Ultra reine Deblur-Ketten von Anime4K: Die Upscaling-Durchgänge entfallen, denn der Bildschirm ist nicht größer als die Quelle — sie würden viel GPU kosten und die ganze App verlangsamen. Die Wirkung hängt weiterhin von der GPU des Geräts ab; bei Rucklern oder Hitze eine Stufe zurückgehen.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv-Ordner: ${path}';
@@ -27782,6 +27802,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -37906,7 +37938,7 @@ class _StringsEs extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'En teléfonos, los shaders solo se aplican en la ruta de renderizado de GPU estándar y su eficacia varía según la GPU del dispositivo; los niveles más altos pueden provocar caídas de fotogramas o calentamiento. Prueba primero Baja/Media y comprueba el resultado en tu dispositivo.';
+      'En teléfonos, Medio/Alto/Ultra usan cadenas de Anime4K solo de desenfoque: se omiten los pases de escalado, porque la pantalla no es mayor que la fuente — costarían mucha GPU y ralentizarían toda la app. El efecto sigue dependiendo de la GPU del dispositivo; baja un nivel si hay saltos o calentamiento.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Carpeta de mpv: ${path}';
@@ -38700,6 +38732,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -48851,7 +48895,7 @@ class _StringsFr extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Sur téléphone, les shaders ne s\'appliquent que sur le chemin de rendu GPU standard et leur efficacité varie selon le GPU de l\'appareil ; les niveaux élevés peuvent causer des chutes de framerate ou une surchauffe. Essayez d\'abord Faible/Moyen et vérifiez le résultat sur votre appareil.';
+      'Sur téléphone, Moyen/Élevé/Ultra utilisent des chaînes Anime4K uniquement de défloutage : les passes d\'agrandissement sont retirées, car l\'écran n\'est pas plus grand que la source — elles coûteraient beaucoup de GPU et ralentiraient toute l\'application. L\'effet dépend encore du GPU de l\'appareil ; descendez d\'un cran en cas de saccades ou de chauffe.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Dossier mpv : ${path}';
@@ -49652,6 +49696,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -59628,7 +59684,7 @@ class _StringsId extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Di ponsel, shader hanya berlaku pada jalur render GPU standar dan efektivitasnya bervariasi per GPU perangkat; tingkat yang lebih tinggi mungkin menyebabkan frame drop atau panas. Coba Rendah/Sedang dulu dan periksa hasilnya di perangkatmu.';
+      'Di ponsel, Sedang/Tinggi/Ultra memakai rantai Anime4K khusus deblur: tahap upscaling dihilangkan, karena layar tidak lebih besar dari sumbernya — tahap itu akan menghabiskan GPU dan memperlambat seluruh aplikasi. Efeknya tetap bergantung pada GPU perangkat; turunkan satu tingkat jika ada frame drop atau panas.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Folder mpv: ${path}';
@@ -60406,6 +60462,18 @@ class _StringsId extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -70465,7 +70533,7 @@ class _StringsIt extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Sui telefoni gli shader si applicano solo sul percorso di rendering GPU standard e l\'efficacia varia in base alla GPU del dispositivo; i livelli più alti possono causare scatti o surriscaldamento. Prova prima Basso/Medio e verifica il risultato sul tuo dispositivo.';
+      'Sui telefoni, Medio/Alto/Ultra usano catene Anime4K di solo deblur: i passaggi di upscaling sono esclusi, perché lo schermo non è più grande della sorgente — costerebbero molta GPU e rallenterebbero tutta l\'app. L\'efficacia dipende ancora dalla GPU del dispositivo; scendi di un livello se noti scatti o surriscaldamento.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Cartella mpv: ${path}';
@@ -71252,6 +71320,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -80741,7 +80821,7 @@ class _StringsJa extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'スマートフォンでは標準の GPU 描画パス上でのみシェーダーが有効になり、効果は機種の GPU によって異なります。高い段階ではコマ落ちや発熱が起こる場合があります。まずは低／中で試し、実機で効果を確認してください。';
+      'スマホでは中／高／最高は「デブラーのみ・拡大なし」の Anime4K チェーンを使います。画面はソースより大きくないため、拡大パスは効果が薄い割に GPU を占有し、アプリ全体が重くなります。効果は機種の GPU によります。コマ落ちや発熱があれば一段階下げてください。';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv フォルダ：${path}';
@@ -81479,6 +81559,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -90974,7 +91066,7 @@ class _StringsKo extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      '휴대폰에서는 셰이더가 표준 GPU 렌더 경로에서만 적용되며 효과는 기기 GPU에 따라 다릅니다. 높은 단계는 프레임 드롭이나 발열을 일으킬 수 있습니다. 먼저 낮음/중간을 써 보고 기기에서 결과를 확인하세요.';
+      '휴대폰에서 중간/높음/최고는 \'디블러만, 업스케일 없음\' Anime4K 체인을 씁니다. 화면이 원본보다 크지 않아 업스케일 패스는 이득에 비해 GPU를 다 쓰고 앱 전체를 느리게 만듭니다. 효과는 기기 GPU에 따라 다릅니다. 프레임 드롭이나 발열이 있으면 한 단계 낮추세요.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv 폴더: ${path}';
@@ -91716,6 +91808,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -101735,7 +101839,7 @@ class _StringsNl extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Op telefoons werken shaders alleen op het standaard GPU-renderpad en de effectiviteit verschilt per apparaat-GPU; hogere niveaus kunnen frames laten vallen of opwarming veroorzaken. Probeer eerst Laag/Gemiddeld en controleer het resultaat op je apparaat.';
+      'Op telefoons gebruiken Gemiddeld/Hoog/Ultra Anime4K-ketens met alleen deblur: de upscaling-passes vervallen, omdat het scherm niet groter is dan de bron — ze zouden veel GPU kosten en de hele app vertragen. De werking hangt nog steeds af van de GPU van het toestel; ga een stap omlaag bij haperingen of warmte.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv-map: ${path}';
@@ -102519,6 +102623,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -112586,7 +112702,7 @@ class _StringsPtBr extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Em celulares, os shaders só são aplicados no caminho de renderização padrão da GPU, e a eficácia varia conforme a GPU do aparelho; níveis mais altos podem perder quadros ou esquentar. Comece com Baixo/Médio e confira o resultado no seu dispositivo.';
+      'Em celulares, Médio/Alto/Ultra usam cadeias do Anime4K apenas de desfoque: os passes de upscaling são omitidos, pois a tela não é maior que a fonte — custariam muita GPU e deixariam o app todo lento. O efeito ainda varia conforme a GPU do aparelho; desça um nível se houver quedas de quadros ou aquecimento.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Pasta do mpv: ${path}';
@@ -113375,6 +113491,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -123416,7 +123544,7 @@ class _StringsRu extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'На телефонах шейдеры применяются только на стандартном пути GPU-рендеринга, и эффективность зависит от GPU устройства; высокие уровни могут вызывать пропуск кадров или нагрев. Сначала попробуйте «Низкое»/«Среднее» и проверьте результат на своём устройстве.';
+      'На телефонах Средний/Высокий/Ультра используют цепочки Anime4K только для убрания размытия: проходы апскейла убраны, ведь экран не больше источника — они съели бы GPU и замедлили всё приложение. Эффект зависит от GPU устройства; при пропусках кадров или нагреве понизьте уровень.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Папка mpv: ${path}';
@@ -124208,6 +124336,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -134069,7 +134209,7 @@ class _StringsTh extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'บนโทรศัพท์ เชเดอร์จะทำงานเฉพาะบนเส้นทางเรนเดอร์ GPU มาตรฐาน และผลที่ได้แตกต่างกันตาม GPU ของเครื่อง ระดับสูงอาจทำให้เฟรมตกหรือเครื่องร้อน แนะนำให้ลองระดับต่ำ/ปานกลางก่อนแล้วตรวจผลบนเครื่องของคุณ';
+      'บนมือถือ ระดับกลาง/สูง/สูงมาก จะใช้ชุด Anime4K ที่ลดความเบลออย่างเดียว โดยตัดขั้นขยายภาพออก เพราะหน้าจอไม่ใหญ่กว่าต้นทาง — มันจะกิน GPU มากและทำให้ทั้งแอพหนืด ผลลัพธ์ยังขึ้นอยู่กับ GPU ของเครื่อง หากเฟรมตกหรือเครื่องร้อน ให้ลดลงหนึ่งระดับ';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'โฟลเดอร์ mpv: ${path}';
@@ -134841,6 +134981,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -144813,7 +144965,7 @@ class _StringsTr extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Telefonlarda shader\'lar yalnızca standart GPU işleme yolunda uygulanır ve etkinlik cihaz GPU\'suna göre değişir; yüksek seviyeler kare düşürebilir veya ısınmaya yol açabilir. Önce Düşük/Orta deneyin ve sonucu kendi cihazınızda kontrol edin.';
+      'Telefonlarda Orta/Yüksek/Ultra yalnızca bulanıklık giderme yapan Anime4K zincirlerini kullanır: ölçekleme aşamaları çıkarılmıştır, çünkü ekran kaynaktan büyük değildir — bunlar çok GPU harcar ve tüm uygulamayı yavaşlatır. Etki yine cihazın GPU\'suna göre değişir; kare atlama veya ısınma görürseniz bir kademe düşün.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv klasörü: ${path}';
@@ -145590,6 +145742,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -155536,7 +155700,7 @@ class _StringsVi extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      'Trên điện thoại, shader chỉ áp dụng trên đường render GPU tiêu chuẩn và hiệu quả khác nhau tùy GPU thiết bị; mức cao có thể rớt khung hình hoặc gây nóng máy. Hãy thử mức Thấp/Trung bình trước và kiểm tra kết quả trên máy của bạn.';
+      'Trên điện thoại, mức Trung bình/Cao/Siêu cao dùng chuỗi Anime4K chỉ khử nhòe: các bước phóng to đã bị bỏ, vì màn hình không lớn hơn nguồn — chúng sẽ ngồn GPU và làm chậm toàn bộ ứng dụng. Hiệu quả vẫn tùy GPU thiết bị; hạ một mức nếu bị rớt khung hình hoặc nóng máy.';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'Thư mục mpv: ${path}';
@@ -156310,6 +156474,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 // Path: <root>
@@ -165446,7 +165622,7 @@ class _StringsZhCn extends _StringsEn {
       '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
   @override
   String get video_shader_mobile_perf_hint =>
-      '手机上着色器仅在标准 GPU 渲染路径下生效，实际效果因机型 GPU 而异；高档位可能掉帧或发热。建议先用低/中档，并在本机确认效果。';
+      '手机上的中/高/极高档使用「只去模糊、不放大」的 Anime4K 链：放大 pass 已移除——屏幕不比片源更大，放大收益有限却会占满 GPU，连带整个 app 变卡。实际效果仍因机型 GPU 而异，掉帧或发热就往下退一档。';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv 目录：${path}';
@@ -166154,6 +166330,18 @@ class _StringsZhCn extends _StringsEn {
   String get download_torrent_invalid => '来源返回的种子数据无效。请稍后重试或更换来源。';
   @override
   String get download_torrent_selection_failed => '无法在种子中唯一匹配这本书。请刷新目录或更换来源。';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv 内置锐化（手机上为 spline36）。无需下载，不增加任何 GPU pass。上面几档掉帧时退回这一档最稳。';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K 去模糊（S），在片源原分辨率上跑。不含放大 pass，开销不随屏幕分辨率增长。手机建议从这一档开始。';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。';
 }
 
 // Path: <root>
@@ -175351,7 +175539,7 @@ class _StringsZhHk extends _StringsEn {
       '自動搜索本機 mpv；未找到時可手動選擇 mpv 目錄。';
   @override
   String get video_shader_mobile_perf_hint =>
-      '在手機上，着色器只在標準 GPU 算繪路徑下生效，實際效果因機型 GPU 而異；高檔位可能掉幀或發熱。建議先試低／中檔，並在本機確認效果。';
+      '手機上的中/高/極高檔使用「只去模糊、不放大」的 Anime4K 鏈：放大 pass 已移除——螢幕不比片源更大，放大收益有限卻會佔滿 GPU，連帶整個 app 變卡。實際效果仍因機型 GPU 而異，掉幀或發熱就往下退一檔。';
   @override
   String video_shader_mpv_dir_current({required Object path}) =>
       'mpv 資料夾：${path}';
@@ -176067,6 +176255,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get download_torrent_selection_failed =>
       'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+  @override
+  String get video_shader_tier_low_hint_mobile =>
+      'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+  @override
+  String get video_shader_tier_medium_hint_mobile =>
+      'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+  @override
+  String get video_shader_tier_high_hint_mobile =>
+      'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+  @override
+  String get video_shader_tier_ultra_hint_mobile =>
+      'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
 }
 
 /// Flat map(s) containing all translations.
@@ -184721,7 +184921,7 @@ extension on _StringsEn {
       case 'video_shader_import_from_mpv_hint':
         return 'Search local mpv automatically, or choose an mpv folder when none is found.';
       case 'video_shader_mobile_perf_hint':
-        return 'On phones, shaders apply only on the standard GPU render path and effectiveness varies by device GPU; higher tiers may drop frames or heat up. Try Low/Medium first and check the result on your device.';
+        return 'On phones, Medium/High/Ultra use deblur-only Anime4K chains: the upscaling passes are left out, because your screen is no larger than the source, so they would cost a lot of GPU for little gain and slow the whole app down. Results still vary by device GPU, and shaders only apply on the standard GPU render path — drop a tier if you see dropped frames or heat.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv folder: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -185383,6 +185583,14 @@ extension on _StringsEn {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -194031,7 +194239,7 @@ extension on _StringsAr {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'على الهواتف، تُطبَّق المظلِّلات فقط على مسار العرض الرسومي القياسي وتختلف الفعالية بحسب معالج الجهاز الرسومي؛ قد تسبب المستويات الأعلى تساقط الإطارات أو ارتفاع الحرارة. جرّب منخفض/متوسط أولًا وتحقق من النتيجة على جهازك.';
+        return 'على الهواتف، تستخدم المستويات المتوسط/العالي/الفائق سلاسل Anime4K لإزالة الضبابية فقط: تُحذف مراحل التكبير لأن الشاشة ليست أكبر من المصدر — فهي تستهلك المعالج الرسومي وتُبطئ التطبيق كله. والتأثير يختلف حسب معالج الجهاز؛ انزل مستوى عند تقطع الإطارات أو الحرارة.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'مجلد mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -194694,6 +194902,14 @@ extension on _StringsAr {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -203385,7 +203601,7 @@ extension on _StringsDe {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Auf Handys werden Shader nur über den Standard-GPU-Renderpfad angewendet und die Wirkung variiert je nach Geräte-GPU; höhere Stufen können Frames verwerfen oder das Gerät erhitzen. Probiere zuerst Niedrig/Mittel und prüfe das Ergebnis auf deinem Gerät.';
+        return 'Auf Telefonen nutzen Mittel/Hoch/Ultra reine Deblur-Ketten von Anime4K: Die Upscaling-Durchgänge entfallen, denn der Bildschirm ist nicht größer als die Quelle — sie würden viel GPU kosten und die ganze App verlangsamen. Die Wirkung hängt weiterhin von der GPU des Geräts ab; bei Rucklern oder Hitze eine Stufe zurückgehen.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv-Ordner: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -204050,6 +204266,14 @@ extension on _StringsDe {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -212733,7 +212957,7 @@ extension on _StringsEs {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'En teléfonos, los shaders solo se aplican en la ruta de renderizado de GPU estándar y su eficacia varía según la GPU del dispositivo; los niveles más altos pueden provocar caídas de fotogramas o calentamiento. Prueba primero Baja/Media y comprueba el resultado en tu dispositivo.';
+        return 'En teléfonos, Medio/Alto/Ultra usan cadenas de Anime4K solo de desenfoque: se omiten los pases de escalado, porque la pantalla no es mayor que la fuente — costarían mucha GPU y ralentizarían toda la app. El efecto sigue dependiendo de la GPU del dispositivo; baja un nivel si hay saltos o calentamiento.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Carpeta de mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -213397,6 +213621,14 @@ extension on _StringsEs {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -222089,7 +222321,7 @@ extension on _StringsFr {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Sur téléphone, les shaders ne s\'appliquent que sur le chemin de rendu GPU standard et leur efficacité varie selon le GPU de l\'appareil ; les niveaux élevés peuvent causer des chutes de framerate ou une surchauffe. Essayez d\'abord Faible/Moyen et vérifiez le résultat sur votre appareil.';
+        return 'Sur téléphone, Moyen/Élevé/Ultra utilisent des chaînes Anime4K uniquement de défloutage : les passes d\'agrandissement sont retirées, car l\'écran n\'est pas plus grand que la source — elles coûteraient beaucoup de GPU et ralentiraient toute l\'application. L\'effet dépend encore du GPU de l\'appareil ; descendez d\'un cran en cas de saccades ou de chauffe.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Dossier mpv : ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -222753,6 +222985,14 @@ extension on _StringsFr {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -231416,7 +231656,7 @@ extension on _StringsId {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Di ponsel, shader hanya berlaku pada jalur render GPU standar dan efektivitasnya bervariasi per GPU perangkat; tingkat yang lebih tinggi mungkin menyebabkan frame drop atau panas. Coba Rendah/Sedang dulu dan periksa hasilnya di perangkatmu.';
+        return 'Di ponsel, Sedang/Tinggi/Ultra memakai rantai Anime4K khusus deblur: tahap upscaling dihilangkan, karena layar tidak lebih besar dari sumbernya — tahap itu akan menghabiskan GPU dan memperlambat seluruh aplikasi. Efeknya tetap bergantung pada GPU perangkat; turunkan satu tingkat jika ada frame drop atau panas.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Folder mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -232080,6 +232320,14 @@ extension on _StringsId {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -240764,7 +241012,7 @@ extension on _StringsIt {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Sui telefoni gli shader si applicano solo sul percorso di rendering GPU standard e l\'efficacia varia in base alla GPU del dispositivo; i livelli più alti possono causare scatti o surriscaldamento. Prova prima Basso/Medio e verifica il risultato sul tuo dispositivo.';
+        return 'Sui telefoni, Medio/Alto/Ultra usano catene Anime4K di solo deblur: i passaggi di upscaling sono esclusi, perché lo schermo non è più grande della sorgente — costerebbero molta GPU e rallenterebbero tutta l\'app. L\'efficacia dipende ancora dalla GPU del dispositivo; scendi di un livello se noti scatti o surriscaldamento.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Cartella mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -241429,6 +241677,14 @@ extension on _StringsIt {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -250048,7 +250304,7 @@ extension on _StringsJa {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'スマートフォンでは標準の GPU 描画パス上でのみシェーダーが有効になり、効果は機種の GPU によって異なります。高い段階ではコマ落ちや発熱が起こる場合があります。まずは低／中で試し、実機で効果を確認してください。';
+        return 'スマホでは中／高／最高は「デブラーのみ・拡大なし」の Anime4K チェーンを使います。画面はソースより大きくないため、拡大パスは効果が薄い割に GPU を占有し、アプリ全体が重くなります。効果は機種の GPU によります。コマ落ちや発熱があれば一段階下げてください。';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv フォルダ：${path}';
       case 'video_shader_mpv_dir_empty':
@@ -250705,6 +250961,14 @@ extension on _StringsJa {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -259327,7 +259591,7 @@ extension on _StringsKo {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return '휴대폰에서는 셰이더가 표준 GPU 렌더 경로에서만 적용되며 효과는 기기 GPU에 따라 다릅니다. 높은 단계는 프레임 드롭이나 발열을 일으킬 수 있습니다. 먼저 낮음/중간을 써 보고 기기에서 결과를 확인하세요.';
+        return '휴대폰에서 중간/높음/최고는 \'디블러만, 업스케일 없음\' Anime4K 체인을 씁니다. 화면이 원본보다 크지 않아 업스케일 패스는 이득에 비해 GPU를 다 쓰고 앱 전체를 느리게 만듭니다. 효과는 기기 GPU에 따라 다릅니다. 프레임 드롭이나 발열이 있으면 한 단계 낮추세요.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv 폴더: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -259985,6 +260249,14 @@ extension on _StringsKo {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -268662,7 +268934,7 @@ extension on _StringsNl {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Op telefoons werken shaders alleen op het standaard GPU-renderpad en de effectiviteit verschilt per apparaat-GPU; hogere niveaus kunnen frames laten vallen of opwarming veroorzaken. Probeer eerst Laag/Gemiddeld en controleer het resultaat op je apparaat.';
+        return 'Op telefoons gebruiken Gemiddeld/Hoog/Ultra Anime4K-ketens met alleen deblur: de upscaling-passes vervallen, omdat het scherm niet groter is dan de bron — ze zouden veel GPU kosten en de hele app vertragen. De werking hangt nog steeds af van de GPU van het toestel; ga een stap omlaag bij haperingen of warmte.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv-map: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -269327,6 +269599,14 @@ extension on _StringsNl {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -278000,7 +278280,7 @@ extension on _StringsPtBr {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Em celulares, os shaders só são aplicados no caminho de renderização padrão da GPU, e a eficácia varia conforme a GPU do aparelho; níveis mais altos podem perder quadros ou esquentar. Comece com Baixo/Médio e confira o resultado no seu dispositivo.';
+        return 'Em celulares, Médio/Alto/Ultra usam cadeias do Anime4K apenas de desfoque: os passes de upscaling são omitidos, pois a tela não é maior que a fonte — custariam muita GPU e deixariam o app todo lento. O efeito ainda varia conforme a GPU do aparelho; desça um nível se houver quedas de quadros ou aquecimento.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Pasta do mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -278664,6 +278944,14 @@ extension on _StringsPtBr {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -287345,7 +287633,7 @@ extension on _StringsRu {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'На телефонах шейдеры применяются только на стандартном пути GPU-рендеринга, и эффективность зависит от GPU устройства; высокие уровни могут вызывать пропуск кадров или нагрев. Сначала попробуйте «Низкое»/«Среднее» и проверьте результат на своём устройстве.';
+        return 'На телефонах Средний/Высокий/Ультра используют цепочки Anime4K только для убрания размытия: проходы апскейла убраны, ведь экран не больше источника — они съели бы GPU и замедлили всё приложение. Эффект зависит от GPU устройства; при пропусках кадров или нагреве понизьте уровень.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Папка mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -288008,6 +288296,14 @@ extension on _StringsRu {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -296662,7 +296958,7 @@ extension on _StringsTh {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'บนโทรศัพท์ เชเดอร์จะทำงานเฉพาะบนเส้นทางเรนเดอร์ GPU มาตรฐาน และผลที่ได้แตกต่างกันตาม GPU ของเครื่อง ระดับสูงอาจทำให้เฟรมตกหรือเครื่องร้อน แนะนำให้ลองระดับต่ำ/ปานกลางก่อนแล้วตรวจผลบนเครื่องของคุณ';
+        return 'บนมือถือ ระดับกลาง/สูง/สูงมาก จะใช้ชุด Anime4K ที่ลดความเบลออย่างเดียว โดยตัดขั้นขยายภาพออก เพราะหน้าจอไม่ใหญ่กว่าต้นทาง — มันจะกิน GPU มากและทำให้ทั้งแอพหนืด ผลลัพธ์ยังขึ้นอยู่กับ GPU ของเครื่อง หากเฟรมตกหรือเครื่องร้อน ให้ลดลงหนึ่งระดับ';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'โฟลเดอร์ mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -297324,6 +297620,14 @@ extension on _StringsTh {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -305992,7 +306296,7 @@ extension on _StringsTr {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Telefonlarda shader\'lar yalnızca standart GPU işleme yolunda uygulanır ve etkinlik cihaz GPU\'suna göre değişir; yüksek seviyeler kare düşürebilir veya ısınmaya yol açabilir. Önce Düşük/Orta deneyin ve sonucu kendi cihazınızda kontrol edin.';
+        return 'Telefonlarda Orta/Yüksek/Ultra yalnızca bulanıklık giderme yapan Anime4K zincirlerini kullanır: ölçekleme aşamaları çıkarılmıştır, çünkü ekran kaynaktan büyük değildir — bunlar çok GPU harcar ve tüm uygulamayı yavaşlatır. Etki yine cihazın GPU\'suna göre değişir; kare atlama veya ısınma görürseniz bir kademe düşün.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv klasörü: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -306655,6 +306959,14 @@ extension on _StringsTr {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -315319,7 +315631,7 @@ extension on _StringsVi {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return 'Trên điện thoại, shader chỉ áp dụng trên đường render GPU tiêu chuẩn và hiệu quả khác nhau tùy GPU thiết bị; mức cao có thể rớt khung hình hoặc gây nóng máy. Hãy thử mức Thấp/Trung bình trước và kiểm tra kết quả trên máy của bạn.';
+        return 'Trên điện thoại, mức Trung bình/Cao/Siêu cao dùng chuỗi Anime4K chỉ khử nhòe: các bước phóng to đã bị bỏ, vì màn hình không lớn hơn nguồn — chúng sẽ ngồn GPU và làm chậm toàn bộ ứng dụng. Hiệu quả vẫn tùy GPU thiết bị; hạ một mức nếu bị rớt khung hình hoặc nóng máy.';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'Thư mục mpv: ${path}';
       case 'video_shader_mpv_dir_empty':
@@ -315980,6 +316292,14 @@ extension on _StringsVi {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }
@@ -324573,7 +324893,7 @@ extension on _StringsZhCn {
       case 'video_shader_import_from_mpv_hint':
         return '自动搜索本机 mpv；未找到时可手动选择 mpv 目录。';
       case 'video_shader_mobile_perf_hint':
-        return '手机上着色器仅在标准 GPU 渲染路径下生效，实际效果因机型 GPU 而异；高档位可能掉帧或发热。建议先用低/中档，并在本机确认效果。';
+        return '手机上的中/高/极高档使用「只去模糊、不放大」的 Anime4K 链：放大 pass 已移除——屏幕不比片源更大，放大收益有限却会占满 GPU，连带整个 app 变卡。实际效果仍因机型 GPU 而异，掉帧或发热就往下退一档。';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv 目录：${path}';
       case 'video_shader_mpv_dir_empty':
@@ -325224,6 +325544,14 @@ extension on _StringsZhCn {
         return '来源返回的种子数据无效。请稍后重试或更换来源。';
       case 'download_torrent_selection_failed':
         return '无法在种子中唯一匹配这本书。请刷新目录或更换来源。';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv 内置锐化（手机上为 spline36）。无需下载，不增加任何 GPU pass。上面几档掉帧时退回这一档最稳。';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K 去模糊（S），在片源原分辨率上跑。不含放大 pass，开销不随屏幕分辨率增长。手机建议从这一档开始。';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。';
       default:
         return null;
     }
@@ -333826,7 +334154,7 @@ extension on _StringsZhHk {
       case 'video_shader_import_from_mpv_hint':
         return '自動搜索本機 mpv；未找到時可手動選擇 mpv 目錄。';
       case 'video_shader_mobile_perf_hint':
-        return '在手機上，着色器只在標準 GPU 算繪路徑下生效，實際效果因機型 GPU 而異；高檔位可能掉幀或發熱。建議先試低／中檔，並在本機確認效果。';
+        return '手機上的中/高/極高檔使用「只去模糊、不放大」的 Anime4K 鏈：放大 pass 已移除——螢幕不比片源更大，放大收益有限卻會佔滿 GPU，連帶整個 app 變卡。實際效果仍因機型 GPU 而異，掉幀或發熱就往下退一檔。';
       case 'video_shader_mpv_dir_current':
         return ({required Object path}) => 'mpv 資料夾：${path}';
       case 'video_shader_mpv_dir_empty':
@@ -334478,6 +334806,14 @@ extension on _StringsZhHk {
         return 'The source returned invalid torrent data. Retry later or choose another source.';
       case 'download_torrent_selection_failed':
         return 'Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.';
+      case 'video_shader_tier_low_hint_mobile':
+        return 'mpv\'s built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.';
+      case 'video_shader_tier_medium_hint_mobile':
+        return 'Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.';
+      case 'video_shader_tier_high_hint_mobile':
+        return 'Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.';
+      case 'video_shader_tier_ultra_hint_mobile':
+        return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Imported $count shader(s)",
   "video_shader_import_from_mpv": "Import from local mpv",
   "video_shader_import_from_mpv_hint": "Search local mpv automatically, or choose an mpv folder when none is found.",
-  "video_shader_mobile_perf_hint": "On phones, shaders apply only on the standard GPU render path and effectiveness varies by device GPU; higher tiers may drop frames or heat up. Try Low/Medium first and check the result on your device.",
+  "video_shader_mobile_perf_hint": "On phones, Medium/High/Ultra use deblur-only Anime4K chains: the upscaling passes are left out, because your screen is no larger than the source, so they would cost a lot of GPU for little gain and slow the whole app down. Results still vary by device GPU, and shaders only apply on the standard GPU render path — drop a tier if you see dropped frames or heat.",
   "video_shader_mpv_dir_current": "mpv folder: $path",
   "video_shader_mpv_dir_empty": "No shaders found in that folder",
   "video_shader_mpv_not_found": "No local mpv shaders found",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "تم استيراد $count مظلِّل",
   "video_shader_import_from_mpv": "استيراد من mpv المحلي",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "على الهواتف، تُطبَّق المظلِّلات فقط على مسار العرض الرسومي القياسي وتختلف الفعالية بحسب معالج الجهاز الرسومي؛ قد تسبب المستويات الأعلى تساقط الإطارات أو ارتفاع الحرارة. جرّب منخفض/متوسط أولًا وتحقق من النتيجة على جهازك.",
+  "video_shader_mobile_perf_hint": "على الهواتف، تستخدم المستويات المتوسط/العالي/الفائق سلاسل Anime4K لإزالة الضبابية فقط: تُحذف مراحل التكبير لأن الشاشة ليست أكبر من المصدر — فهي تستهلك المعالج الرسومي وتُبطئ التطبيق كله. والتأثير يختلف حسب معالج الجهاز؛ انزل مستوى عند تقطع الإطارات أو الحرارة.",
   "video_shader_mpv_dir_current": "مجلد mpv: $path",
   "video_shader_mpv_dir_empty": "لم يُعثر على مظلِّلات في ذلك المجلد",
   "video_shader_mpv_not_found": "لم يُعثر على مظلِّلات mpv محلية",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "$count Shader importiert",
   "video_shader_import_from_mpv": "Aus lokalem mpv importieren",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Auf Handys werden Shader nur über den Standard-GPU-Renderpfad angewendet und die Wirkung variiert je nach Geräte-GPU; höhere Stufen können Frames verwerfen oder das Gerät erhitzen. Probiere zuerst Niedrig/Mittel und prüfe das Ergebnis auf deinem Gerät.",
+  "video_shader_mobile_perf_hint": "Auf Telefonen nutzen Mittel/Hoch/Ultra reine Deblur-Ketten von Anime4K: Die Upscaling-Durchgänge entfallen, denn der Bildschirm ist nicht größer als die Quelle — sie würden viel GPU kosten und die ganze App verlangsamen. Die Wirkung hängt weiterhin von der GPU des Geräts ab; bei Rucklern oder Hitze eine Stufe zurückgehen.",
   "video_shader_mpv_dir_current": "mpv-Ordner: $path",
   "video_shader_mpv_dir_empty": "Keine Shader in diesem Ordner gefunden",
   "video_shader_mpv_not_found": "Keine lokalen mpv-Shader gefunden",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Se importaron $count shader(s)",
   "video_shader_import_from_mpv": "Importar desde mpv local",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "En teléfonos, los shaders solo se aplican en la ruta de renderizado de GPU estándar y su eficacia varía según la GPU del dispositivo; los niveles más altos pueden provocar caídas de fotogramas o calentamiento. Prueba primero Baja/Media y comprueba el resultado en tu dispositivo.",
+  "video_shader_mobile_perf_hint": "En teléfonos, Medio/Alto/Ultra usan cadenas de Anime4K solo de desenfoque: se omiten los pases de escalado, porque la pantalla no es mayor que la fuente — costarían mucha GPU y ralentizarían toda la app. El efecto sigue dependiendo de la GPU del dispositivo; baja un nivel si hay saltos o calentamiento.",
   "video_shader_mpv_dir_current": "Carpeta de mpv: $path",
   "video_shader_mpv_dir_empty": "No se encontraron shaders en esa carpeta",
   "video_shader_mpv_not_found": "No se encontraron shaders de mpv locales",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "$count shader(s) importé(s)",
   "video_shader_import_from_mpv": "Importer depuis le mpv local",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Sur téléphone, les shaders ne s'appliquent que sur le chemin de rendu GPU standard et leur efficacité varie selon le GPU de l'appareil ; les niveaux élevés peuvent causer des chutes de framerate ou une surchauffe. Essayez d'abord Faible/Moyen et vérifiez le résultat sur votre appareil.",
+  "video_shader_mobile_perf_hint": "Sur téléphone, Moyen/Élevé/Ultra utilisent des chaînes Anime4K uniquement de défloutage : les passes d'agrandissement sont retirées, car l'écran n'est pas plus grand que la source — elles coûteraient beaucoup de GPU et ralentiraient toute l'application. L'effet dépend encore du GPU de l'appareil ; descendez d'un cran en cas de saccades ou de chauffe.",
   "video_shader_mpv_dir_current": "Dossier mpv : $path",
   "video_shader_mpv_dir_empty": "Aucun shader trouvé dans ce dossier",
   "video_shader_mpv_not_found": "Aucun shader mpv local trouvé",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Mengimpor $count shader",
   "video_shader_import_from_mpv": "Impor dari mpv lokal",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Di ponsel, shader hanya berlaku pada jalur render GPU standar dan efektivitasnya bervariasi per GPU perangkat; tingkat yang lebih tinggi mungkin menyebabkan frame drop atau panas. Coba Rendah/Sedang dulu dan periksa hasilnya di perangkatmu.",
+  "video_shader_mobile_perf_hint": "Di ponsel, Sedang/Tinggi/Ultra memakai rantai Anime4K khusus deblur: tahap upscaling dihilangkan, karena layar tidak lebih besar dari sumbernya — tahap itu akan menghabiskan GPU dan memperlambat seluruh aplikasi. Efeknya tetap bergantung pada GPU perangkat; turunkan satu tingkat jika ada frame drop atau panas.",
   "video_shader_mpv_dir_current": "Folder mpv: $path",
   "video_shader_mpv_dir_empty": "Tidak ada shader di folder itu",
   "video_shader_mpv_not_found": "Tidak ada shader mpv lokal yang ditemukan",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Importati $count shader",
   "video_shader_import_from_mpv": "Importa da mpv locale",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Sui telefoni gli shader si applicano solo sul percorso di rendering GPU standard e l'efficacia varia in base alla GPU del dispositivo; i livelli più alti possono causare scatti o surriscaldamento. Prova prima Basso/Medio e verifica il risultato sul tuo dispositivo.",
+  "video_shader_mobile_perf_hint": "Sui telefoni, Medio/Alto/Ultra usano catene Anime4K di solo deblur: i passaggi di upscaling sono esclusi, perché lo schermo non è più grande della sorgente — costerebbero molta GPU e rallenterebbero tutta l'app. L'efficacia dipende ancora dalla GPU del dispositivo; scendi di un livello se noti scatti o surriscaldamento.",
   "video_shader_mpv_dir_current": "Cartella mpv: $path",
   "video_shader_mpv_dir_empty": "Nessuno shader trovato in quella cartella",
   "video_shader_mpv_not_found": "Nessuno shader mpv locale trovato",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "シェーダーを $count 件インポートしました",
   "video_shader_import_from_mpv": "ローカルの mpv からインポート",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "スマートフォンでは標準の GPU 描画パス上でのみシェーダーが有効になり、効果は機種の GPU によって異なります。高い段階ではコマ落ちや発熱が起こる場合があります。まずは低／中で試し、実機で効果を確認してください。",
+  "video_shader_mobile_perf_hint": "スマホでは中／高／最高は「デブラーのみ・拡大なし」の Anime4K チェーンを使います。画面はソースより大きくないため、拡大パスは効果が薄い割に GPU を占有し、アプリ全体が重くなります。効果は機種の GPU によります。コマ落ちや発熱があれば一段階下げてください。",
   "video_shader_mpv_dir_current": "mpv フォルダ：$path",
   "video_shader_mpv_dir_empty": "そのフォルダにシェーダーが見つかりません",
   "video_shader_mpv_not_found": "ローカルの mpv シェーダーが見つかりません",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "셰이더 $count개를 가져왔습니다",
   "video_shader_import_from_mpv": "로컬 mpv에서 가져오기",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "휴대폰에서는 셰이더가 표준 GPU 렌더 경로에서만 적용되며 효과는 기기 GPU에 따라 다릅니다. 높은 단계는 프레임 드롭이나 발열을 일으킬 수 있습니다. 먼저 낮음/중간을 써 보고 기기에서 결과를 확인하세요.",
+  "video_shader_mobile_perf_hint": "휴대폰에서 중간/높음/최고는 '디블러만, 업스케일 없음' Anime4K 체인을 씁니다. 화면이 원본보다 크지 않아 업스케일 패스는 이득에 비해 GPU를 다 쓰고 앱 전체를 느리게 만듭니다. 효과는 기기 GPU에 따라 다릅니다. 프레임 드롭이나 발열이 있으면 한 단계 낮추세요.",
   "video_shader_mpv_dir_current": "mpv 폴더: $path",
   "video_shader_mpv_dir_empty": "그 폴더에서 셰이더를 찾지 못했습니다",
   "video_shader_mpv_not_found": "로컬 mpv 셰이더를 찾지 못했습니다",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "$count shader(s) geïmporteerd",
   "video_shader_import_from_mpv": "Importeren uit lokale mpv",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Op telefoons werken shaders alleen op het standaard GPU-renderpad en de effectiviteit verschilt per apparaat-GPU; hogere niveaus kunnen frames laten vallen of opwarming veroorzaken. Probeer eerst Laag/Gemiddeld en controleer het resultaat op je apparaat.",
+  "video_shader_mobile_perf_hint": "Op telefoons gebruiken Gemiddeld/Hoog/Ultra Anime4K-ketens met alleen deblur: de upscaling-passes vervallen, omdat het scherm niet groter is dan de bron — ze zouden veel GPU kosten en de hele app vertragen. De werking hangt nog steeds af van de GPU van het toestel; ga een stap omlaag bij haperingen of warmte.",
   "video_shader_mpv_dir_current": "mpv-map: $path",
   "video_shader_mpv_dir_empty": "Geen shaders in die map gevonden",
   "video_shader_mpv_not_found": "Geen lokale mpv-shaders gevonden",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "$count shader(s) importado(s)",
   "video_shader_import_from_mpv": "Importar do mpv local",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Em celulares, os shaders só são aplicados no caminho de renderização padrão da GPU, e a eficácia varia conforme a GPU do aparelho; níveis mais altos podem perder quadros ou esquentar. Comece com Baixo/Médio e confira o resultado no seu dispositivo.",
+  "video_shader_mobile_perf_hint": "Em celulares, Médio/Alto/Ultra usam cadeias do Anime4K apenas de desfoque: os passes de upscaling são omitidos, pois a tela não é maior que a fonte — custariam muita GPU e deixariam o app todo lento. O efeito ainda varia conforme a GPU do aparelho; desça um nível se houver quedas de quadros ou aquecimento.",
   "video_shader_mpv_dir_current": "Pasta do mpv: $path",
   "video_shader_mpv_dir_empty": "Nenhum shader encontrado nessa pasta",
   "video_shader_mpv_not_found": "Nenhum shader do mpv local encontrado",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Импортировано шейдеров: $count",
   "video_shader_import_from_mpv": "Импорт из локального mpv",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "На телефонах шейдеры применяются только на стандартном пути GPU-рендеринга, и эффективность зависит от GPU устройства; высокие уровни могут вызывать пропуск кадров или нагрев. Сначала попробуйте «Низкое»/«Среднее» и проверьте результат на своём устройстве.",
+  "video_shader_mobile_perf_hint": "На телефонах Средний/Высокий/Ультра используют цепочки Anime4K только для убрания размытия: проходы апскейла убраны, ведь экран не больше источника — они съели бы GPU и замедлили всё приложение. Эффект зависит от GPU устройства; при пропусках кадров или нагреве понизьте уровень.",
   "video_shader_mpv_dir_current": "Папка mpv: $path",
   "video_shader_mpv_dir_empty": "В этой папке шейдеры не найдены",
   "video_shader_mpv_not_found": "Локальные шейдеры mpv не найдены",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "นำเข้า $count เชเดอร์แล้ว",
   "video_shader_import_from_mpv": "นำเข้าจาก mpv ในเครื่อง",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "บนโทรศัพท์ เชเดอร์จะทำงานเฉพาะบนเส้นทางเรนเดอร์ GPU มาตรฐาน และผลที่ได้แตกต่างกันตาม GPU ของเครื่อง ระดับสูงอาจทำให้เฟรมตกหรือเครื่องร้อน แนะนำให้ลองระดับต่ำ/ปานกลางก่อนแล้วตรวจผลบนเครื่องของคุณ",
+  "video_shader_mobile_perf_hint": "บนมือถือ ระดับกลาง/สูง/สูงมาก จะใช้ชุด Anime4K ที่ลดความเบลออย่างเดียว โดยตัดขั้นขยายภาพออก เพราะหน้าจอไม่ใหญ่กว่าต้นทาง — มันจะกิน GPU มากและทำให้ทั้งแอพหนืด ผลลัพธ์ยังขึ้นอยู่กับ GPU ของเครื่อง หากเฟรมตกหรือเครื่องร้อน ให้ลดลงหนึ่งระดับ",
   "video_shader_mpv_dir_current": "โฟลเดอร์ mpv: $path",
   "video_shader_mpv_dir_empty": "ไม่พบเชเดอร์ในโฟลเดอร์นั้น",
   "video_shader_mpv_not_found": "ไม่พบเชเดอร์ mpv ในเครื่อง",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "$count shader içe aktarıldı",
   "video_shader_import_from_mpv": "Yerel mpv'den içe aktar",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Telefonlarda shader'lar yalnızca standart GPU işleme yolunda uygulanır ve etkinlik cihaz GPU'suna göre değişir; yüksek seviyeler kare düşürebilir veya ısınmaya yol açabilir. Önce Düşük/Orta deneyin ve sonucu kendi cihazınızda kontrol edin.",
+  "video_shader_mobile_perf_hint": "Telefonlarda Orta/Yüksek/Ultra yalnızca bulanıklık giderme yapan Anime4K zincirlerini kullanır: ölçekleme aşamaları çıkarılmıştır, çünkü ekran kaynaktan büyük değildir — bunlar çok GPU harcar ve tüm uygulamayı yavaşlatır. Etki yine cihazın GPU'suna göre değişir; kare atlama veya ısınma görürseniz bir kademe düşün.",
   "video_shader_mpv_dir_current": "mpv klasörü: $path",
   "video_shader_mpv_dir_empty": "Bu klasörde shader bulunamadı",
   "video_shader_mpv_not_found": "Yerel mpv shader'ı bulunamadı",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "Đã nhập $count shader",
   "video_shader_import_from_mpv": "Nhập từ mpv cục bộ",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "Trên điện thoại, shader chỉ áp dụng trên đường render GPU tiêu chuẩn và hiệu quả khác nhau tùy GPU thiết bị; mức cao có thể rớt khung hình hoặc gây nóng máy. Hãy thử mức Thấp/Trung bình trước và kiểm tra kết quả trên máy của bạn.",
+  "video_shader_mobile_perf_hint": "Trên điện thoại, mức Trung bình/Cao/Siêu cao dùng chuỗi Anime4K chỉ khử nhòe: các bước phóng to đã bị bỏ, vì màn hình không lớn hơn nguồn — chúng sẽ ngồn GPU và làm chậm toàn bộ ứng dụng. Hiệu quả vẫn tùy GPU thiết bị; hạ một mức nếu bị rớt khung hình hoặc nóng máy.",
   "video_shader_mpv_dir_current": "Thư mục mpv: $path",
   "video_shader_mpv_dir_empty": "Không tìm thấy shader trong thư mục đó",
   "video_shader_mpv_not_found": "Không tìm thấy shader mpv cục bộ",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "已导入 $count 个着色器",
   "video_shader_import_from_mpv": "从本机 mpv 导入",
   "video_shader_import_from_mpv_hint": "自动搜索本机 mpv；未找到时可手动选择 mpv 目录。",
-  "video_shader_mobile_perf_hint": "手机上着色器仅在标准 GPU 渲染路径下生效，实际效果因机型 GPU 而异；高档位可能掉帧或发热。建议先用低/中档，并在本机确认效果。",
+  "video_shader_mobile_perf_hint": "手机上的中/高/极高档使用「只去模糊、不放大」的 Anime4K 链：放大 pass 已移除——屏幕不比片源更大，放大收益有限却会占满 GPU，连带整个 app 变卡。实际效果仍因机型 GPU 而异，掉帧或发热就往下退一档。",
   "video_shader_mpv_dir_current": "mpv 目录：$path",
   "video_shader_mpv_dir_empty": "该目录没找到着色器",
   "video_shader_mpv_not_found": "未发现本机 mpv 着色器",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "无法创建下载。请检查下载设置和任务列表后重试。",
   "download_resource_resolve_failed": "无法获取下载资源。请检查网络和代理设置后重试。",
   "download_torrent_invalid": "来源返回的种子数据无效。请稍后重试或更换来源。",
-  "download_torrent_selection_failed": "无法在种子中唯一匹配这本书。请刷新目录或更换来源。"
+  "download_torrent_selection_failed": "无法在种子中唯一匹配这本书。请刷新目录或更换来源。",
+  "video_shader_tier_low_hint_mobile": "mpv 内置锐化（手机上为 spline36）。无需下载，不增加任何 GPU pass。上面几档掉帧时退回这一档最稳。",
+  "video_shader_tier_medium_hint_mobile": "Anime4K 去模糊（S），在片源原分辨率上跑。不含放大 pass，开销不随屏幕分辨率增长。手机建议从这一档开始。",
+  "video_shader_tier_high_hint_mobile": "Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4211,7 +4211,7 @@
   "video_shader_import_done": "已匯入 $count 個着色器",
   "video_shader_import_from_mpv": "從本機 mpv 匯入",
   "video_shader_import_from_mpv_hint": "自動搜索本機 mpv；未找到時可手動選擇 mpv 目錄。",
-  "video_shader_mobile_perf_hint": "在手機上，着色器只在標準 GPU 算繪路徑下生效，實際效果因機型 GPU 而異；高檔位可能掉幀或發熱。建議先試低／中檔，並在本機確認效果。",
+  "video_shader_mobile_perf_hint": "手機上的中/高/極高檔使用「只去模糊、不放大」的 Anime4K 鏈：放大 pass 已移除——螢幕不比片源更大，放大收益有限卻會佔滿 GPU，連帶整個 app 變卡。實際效果仍因機型 GPU 而異，掉幀或發熱就往下退一檔。",
   "video_shader_mpv_dir_current": "mpv 資料夾：$path",
   "video_shader_mpv_dir_empty": "此資料夾找不到着色器",
   "video_shader_mpv_not_found": "找不到本機 mpv 着色器",
@@ -4526,5 +4526,9 @@
   "download_request_failed": "Could not create the download. Check the download settings and task list, then try again.",
   "download_resource_resolve_failed": "Could not fetch the download resource. Check the network and proxy settings, then try again.",
   "download_torrent_invalid": "The source returned invalid torrent data. Retry later or choose another source.",
-  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source."
+  "download_torrent_selection_failed": "Could not uniquely match this volume in the torrent. Refresh the catalog or choose another source.",
+  "video_shader_tier_low_hint_mobile": "mpv's built-in sharpening (spline36 on phones). No download, no extra GPU passes. The safe choice if anything above this drops frames.",
+  "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
+  "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
+  "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames."
 }

--- a/fushi/lib/src/media/video/video_shader_downloader.dart
+++ b/fushi/lib/src/media/video/video_shader_downloader.dart
@@ -219,6 +219,61 @@ const Anime4kPreset kAnime4kUltraDeblurPreset = Anime4kPreset(
   ],
 );
 
+/// ── 移动端画质档位用的 GLSL 预设（「只修复、不放大」）─────────────────────────
+/// 桌面三档（中/高/极高）的开销主体是 Anime4K 链里的两个 `Upscale_CNN_x2` 加两个
+/// `AutoDownscalePre`，它们为「1080p 片源 → 4K 桌面显示器」设计。手机的输出分辨率通常
+/// **不高于**片源分辨率，放大出来的中间帧最终仍被压回屏幕尺寸——GPU 代价全额付（2x/4x
+/// 中间帧缓冲 + 每帧 3 个 CNN pass），收益却被显示分辨率截断。而移动端 libmpv 的 vo=gpu
+/// 与 Flutter 的 raster 共用同一块 GPU 和 EGL 驱动，GPU 被占满时**播放和整个 app 一起
+/// 掉帧**（用户实测：手机上选高于「低」的任意档就卡）。
+///
+/// 所以移动端不是「换一条更弱的 Anime4K」，而是**砍掉整条放大链，只留修复 pass**：
+/// `Clamp_Highlights`（保高光）+ `Restore_CNN_*`（去模糊/降噪，在**原分辨率**上跑）。
+/// pass 数 6~7 → 2~3，中间帧缓冲 2x/4x → 1x，是数量级削减而非调参；而 1:1 观看时真正
+/// 改善观感的本来就是修复 pass，放大 pass 的贡献在小屏上几乎被采样回原尺寸抵消。
+///
+/// 三档梯度靠 CNN kernel 规模拉开（S → M → M+Soft_M），仍是可往下调的阶梯：某机型连
+/// 「中」都吃不消时，用户退回「低」（纯 mpv 内置 spline36，零 GLSL）即可。
+///
+/// 全部文件均在 bloc97/Anime4K master 存在（联网核对 2026-09-09：`glsl/Restore/` 下
+/// `Anime4K_Restore_CNN_S/M.glsl` 与 `Anime4K_Restore_CNN_Soft_M.glsl` 均在列），MIT，
+/// 与桌面档共用同一套多镜像下载/落盘/勾选管线。
+
+/// 移动「中」档：保高光 + 最轻的 CNN 去模糊（S）。
+const Anime4kPreset kAnime4kMobileRestoreSPreset = Anime4kPreset(
+  id: 'mobile_restore_s',
+  name: 'Anime4K Restore (S, mobile)',
+  description: 'Deblur only, no upscaling passes. Lightest tier for phones.',
+  shaders: <Anime4kShaderFile>[
+    Anime4kShaderFile('glsl/Restore/Anime4K_Clamp_Highlights.glsl'),
+    Anime4kShaderFile('glsl/Restore/Anime4K_Restore_CNN_S.glsl'),
+  ],
+);
+
+/// 移动「高」档：保高光 + 更大 kernel 的 CNN 去模糊（M）。
+const Anime4kPreset kAnime4kMobileRestoreMPreset = Anime4kPreset(
+  id: 'mobile_restore_m',
+  name: 'Anime4K Restore (M, mobile)',
+  description: 'Deblur only, larger kernel. For faster phone GPUs.',
+  shaders: <Anime4kShaderFile>[
+    Anime4kShaderFile('glsl/Restore/Anime4K_Clamp_Highlights.glsl'),
+    Anime4kShaderFile('glsl/Restore/Anime4K_Restore_CNN_M.glsl'),
+  ],
+);
+
+/// 移动「极高」档：保高光 + 去模糊（M）+ 额外柔化修复（Soft_M），对 web 压制番双重修复。
+/// 文件集比「高」档多一个 Soft_M → 与其余移动档两两不等，[tierFromState] 反查无歧义。
+const Anime4kPreset kAnime4kMobileRestoreMSoftPreset = Anime4kPreset(
+  id: 'mobile_restore_m_soft',
+  name: 'Anime4K Restore (M + Soft, mobile)',
+  description: 'Deblur plus an extra soft restore pass. Still no upscaling.',
+  shaders: <Anime4kShaderFile>[
+    Anime4kShaderFile('glsl/Restore/Anime4K_Clamp_Highlights.glsl'),
+    Anime4kShaderFile('glsl/Restore/Anime4K_Restore_CNN_M.glsl'),
+    Anime4kShaderFile('glsl/Restore/Anime4K_Restore_CNN_Soft_M.glsl'),
+  ],
+);
+
 /// GitHub raw 直连不通（GFW 机器、app 运行时**不走**本机命令行代理）时的镜像回退源。
 /// 与 `update_checker.dart` 的 `_kProxyPrefixes`（BUG-319）同一范式：公共镜像会不定期
 /// 轮换/下线，按顺序逐个尝试，全部失败才放弃；具体哪个通取决于用户机器与时段，多备几个。
@@ -538,6 +593,10 @@ List<String> anime4kManifestFileNames() {
   for (final Anime4kPreset preset in <Anime4kPreset>[
     ...kAnime4kPresets,
     kAnime4kUltraDeblurPreset,
+    // 移动档同样经本管线落盘，漏登记会让存储页删不掉这几个文件（留下孤儿）。
+    kAnime4kMobileRestoreSPreset,
+    kAnime4kMobileRestoreMPreset,
+    kAnime4kMobileRestoreMSoftPreset,
   ]) {
     for (final String name in preset.fileNames) {
       if (!out.contains(name)) out.add(name);

--- a/fushi/lib/src/media/video/video_shader_tier.dart
+++ b/fushi/lib/src/media/video/video_shader_tier.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:fushi/src/media/video/video_shader_downloader.dart';
 
 /// 视频画质增强「档位」：把用户面前的「无/低/中/高/极高」五档，投影到底层两套**正交**
@@ -51,7 +53,8 @@ class VideoShaderTierSpec {
       preset == null ? const <String>[] : preset!.fileNames;
 }
 
-/// 五档的权威定义表（顺序即 UI 从左到右 无→极高）。
+/// **桌面**五档的权威定义表（顺序即 UI 从左到右 无→极高）。移动端另有一张
+/// [kMobileVideoShaderTiers]，取哪张一律经 [shaderTiersFor] 投影，别直接引用本表。
 final List<VideoShaderTierSpec> kVideoShaderTiers = <VideoShaderTierSpec>[
   VideoShaderTierSpec(
     tier: VideoShaderTier.off,
@@ -85,13 +88,69 @@ final List<VideoShaderTierSpec> kVideoShaderTiers = <VideoShaderTierSpec>[
   ),
 ];
 
+/// **移动端**五档定义表。与桌面表**同语义、不同投影**：档位含义（无→极高，越高越强）
+/// 一字不变，变的只是每档映射到哪条 GLSL 链。
+///
+/// 无/低 与桌面完全相同（低=纯 mpv 内置缩放，移动端回落 spline36，见
+/// `resolveScaleProperties`，零 GLSL）。中/高/极高 换成**只修复、不放大**的链
+/// （[kAnime4kMobileRestoreSPreset] 等三个常量，理由见其 doc）：桌面链的开销主体是两个
+/// `Upscale_CNN_x2` + 两个 `AutoDownscalePre`，而手机屏幕不比片源更大，放大收益被显示
+/// 分辨率截断、代价却全额付；GPU 占满时连带 Flutter raster 一起卡（用户实测：手机上选
+/// 高于「低」的任意档，播放和整个 app 一起卡）。
+///
+/// 这与 `resolveScaleProperties` 早就为移动端做的降级（EWA polar → spline36，TODO-1196）
+/// 是同一条判断——那次只做了「内置缩放」这一半，GLSL 这一半一直漏着，本表补上。
+final List<VideoShaderTierSpec> kMobileVideoShaderTiers = <VideoShaderTierSpec>[
+  VideoShaderTierSpec(
+    tier: VideoShaderTier.off,
+    id: 'off',
+    highQuality: false,
+    preset: null,
+  ),
+  VideoShaderTierSpec(
+    tier: VideoShaderTier.low,
+    id: 'low',
+    highQuality: true,
+    preset: null,
+  ),
+  VideoShaderTierSpec(
+    tier: VideoShaderTier.medium,
+    id: 'medium',
+    highQuality: true,
+    preset: kAnime4kMobileRestoreSPreset,
+  ),
+  VideoShaderTierSpec(
+    tier: VideoShaderTier.high,
+    id: 'high',
+    highQuality: true,
+    preset: kAnime4kMobileRestoreMPreset,
+  ),
+  VideoShaderTierSpec(
+    tier: VideoShaderTier.ultra,
+    id: 'ultra',
+    highQuality: true,
+    preset: kAnime4kMobileRestoreMSoftPreset,
+  ),
+];
+
+/// **纯函数**：取本平台该用的档位表（[kVideoShaderTiers] / [kMobileVideoShaderTiers]）。
+///
+/// 与 `resolveScaleProperties` 同签名范式：[isMobile] 显式传入便于单测两端都断言，不传
+/// 则按运行平台判定。**本文件所有档位查询都经这里取表**，保证「选档写入」与「反查回读」
+/// 用的是同一张表——两边取不同表会让刚选的档立刻显示成「自定义」。
+List<VideoShaderTierSpec> shaderTiersFor({bool? isMobile}) {
+  final bool mobile = isMobile ?? (Platform.isAndroid || Platform.isIOS);
+  return mobile ? kMobileVideoShaderTiers : kVideoShaderTiers;
+}
+
 /// 取某档的规格。纯函数。
-VideoShaderTierSpec shaderTierSpec(VideoShaderTier tier) =>
-    kVideoShaderTiers.firstWhere((VideoShaderTierSpec s) => s.tier == tier);
+VideoShaderTierSpec shaderTierSpec(VideoShaderTier tier, {bool? isMobile}) =>
+    shaderTiersFor(isMobile: isMobile)
+        .firstWhere((VideoShaderTierSpec s) => s.tier == tier);
 
 /// 该档需要的 GLSL 文件名集合（落盘 + 启用）。纯函数。
-List<String> shaderFilesForTier(VideoShaderTier tier) =>
-    shaderTierSpec(tier).shaderFileNames;
+List<String> shaderFilesForTier(VideoShaderTier tier, {bool? isMobile}) =>
+    shaderTierSpec(tier, isMobile: isMobile).shaderFileNames;
 
 /// **纯函数**：从当前底层状态（内置缩放开关 [highQuality] + 已启用 GLSL 文件名集
 /// [enabledShaders]）反查命中的档位；都不命中（用户手工勾了非标准集）返回 null=自定义。
@@ -101,9 +160,10 @@ List<String> shaderFilesForTier(VideoShaderTier tier) =>
 VideoShaderTier? tierFromState({
   required bool highQuality,
   required List<String> enabledShaders,
+  bool? isMobile,
 }) {
   final Set<String> enabled = enabledShaders.toSet();
-  for (final VideoShaderTierSpec spec in kVideoShaderTiers) {
+  for (final VideoShaderTierSpec spec in shaderTiersFor(isMobile: isMobile)) {
     if (spec.highQuality != highQuality) continue;
     final Set<String> want = spec.shaderFileNames.toSet();
     if (_setEquals(enabled, want)) return spec.tier;
@@ -122,10 +182,11 @@ bool _setEquals(Set<String> a, Set<String> b) =>
 /// 不会让 libmpv 加载缺失路径。
 List<String> orderedEnabledForTier(
   VideoShaderTier tier,
-  Set<String> presentFiles,
-) {
+  Set<String> presentFiles, {
+  bool? isMobile,
+}) {
   return <String>[
-    for (final String name in shaderFilesForTier(tier))
+    for (final String name in shaderFilesForTier(tier, isMobile: isMobile))
       if (presentFiles.contains(name)) name,
   ];
 }

--- a/fushi/lib/src/pages/implementations/video_shader_dialog.dart
+++ b/fushi/lib/src/pages/implementations/video_shader_dialog.dart
@@ -765,7 +765,27 @@ String shaderTierLabel(VideoShaderTier tier) {
 }
 
 /// 画质档位一句话说明（选谁用谁，告诉用户该档画质/GPU 取舍）。纯映射。
-String shaderTierLabelDescription(VideoShaderTier tier) {
+///
+/// **按平台分文案**：中/高/极高 在两端映射到不同的着色器链（见 [shaderTiersFor]），
+/// 桌面文案写的是「Anime4K HQ / 需要 RTX 4060」这类**桌面显卡门槛**，照搬到手机上等于
+/// 让用户按一个不存在的标准选档——这正是「手机上选了中档就卡」的表层诱因。移动端换成
+/// 描述「只修复不放大」的那套文案。
+String shaderTierLabelDescription(VideoShaderTier tier, {bool? isMobile}) {
+  final bool mobile = isMobile ?? isMobilePlatform;
+  if (mobile) {
+    switch (tier) {
+      case VideoShaderTier.off:
+        return t.video_shader_tier_off_hint;
+      case VideoShaderTier.low:
+        return t.video_shader_tier_low_hint_mobile;
+      case VideoShaderTier.medium:
+        return t.video_shader_tier_medium_hint_mobile;
+      case VideoShaderTier.high:
+        return t.video_shader_tier_high_hint_mobile;
+      case VideoShaderTier.ultra:
+        return t.video_shader_tier_ultra_hint_mobile;
+    }
+  }
   switch (tier) {
     case VideoShaderTier.off:
       return t.video_shader_tier_off_hint;
@@ -806,7 +826,7 @@ class VideoShaderTierSelector extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 4),
         child: SegmentedButton<VideoShaderTier>(
           segments: <ButtonSegment<VideoShaderTier>>[
-            for (final VideoShaderTierSpec spec in kVideoShaderTiers)
+            for (final VideoShaderTierSpec spec in shaderTiersFor())
               ButtonSegment<VideoShaderTier>(
                 value: spec.tier,
                 label: Text(shaderTierLabel(spec.tier)),
@@ -849,7 +869,7 @@ class VideoShaderTierComparison extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          for (final VideoShaderTierSpec spec in kVideoShaderTiers)
+          for (final VideoShaderTierSpec spec in shaderTiersFor())
             () {
               final bool active = current == spec.tier;
               return Padding(

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -1709,7 +1709,7 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
                 unawaited(_selectShaderTier(tier)),
             itemBuilder: (BuildContext context) =>
                 <PopupMenuEntry<VideoShaderTier>>[
-                  for (final VideoShaderTierSpec spec in kVideoShaderTiers)
+                  for (final VideoShaderTierSpec spec in shaderTiersFor())
                     if (spec.tier != VideoShaderTier.low)
                       CheckedPopupMenuItem<VideoShaderTier>(
                         value: spec.tier,

--- a/fushi/test/media/video/video_shader_tier_test.dart
+++ b/fushi/test/media/video/video_shader_tier_test.dart
@@ -229,4 +229,113 @@ void main() {
           isEmpty);
     });
   });
+
+  // ── 移动端档位投影守卫（BUG：手机上选高于「低」的任意档，播放和整个 app 一起卡）──
+  // 根因是档位表只有一张桌面表：中/高/极高 把为「1080p → 4K 桌面显示器」设计的
+  // Anime4K 放大链原样丢给手机 GPU。手机屏幕不比片源更大，放大收益被显示分辨率截断、
+  // 代价却全额付，GPU 占满时连带 Flutter raster 一起掉帧。移动端改成只保留修复 pass。
+  //
+  // 本组把「移动链不含放大 pass」钉成不变式：日后谁把桌面链复制回移动表就会红。
+  group('移动端档位投影（shaderTiersFor / kMobileVideoShaderTiers）', () {
+    /// 放大 / 自动降采样类文件的判据（Anime4K 上游按目录+文件名区分）。
+    bool isUpscalePass(String fileName) =>
+        fileName.contains('Upscale') || fileName.contains('AutoDownscale');
+
+    test('shaderTiersFor 按平台取表，两端都不为空且互为独立对象', () {
+      expect(shaderTiersFor(isMobile: false), same(kVideoShaderTiers));
+      expect(shaderTiersFor(isMobile: true), same(kMobileVideoShaderTiers));
+    });
+
+    test('移动表档位语义与桌面一致：同样五档、同序、同 id', () {
+      expect(
+          kMobileVideoShaderTiers.map((VideoShaderTierSpec s) => s.tier)
+              .toList(),
+          kVideoShaderTiers.map((VideoShaderTierSpec s) => s.tier).toList());
+      expect(
+          kMobileVideoShaderTiers.map((VideoShaderTierSpec s) => s.id).toList(),
+          <String>['off', 'low', 'medium', 'high', 'ultra']);
+    });
+
+    test('无/低 两端完全相同（低=纯 mpv 内置缩放，零 GLSL，无平台差异）', () {
+      for (final VideoShaderTier tier
+          in <VideoShaderTier>[VideoShaderTier.off, VideoShaderTier.low]) {
+        final VideoShaderTierSpec desktop =
+            shaderTierSpec(tier, isMobile: false);
+        final VideoShaderTierSpec mobile = shaderTierSpec(tier, isMobile: true);
+        expect(mobile.highQuality, desktop.highQuality);
+        expect(mobile.shaderFileNames, desktop.shaderFileNames);
+        expect(mobile.shaderFileNames, isEmpty);
+      }
+    });
+
+    test('移动 中/高/极高 一个放大 pass 都不含（本次修复的核心不变式）', () {
+      for (final VideoShaderTier tier in <VideoShaderTier>[
+        VideoShaderTier.medium,
+        VideoShaderTier.high,
+        VideoShaderTier.ultra,
+      ]) {
+        final List<String> files =
+            shaderFilesForTier(tier, isMobile: true);
+        expect(files.where(isUpscalePass), isEmpty,
+            reason: '移动 $tier 档混进了放大/降采样 pass：$files');
+        // 对照组：同一档在桌面上**确实**含放大 pass —— 否则本断言恒真、成空壳守卫。
+        expect(
+            shaderFilesForTier(tier, isMobile: false).where(isUpscalePass),
+            isNotEmpty,
+            reason: '桌面 $tier 档应含放大 pass，否则上面的移动端断言没有区分力');
+      }
+    });
+
+    test('移动 中/高/极高 都以保高光开头，且 pass 数不超过 3', () {
+      for (final VideoShaderTier tier in <VideoShaderTier>[
+        VideoShaderTier.medium,
+        VideoShaderTier.high,
+        VideoShaderTier.ultra,
+      ]) {
+        final List<String> files = shaderFilesForTier(tier, isMobile: true);
+        expect(files.first, 'Anime4K_Clamp_Highlights.glsl');
+        expect(files.length, lessThanOrEqualTo(3),
+            reason: '移动档 pass 数超过 3 就失去「数量级削减」的意义：$files');
+      }
+    });
+
+    test('移动五档文件集两两互异 → tierFromState(isMobile: true) 反查无歧义', () {
+      final Set<VideoShaderTier> hit = <VideoShaderTier>{};
+      for (final VideoShaderTierSpec spec in kMobileVideoShaderTiers) {
+        final VideoShaderTier? back = tierFromState(
+          highQuality: spec.highQuality,
+          enabledShaders: spec.shaderFileNames,
+          isMobile: true,
+        );
+        expect(back, spec.tier, reason: '移动 ${spec.id} 档反查落到了 $back');
+        hit.add(back!);
+      }
+      expect(hit.length, kMobileVideoShaderTiers.length);
+    });
+
+    test('orderedEnabledForTier 在移动端按移动链过滤保序', () {
+      final List<String> want =
+          shaderFilesForTier(VideoShaderTier.ultra, isMobile: true);
+      expect(
+          orderedEnabledForTier(VideoShaderTier.ultra, want.toSet(),
+              isMobile: true),
+          want);
+      // 缺一个文件（下载失败）时只启用真正存在的，不给 libmpv 递缺失路径。
+      final Set<String> present = want.take(want.length - 1).toSet();
+      expect(
+          orderedEnabledForTier(VideoShaderTier.ultra, present,
+              isMobile: true),
+          want.take(want.length - 1).toList());
+    });
+
+    test('移动档文件全部登记进 anime4kManifestFileNames（否则存储页删不掉）', () {
+      final Set<String> manifest = anime4kManifestFileNames().toSet();
+      for (final VideoShaderTierSpec spec in kMobileVideoShaderTiers) {
+        for (final String name in spec.shaderFileNames) {
+          expect(manifest, contains(name),
+              reason: '$name 未登记 → 下载后成为存储页删不掉的孤儿文件');
+        }
+      }
+    });
+  });
 }


### PR DESCRIPTION
## 用户报告

> "If I set the video quality to anything higher than 'Low,' both the playback and the entire app start lagging severely."

追问后确认是**手机端**。

## 根因（BUG-2334）

「视频画质」= 画质增强档位（无/低/中/高/极高）。它不是连续强度旋钮，而是把档位投影到两套正交状态：mpv 内置缩放开关 + GLSL 启用集。**低** = 内置缩放 on + 零 GLSL；**中/高/极高** = 额外叠 Anime4K 链。用户报的分界线（「高于低就卡」）与「有没有 GLSL」这条线一字不差。

`kVideoShaderTiers`（`video_shader_tier.dart:57`）改前是**唯一一张桌面表**。中/高/极高 在手机上拿到的是为「1080p 片源 → 4K 桌面显示器」设计的桌面链：

```
Clamp_Highlights → Restore_CNN_M → Upscale_CNN_x2_M
  → AutoDownscalePre_x2 → AutoDownscalePre_x4 → Upscale_CNN_x2_S
```

6~7 个 pass，含 2x/4x 中间帧缓冲；而档位说明文案写的门槛是「GTX 1660 / RX 6600」这类桌面显卡。手机屏幕不高于片源分辨率，放大出的中间帧最终仍被压回屏幕尺寸——**GPU 代价全额付，收益被显示分辨率截断**。

「连整个 app 一起卡」不是第二个 bug：移动端 libmpv 的 `vo=gpu` 与 Flutter 的 raster 共用同一块 GPU 与 EGL 驱动，CNN pass 占满 GPU 时 Flutter 合成排队等待 → 全局掉帧。

**同一判断此前只做了一半**：`video_mpv_config.dart:492` 的 `resolveScaleProperties` 早就为移动端把 EWA polar 降级成 spline36（「移动中端 GPU 扛不住」，TODO-1196）。那次只改了「内置缩放」这一半，**GLSL 这一半一直漏着**。改前唯一的应对是加了一句「高档位可能掉帧或发热」的提示文案——那是补丁式绕过，不是修复：档位说明照旧写着桌面显卡型号，用户按说明选，然后卡死。

## 修复

档位表改成**按平台投影**，与 `resolveScaleProperties` 同签名范式。

- **`video_shader_tier.dart`**：新增 `kMobileVideoShaderTiers` + `shaderTiersFor({bool? isMobile})`；`shaderTierSpec` / `shaderFilesForTier` / `tierFromState` / `orderedEnabledForTier` 四个纯函数统一接 `isMobile`，保证「选档写入」与「反查回读」取同一张表（取不同表会让刚选的档立刻显示成「自定义」）。
- **`video_shader_downloader.dart`**：新增三个**只修复、不放大**的移动端预设，并登记进 `anime4kManifestFileNames()`（漏登记会让存储页删不掉这几个文件）。

  | 档位 | 桌面 | 移动 |
  |---|---|---|
  | 中 | Mode A Fast（6 pass，含 2 次 x2 放大） | `Clamp_Highlights + Restore_CNN_S`（2 pass） |
  | 高 | Mode A HQ（6 pass） | `Clamp_Highlights + Restore_CNN_M`（2 pass） |
  | 极高 | Mode A VL + Deblur（7 pass） | `+ Restore_CNN_Soft_M`（3 pass） |

  pass 数 6~7 → 2~3，中间帧缓冲 2x/4x → 1x。**这是数量级削减而不是调参**：1:1 观看时真正改善观感的本来就是修复 pass，被砍掉的恰是收益被屏幕分辨率截断的那半条链。三档梯度靠 CNN kernel 规模拉开，仍是可往下调的阶梯——某机型连「中」都吃不消时退回「低」（纯 mpv 内置 spline36，零 GLSL）即可。
- **UI**：档位选择器与对照表走 `shaderTiersFor()`；`shaderTierLabelDescription` 按平台分文案，移动端不再显示 RTX 4060 这类桌面门槛。
- **i18n**：新增 4 个 `*_hint_mobile` key（经 `tool/i18n_sync.dart --add`），并改写 17 语言的 `video_shader_mobile_perf_hint`（旧文案「建议先用低/中档」已与新行为不符）。

**向后兼容**：档位语义（无→极高，越高越强）一字不变，持久化键与已启用集格式不动，桌面链一字未改，老用户手工勾选的自定义集仍走「自定义」通路。

## 测试

`video_shader_tier_test.dart` 新增 group「移动端档位投影」8 条。核心不变式是**移动 中/高/极高 一个 `Upscale` / `AutoDownscale` 文件都不含**，并对桌面档同一断言取反（`isNotEmpty`）作对照组——防止写成恒真的空壳守卫。另含：两端选表正确、移动表五档同序同 id、无/低 两端完全相同、pass ≤ 3 且以 `Clamp_Highlights` 开头、五档文件集两两互异使 `tierFromState(isMobile: true)` 反查无歧义、`orderedEnabledForTier` 缺文件时保序过滤、移动档文件全部登记进 manifest。

## 验证

- `flutter analyze` 全量（含 test）：**No issues found**（31.2s，exit 0）
- 定向：`test/media/video/` 全目录 + `video_shader_guards_test` + `video_player_settings_master_detail_guard_test` + `video_quick_settings_sheet_test` → **3769 passed**。唯一一条红是 `anidb_udp_file_client_test` 的真 UDP 用例，单跑 **16/16 绿**，是已知并发 flaky，与本改动无关。
- 目录枚举型守卫整批（56 个文件）：见下方评论。

## 未覆盖的缺口（如实记录）

- **未做真机复测**（该步骤按用户 2026-07-29 的决定已取消）。因此有一种情形本次区分不了：除了纯 GPU 成本，是否还叠加了 **fp16 FBO 回落**——Anime4K 需要 `rgba16f` 中间缓冲，移动 GPU 上 mpv `fbo-format` 协商若回落，代价会再翻几倍。这条线有前科（BUG-465 因 Mali 16-bit 纹理 OOM 强制过 `vf=format=yuv420p`）。判据现成：`FUSHI_TEST_MPV_LOG_FILE` + `msg-level=all=v`（`video_player_controller.dart:1449`）会打出 VO / FBO 协商。
- 移动三档的绝对开销未在真机量化。

https://claude.ai/code/session_013QxjRUeh7DUaixFhYSZoU1
