### PR TITLE
集号改由同目录兄弟文件差分定号，不再赌单文件名数字位数 (BUG-2369)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2369](bugs/BUG-2369-local-episode-numbering-single-filename-gamble.md) | ✅ | ✅ | 本地目录集号靠单文件名赌数字位数，1-9 与 10+ 各错一半 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2369-local-episode-numbering-single-filename-gamble.md
+++ b/docs/bugs/BUG-2369-local-episode-numbering-single-filename-gamble.md
@@ -1,0 +1,89 @@
+## BUG-2369 · 本地目录集号靠单文件名赌数字位数，1-9 与 10+ 各错一半
+
+- **报告**：2026-09-09（用户：本地文件夹「10 集以上读不出来」，Zankyou no Terror 11 集全对，Chuunibyou 12 集只认 9 集、10–12 被排到第 1 集后面）
+- **真实性**：✅ 真 bug，根因 `fushi/lib/src/media/video/scraper/filename_parser.dart:464`（`_bareTrailingEpisode`）+ `fushi/lib/src/media/video/video_filename_parser.dart` 的逐文件解析口径
+
+### 现象与实测
+
+仓内解析器（develop `4b8263aee2`）跑 18 种命名 × 集号 1..12，实测：
+
+| 命名形态 | 1..9 | 10..12 |
+|---|---|---|
+| 补零（`- 01` / `01` / `[01]` / `S01E01` / `第01话` / `EP01`） | 全对 | 全对 |
+| **不补零 + 空格/点分隔**（`Show 1.mkv`、`Show.1.1080p.mkv`） | **全部解不出** | 解得出 |
+| **集号紧贴标题无分隔**（`Show!1.mkv`、`Show!-1.mkv`） | 解不出 | 解不出 |
+
+两种坏形态的下游后果一致，且正好复现用户看到的两个症状：
+
+- **集号一半有一半没有** → `_compareEpisodes` 把 null 排到末尾、非 null 排前面，或（全 null 时）退化成裸字符串序 `1, 10, 11, 12, 2, …`；
+- **解不出集号的文件，集号还留在系列名里**（`Show 1` / `Show 2` 各成一个系列）→ `_groupingSeries` 按 series 分组，同一部番被拆成一堆单集卡，「主计数」自然对不上文件数。
+
+### 根因
+
+集号被当成了「单个文件名的函数」。单看一个文件名，`Show 2` 是第 2 季还是第 2 集**无法判定**，
+所以引擎只能赌：`_bareTrailingEpisode`（`filename_parser.dart:464`）赌「尾部裸数字要两位或带前导零
+才算集号」，`_trailingNumericSeason`（`:533`）赌「单个 2–9 算季号」。这个赌局本身没写错——它是为了
+不吞掉 `Hibike! Euphonium 2` / `Mob Psycho 100` / `Gundam 00` 这些标题自带数字的作品（BUG-1543）——
+但它在「不补零」的目录里必然把同一批兄弟文件劈成两半：`10/11/12` 位数够、赌赢，`1..9` 赌输。
+
+**而一批兄弟文件放在一起时，这个歧义根本不存在**：它们只在集号那一段不同，公共前后缀之外那段
+变化的数字就是集号。这是集合的性质，不需要猜。
+
+顺带查出同源的第二处口径分叉：`parseVideoPath` 直接拿路径最后一段解析，**不解码 URL 段**，而
+`groupVideosIntoPlaylists` 解码后再解析。`Show%20A%20S01E01.mkv` 里 `S` 前面是 `0`，`SxxEyy` 的
+分隔边界不成立 → 同一个文件两条通路一个解得出集号、一个解不出（既有用例 `URL 路径（网络来源）`
+在本次改动下立刻把它照了出来）。
+
+### [x] ① 已修复
+
+`fushi/lib/src/media/video/video_filename_parser.dart` 新增**兄弟集合差分定号**：
+
+- `resolveSiblingEpisodeNumbers(paths)` —— 同目录一批文件取公共前缀/后缀，中间那段就是集号，
+  同时用公共前缀推出系列名（前缀过一遍同一个 `FilenameParser` 剥字幕组/画质块）；
+- `fillEpisodeNumbersFromSiblings(paths, perFile)` / `parsedEpisodeNumbersOf(paths)` —— 批量入口；
+- `groupVideosIntoPlaylists` 的集号与分组键都吃差分结果（集号解出来了，系列名里就不能再留着它，
+  否则番还是散的）；
+- `_compareEpisodes` 的末位判据从裸字符串序改 `naturalCompare`（复用 `shelf_sort.dart` 那套，不另起
+  一份）：集号真的解不出时也不能排成 `1, 10, 11, 12, 2`；
+- 显示侧两个调用点改批量：`video_fushi/episode.part.dart` 的选集轨道、
+  `media_collection_detail_page.dart` 的集卡序号（后者按 `_slots` 对象身份缓存，四个赋值点不必手动失效）；
+- `parseVideoPath` 与归组同口径先解码 URL 段。
+
+**零回归靠四道门**（任一不成立就整个目录保持原行为，逐字不变）：
+
+1. 目录里至少 2 个文件、stem 两两不同；
+2. **目录里每个文件都自带集号时差分根本不介入**——补零命名一个字节不动；
+3. 公共前后缀不得切断数字段（否则 `Show 10/11/12` 会被切成 `0/1/2`），中段必须只剩 1–3 位数字
+   （4 位挡掉 `Movie (1979)` 这种按年份区分的目录），且各文件数值两两不同；
+4. **只补 null、从不覆盖已解出的集号**，且差分结果必须与该目录每一个已解出的集号都对得上；
+   对不上（绝对集号与分季集号混在一个目录）整目录放弃。
+
+差分推出的系列名还要过一道「不许留季/集残词」：公共前缀是按字符切的，`Show S01E01/02` 的公共
+前缀会停在 `Show S01E`，直接当番名会把 `S01E` 焊死进去；残词削完为空就等于「推不出系列名」，
+回落 BUG-2286 的父目录口径。
+
+### [x] ② 已加自动化测试
+
+`fushi/test/media/video/video_filename_parser_test.dart` 新增 14 条（两组）：
+
+- 正样本 7 条：不补零 12 集目录整批定号并归一组、集号紧贴标题、公共前缀不得切断数字段
+  （只有 10/11/12 的目录不得解成 0/1/2）、`parsedEpisodeNumbersOf` 批量、只补不覆盖、
+  不同目录各自定号互不偷号、**补零命名不经过差分**（回归钉）；
+- 负样本 7 条：混入特典不硬凑、4 位年份不当集号、与已解出集号对不上就整目录放弃、
+  stem 重名、单文件不差分、集号解不出时按自然序排。
+
+验证：`video_filename_parser_test.dart` + `episode_display_number_test.dart` 58 条全绿；
+`test/media/video` + `test/media/source_library` + `test/media/collections` + 3 个合集页用例
+共 3796 条跑完，3 条红全部定性为非本次改动：`long enqueue renews its lease` 与
+`anidb real UDP` 在**未改动的 develop 上同样红**（既有 flaky），
+`long provider search renews the subscription lease` 只在高负载并跑时红、单独跑与整文件跑
+（22 条）在本分支全绿。`flutter analyze` 零问题。
+
+### 备注 / 有意的取舍
+
+- **同目录下「只差一个数字」的一批文件会被当成一部番**：`Ip Man 1/2/3.mkv` 这种电影三部曲放同一个
+  目录里，会归成一个播放列表、集号 1/2/3。这与 BUG-2286 「同一目录混着不同番的纯集号文件按目录归组」
+  是同一条取舍——单从文件名无法区分，用户可在合集里拆分。**只影响那些今天本来就是散的目录**
+  （目录里每个文件都自带集号时差分不介入）。
+- `[Disc 1] / [Disc 2]` 这类只差一个数字的分卷目录同理会被编成 1/2 集。同上，今天它们本来也是散的。
+- 已入库的老条目要**重扫来源**才会按新口径归组/定号，扫描期改动不追改存量行。

--- a/fushi/lib/src/media/video/video_filename_parser.dart
+++ b/fushi/lib/src/media/video/video_filename_parser.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'package:fushi/src/media/collections/shelf_sort.dart'
+    show naturalCompare;
 import 'package:fushi/src/media/media_extensions.dart';
 import 'package:fushi/src/media/video/external_video.dart'
     show decodedSourceBasename;
@@ -88,7 +90,11 @@ VideoNameInfo parseVideoFilename(String filename) {
 /// （`Hibike! Euphonium 2/`），两者同源于 [FilenameParser]。
 VideoNameInfo parseVideoPath(String path) {
   final List<String> segments = _pathSegments(path);
-  final String filename = segments.isEmpty ? path : segments.last;
+  // 网络来源的 URL 段是百分号编码的，必须与 [groupVideosIntoPlaylists] 同口径
+  // 先解码：`Show%20A%20S01E01` 里 `S` 前面是 `0`，`SxxEyy` 的分隔边界不成立，
+  // 不解码就整批解不出集号（两条通路口径分叉，同一文件两处不同解）。
+  final String filename =
+      _decodedSegment(path, segments.isEmpty ? path : segments.last);
   final VideoNameInfo info = parseVideoFilename(filename);
   if (info.season != null || info.episode == null || segments.length < 2) {
     return info;
@@ -112,6 +118,218 @@ VideoNameInfo parseVideoPath(String path) {
 /// 标成 `03`。集号是文件名里写着的事实，不是列表下标的函数，故一律现场解析。
 int? parsedEpisodeNumberOf(String pathOrName) =>
     parseVideoPath(pathOrName).episode;
+
+/// 一批路径的**显示集号**（BUG-2369）：先按单文件名规则解析，解不出的再用
+/// 同目录兄弟文件的差分定号补齐。返回值与 [pathsOrNames] 同序、同长。
+///
+/// 显示侧（选集轨道 / 合集详情页）拿到的本来就是整批路径，没有理由退化成逐个
+/// 文件猜——单文件名解不出时，兄弟集合往往一眼就能定号。
+List<int?> parsedEpisodeNumbersOf(List<String> pathsOrNames) =>
+    _resolveWithSiblings(pathsOrNames).episodes;
+
+/// 一个目录的兄弟差分结论：路径 → 集号，外加公共前缀推出的系列名。
+class SiblingEpisodeNumbering {
+  const SiblingEpisodeNumbering({required this.numbers, required this.series});
+
+  /// 路径 → 集号（覆盖该目录里的每一个文件）。
+  final Map<String, int> numbers;
+
+  /// 公共前缀过一遍 [FilenameParser] 后的系列名；推不出时为空串。
+  final String series;
+}
+
+/// 兄弟集合差分定号（BUG-2369）：把**同一目录**下的一批文件名放在一起看，
+/// 公共前后缀之外那段变化的数字就是集号。判据不成立时返回 null。
+///
+/// 单文件名解析必须在「`Show 2` 是第 2 季还是第 2 集」这种歧义上赌一把，
+/// [FilenameParser] 的赌法是「尾部裸数字要两位或带前导零才算集号」
+/// （`_bareTrailingEpisode`）——于是 `Show 1.mkv … Show 12.mkv` 这种不补零的
+/// 目录里 `10/11/12` 赌赢、`1..9` 赌输：同一批文件一半有集号一半没有，排序、
+/// 计数、角标、归组全跟着错。**而一批兄弟文件放在一起时这个歧义根本不存在**：
+/// 它们只在集号那一段不同，那段就是集号。这是集合的性质，不是猜出来的。
+///
+/// 判据刻意收紧到「全成立才用」，任一条不成立就返回 null、调用方保持原行为：
+/// - 至少 2 个文件，stem 两两不同；
+/// - 公共前缀/后缀不得切断数字段（否则 `Show 10/11/12` 会被切成 `0/1/2`）；
+/// - 每个文件去掉公共前后缀后**必须**只剩 1–3 位数字（4 位挡掉 `Movie (1979)`
+///   这种按年份区分的目录），且各文件解出的数值两两不同。
+SiblingEpisodeNumbering? resolveSiblingEpisodeNumbers(List<String> paths) {
+  if (paths.length < 2) return null;
+  final List<String> stems = <String>[
+    for (final String path in paths)
+      p.basenameWithoutExtension(decodedSourceBasename(path)),
+  ];
+  if (stems.toSet().length != stems.length) return null;
+
+  final String first = stems.first;
+  int prefixLen = first.length;
+  int suffixLen = first.length;
+  for (final String s in stems.skip(1)) {
+    prefixLen = _commonPrefixLen(first, s, prefixLen);
+    suffixLen = _commonSuffixLen(first, s, suffixLen);
+  }
+  // 公共前后缀不得切断数字段：`Show 10/11/12` 的公共前缀是 `Show 1`，不回退
+  // 就会把集号切成 `0/1/2`。前缀退回数字段起点，后缀推过数字段。
+  while (prefixLen > 0 && _isAsciiDigit(first.codeUnitAt(prefixLen - 1))) {
+    prefixLen--;
+  }
+  while (suffixLen > 0 &&
+      _isAsciiDigit(first.codeUnitAt(first.length - suffixLen))) {
+    suffixLen--;
+  }
+
+  final Map<String, int> numbers = <String, int>{};
+  final Set<int> seen = <int>{};
+  for (int i = 0; i < paths.length; i++) {
+    final String stem = stems[i];
+    if (prefixLen + suffixLen > stem.length) return null;
+    final String middle = stem.substring(prefixLen, stem.length - suffixLen);
+    if (!_pureEpisodeDigits.hasMatch(middle)) return null;
+    final int? value = int.tryParse(middle);
+    if (value == null || !seen.add(value)) return null;
+    numbers[paths[i]] = value;
+  }
+  // 系列名从公共前缀来，并过一遍同一个规则引擎剥字幕组/画质块；引擎给不出
+  // 标题时退回清理后的原前缀（`第` / `EP` 这类残词由 [_trimSeriesEdges] 削掉）。
+  final String rawPrefix = first.substring(0, prefixLen);
+  final String parsed = FilenameParser.parse(rawPrefix).title.trim();
+  final String series =
+      _stripTrailingEpisodeMarker(parsed.isNotEmpty ? parsed : rawPrefix);
+  return SiblingEpisodeNumbering(numbers: numbers, series: series);
+}
+
+/// 用同目录兄弟文件的差分定号补齐 [perFile] 里的 null（BUG-2369）。
+///
+/// **只补 null、从不覆盖已解出的值**——零回归靠这条保证。补之前还要求差分结果
+/// 与同目录每一个已解出的集号都对得上；对不上说明两套口径不同（例如绝对集号与
+/// 分季集号混在一个目录里），此时整个目录放弃、保持原样。
+List<int?> fillEpisodeNumbersFromSiblings(
+  List<String> paths,
+  List<int?> perFile,
+) {
+  if (paths.length != perFile.length) return perFile;
+  if (!perFile.contains(null)) return perFile;
+  final List<int?> out = List<int?>.of(perFile);
+  for (final List<int> indices in _byDirectory(paths).values) {
+    final SiblingEpisodeNumbering? sib =
+        _acceptedSiblingNumbering(paths, perFile, indices);
+    if (sib == null) continue;
+    for (final int i in indices) {
+      out[i] ??= sib.numbers[paths[i]];
+    }
+  }
+  return out;
+}
+
+/// [fillEpisodeNumbersFromSiblings] 的内部形态：集号之外再带上「该目录的兄弟
+/// 差分系列名」，供 [groupVideosIntoPlaylists] 统一整个目录的分组键。
+class _SiblingResolution {
+  const _SiblingResolution(this.episodes, this.series);
+
+  /// 与输入同序同长的集号（含兄弟补齐）。
+  final List<int?> episodes;
+
+  /// 与输入同序同长的系列名覆盖；无覆盖为 null。
+  final List<String?> series;
+}
+
+_SiblingResolution _resolveWithSiblings(List<String> paths) {
+  final List<int?> perFile = <int?>[
+    for (final String path in paths) parsedEpisodeNumberOf(path),
+  ];
+  final List<int?> episodes = List<int?>.of(perFile);
+  final List<String?> series = List<String?>.filled(paths.length, null);
+  for (final List<int> indices in _byDirectory(paths).values) {
+    final SiblingEpisodeNumbering? sib =
+        _acceptedSiblingNumbering(paths, perFile, indices);
+    if (sib == null) continue;
+    for (final int i in indices) {
+      episodes[i] ??= sib.numbers[paths[i]];
+      if (sib.series.isNotEmpty) series[i] = sib.series;
+    }
+  }
+  return _SiblingResolution(episodes, series);
+}
+
+/// 某目录的兄弟差分结论，已过「值得用」的三道门：目录里至少 2 个文件、至少有
+/// 一个文件单看文件名解不出集号（全解得出的目录一个字节都不动），差分结果与每
+/// 个已解出的集号都对得上。
+SiblingEpisodeNumbering? _acceptedSiblingNumbering(
+  List<String> paths,
+  List<int?> perFile,
+  List<int> indices,
+) {
+  if (indices.length < 2) return null;
+  if (indices.every((int i) => perFile[i] != null)) return null;
+  final SiblingEpisodeNumbering? sib = resolveSiblingEpisodeNumbers(
+    <String>[for (final int i in indices) paths[i]],
+  );
+  if (sib == null) return null;
+  final bool agrees = indices.every(
+      (int i) => perFile[i] == null || perFile[i] == sib.numbers[paths[i]]);
+  return agrees ? sib : null;
+}
+
+/// 按父目录把下标分桶（无目录段的裸文件名归同一桶）。
+Map<String, List<int>> _byDirectory(List<String> paths) {
+  final Map<String, List<int>> byDir = <String, List<int>>{};
+  for (int i = 0; i < paths.length; i++) {
+    final List<String> segments = _pathSegments(paths[i]);
+    final String key = segments.length < 2
+        ? ''
+        : segments.sublist(0, segments.length - 1).join('/').toLowerCase();
+    byDir.putIfAbsent(key, () => <int>[]).add(i);
+  }
+  return byDir;
+}
+
+/// 削掉公共前缀尾巴上的季/集标记残词再清理两端：公共前缀是按字符切的，
+/// `Show S01E01/02` 的公共前缀会停在 `Show S01E`，直接拿去当系列名就会把
+/// `S01E` 焊死进番名。这类残词一律削掉；削完为空就等于「推不出系列名」，
+/// 由调用方回落既有行为（`第1话/第12话` 的公共前缀 `第` 就走这条）。
+String _stripTrailingEpisodeMarker(String s) {
+  final String out = _trimSeriesEdges(s).replaceFirst(
+    RegExp(r'(?:^|[\s._-])(?:[Ss]\d{1,2}[\s._-]*)?(?:[Ee][Pp]?|#|第)$'),
+    '',
+  );
+  return _trimSeriesEdges(out);
+}
+
+/// 削掉系列名两端的分隔残渣（`Show - ` / `Show_` / `[组] Show.`）。
+String _trimSeriesEdges(String s) {
+  String out = s.replaceAll('_', ' ').replaceAll(RegExp(r'\s+'), ' ').trim();
+  out = out.replaceFirst(RegExp(r'^[\s\-_.·\[(【]+'), '');
+  out = out.replaceFirst(RegExp(r'[\s\-_.·\[(【]+$'), '');
+  return out.trim();
+}
+
+/// 集号中段：1–3 位数字（含前导零）。4 位挡掉按年份区分的目录。
+final RegExp _pureEpisodeDigits = RegExp(r'^\d{1,3}$');
+
+bool _isAsciiDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
+
+/// [a] 与 [b] 的公共前缀长度，上限 [cap]。
+int _commonPrefixLen(String a, String b, int cap) {
+  int n = cap < b.length ? cap : b.length;
+  if (n > a.length) n = a.length;
+  int i = 0;
+  while (i < n && a.codeUnitAt(i) == b.codeUnitAt(i)) {
+    i++;
+  }
+  return i;
+}
+
+/// [a] 与 [b] 的公共后缀长度，上限 [cap]。
+int _commonSuffixLen(String a, String b, int cap) {
+  int n = cap < b.length ? cap : b.length;
+  if (n > a.length) n = a.length;
+  int i = 0;
+  while (i < n &&
+      a.codeUnitAt(a.length - 1 - i) == b.codeUnitAt(b.length - 1 - i)) {
+    i++;
+  }
+  return i;
+}
 
 /// 路径切段（平台无关：同时认 `/` 与 `\`，与 [FilenameParser.candidatesForPath]
 /// 同口径）。`p.basename` 在 Linux 上不认 `\`，而库里存的可能是 Windows 路径。
@@ -200,20 +418,28 @@ List<VideoGroup> groupVideosIntoPlaylists(List<String> paths) {
   final Map<String, List<VideoEpisode>> byKey = <String, List<VideoEpisode>>{};
   final Map<String, String> displaySeries = <String, String>{};
 
-  for (final String path in paths) {
+  // 集号与系列名都先过一遍**兄弟集合差分**（BUG-2369）：同目录里只要有文件
+  // 单看文件名解不出集号，就用「公共前后缀之外那段数字」定号，并让整个目录
+  // 共用同一个系列名——否则 `Show 1.mkv … Show 12.mkv` 里 1..9 的集号留在系列
+  // 名里（`Show 1` / `Show 2`），同一部番会被拆成一堆单集卡。
+  // 目录里每个文件都自带集号时差分不介入，行为与修复前逐字相同。
+  final _SiblingResolution sib = _resolveWithSiblings(paths);
+
+  for (int i = 0; i < paths.length; i++) {
+    final String path = paths[i];
     // 解码后的文件名参与解析/展示（decodedSourceBasename）：网络来源的
     // http(s) URL 段是百分号编码的，不解码会把 %20 之类渗进系列名与集标题；
     // 本地路径原样返回，行为不变。
     final String name = decodedSourceBasename(path);
     final VideoNameInfo info = parseVideoFilename(name);
-    final String series = _groupingSeries(path, name, info);
+    final String series = sib.series[i] ?? _groupingSeries(path, name, info);
     final String key = series.toLowerCase();
     displaySeries.putIfAbsent(key, () => series);
     byKey.putIfAbsent(key, () => <VideoEpisode>[]).add(VideoEpisode(
           path: path,
           title: p.basenameWithoutExtension(name),
           season: info.season,
-          episode: info.episode,
+          episode: sib.episodes[i],
         ));
   }
 
@@ -227,7 +453,11 @@ List<VideoGroup> groupVideosIntoPlaylists(List<String> paths) {
   return groups;
 }
 
-/// 排序：季升序（null 视作 1）→ 集升序（null 排末尾）→ 标题。
+/// 排序：季升序（null 视作 1）→ 集升序（null 排末尾）→ 标题**自然序**。
+///
+/// 末位判据用 [naturalCompare]（与书架「按名称」同一套）而不是裸字符串序：
+/// 集号真的解不出时（特典/PV 混排、兄弟差分不成立），裸字符串序会排成
+/// `1, 10, 11, 12, 2, …`——数字段该按数值比，这是显示层的最低要求（BUG-2369）。
 int _compareEpisodes(VideoEpisode a, VideoEpisode b) {
   final int sa = a.season ?? 1;
   final int sb = b.season ?? 1;
@@ -235,7 +465,7 @@ int _compareEpisodes(VideoEpisode a, VideoEpisode b) {
   final int ea = a.episode ?? (1 << 30);
   final int eb = b.episode ?? (1 << 30);
   if (ea != eb) return ea.compareTo(eb);
-  return a.title.toLowerCase().compareTo(b.title.toLowerCase());
+  return naturalCompare(a.title, b.title);
 }
 
 /// 递归扫描 [directory] 及其所有子目录里的视频文件，返回绝对路径列表

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -504,7 +504,29 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// （BUG-1544）。缺集 / 只导入了一部分时顺位号必然与真实集号错位——用户看到
   /// 「03」点开却是 E05。集号是文件名里写着的事实，不是列表下标的函数。
   int _episodeDisplayNumber(CollectionEpisodeSlot slot, int index) =>
-      parsedEpisodeNumberOf(slot.filename) ?? index + 1;
+      _episodeNumbers[slot.entryKey] ?? index + 1;
+
+  /// [_slots] 整批解析出的集号（entryKey → 集号），按 [_slots] 的**对象身份**
+  /// 缓存：`_slots` 每次变更都是整体替换成新列表，所以 identical 即可当缓存键，
+  /// 四个赋值点都不必记得手动失效。
+  ///
+  /// 整批（而非逐个文件名）解析是 BUG-2369 的要求：不补零的目录里逐个解析会
+  /// 1..9 全解不出、10.. 解得出，一半集卡掉回顺位号，序号与真实集号错位。
+  List<CollectionEpisodeSlot>? _episodeNumbersSlots;
+  Map<String, int> _episodeNumbersCache = const <String, int>{};
+
+  Map<String, int> get _episodeNumbers {
+    if (identical(_episodeNumbersSlots, _slots)) return _episodeNumbersCache;
+    final List<int?> numbers = parsedEpisodeNumbersOf(<String>[
+      for (final CollectionEpisodeSlot slot in _slots) slot.filename,
+    ]);
+    _episodeNumbersCache = <String, int>{
+      for (int i = 0; i < _slots.length; i++)
+        if (numbers[i] != null) _slots[i].entryKey: numbers[i]!,
+    };
+    _episodeNumbersSlots = _slots;
+    return _episodeNumbersCache;
+  }
 
   /// 集简介（集级刮削 summary；无 → null 不占位）。
   String? _episodeSummary(CollectionEpisodeSlot slot) {

--- a/fushi/lib/src/pages/implementations/video_fushi/episode.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/episode.part.dart
@@ -291,14 +291,24 @@ extension _VideoEpisode on _VideoFushiPageState {
     final RemoteCoverFetcher? fetcher =
         remoteCoverFetcherFor(widget.remoteClient ?? _resolvedStreamClient);
     final ImageProvider? seriesFallback = _playlistSeriesFallbackCover();
+    // 集号**整批**解析（BUG-2369）：逐个文件名解析在「不补零」的目录里会
+    // 1..9 解不出、10.. 解得出，一半卡片掉回顺位号；整批交给解析器，解不出的
+    // 由同目录兄弟文件差分补齐。键与下面查表口径必须一致。
+    final List<String> numberKeys = <String>[
+      for (final _PlaylistEpisodeRef e in _episodes)
+        e.path.isNotEmpty ? e.path : e.title,
+    ];
+    final List<int?> numbers = parsedEpisodeNumbersOf(numberKeys);
+    final Map<String, int?> numberByKey = <String, int?>{
+      for (int i = 0; i < numberKeys.length; i++) numberKeys[i]: numbers[i],
+    };
     return <VideoEpisodeEntry>[
       for (final _PlaylistEpisodeRef e in _episodes)
         VideoEpisodeEntry(
           title: e.displayTitle ?? e.title,
           // 角标集号取**文件名解析值**而非列表下标（BUG-1544）：缺集时下标必然
           // 说谎。远端集无路径 → 退回按标题解析；再解不出由卡片回落顺位号。
-          episodeNumber:
-              parsedEpisodeNumberOf(e.path.isNotEmpty ? e.path : e.title),
+          episodeNumber: numberByKey[e.path.isNotEmpty ? e.path : e.title],
           cover: resolveMediaCoverImage(
                 kind: MediaKind.video,
                 localPath: e.coverPath,

--- a/fushi/test/media/video/video_filename_parser_test.dart
+++ b/fushi/test/media/video/video_filename_parser_test.dart
@@ -352,6 +352,162 @@ void main() {
     });
   });
 
+  group('兄弟集合差分定号（BUG-2369）', () {
+    /// 用户报障形态：12 集的目录里集号不补零。单文件名规则只认「两位数或带前导
+    /// 零」的尾部裸集数，于是 1..9 全部解不出、10..12 解得出——一半文件没有集号，
+    /// 番名里还留着那个数字，同一部番被拆成一堆单集卡、顺序变成 1,10,11,12,2…
+    test('不补零的 12 集目录：整批定号、归一组、按集号排序', () {
+      final List<String> paths = <String>[
+        for (int i = 1; i <= 12; i++) '/anime/Chuunibyou/Chuunibyou $i.mkv',
+      ];
+      final List<VideoGroup> groups = groupVideosIntoPlaylists(paths);
+      expect(groups, hasLength(1), reason: '12 个文件必须归一组，不是 10 组');
+      final VideoGroup g = groups.single;
+      expect(g.series, 'Chuunibyou', reason: '系列名里不能留着集号');
+      expect(g.isPlaylist, isTrue);
+      expect(
+        g.episodes.map((VideoEpisode e) => e.episode).toList(),
+        <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      );
+    });
+
+    test('集号紧贴标题（无分隔符）同样定号', () {
+      final List<String> paths = <String>[
+        for (int i = 1; i <= 12; i++) '/anime/Show/Show!$i.mkv',
+      ];
+      final VideoGroup g = groupVideosIntoPlaylists(paths).single;
+      expect(
+        g.episodes.map((VideoEpisode e) => e.episode).toList(),
+        <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      );
+    });
+
+    test('公共前缀不得切断数字段：只有 10/11/12 的目录不能解成 0/1/2', () {
+      final SiblingEpisodeNumbering? sib =
+          resolveSiblingEpisodeNumbers(<String>[
+        '/a/Show 10.mkv',
+        '/a/Show 11.mkv',
+        '/a/Show 12.mkv',
+      ]);
+      expect(sib, isNotNull);
+      expect(sib!.numbers.values.toList(), <int>[10, 11, 12]);
+      expect(sib.series, 'Show');
+    });
+
+    test('parsedEpisodeNumbersOf：整批解析补齐单文件名解不出的集号', () {
+      final List<String> paths = <String>[
+        for (int i = 1; i <= 12; i++) '/anime/Show/Show $i.mkv',
+      ];
+      expect(
+        parsedEpisodeNumbersOf(paths),
+        <int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      );
+    });
+
+    test('已解出的集号只补不覆盖（后缀带画质块的真实命名）', () {
+      final List<String> paths = <String>[
+        '/a/Show - Interview 1 [BD].mkv',
+        '/a/Show - Interview 2 [BD].mkv',
+        '/a/Show - Interview 10 [BD].mkv',
+      ];
+      // 第三个单看文件名就解得出 10（尾部两位裸数字），前两个解不出。
+      expect(parsedEpisodeNumberOf(paths[2]), 10);
+      expect(parsedEpisodeNumberOf(paths[0]), isNull);
+      expect(parsedEpisodeNumbersOf(paths), <int>[1, 2, 10]);
+    });
+
+    test('不同目录各自定号，互不偷号', () {
+      final List<String> paths = <String>[
+        '/a/S1/Show 1.mkv',
+        '/a/S1/Show 2.mkv',
+        '/a/S2/Show 10.mkv',
+        '/a/S2/Show 11.mkv',
+      ];
+      expect(parsedEpisodeNumbersOf(paths), <int>[1, 2, 10, 11]);
+    });
+
+    test('补零命名不经过差分，行为与修复前逐字相同', () {
+      final List<String> paths = <String>[
+        '/a/[Nekomoe] Show - 01 [1080p].mkv',
+        '/a/[Nekomoe] Show - 02 [1080p].mkv',
+        '/a/[Nekomoe] Show - 03 [1080p].mkv',
+      ];
+      // 每个文件都自带集号 → 差分整条通路不介入。
+      expect(fillEpisodeNumbersFromSiblings(paths, <int?>[1, 2, 3]),
+          <int>[1, 2, 3]);
+      final VideoGroup g = groupVideosIntoPlaylists(paths).single;
+      expect(g.series, 'Show');
+      expect(g.episodes.map((VideoEpisode e) => e.episode).toList(),
+          <int>[1, 2, 3]);
+    });
+  });
+
+  group('兄弟差分的负样本：判据不成立就整目录放弃（BUG-2369）', () {
+    test('混入特典 → 不硬凑集号', () {
+      final List<String> paths = <String>[
+        '/a/Show 1.mkv',
+        '/a/Show 2.mkv',
+        '/a/Show OVA.mkv',
+      ];
+      expect(resolveSiblingEpisodeNumbers(paths), isNull);
+      expect(parsedEpisodeNumbersOf(paths), <int?>[null, null, null]);
+    });
+
+    test('按年份区分的目录：4 位数字不当集号', () {
+      final List<String> paths = <String>[
+        '/a/Movie (1979).mkv',
+        '/a/Movie (2005).mkv',
+      ];
+      expect(resolveSiblingEpisodeNumbers(paths), isNull);
+      expect(parsedEpisodeNumbersOf(paths), <int?>[null, null]);
+    });
+
+    test('差分结果与已解出的集号对不上 → 整目录放弃，不覆盖已有值', () {
+      final List<String> paths = <String>[
+        '/a/Show 1.mkv',
+        '/a/Show 2.mkv',
+        '/a/Show 3.mkv',
+      ];
+      // 差分给的是 1/2/3；已解出的那个说自己是 7（绝对集号口径），两套口径不同。
+      expect(
+        fillEpisodeNumbersFromSiblings(paths, <int?>[null, null, 7]),
+        <int?>[null, null, 7],
+      );
+    });
+
+    test('stem 重名（不同目录同名文件）→ 该目录判据不成立', () {
+      expect(
+        resolveSiblingEpisodeNumbers(<String>['/a/01.mkv', '/b/01.mkv']),
+        isNull,
+      );
+    });
+
+    test('单个文件不做差分', () {
+      expect(resolveSiblingEpisodeNumbers(<String>['/a/Show 1.mkv']), isNull);
+    });
+
+    test('集号真的解不出时按自然序排，不是裸字符串序', () {
+      // 三个文件差在「9 / 100 / extra」上：差分因 extra 不是纯数字而放弃，
+      // 集号全为 null，末位判据只剩标题。裸字符串序会把 100 排到 9 前面。
+      final List<String> paths = <String>[
+        '/a/Show - Talk 100 (x).mkv',
+        '/a/Show - Talk extra (x).mkv',
+        '/a/Show - Talk 9 (x).mkv',
+      ];
+      final VideoGroup g = groupVideosIntoPlaylists(paths).single;
+      expect(g.episodes.every((VideoEpisode e) => e.episode == null), isTrue,
+          reason: '前提：这三个都解不出集号，否则这条用例没在测末位判据');
+      expect(
+        g.episodes.map((VideoEpisode e) => e.title).toList(),
+        <String>[
+          'Show - Talk 9 (x)',
+          'Show - Talk 100 (x)',
+          'Show - Talk extra (x)',
+        ],
+      );
+    });
+  });
+
   group('listVideoFilesInDirectory', () {
     late Directory root;
 


### PR DESCRIPTION
用户报障：本地文件夹「10 集以上读不出来」——Zankyou no Terror 11 集全对，Chuunibyou 12 集只认 9 集、10–12 被排到第 1 集后面。

## 根因

集号被当成了「单个文件名的函数」。单看一个文件名，`Show 2` 是第 2 季还是第 2 集**无法判定**，所以引擎只能赌：`_bareTrailingEpisode`（`filename_parser.dart:464`）赌「尾部裸数字要两位或带前导零才算集号」（为了不吞掉 `Hibike! Euphonium 2` / `Mob Psycho 100`，BUG-1543）。

于是在**不补零**的目录里，同一批兄弟文件被劈成两半——实测 18 种命名 × 集号 1..12：

| 命名形态 | 1..9 | 10..12 |
|---|---|---|
| 补零（`- 01` / `[01]` / `S01E01` / `第01话` / `EP01`…） | 全对 | 全对 |
| **不补零 + 空格/点分隔**（`Show 1.mkv`） | **全解不出** | 解得出 |
| **集号紧贴标题无分隔**（`Show!1.mkv`） | 解不出 | 解不出 |

集号一半有一半没有 → 排序/计数/角标全错；解不出的那些集号还留在系列名里（`Show 1` / `Show 2` 各成一个系列）→ 整部番被拆成一堆单集卡，主计数自然对不上文件数。

**而一批兄弟文件放在一起时这个歧义根本不存在**：它们只在集号那一段不同，公共前后缀之外那段数字就是集号。这是集合的性质，不是猜的。

## 改动

- 新增 `resolveSiblingEpisodeNumbers` / `fillEpisodeNumbersFromSiblings` / `parsedEpisodeNumbersOf`（`video_filename_parser.dart`）：同目录取公共前后缀差分定号，并用公共前缀推系列名（前缀过同一个 `FilenameParser` 剥字幕组/画质块）。
- `groupVideosIntoPlaylists` 的集号与分组键都吃差分结果——集号解出来了，系列名里就不能再留着它，否则番还是散的。
- `_compareEpisodes` 末位判据从裸字符串序改 `naturalCompare`（复用 `shelf_sort.dart` 那套）：真解不出时也不能排成 `1, 10, 11, 12, 2`。
- 显示侧两个调用点改批量：选集轨道（`video_fushi/episode.part.dart`）、合集详情页集卡序号（按 `_slots` 对象身份缓存，四个赋值点不必手动失效）。
- 顺带修掉 `parseVideoPath` 不解码 URL 段导致的口径分叉（`Show%20A%20S01E01` 里 `S` 前面是 `0`，`SxxEyy` 边界不成立 → 同一文件两条通路一个解得出一个解不出；既有用例把它照了出来）。

## 零回归的四道门

1. 目录里至少 2 个文件、stem 两两不同；
2. **目录里每个文件都自带集号时差分根本不介入**——补零命名一个字节不动；
3. 公共前后缀不得切断数字段（否则 `Show 10/11/12` 会被切成 `0/1/2`），中段必须只剩 1–3 位数字（4 位挡掉 `Movie (1979)` 这种年份目录），且各文件数值两两不同；
4. **只补 null、从不覆盖已解出的集号**，且差分结果必须与该目录每一个已解出的集号都对得上；对不上（绝对集号 vs 分季集号）整目录放弃。

差分推出的系列名还要过一道「不许留季/集残词」（`Show S01E01/02` 的公共前缀会停在 `Show S01E`）；削完为空即「推不出系列名」，回落 BUG-2286 的父目录口径。

## 验证

- `video_filename_parser_test.dart`（新增 14 条：7 正 7 负）+ `episode_display_number_test.dart` → 58 条全绿，退出码 0。
- 爆炸半径：`test/media/video` + `test/media/source_library` + `test/media/collections` + 3 个合集页用例，3796 条。3 条红全部定性为非本次改动：`long enqueue renews its lease` 与 `anidb real UDP` 在**未改动的 develop 基线上同样红**；`long provider search renews the subscription lease` 只在高负载并跑时红，单独跑与整文件跑（22 条）在本分支全绿。
- `flutter analyze`：No issues found。

## 有意的取舍

同目录下「只差一个数字」的一批文件会被当成一部番（`Ip Man 1/2/3.mkv`、`[Disc 1]/[Disc 2]`）。与 BUG-2286 同一条取舍——单从文件名无法区分，用户可在合集里拆分；**只影响那些今天本来就是散的目录**。已入库的老条目需重扫来源才按新口径归组/定号。
