### PR TITLE
fix(video): 字幕列表查词浮层不再压住换行到第二排的被查词 (BUG-2367)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2367](bugs/BUG-2367-subtitle-list-lookup-anchor.md) | ✅ | ✅ | 字幕列表查词：词换行到第二排时被查词弹窗遮住 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2367-subtitle-list-lookup-anchor.md
+++ b/docs/bugs/BUG-2367-subtitle-list-lookup-anchor.md
@@ -1,0 +1,10 @@
+## BUG-2367 · 字幕列表查词：词换行到第二排时被查词弹窗遮住
+
+- **报告**：2026-09-09（用户：视频的字幕列表查词，如果查的词占了两排，查词弹窗会挡住第二排；附截图）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/video_subtitle_jump_panel.dart:449`（`subtitleListCharHitFromParagraph` 返回的 `charRect` 只是**被点那一个字**的盒）与同文件 `_buildRowText` 内 `hitAt` 的同款返回；该 rect 一路当查词浮层锚点传到 `fushi/lib/src/pages/implementations/video_fushi/lookup_favorite.part.dart:82`（`pushNestedPopup(selectionRect: charRect)`），最终喂给 `fushi/lib/src/pages/implementations/dictionary_popup_layer.dart:66` 的 `placeAboveBelow()`。
+  - 浮层定位的不变式是 **BUG-098「绝不盖住被查词」**：只按锚点的 `top`/`bottom` 贴在它上方或下方。
+  - 但**被查词的长度在推浮层时还不知道**——查询串恒是「被点字位 → 句末」（`subtitleLookupSpan`），真实匹配长度是引擎查完才回报的 `matchedRunes`。
+  - 于是锚只有单个字：词被软换行拆到第二排时，第二排不在锚里，浮层贴在第一排下方就正好压住它。列表面板窄、行文本满宽，长句常年换行，这是常态不是边角。
+- **[x] ① 已修复** — 锚改为「被点字位 → 句末」的字形盒并集（新增 `subtitleListLookupAnchorRect`，`video_subtitle_jump_panel.dart`）。匹配串恒是这段的前缀，锚**必然包含**被查词，不需要知道它多长，也不需要查完再挪浮层（挪＝肉眼可见的跳）。`SubtitleListCharHit` / `SubtitleListHit` 加 `anchorRect` 字段与既有 `charRect`（命中/去重语义）并存，tap / barrier 换词 / Shift-悬停 / 键盘查词四条入口统一改用 `anchorRect`。纵向只多让出被点字位之后那几行，横向不受影响（横排避让只读 top/bottom）。提交见下。
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/video_subtitle_list_lookup_anchor_test.dart`：① 纯函数并集跨行 + 不回头包含前面的行 + 越界；② widget 层在 360px 窄面板里真点一个换行句的第一排，把回调拿到的锚喂进真实 `calcPopupPosition`，断言浮层与「被点字位→句末」那段文字零垂直重叠（并先断言语料确实换了行，防空壳）。变异实测：把 tap 路径的锚改回 `charRect` 立即转红（锚底 109 < 需要的 126.5）。
+- **备注**：画面底部字幕 overlay（`video_subtitle_overlay.dart`）同样传单字 rect，理论上同病；但底部字幕没有下方空间、浮层恒往上翻，压不到自己，本轮不动。

--- a/fushi/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/fushi/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -324,14 +324,27 @@ const List<double> _kFontScaleSteps = <double>[
 /// 的 `videoSubtitleListFontScaleIndex` 默认值一致。
 const int _kDefaultFontScaleIndex = 1;
 
-/// 字幕列表行内点击命中的字符：被点 grapheme 下标 + 该字符的全局屏幕矩形。
-/// 供 [VideoSubtitleJumpPanel.onLookupCue] 精确查词（TODO-340）。
-typedef SubtitleListCharHit = ({int graphemeIndex, Rect charRect});
+/// 字幕列表行内点击命中的字符：被点 grapheme 下标 + 该字符的全局屏幕矩形 +
+/// 查词浮层锚点矩形。供 [VideoSubtitleJumpPanel.onLookupCue] 精确查词（TODO-340）。
+///
+/// [charRect] 是被点字符本身的盒（命中语义、去重与调试用）；[anchorRect] 是喂给
+/// 查词浮层定位的锚（BUG-2367，见 [subtitleListLookupAnchorRect]）。两者只在
+/// 被查词跨行时不同。
+typedef SubtitleListCharHit = ({
+  int graphemeIndex,
+  Rect charRect,
+  Rect anchorRect,
+});
 
-/// 命中字幕列表某行某字符：整条 [cue] + grapheme 下标 + 该字符的全局屏幕矩形。
-/// 比 [SubtitleListCharHit] 多带所属 [cue]，供查词浮层 dismiss barrier 直接切换查词
-/// （BUG-874）。
-typedef SubtitleListHit = ({AudioCue cue, int graphemeIndex, Rect charRect});
+/// 命中字幕列表某行某字符：整条 [cue] + grapheme 下标 + 该字符的全局屏幕矩形 +
+/// 浮层锚点矩形。比 [SubtitleListCharHit] 多带所属 [cue]，供查词浮层 dismiss barrier
+/// 直接切换查词（BUG-874）。
+typedef SubtitleListHit = ({
+  AudioCue cue,
+  int graphemeIndex,
+  Rect charRect,
+  Rect anchorRect,
+});
 
 /// 给上层（查词浮层的 dismiss barrier）按全局坐标反查「点到的是字幕列表哪行哪个字符」
 /// 用的句柄。[VideoSubtitleJumpPanel] 每帧 build 把命中实现绑进来；上层持有同一对象、
@@ -396,6 +409,33 @@ Rect _subtitleUnionBoxes(List<TextBox> boxes) {
   return rect;
 }
 
+/// 查词浮层的锚点矩形（BUG-2367）：被点字位 [graphemeIndex] 起、直到句末的所有字形盒
+/// 并集（[rects] 是本行每个 grapheme 的渲染盒，行内坐标）。
+///
+/// 浮层定位的不变式是「绝不盖住被查词」（BUG-098，`calcPopupPosition` 只按锚点的
+/// top/bottom 往上或往下贴）。而**被查词的长度在推浮层时还不知道**——查询串恒是
+/// 「被点字位 → 句末」，引擎回报的最长匹配（`matchedRunes`）要等查完才有。若拿被点
+/// 的**单个字**当锚，词被换行拆开时第二排就不在锚里，浮层贴在第一排下方正好压住它
+/// （列表面板窄、行文本满宽，长句常年换行，这是常态不是边角）。
+///
+/// 取「被点字位到句末」的并集即可让锚**必然包含**被查词——匹配串恒是这段的前缀，
+/// 不需要知道它到底多长，也不需要查完再挪浮层（挪＝肉眼可见的跳）。纵向只会多让出
+/// 被点字位之后的那几行，横向不影响（横排避让只读 top/bottom）。
+///
+/// 拉丁词点在词中间时起点会回退到词首（`subtitleLookupSpan`），但 Flutter 软换行不
+/// 在单词内部断行，词首与被点字母恒在同一视觉行，锚的上边界因此不会漏。
+@visibleForTesting
+Rect subtitleListLookupAnchorRect(List<Rect> rects, int graphemeIndex) {
+  if (graphemeIndex < 0 || graphemeIndex >= rects.length) return Rect.zero;
+  Rect anchor = rects[graphemeIndex];
+  for (int i = graphemeIndex + 1; i < rects.length; i++) {
+    final Rect r = rects[i];
+    if (r.isEmpty) continue;
+    anchor = anchor.expandToInclude(r);
+  }
+  return anchor;
+}
+
 /// 在一个已布局的行文本 [RenderParagraph] 上，按行内 [localPosition] 反查命中的字符
 /// （BUG-874，供 [VideoSubtitleListHitTester] 用）。逻辑与 [VideoSubtitleJumpPanel] 行内 tap
 /// 的 `hitAt` 同构（同一 grapheme 映射 + 选区盒并集 + 1px 容差），只是取位置 / 选区盒改用
@@ -444,9 +484,14 @@ SubtitleListCharHit? subtitleListCharHitFromParagraph(
     );
   }
   final Offset globalOrigin = globalPosition - localPosition;
+  // BUG-2367：浮层锚取「被点字位→句末」并集（含容差扩过的 localRect），保证被查词
+  // 换行后的第二排也在锚里、不会被浮层压住。
+  final Rect anchor = subtitleListLookupAnchorRect(rects, graphemeIndex)
+      .expandToInclude(localRect);
   return (
     graphemeIndex: graphemeIndex,
     charRect: localRect.shift(globalOrigin),
+    anchorRect: anchor.shift(globalOrigin),
   );
 }
 
@@ -931,7 +976,7 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
     _lastRowHoverPos = event.position;
     _lastRowHoverCueKey = hit.cue;
     _lastRowHoverGrapheme = hit.graphemeIndex;
-    onLookup(hit.cue, hit.graphemeIndex, hit.charRect);
+    onLookup(hit.cue, hit.graphemeIndex, hit.anchorRect);
   }
 
   @override
@@ -1013,6 +1058,7 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
         cue: cue,
         graphemeIndex: hit.graphemeIndex,
         charRect: hit.charRect,
+        anchorRect: hit.anchorRect,
       );
     }
     return null;
@@ -1986,9 +2032,15 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
               );
             }
             final Offset globalOrigin = globalPosition - localPosition;
+            // BUG-2367：浮层锚 = 被点字位→句末的字形盒并集（见
+            // [subtitleListLookupAnchorRect]），跨行词的第二排不再被浮层压住。
+            final Rect anchor =
+                subtitleListLookupAnchorRect(rects, graphemeIndex)
+                    .expandToInclude(localRect);
             return (
               graphemeIndex: graphemeIndex,
               charRect: localRect.shift(globalOrigin),
+              anchorRect: anchor.shift(globalOrigin),
             );
           } finally {
             painter.dispose();
@@ -2011,7 +2063,7 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
             // 用返回的 charRect 定位，不再额外 `contains` 二次收窄（那会把容差内命中又判成
             // 空白误退 seek，正是「点了不出词」的一半病因）。
             if (hit != null) {
-              onLookup(cue, hit.graphemeIndex, hit.charRect);
+              onLookup(cue, hit.graphemeIndex, hit.anchorRect);
               return;
             }
             widget.onTapCue(cue);

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1565,7 +1565,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _handleSubtitleListLookup(
         listHit.cue,
         listHit.graphemeIndex,
-        listHit.charRect,
+        listHit.anchorRect,
       );
     }
   }
@@ -4437,7 +4437,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _handleSubtitleListLookup(
         listHit.cue,
         listHit.graphemeIndex,
-        listHit.charRect,
+        listHit.anchorRect,
       );
     }
   }
@@ -4524,7 +4524,7 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
       _handleSubtitleListLookup(
         listHit.cue,
         listHit.graphemeIndex,
-        listHit.charRect,
+        listHit.anchorRect,
       );
       return;
     }

--- a/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/web_video_fushi_page.dart
@@ -1381,7 +1381,7 @@ class _WebVideoFushiPageState extends ConsumerState<WebVideoFushiPage>
       exactOnly: true,
     );
     if (listHit != null) {
-      _handleListLookup(listHit.cue, listHit.graphemeIndex, listHit.charRect);
+      _handleListLookup(listHit.cue, listHit.graphemeIndex, listHit.anchorRect);
       return;
     }
     _popNestedPopupAt(0);

--- a/fushi/test/media/video/video_subtitle_list_lookup_anchor_test.dart
+++ b/fushi/test/media/video/video_subtitle_list_lookup_anchor_test.dart
@@ -1,0 +1,174 @@
+import 'dart:ui' show BoxHeightStyle;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/media/video/video_player_controller.dart';
+import 'package:fushi/src/media/video/video_subtitle_jump_panel.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+
+// BUG-2367：字幕列表点词查词时，浮层锚点原先只有**被点那一个字**的矩形。查询串恒是
+// 「被点字位 → 句末」、真实匹配长度要等引擎回报，故被查词跨行时第二排不在锚里，
+// 而 [calcPopupPosition] 只按锚的 top/bottom 贴上/贴下（BUG-098「绝不盖住被查词」），
+// 浮层就正好压住第二排。修复把锚改成「被点字位 → 句末」的字形盒并集
+// （[subtitleListLookupAnchorRect]）——匹配串恒是这段的前缀，锚必然包含被查词。
+//
+// 本测试钉两层：纯函数并集覆盖跨行；widget 层真点一个换行句的第一排，把回调拿到的锚
+// 喂进真实浮层定位函数，断言浮层矩形与「被点字位→句末」那段文字零垂直重叠。
+
+AudioCue _cue(int i, int s, int e, String text) => AudioCue()
+  ..bookKey = 'video/1'
+  ..chapterHref = 'video://default'
+  ..sentenceIndex = i
+  ..textFragmentId = ''
+  ..text = text
+  ..startMs = s
+  ..endMs = e
+  ..audioFileIndex = 0;
+
+Widget _wrap(Widget child) => MaterialApp(
+      home: Scaffold(body: Stack(children: <Widget>[child])),
+    );
+
+Rect _unionRects(Iterable<Rect> rects) {
+  final Iterator<Rect> it = rects.iterator;
+  if (!it.moveNext()) return Rect.zero;
+  Rect union = it.current;
+  while (it.moveNext()) {
+    union = union.expandToInclude(it.current);
+  }
+  return union;
+}
+
+typedef _RowMeasure = ({
+  Offset globalPoint,
+  Rect tailRect,
+  Rect charRect,
+});
+
+/// 复算某行文本从 [fromGrapheme] 起到句末的**全局**矩形，并给出该 grapheme 的中心点。
+_RowMeasure _measureRow(
+  WidgetTester tester,
+  String sentence,
+  int fromGrapheme,
+) {
+  final Finder textFinder = find.text(sentence, findRichText: true);
+  expect(textFinder, findsOneWidget);
+  final BuildContext context = tester.element(textFinder);
+  final RichText richText = tester.widget<RichText>(textFinder);
+  final RenderBox textBox = tester.renderObject<RenderBox>(textFinder);
+  final List<int> starts = subtitleGraphemeStartOffsets(sentence);
+  final List<int> ends = subtitleGraphemeEndOffsets(sentence);
+  final TextPainter painter = TextPainter(
+    text: richText.text,
+    textAlign: TextAlign.start,
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+    maxLines: null,
+    ellipsis: null,
+  )..layout(maxWidth: textBox.size.width);
+  Rect boxFor(int start, int end) => _unionRects(
+        painter
+            .getBoxesForSelection(
+              TextSelection(baseOffset: start, extentOffset: end),
+              boxHeightStyle: BoxHeightStyle.max,
+            )
+            .map((TextBox box) => box.toRect()),
+      );
+  final Rect charRect = boxFor(starts[fromGrapheme], ends[fromGrapheme]);
+  final Rect tailRect = boxFor(starts[fromGrapheme], ends.last);
+  painter.dispose();
+  final Offset origin = textBox.localToGlobal(Offset.zero);
+  return (
+    globalPoint: textBox.localToGlobal(charRect.center),
+    tailRect: tailRect.shift(origin),
+    charRect: charRect.shift(origin),
+  );
+}
+
+void main() {
+  group('subtitleListLookupAnchorRect (BUG-2367)', () {
+    test('锚是「被点字位→句末」的并集，跨行时含第二排', () {
+      // 两排：0..2 在第一排（y 0..20），3..4 换到第二排（y 20..40）。
+      const List<Rect> rects = <Rect>[
+        Rect.fromLTWH(0, 0, 10, 20),
+        Rect.fromLTWH(10, 0, 10, 20),
+        Rect.fromLTWH(20, 0, 10, 20),
+        Rect.fromLTWH(0, 20, 10, 20),
+        Rect.fromLTWH(10, 20, 10, 20),
+      ];
+      // 点第一排最后一个字：锚必须一路盖到第二排底（否则浮层贴在第一排下方压住它）。
+      expect(
+        subtitleListLookupAnchorRect(rects, 2),
+        const Rect.fromLTRB(0, 0, 30, 40),
+      );
+      // 点第二排的字：锚不回头包含第一排——浮层可以贴得更近，不白让空间。
+      expect(
+        subtitleListLookupAnchorRect(rects, 3),
+        const Rect.fromLTRB(0, 20, 20, 40),
+      );
+      // 越界返回零矩形（调用方的容差扩盒兜底）。
+      expect(subtitleListLookupAnchorRect(rects, -1), Rect.zero);
+      expect(subtitleListLookupAnchorRect(rects, 5), Rect.zero);
+    });
+  });
+
+  group('字幕列表查词浮层不压住换行到第二排的词 (BUG-2367)', () {
+    testWidgets('点第一排的字，浮层矩形与「被点字位→句末」零垂直重叠', (WidgetTester tester) async {
+      final VideoPlayerController controller = VideoPlayerController();
+      addTearDown(controller.dispose);
+      // 窄面板 + 长句 → 必然换行（与用户截图同形：列表面板窄、行文本满宽）。
+      const String sentence = 'も 推薦人の２人には 喜んでもらえたみたいだ ほんとうによかった';
+      controller.setCues(<AudioCue>[_cue(0, 0, 1000, sentence)]);
+
+      Rect? anchor;
+      await tester.pumpWidget(_wrap(SizedBox(
+        width: 360,
+        height: 600,
+        child: VideoSubtitleJumpPanel(
+          controller: controller,
+          onTapCue: (_) {},
+          onLookupCue: (AudioCue _, int __, Rect rect) => anchor = rect,
+          onClose: () {},
+          onCopyCue: (_) => true,
+          onFavoriteCue: (_) async {},
+          isCueFavorited: (_) => false,
+          colorScheme: const ColorScheme.dark(),
+          title: 'Subtitle list',
+          emptyHint: 'empty',
+          width: 360,
+        ),
+      )));
+      await tester.pump();
+
+      final _RowMeasure row = _measureRow(tester, sentence, 0);
+      // 前提：这句真的换了行，否则本用例证明不了任何事（空壳断言防线）。
+      expect(
+        row.tailRect.height,
+        greaterThan(row.charRect.height * 1.5),
+        reason: '测试语料必须在 360px 面板里换行，否则跨行锚点无从谈起',
+      );
+
+      await tester.tapAt(row.globalPoint);
+      await tester.pump();
+
+      expect(anchor, isNotNull, reason: '点列表行文本必须触发查词回调');
+      // 锚必须盖住整段「被点字位→句末」，被查词无论多长都在里面。
+      expect(anchor!.bottom, greaterThanOrEqualTo(row.tailRect.bottom - 0.5));
+
+      // 真实浮层定位（BUG-098 的上/下避让）：浮层与那段文字零垂直重叠。
+      final Rect popup = calcPopupPosition(
+        selectionRect: anchor!,
+        screen: tester.view.physicalSize / tester.view.devicePixelRatio,
+        maxWidth: 360,
+        maxHeight: 360,
+      );
+      expect(
+        popup.top >= row.tailRect.bottom || popup.bottom <= row.tailRect.top,
+        isTrue,
+        reason: '浮层压住了被查词所在的行（$popup vs ${row.tailRect}）',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 症状（用户报 + 截图）

视频字幕列表里查词，**如果查的词占了两排，查词弹窗会挡住第二排**。

## 根因

查词浮层定位的不变式是 **BUG-098「绝不盖住被查词」**——`calcPopupPosition` 只按锚点矩形的 `top`/`bottom` 把浮层贴在它上方或下方。

但字幕列表传给它的锚只有**被点那一个字**的矩形（`video_subtitle_jump_panel.dart` 的 `charRect`）。而**被查词的长度在推浮层时还不知道**：查询串恒是「被点字位 → 句末」（`subtitleLookupSpan`），真实匹配长度是引擎查完才回报的 `matchedRunes`。于是词被软换行拆到第二排时，第二排不在锚里，浮层贴在第一排下方就正好压住它。列表面板窄、行文本满宽，长句常年换行，这是常态不是边角。

## 修复

锚改为「被点字位 → 句末」的字形盒**并集**（新增 `subtitleListLookupAnchorRect`）。匹配串恒是这段的前缀，锚**必然包含**被查词——既不必知道它多长，也不必等查完再挪浮层（挪＝肉眼可见的跳）。

`SubtitleListCharHit` / `SubtitleListHit` 新增 `anchorRect`，与既有 `charRect`（命中 / 去重语义）并存；tap、barrier 换词、Shift-悬停、键盘查词四条入口统一改用 `anchorRect`。纵向只多让出被点字位之后那几行，横向不受影响（横排避让只读 top/bottom）。

## 验证

- `fushi/test/media/video/video_subtitle_list_lookup_anchor_test.dart`（新增）：① 纯函数并集跨行 + 不回头包含前面的行 + 越界；② widget 层在 360px 窄面板真点一个换行句的第一排，把回调拿到的锚喂进真实 `calcPopupPosition`，断言浮层与「被点字位→句末」那段文字**零垂直重叠**（先断言语料确实换行，防空壳）。
- **变异实测**：把 tap 路径的锚改回 `charRect`，用例立刻转红（锚底 109 < 需要的 126.5）。
- 定向测试：`video_subtitle_list_lookup_anchor` / `video_subtitle_jump_panel_hit_tester` / `video_subtitle_jump_panel` / `video_subtitle_list_wiring_guard` / `video_subtitle_shift_hover_lookup` 共 84 条全绿（exit 0）；`bugs_per_file_guard` 绿。
- `flutter analyze`（含 test 目录）：`No issues found!`

## 备注

画面底部字幕 overlay 同样传单字 rect，理论同病；但底部字幕没有下方空间、浮层恒往上翻，压不到自己，本轮不动。

https://claude.ai/code/session_01282UvKrcfhVPspwGtQq6JW
