### PR TITLE
fix(gal): 台词浮窗正文窗加置顶守卫，全屏游戏不再把它压下去 (BUG-2365)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2365](bugs/BUG-2365-gal-overlay-body-sinks-under-fullscreen-game.md) | ✅ | ✅ | galgame 全屏后台词浮窗正文窗沉到游戏底下（顶条还在、文字没了） |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2365-gal-overlay-body-sinks-under-fullscreen-game.md
+++ b/docs/bugs/BUG-2365-gal-overlay-body-sinks-under-fullscreen-game.md
@@ -1,0 +1,44 @@
+## BUG-2365 · galgame 全屏后台词浮窗正文窗沉到游戏底下（顶条还在、文字没了）
+- **报告**：2026-09-09（用户：游戏切全屏后「显示不了字幕」；追问后确认是「字幕栏顶条还在，文字没了」）
+- **真实性**：✅ 真 bug。根因 `fushi/windows/runner/floating_lyric_window.cpp`（正文窗从无周期性置顶重申）
+  vs `fushi/windows/runner/hook_toolbar_window.cpp:735/745/749`（工具条窗每次 Sync 都无条件重申）。
+
+### 根因
+
+穿透态下台词浮层是**两个窗口**：
+
+| 窗口 | 谁重申 Z | 频率 |
+|---|---|---|
+| 独立逃生工具条窗 `HookToolbarWindow` | `Sync()` 里无条件 `SetWindowPos(HWND_TOPMOST)`（连「无需重绘」的早退分支里也做，注释点名 BUG-951 不变式） | **每次渲染**（每条台词） |
+| 台词正文窗 `FloatingLyricWindow` | 只有 `Show` / `ClampCurrentPositionToWindowMonitor` / WM_DPICHANGED / `SetTopmost`（📌 按钮） | **事件驱动，全屏切换不在其中** |
+
+galgame 切全屏时会把游戏窗口抬进置顶带（KiriKiri / Siglus 等引擎的常规动作）。同一置顶带内是
+「最后一次 `SetWindowPos` 的赢」——**这不是独占全屏那条 OS 硬限制**，BUG-1479 已在查词卡上确认过
+同一机制并给出结论（见 `global_lookup_window.cpp` `HandleMessage` 的 WM_TIMER 注释）。
+
+于是全屏那一刻两个窗口一起被压到游戏底下，**下一帧工具条自己爬回来，正文窗永远留在底下**：
+用户看到的正是「顶条还在、文字没了」。`DispatchControlAction` 里 📌 的注释早就写明
+「Re-pinning 是被别的窗口爬过去之后回来的路」——问题是它**只有手动那一条路**。
+
+### 修复
+
+- **[x] ① 已修复** — 正文窗拿到与查词卡同形状的 800ms 置顶守卫
+  （`kTopmostGuardTimerId` + `ReassertTopmost` / `StartTopmostGuard` / `StopTopmostGuard`，
+  `floating_lyric_window.cpp`）。两条纪律：
+  - `topmost_` 为假（用户按 📌 主动取消置顶）时早退——守卫不得把显式意图顶回去；
+  - 重申后立刻 `SyncPassThroughToolbar()` 把逃生工具条重新顶到正文之上（BUG-951 不变式）。
+
+  同时避免与查词卡的守卫互抢：卡片自己也每 800ms 重申置顶（BUG-1479），两边都抢置顶带最顶
+  会让卡片周期性闪到浮窗底下。新增 `GlobalLookupWindow::TopmostCeilingHandle()` +
+  `FloatingLyricWindow::SetTopmostCeilingProvider()`，有可见卡片时正文窗**插在卡片正下方**
+  （仍在全屏游戏之上，因为卡片的守卫保证卡片在游戏之上），没有卡片时才抢最顶。
+  有声书悬浮字幕与 galgame 台词浮窗是同一个类的两个实例，两处都接了天花板。
+
+- **[x] ② 已加自动化测试** — `fushi/test/native/gal_overlay_topmost_guard_static_test.dart`
+  （4 条源码守卫：定时器真接线、pin 语义早退、让位天花板 + 工具条回顶、两个实例都接天花板）。
+
+### 备注
+
+- 这条与 BUG-1479（查词卡被 galgame 盖住）是**同一个机制的两个受害者**；当年只修了卡片。
+- `test/native` 是改 `windows/runner/*.cpp` 的真实爆炸半径，按功能域挑测试结构上挑不到。
+- 尚未在真实全屏 galgame 上复测（原始失败路径的真机验证缺口），仅有编译 + 源码守卫。

--- a/fushi/test/native/gal_overlay_topmost_guard_static_test.dart
+++ b/fushi/test/native/gal_overlay_topmost_guard_static_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2365 源码守卫：台词浮窗**正文窗**的置顶重申。
+///
+/// 根因：穿透态下浮层是两个窗口——正文窗 + 独立逃生工具条窗。
+/// `HookToolbarWindow::Sync` 每次渲染都无条件重申 `HWND_TOPMOST`（BUG-951 的不变式），
+/// 正文窗却只在 show / clamp / DPI 变化时设过一次。galgame 切全屏会把游戏窗口抬进
+/// 置顶带，同一带内是「最后一次 SetWindowPos 的赢」（BUG-1479 已在查词卡上确认过同一
+/// 机制），于是正文窗被压到游戏底下再也上不来，而工具条下一帧就爬回去——用户看到的
+/// 正是「字幕栏顶条还在、文字没了」。
+///
+/// 修复：正文窗拿到与查词卡同形状的 800ms 置顶守卫（`ReassertTopmost` + WM_TIMER），
+/// 并在守卫里让位给可见的查词卡（否则两个 800ms 守卫互相抢置顶带最顶，卡片会周期性
+/// 闪到浮窗底下）。
+///
+/// 守卫断言这三段结构在位：定时器接线、pin 语义、Z 序天花板。删掉任一段即红。
+void main() {
+  String read(String rel) {
+    final File f = File(rel);
+    expect(f.existsSync(), isTrue, reason: '文件不存在：$rel');
+    return f.readAsStringSync().replaceAll('\r\n', '\n');
+  }
+
+  late final String body = read('windows/runner/floating_lyric_window.cpp');
+  late final String bodyHeader = read('windows/runner/floating_lyric_window.h');
+  late final String card = read('windows/runner/global_lookup_window.cpp');
+  late final String wiring = read('windows/runner/flutter_window.cpp');
+
+  test('正文窗有周期性置顶重申，且真的挂在定时器上', () {
+    expect(body.contains('void FloatingLyricWindow::ReassertTopmost()'), isTrue,
+        reason: 'BUG-2365：正文窗必须有置顶重申实现');
+    expect(body.contains('kTopmostGuardTimerId'), isTrue,
+        reason: '置顶守卫必须有自己的定时器 id');
+    // 光有函数不算接线：WM_TIMER 必须真的把这个 id 分派到重申上，否则守卫永不触发。
+    final int timerCase = body.indexOf('case WM_TIMER:');
+    expect(timerCase, greaterThan(0), reason: '找不到 WM_TIMER 分支');
+    final int dispatch = body.indexOf('kTopmostGuardTimerId', timerCase);
+    expect(dispatch, greaterThan(0),
+        reason: 'WM_TIMER 必须分派 kTopmostGuardTimerId → ReassertTopmost');
+    expect(body.indexOf('ReassertTopmost();', dispatch), greaterThan(0),
+        reason: 'kTopmostGuardTimerId 分支必须调 ReassertTopmost');
+    // 显示时起表、隐藏 / 句柄失效时停表——留着就是后台空转，且下一次 Show 不再起表。
+    expect(body.contains('StartTopmostGuard();'), isTrue,
+        reason: 'Show 成功后必须起置顶守卫');
+    expect(body.contains('StopTopmostGuard();'), isTrue,
+        reason: '隐藏 / 句柄失效时必须停置顶守卫');
+  });
+
+  test('置顶守卫尊重 pin：用户取消置顶后不得把正文窗顶回去', () {
+    // 📌 是显式意图。守卫无条件抬窗 = 这个按钮再也关不掉置顶。
+    final int fn = body.indexOf('void FloatingLyricWindow::ReassertTopmost()');
+    expect(fn, greaterThan(0));
+    final int end = body.indexOf('\n}\n', fn);
+    expect(end, greaterThan(fn));
+    final String bodyBlock = body.substring(fn, end);
+    expect(bodyBlock.contains('!topmost_'), isTrue,
+        reason: 'BUG-2365：topmost_ 为假（用户取消置顶）时守卫必须早退');
+  });
+
+  test('置顶守卫让位给查词卡，两个守卫不互相抢最顶', () {
+    // 查词卡自己也有 800ms 置顶守卫（BUG-1479）。两边都抢 HWND_TOPMOST 的话，
+    // 卡片会周期性闪到浮窗底下——所以正文窗有卡片时插在卡片正下方。
+    expect(card.contains('kTopmostGuardTimerId'), isTrue,
+        reason: 'BUG-1479：查词卡的置顶守卫是本条让位逻辑的前提');
+    expect(
+        card.contains('HWND GlobalLookupWindow::TopmostCeilingHandle() const'),
+        isTrue,
+        reason: '查词卡必须暴露 Z 序天花板句柄');
+    expect(bodyHeader.contains('void SetTopmostCeilingProvider('), isTrue,
+        reason: '正文窗必须能接收 Z 序天花板');
+    final int fn = body.indexOf('void FloatingLyricWindow::ReassertTopmost()');
+    final int end = body.indexOf('\n}\n', fn);
+    final String bodyBlock = body.substring(fn, end);
+    expect(bodyBlock.contains('topmost_ceiling_'), isTrue,
+        reason: 'BUG-2365：重申时必须查天花板');
+    // 有天花板时是「插到它下面」（insertAfter = ceiling），不是抢最顶。
+    expect(bodyBlock.contains('SetWindowPos(hwnd_, ceiling,'), isTrue,
+        reason: '有可见查词卡时正文窗必须插在卡片之下，而不是 HWND_TOPMOST');
+    // 抬完正文窗必须把逃生工具条重新顶上去，否则 BUG-951 的唯一出路被自己的正文盖住。
+    expect(bodyBlock.contains('SyncPassThroughToolbar();'), isTrue,
+        reason: 'BUG-951：重申后必须把逃生工具条重新顶到正文之上');
+  });
+
+  test('两个 FloatingLyricWindow 实例都接了 Z 序天花板', () {
+    // 有声书悬浮字幕与 galgame 台词浮窗是同一个类的两个实例，Z 策略必须同一份。
+    expect('SetTopmostCeilingProvider'.allMatches(wiring).length, 2,
+        reason: 'floating_lyric_window_ 与 gal_hook_text_window_ 都要接天花板');
+  });
+}

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -54,6 +54,14 @@ constexpr UINT_PTR kHoverLookupTimerId = 1;
 // 查词那样需要 60ms 级精度——它只决定一个窗口显不显示。
 constexpr UINT_PTR kToolbarRevealTimerId = 2;
 constexpr UINT kToolbarRevealPollMs = 120;
+// 正文窗置顶守卫（BUG-2365）。与查词卡的 BUG-1479 守卫同一形状、同一间隔：
+// galgame 切全屏时会把自己抬进置顶带（KiriKiri / Siglus 等引擎的常规动作），同一
+// 置顶带内是「最后一次 SetWindowPos 的赢」，而正文窗只在 show / clamp / DPI 变化时
+// 设过一次，于是被压到游戏底下再也上不来。独立工具条窗有自己的按帧重申
+//（HookToolbarWindow::Sync 无条件 HWND_TOPMOST，BUG-951 的逃生口），所以用户看到的
+// 正是「顶条还在、文字没了」。800ms 取自 BUG-1479 的同一权衡。
+constexpr UINT_PTR kTopmostGuardTimerId = 3;
+constexpr UINT kTopmostGuardIntervalMs = 800;
 // 揭示区在正文窗 ∪ 工具条矩形之外再放宽这么多，避免指针刚离开边缘一像素就消失，
 // 以及「从工具条移向正文」的途中出现空档。
 constexpr float kToolbarRevealMarginDip = 24.0f;
@@ -227,6 +235,7 @@ void FloatingLyricWindow::ResetWindowInteractionState() {
   CancelPointerGesture();
   StopHoverLookupPolling();
   StopToolbarRevealPolling();
+  StopTopmostGuard();
   ResetHoverLookupAnchor();
 }
 
@@ -511,6 +520,7 @@ bool FloatingLyricWindow::Show(HWND owner) {
   // BUG-951: a re-show while pass-through is still on must re-create the
   // escape-hatch toolbar and re-arm the body's click-through in one place.
   ApplyPassThroughExStyle();
+  StartTopmostGuard();
   RequestRender();
   return true;
 }
@@ -541,6 +551,7 @@ void FloatingLyricWindow::Hide() {
   // 隐藏后收不到 WM_MOUSELEAVE：定时器留着就是后台空转。
   StopHoverLookupPolling();
   StopToolbarRevealPolling();
+  StopTopmostGuard();
   toolbar_revealed_ = false;
   ResetHoverLookupAnchor();
   // BUG-951: hand clicks back unconditionally and take the toolbar down with
@@ -1103,6 +1114,56 @@ void FloatingLyricWindow::SyncPassThroughToolbar() {
                              ToolbarStates());
 }
 
+void FloatingLyricWindow::SetTopmostCeilingProvider(
+    std::function<HWND()> provider) {
+  topmost_ceiling_ = std::move(provider);
+}
+
+void FloatingLyricWindow::ReassertTopmost() {
+  if (!OwnsLiveWindow()) {
+    return;
+  }
+  // 用户按 📌 主动取消置顶是显式意图，守卫不得把它顶回去。
+  if (!topmost_) {
+    return;
+  }
+  // 查词卡也有自己的 800ms 置顶守卫（BUG-1479）。两个窗口都往置顶带最顶抢的话，
+  // 卡片会周期性地闪到浮窗底下，所以有卡片时正文窗插在**卡片正下方**：既仍在游戏
+  // 之上（卡片的守卫保证卡片在游戏之上），又不会把卡片压掉。没有卡片时才抢最顶。
+  HWND ceiling = topmost_ceiling_ ? topmost_ceiling_() : nullptr;
+  if (ceiling != nullptr && IsWindow(ceiling) && ceiling != hwnd_) {
+    SetWindowPos(hwnd_, ceiling, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  } else {
+    SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  }
+  // 正文窗刚抬到工具条窗之上，逃生口就被自己的正文盖住了（BUG-951 说的「用户再也
+  // 点不回来」）。同一个 tick 里把工具条重新顶上去——它的 Sync 在无需重绘时只做一次
+  // SetWindowPos，代价与这里的一次相同。
+  SyncPassThroughToolbar();
+}
+
+void FloatingLyricWindow::StartTopmostGuard() {
+  if (topmost_guard_active_ || hwnd_ == nullptr) {
+    return;
+  }
+  if (SetTimer(hwnd_, kTopmostGuardTimerId, kTopmostGuardIntervalMs,
+               nullptr) != 0) {
+    topmost_guard_active_ = true;
+  }
+}
+
+void FloatingLyricWindow::StopTopmostGuard() {
+  if (!topmost_guard_active_) {
+    return;
+  }
+  if (hwnd_ != nullptr) {
+    KillTimer(hwnd_, kTopmostGuardTimerId);
+  }
+  topmost_guard_active_ = false;
+}
+
 void FloatingLyricWindow::MoveBodyTo(int x, int y) {
   if (hwnd_ == nullptr) {
     return;
@@ -1293,6 +1354,10 @@ LRESULT FloatingLyricWindow::HandleMessage(HWND hwnd, UINT message,
       return 0;
     }
     case WM_TIMER: {
+      if (wparam == kTopmostGuardTimerId) {
+        ReassertTopmost();
+        return 0;
+      }
       if (wparam == kToolbarRevealTimerId) {
         UpdateToolbarReveal();
         return 0;

--- a/fushi/windows/runner/floating_lyric_window.h
+++ b/fushi/windows/runner/floating_lyric_window.h
@@ -238,6 +238,10 @@ class FloatingLyricWindow {
   // Restores a physical-pixel window rectangle before the next Show. Invalid
   // rectangles are ignored and Show uses its DPI-aware default.
   void SetInitialBounds(int left, int top, int width, int height);
+  // BUG-2365 —— 置顶守卫的「Z 序天花板」。返回一个必须留在正文窗**之上**的窗口
+  // 句柄（当前是可见的查词卡，见 GlobalLookupWindow::TopmostCeilingHandle），
+  // nullptr = 没有天花板、正文窗抢置顶带最顶。不设 provider 时行为等同于恒 nullptr。
+  void SetTopmostCeilingProvider(std::function<HWND()> provider);
 
  private:
   static LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam,
@@ -251,6 +255,11 @@ class FloatingLyricWindow {
 
   void EnsureWindowClass();
   bool OwnsLiveWindow() const;
+  // BUG-2365 —— 显示期间周期性把正文窗重申回置顶带（全屏游戏会把自己抬上来）。
+  // 见 .cpp 里 kTopmostGuardTimerId 的注释。
+  void ReassertTopmost();
+  void StartTopmostGuard();
+  void StopTopmostGuard();
   void ResetWindowInteractionState();
   void ForgetDeadWindow();
   bool EnsureDeviceResources();
@@ -462,6 +471,10 @@ class FloatingLyricWindow {
   bool toolbar_revealed_ = false;
   // 揭示轮询定时器是否已挂。
   bool toolbar_reveal_poll_active_ = false;
+  // 置顶守卫定时器是否已挂（BUG-2365）。
+  bool topmost_guard_active_ = false;
+  // 置顶守卫的 Z 序天花板取值口（见 SetTopmostCeilingProvider）。
+  std::function<HWND()> topmost_ceiling_;
   // 穿透态下文字行盒是否仍接鼠标（见 SetPassThroughBlocksMouse）。
   bool passthrough_blocks_mouse_ = true;
   // 「悬停即查词」偏好镜像（见 SetHoverAutoLookup）。false 时悬停查词需按住 Shift。

--- a/fushi/windows/runner/flutter_window.cpp
+++ b/fushi/windows/runner/flutter_window.cpp
@@ -1218,6 +1218,14 @@ void FlutterWindow::RegisterFloatingLyricChannel() {
   // 旧的自绘 5 槽歌词条形态已删 —— 它是同一件事的第二份实现，且只有它还在用无坐标
   // 的旧 LookupCallback（卡片只能跟着鼠标飘）。
   floating_lyric_window_->SetHookTextMode(true);
+  // BUG-2365 —— 正文窗的置顶守卫必须让位给查词卡：卡片自己也每 800ms 重申置顶
+  // （BUG-1479），两个窗口都抢置顶带最顶就会互相顶掉、卡片周期性闪到浮窗底下。
+  // 有可见卡片时正文窗插在卡片正下方，仍在全屏游戏之上。
+  floating_lyric_window_->SetTopmostCeilingProvider([this]() -> HWND {
+    return global_lookup_window_ != nullptr
+               ? global_lookup_window_->TopmostCeilingHandle()
+               : nullptr;
+  });
   // 但按钮语义不同：这里是上一句 / 播放暂停 / 下一句，不是试听 / 重捕 / 工作台。
   floating_lyric_window_->SetToolbarProfile(
       hook_toolbar::Profile::kAudiobook);
@@ -1458,6 +1466,14 @@ void FlutterWindow::RegisterImeGuardChannel() {
 void FlutterWindow::RegisterGalHookTextChannel() {
   gal_hook_text_window_ = std::make_unique<FloatingLyricWindow>();
   gal_hook_text_window_->SetHookTextMode(true);
+  // BUG-2365 —— 正文窗的置顶守卫必须让位给查词卡：卡片自己也每 800ms 重申置顶
+  // （BUG-1479），两个窗口都抢置顶带最顶就会互相顶掉、卡片周期性闪到浮窗底下。
+  // 有可见卡片时正文窗插在卡片正下方，仍在全屏游戏之上。
+  gal_hook_text_window_->SetTopmostCeilingProvider([this]() -> HWND {
+    return global_lookup_window_ != nullptr
+               ? global_lookup_window_->TopmostCeilingHandle()
+               : nullptr;
+  });
   attached_text_surface_window_ =
       std::make_unique<AttachedTextSurfaceWindow>();
 

--- a/fushi/windows/runner/global_lookup_window.cpp
+++ b/fushi/windows/runner/global_lookup_window.cpp
@@ -1742,6 +1742,13 @@ bool GlobalLookupWindow::IsShowing() const {
   return visible_ && OwnsLiveWindow() && IsWindowVisible(hwnd_);
 }
 
+HWND GlobalLookupWindow::TopmostCeilingHandle() const {
+  // 复用 IsShowing() 的 OwnsLiveWindow 判据：句柄悬空 / 被系统回收时返回 nullptr，
+  // 否则调用方会把台词浮窗插到一个已经不存在的窗口下面（SetWindowPos 对失效句柄
+  // 不抛异常，只是静默失败——浮窗于是一次都没被抬起来）。
+  return IsShowing() ? hwnd_ : nullptr;
+}
+
 bool GlobalLookupWindow::CaptureRouteIsCurrent() const {
   return route_context_bound_ &&
          capture_route_.source == route_context_.source &&

--- a/fushi/windows/runner/global_lookup_window.h
+++ b/fushi/windows/runner/global_lookup_window.h
@@ -154,6 +154,12 @@ class GlobalLookupWindow {
   void Hide(bool notify = true);
   bool IsShowing() const;
 
+  // 置顶带内的 Z 序天花板句柄：卡片正在显示时返回它的 HWND，否则 nullptr。
+  // 台词浮窗正文窗的置顶守卫据此把自己插到卡片**正下方**，而不是抢到置顶带最顶
+  // ——两个窗口都按固定间隔重申 HWND_TOPMOST 的话会互相顶掉，查词卡会周期性地
+  // 闪到浮窗底下。这里只暴露句柄，不暴露窗口对象。
+  HWND TopmostCeilingHandle() const;
+
   // Temporarily removes the lookup card from the DWM composition tree while a
   // galgame mining capture is taken.  Unlike Hide(), this preserves the live
   // WebView route, dismissal hooks and card geometry so the exact same lookup


### PR DESCRIPTION
## 症状

用户报「galgame 全屏显示不了字幕」。追问后确认真实形态是 **「字幕栏顶条还在，文字没了」** —— 不是被游戏整个盖住，也不是独占全屏的 OS 硬限制。

## 根因

穿透态下台词浮层是**两个窗口**：

| 窗口 | 谁重申 Z | 频率 |
|---|---|---|
| 独立逃生工具条窗 `HookToolbarWindow` | `Sync()` 无条件 `SetWindowPos(HWND_TOPMOST)`（连「无需重绘」早退分支里也做，BUG-951 不变式） | **每次渲染** |
| 台词正文窗 `FloatingLyricWindow` | 只有 `Show` / clamp / WM_DPICHANGED / 📌 `SetTopmost` | **全屏切换不在其中** |

galgame 切全屏会把游戏窗口抬进置顶带，同一带内是「最后一次 `SetWindowPos` 的赢」。BUG-1479 已经在**查词卡**上确认过同一机制并给出结论。于是全屏那一刻两个窗口一起被压下去，**工具条下一帧自己爬回来，正文窗永远留在游戏底下** —— 正是用户看到的现象。`DispatchControlAction` 里 📌 的注释早写明「Re-pinning 是被别的窗口爬过去之后回来的路」，问题是它只有手动那一条路。

## 修复

正文窗拿到与查词卡**同形状**的 800ms 置顶守卫（`kTopmostGuardTimerId` + `ReassertTopmost` / `Start` / `StopTopmostGuard`）。两条纪律：

- `topmost_` 为假（用户按 📌 主动取消置顶）时早退 —— 守卫不得把显式意图顶回去；
- 重申后立刻 `SyncPassThroughToolbar()`，否则正文刚抬上去就把 BUG-951 的唯一逃生口盖住。

并消除两个守卫互抢：卡片自己也每 800ms 重申置顶，两边都抢置顶带最顶会让卡片周期性闪到浮窗底下。新增 `GlobalLookupWindow::TopmostCeilingHandle()` + `FloatingLyricWindow::SetTopmostCeilingProvider()`，有可见卡片时正文窗**插在卡片正下方**（仍在全屏游戏之上，因为卡片的守卫保证卡片在游戏之上）。有声书悬浮字幕与 galgame 台词浮窗是同一个类的两个实例，两处都接了天花板。

## 验证

- `flutter build windows --debug` → `√ Built build\windows\x64\runner\Debug\fushi.exe`（exit 0）
- `flutter analyze`（含 test）→ No issues found
- `flutter test test/native test/tools test/build test/lookup test/windows` → **+1709 -9**；9 条红全部在 `update_manifest_publish_race_test.dart`，原因是 PowerShell PATH 无 `bash`（`ProcessException: 系统找不到指定的文件, Command: bash tool/publish_update_manifest.sh`）。同一文件在有 bash 的环境单跑 **exit=0 / All tests passed**，与本改动无关。
- 新增守卫 `fushi/test/native/gal_overlay_topmost_guard_static_test.dart` 4 条全绿（`test/native` 是改 `windows/runner/*.cpp` 的真实爆炸半径，按功能域挑测试结构上挑不到）。

**缺口**：尚未在真实全屏 galgame 上复测原始失败路径，只有编译 + 源码守卫。

https://claude.ai/code/session_01WmpyozLwKc768SP6zGgAPd