### PR TITLE
fix(gal): 穿透态碰撞箱改成文字块外接矩形，块内不再有漏点带 (BUG-2371)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2181 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2372](bugs/BUG-2372-gal-overlay-lookup-card-not-anchored-to-word.md) | 🚧 | 🚧 | 悬浮字幕查词弹窗没锚在被点的词上 |
+| [BUG-2371](bugs/BUG-2371-gal-passthrough-block-interior-holes.md) | ✅ | ✅ | 穿透态点字幕文字有时仍透给游戏（行盒并集在块内部留 alpha 0 空洞） |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2371-gal-passthrough-block-interior-holes.md
+++ b/docs/bugs/BUG-2371-gal-passthrough-block-interior-holes.md
@@ -1,0 +1,44 @@
+## BUG-2371 · 穿透态点字幕文字有时仍透给游戏（行盒并集在块内部留 alpha 0 空洞）
+- **报告**：2026-09-09（用户：「悬浮字幕，下面的文字点击的时候有时候会传到下面的游戏」）
+- **真实性**：✅ 真 bug，且**是 [[BUG-1853]] 自己在「已知缺口」里写下、当轮未修的那条**。
+  根因 `fushi/windows/runner/floating_lyric_window.cpp` `Render()` 的 catch fill 循环。
+
+### 根因
+
+穿透态整窗背景是真 alpha 0（`body_bg &= 0x00FFFFFF`），命中判定整个交给
+`UpdateLayeredWindow` 的逐像素 alpha。BUG-1853 把碰撞箱从「字形轮廓」放大到
+「文字**行盒**并集」，但行盒宽度是 `HitTestTextRange` 给出的**该行文字实际排版范围**，
+于是文字块**内部**仍剩三类 alpha 0 空洞，点上去照样推进游戏：
+
+1. **空行**（台词含连续换行）得到宽度 0 的行盒，`FillRectangle` 一个像素都画不出
+   → 文字块中间横着一条整行高的漏点带。（BUG-1853 文件里已记，未修。）
+2. **多行参差时短行两侧的内凹**——居中对齐（`text_alignment` 默认 CENTER）时尤其明显：
+   长行与短行之间那两块楔形区在块内部，视觉上就是「字幕这一块」，判定上却是背景。
+3. 行与行之间若排版留了缝，缝里同样是 0。
+
+三类的共同点是：**用户明明点在字幕这一块上，却被判成点背景**。「有时候」正是它——
+命中与否取决于这一句有没有换行、有几行、行长差多少。
+
+### 修复
+
+- **[x] ① 已修复** — 碰撞箱从「逐行行盒并集」改成「**文字块的外接矩形**」：对
+  `HitTestTextRange(0, text_.size())` 的行盒取 min/max 并成一个矩形，`FillRectangle`
+  一次。零宽行盒只跳过**横向**并集、**纵向照并**（它就是那条漏点带）。
+  - 这是消除特殊情况，不是加分支：没有为空行写 `if (m.width <= 0) 用整行宽` 的特例。
+  - 块**外**（上下留白、居中块两侧的整片空白）仍是真 alpha 0，
+    「点背景推台词」的不变式一字不动。
+  - **单行文本时外接矩形 == 那一行的行盒，逐像素等于改动前**（Never break userspace）。
+
+- **[x] ② 已加自动化测试** — `fushi/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`
+  的 BUG-1853 那条改钉新不变式：`min_left/min_top/max_right/max_bottom` 四个并集变量在位、
+  `FillRectangle(` 在该块内**只出现一次**（出现多次 = 退回逐行铺，漏点带回来）、填的就是
+  `D2D1::RectF(min_left, min_top, max_right, max_bottom)`、零宽行盒只跳横向。
+  同时把该守卫从**固定 2200 字符窗口**改成**结构锚**（块尾锚 `// Highlight range background.`），
+  否则往块里插几行合法代码就会让它错位变红——见 `reference_literal_pinned_wiring_guards_break_on_gating`。
+
+### 备注
+
+- 用户真实设置（读生产库 `D:\APP\HIBIKI_date\support\fushi.db` 确认）：
+  `gal_hook_passthrough_blocks_mouse` 未设 = 默认 `true`，所以 catch fill 这条路是开着的，
+  症状只可能来自块内部空洞；浮窗 rect `2618x219` 物理 px（宽而扁，居中对齐下内凹面积大）。
+- 尚未在真实游戏上复测（真机验证缺口），只有编译 + 源码守卫。

--- a/docs/bugs/BUG-2372-gal-overlay-lookup-card-not-anchored-to-word.md
+++ b/docs/bugs/BUG-2372-gal-overlay-lookup-card-not-anchored-to-word.md
@@ -1,0 +1,40 @@
+## BUG-2372 · 悬浮字幕查词弹窗没锚在被点的词上
+- **报告**：2026-09-09（用户：「galgame 的这个悬浮字幕的辞典弹窗位置也不对」→ 追加「悬浮字幕的查词弹窗位置 应该是对应单词的位置」）
+- **真实性**：⏳ **未定位**。已排除三条最像的假根因（见下），锚点接线本身是通的；
+  缺的是真实落点数值，已加诊断日志待一次复现。
+
+### 已排除（都有实测依据，不是读代码读出来的印象）
+
+1. **不是**「根卡按最大高钳位、渲染却更矮 → 留出空档」（[[BUG-2082]] 在桌面 route 的同形缺陷）。
+   `hibiki_glookup.log` 的 `reveal(box)` 行里 `root=773`，而 `cardH*dpr = h0/2.0 = 773`
+   —— **根卡渲染高度恒等于最大高度**，钳位没有多余量可留。
+2. **不是**游戏内查词的画布 cap 污染桌面 route。`setPhysicalCap()` 在 gal route hide 时会清；
+   且日志显示这台机上 gal 内查词全程 `geometryAdmission=disabled`。
+3. **不是**锚点没接线。`gal_hook_text_overlay_channel.dart:1168` 确实传了 `_wordRect(args)`，
+   一路到 `GlobalLookupController.lookupText(anchorScreenRect:)` → `showAt(atCursor:false)`。
+   native 侧 `DispatchLookupAt` 的换算（client 物理 px + `GetWindowRect` → `/scale`）也自洽，
+   `showAt` 选显示器用的是**锚点**而不是光标。
+
+### 按用户真实设置算出来的期望落点（读生产库）
+
+- 浮窗 rect：`left=555 top=152 width=2618 height=219`（物理 px）→ CSS `370,101,1745x146`，
+  **在屏幕顶部**。
+- 卡片：`overlay_lookup_max_*` = `641x368` CSS × `appUiScale 1.4` = `897x515` CSS。
+- 工作区 CSS `2560x1440`（4K@150%）。
+
+词在 y≈101..247 CSS，下方余量 1193 > 515 → `computeRootShellOffset` 纵向偏移应为 **0**，
+卡片应当正好贴在词的下方。横向仅当词的 x > 1663 CSS 时才左移（贴屏幕右缘，仍紧邻词）。
+**也就是说按现有模型算，卡片本该就在词下面——与用户观察矛盾，说明模型里有一个我还没找到的输入是错的。**
+
+### 待办
+
+- **[ ] ① 未修复** —
+- **[ ] ② 未加自动化测试** —
+
+已在 `global_lookup_controller.dart` 加一条诊断 glog（本 PR）：一次记全
+`anchor`（逻辑 px）/ `dpr` / `appUiScale` / 真正投给 native 的**物理** `showAt` 坐标 /
+`cardCss` / `cap` / native 回报的 `work`+`origin`+`monitorDpr`。配合随后的 `reveal(box)`
+即可把卡片最终屏幕位置反算到像素，定位「模型里哪个输入是错的」。
+
+复现方法：跑本分支构建的 `fushi.exe`，在悬浮字幕上点一次词，然后取
+`%TEMP%\hibiki_glookup.log` 里最后的 `lookup: anchor=...` 与 `reveal(box):` 两行。

--- a/fushi/lib/src/lookup/global_lookup_controller.dart
+++ b/fushi/lib/src/lookup/global_lookup_controller.dart
@@ -947,6 +947,23 @@ class GlobalLookupController {
               capOriginX: capX,
               capOriginY: capY,
             );
+      // BUG-2372 诊断线 —— 「弹窗没锚在被点的词上」这类报告，光看截图量不出
+      // 锚点到卡片的真实偏移。把锚点（逻辑 px）、dpr、真正投给 native 的物理
+      // 坐标、以及 native 回报的工作区/原点一次记全；配合随后的 reveal(box)
+      // 就能把卡片的最终屏幕位置反算到像素，不必再让用户反复截图。
+      glog(
+        'lookup: anchor=${anchorScreenRect == null ? 'null(atCursor)' : '('
+            '${anchorScreenRect.left},${anchorScreenRect.top},'
+            '${anchorScreenRect.width}x${anchorScreenRect.height})'} '
+        'dpr=$dpr appUiScale=${model.appUiScale} '
+        'showAt=(${anchorScreenRect == null ? 'cursor' : '${(anchorScreenRect.left * dpr).round()},'
+            '${((anchorScreenRect.bottom + 4) * dpr).round()}'}) '
+        'cardCss=${overlaySize.width}x${overlaySize.height} '
+        'cap=(${capW}x$capH @$capX,$capY) '
+        'reply=(work=${shown.workWidth}x${shown.workHeight} '
+        'origin=${shown.cursorWorkX},${shown.cursorWorkY} '
+        'monitorDpr=${shown.monitorDpr})',
+      );
       if (!_isCurrentRoute) return false;
       if (!shown.ok) {
         glog('lookup: showAt rejected the current route');

--- a/fushi/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/fushi/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -224,41 +224,93 @@ void main() {
           reason: '穿透态背景必须无条件清零 alpha');
     });
 
-    // BUG-1853 — 穿透态的碰撞箱是「文字行矩形并集」，不是字形轮廓。
-    // 整窗 alpha 0 + 逐像素命中 = 只有字形像素归我们；口/国/目 的内部、笔画之间、
-    // 字距行距的镂空全透给游戏，点字查词变成看运气。修法是在每行文字的行盒里铺
-    // 一层 kHookTextMinCatchAlpha 的不可见 catch fill：行盒内任何一点都算点在字
-    // 上，行盒外仍是真 alpha 0（「点背景推台词」的不变式不动）。
-    test('穿透态必须在文字行矩形内铺不可见 catch fill（BUG-1853）', () {
-      final String render =
-          functionBody(body, 'void FloatingLyricWindow::Render()');
+    // BUG-1853 / BUG-2371 — 穿透态的碰撞箱是「文字块的外接矩形」，不是字形轮廓，
+    // 也不再是逐行行盒并集。整窗 alpha 0 + 逐像素命中 = 只有窗口像素归我们；逐行铺
+    // 会在块**内部**留下三类 alpha 0 空洞（空行的零宽行盒、多行参差的内凹、行间缝），
+    // 用户明明点在字幕这一块上却被判成背景、点击透给游戏推台词。外接矩形一次消掉
+    // 三类；块**外**（上下留白、居中块两侧整片空白）仍是真 alpha 0，「点背景推台词」
+    // 的不变式不动。
+    test('穿透态必须在文字块外接矩形内铺不可见 catch fill（BUG-1853/2371）', () {
+      final String render = functionBody(
+        body,
+        'void FloatingLyricWindow::Render()',
+      );
       // 判据多了一维 `passthrough_blocks_mouse_`（「穿透时是否仍拦鼠标」可配），
       // 所以锚点只取到那一维之前；后面 `contains` 再确认它确实在同一个条件里。
-      final int catchFill =
-          render.indexOf('if (hook_text_mode_ && pass_through_ &&');
-      expect(catchFill, isNot(-1),
-          reason: '穿透态行矩形 catch fill 的守门条件必须存在，且只在'
-              'hook 台词 + 穿透态下生效（歌词条 / 非穿透态整窗兜底已经可点）');
+      final int catchFill = render.indexOf(
+        'if (hook_text_mode_ && pass_through_ &&',
+      );
+      expect(
+        catchFill,
+        isNot(-1),
+        reason: '穿透态 catch fill 的守门条件必须存在，且只在'
+            'hook 台词 + 穿透态下生效（歌词条 / 非穿透态整窗兜底已经可点）',
+      );
+      // 结构锚，不用固定字符窗口：块尾取下一段「高亮底色」的注释，往里插几行
+      // 合法代码不会让守卫错位。
+      final int blockEnd = render.indexOf(
+        '// Highlight range background.',
+        catchFill,
+      );
+      expect(
+        blockEnd,
+        greaterThan(catchFill),
+        reason: '找不到 catch fill 块的结构尾锚',
+      );
+      final String block = render.substring(catchFill, blockEnd);
       // 行盒必须来自 DirectWrite 自己的排版（HitTestTextRange 全文范围），
       // 不能手算——手算行高会和有注音时 SetLineSpacing 加高后的真实行盒漂移。
-      final String block = render.substring(catchFill, catchFill + 2200);
       expect(
         block.contains('HitTestTextRange(0, static_cast<UINT32>(text_.size())'),
         isTrue,
-        reason: '行矩形必须取自 HitTestTextRange(0, text_.size())，'
-            '即 DirectWrite 排好版的逐行行盒',
+        reason: '行盒必须取自 HitTestTextRange(0, text_.size())，'
+            '即 DirectWrite 排好版的结果',
       );
-      expect(block.contains('kHookTextMinCatchAlpha << 24'), isTrue,
-          reason: 'catch fill 必须用 kHookTextMinCatchAlpha（不可见但可命中），'
-              '不能用可见 alpha——否则穿透态多出一块底色');
-      expect(block.contains('FillRectangle('), isTrue,
-          reason: '行矩形要真的填进 layered 位图，命中判定才会把它算成窗口像素');
+      expect(
+        block.contains('kHookTextMinCatchAlpha << 24'),
+        isTrue,
+        reason: 'catch fill 必须用 kHookTextMinCatchAlpha（不可见但可命中），'
+            '不能用可见 alpha——否则穿透态多出一块底色',
+      );
+      // BUG-2371：必须是**一个**外接矩形，不是逐行填。逐行填 = 把三类内部空洞留着。
+      for (final String token in <String>[
+        'min_left',
+        'min_top',
+        'max_right',
+        'max_bottom',
+      ]) {
+        expect(
+          block.contains(token),
+          isTrue,
+          reason: 'BUG-2371：碰撞箱必须并成外接矩形（缺 $token 说明退回了逐行铺）',
+        );
+      }
+      expect(
+        'FillRectangle('.allMatches(block).length,
+        1,
+        reason: 'BUG-2371：catch fill 只能填一次外接矩形；出现多次 = 又变回逐行铺，'
+            '空行 / 参差内凹的漏点带会回来',
+      );
+      expect(
+        block.contains('D2D1::RectF(min_left, min_top, max_right, max_bottom)'),
+        isTrue,
+        reason: '填的必须就是并出来的外接矩形本身',
+      );
+      // 空行（宽度 0）不能把横向并集拉坏，但必须参与纵向并集——它就是那条漏点带。
+      expect(
+        block.contains('if (m.width <= 0.0f) {'),
+        isTrue,
+        reason: 'BUG-2371：零宽行盒只跳过横向并集，纵向必须照并',
+      );
       // 铺在 PushAxisAlignedClip(text_clip) 之后：滚出视口的行不能吃点击。
       final int clip = render.indexOf('PushAxisAlignedClip(text_clip');
       expect(clip, isNot(-1));
-      expect(clip < catchFill, isTrue,
-          reason: 'catch fill 必须在 text_clip 裁剪之内绘制，'
-              '否则滚出视口的行仍会拦截本该给游戏的点击');
+      expect(
+        clip < catchFill,
+        isTrue,
+        reason: 'catch fill 必须在 text_clip 裁剪之内绘制，'
+            '否则滚出视口的行仍会拦截本该给游戏的点击',
+      );
     });
 
     test('a toolbar that cannot be created cancels pass-through', () {
@@ -321,8 +373,8 @@ void main() {
       expect(body.contains('hook_toolbar::SlotAction(toolbar_profile_, slot)'),
           isTrue,
           reason: 'The body must not keep a private copy of the mapping.');
-      expect(toolbar.contains('hook_toolbar::SlotAction(profile_, slot)'),
-          isTrue);
+      expect(
+          toolbar.contains('hook_toolbar::SlotAction(profile_, slot)'), isTrue);
 
       final String dispatcher = functionBody(body,
           'void FloatingLyricWindow::DispatchControlAction(const std::string& action)');
@@ -348,7 +400,8 @@ void main() {
         // memory (rightmost is always 关闭), so a reorder must be a deliberate
         // edit here and not something a refactor can do quietly.
         expect(found, expected,
-            reason: 'Slot order is the wire contract with the Dart controller.');
+            reason:
+                'Slot order is the wire contract with the Dart controller.');
         // Derived, not a second literal to keep in sync: a table that grows
         // while its count does not is an out-of-bounds read in both windows.
         expect(
@@ -434,11 +487,10 @@ void main() {
           body.contains(
               'hook_toolbar::SlotGlyph(toolbar_profile_, slot, tb_states)'),
           isTrue);
-      expect(
-          body.contains(
-              'hook_toolbar::SlotActive(toolbar_profile_, slot,'),
+      expect(body.contains('hook_toolbar::SlotActive(toolbar_profile_, slot,'),
           isTrue);
-      expect(toolbar.contains('hook_toolbar::SlotGlyph(profile_, slot, states_)'),
+      expect(
+          toolbar.contains('hook_toolbar::SlotGlyph(profile_, slot, states_)'),
           isTrue);
     });
 
@@ -497,8 +549,7 @@ void main() {
       // Tightened from `!(hook_text_mode_ && pass_through_)`: the hook-text
       // overlay now always uses the standalone pill window, click-through or
       // not, so the body paints no buttons at all in that mode.
-      expect(
-          body.contains('const bool draw_body_toolbar = !hook_text_mode_;'),
+      expect(body.contains('const bool draw_body_toolbar = !hook_text_mode_;'),
           isTrue,
           reason: 'Two toolbars drawn at the same spot, one of them dead, is '
               'the UI lie this design exists to remove.');
@@ -526,8 +577,8 @@ void main() {
     setUpAll(() => masked = maskComments(body));
 
     test('MoveBodyTo 是那条原语：钳制 + 顶栏同步都在里面', () {
-      final String moveBody =
-          functionBody(masked, 'void FloatingLyricWindow::MoveBodyTo(int x, int y)');
+      final String moveBody = functionBody(
+          masked, 'void FloatingLyricWindow::MoveBodyTo(int x, int y)');
       expect(moveBody.contains('SyncPassThroughToolbar();'), isTrue,
           reason: '移动正文窗后不同步顶栏，两个窗就会漂开。');
       expect(moveBody.contains('ClampOriginToWorkArea('), isTrue,

--- a/fushi/windows/runner/floating_lyric_window.cpp
+++ b/fushi/windows/runner/floating_lyric_window.cpp
@@ -6,6 +6,7 @@
 #include <windowsx.h>
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 #include <string>
@@ -1834,11 +1835,43 @@ void FloatingLyricWindow::Render() {
                               (style_.bg_color & 0x00FFFFFF)),
                 catch_brush.GetAddressOf());
             if (catch_brush != nullptr) {
+              // BUG-2371 —— 碰撞箱是**文字块的外接矩形**，不是逐行行盒并集。
+              //
+              // 逐行铺留下三类块**内部**的 alpha 0 空洞，点上去照样推进游戏
+              // （BUG-1853 自己在「已知缺口」里记了第一类，另两类同源）：
+              //   ① 空行（台词含连续换行）的行盒宽度为 0，FillRectangle 一个像素
+              //      都画不出 → 文字块中间横着一条整行高的漏点带；
+              //   ② 多行参差时短行两侧的**内凹**（居中对齐尤其明显）；
+              //   ③ 行与行之间若排版留了缝，缝里也是 0。
+              // 三类都是「用户明明点在字幕这一块上」却被判成背景。外接矩形一次
+              // 消掉它们，而不是给空行加一条 `if (m.width <= 0)` 特例分支。
+              //
+              // 块**外**（上下留白、居中块两侧的整片空白）仍是真 alpha 0，
+              // 「点背景推台词」的不变式一字不动。单行文本时外接矩形 == 那一行的
+              // 行盒，逐像素等于改动前。
+              float min_left = FLT_MAX;
+              float min_top = FLT_MAX;
+              float max_right = -FLT_MAX;
+              float max_bottom = -FLT_MAX;
               for (const auto& m : line_metrics) {
+                if (m.height <= 0.0f) {
+                  continue;  // 退化行：没有垂直范围可并，跳过。
+                }
+                // 宽度为 0 的空行仍参与**纵向**并集（它就是那条漏点带），横向由
+                // 有字的行决定；整块都没有字时下面的空判据会挡住。
+                min_top = std::min(min_top, text_origin_y + m.top);
+                max_bottom =
+                    std::max(max_bottom, text_origin_y + m.top + m.height);
+                if (m.width <= 0.0f) {
+                  continue;
+                }
+                min_left = std::min(min_left, text_rect_.left + m.left);
+                max_right =
+                    std::max(max_right, text_rect_.left + m.left + m.width);
+              }
+              if (max_right > min_left && max_bottom > min_top) {
                 render_target_->FillRectangle(
-                    D2D1::RectF(text_rect_.left + m.left, text_origin_y + m.top,
-                                text_rect_.left + m.left + m.width,
-                                text_origin_y + m.top + m.height),
+                    D2D1::RectF(min_left, min_top, max_right, max_bottom),
                     catch_brush.Get());
               }
             }


### PR DESCRIPTION
## 症状

用户：「悬浮字幕，下面的文字点击的时候**有时候**会传到下面的游戏」。

## 根因

穿透态整窗背景是真 alpha 0（`body_bg &= 0x00FFFFFF`），命中判定整个交给 `UpdateLayeredWindow` 的逐像素 alpha。BUG-1853 已把碰撞箱从「字形轮廓」放大到「文字**行盒**并集」，但行盒宽度是 `HitTestTextRange` 给出的**该行文字实际排版范围**，于是文字块**内部**仍剩三类 alpha 0 空洞：

| # | 空洞 | 触发条件 |
|---|---|---|
| ① | **空行**的行盒宽度为 0，`FillRectangle` 一个像素都画不出 → 块中间横着一条整行高的漏点带 | 台词含连续换行 |
| ② | 多行参差时**短行两侧的内凹** | 居中对齐（`text_alignment` 默认 CENTER）下面积很大 |
| ③ | 行与行之间若排版留了缝 | 行距设置 |

①**是 BUG-1853 自己在「已知缺口（审查发现，本轮未修）」里写下的那条**，②③同源。三类的共同点：用户明明点在字幕这一块上，却被判成点背景。「**有时候**」正是它——命中与否取决于这一句有没有换行、有几行、行长差多少。

读用户生产库确认了前提：`gal_hook_passthrough_blocks_mouse` 未设 = 默认 `true`（catch fill 这条路是开着的），浮窗 rect `2618x219` 物理 px（宽而扁，居中对齐下内凹面积大）。

## 修复

碰撞箱从「逐行行盒并集」改成「**文字块的外接矩形**」：对行盒取 min/max 并成一个矩形，`FillRectangle` 一次。零宽行盒只跳过**横向**并集、**纵向照并**（它就是那条漏点带）。

- 这是**消除特殊情况**，不是加分支——没有为空行写 `if (m.width <= 0) 用整行宽` 的特例。
- 块**外**（上下留白、居中块两侧的整片空白）仍是真 alpha 0，「点背景推台词」的不变式一字不动。
- **单行文本时外接矩形 == 那一行的行盒，逐像素等于改动前。**

另附 BUG-2372（悬浮字幕查词弹窗没锚在被点的词上）的**诊断日志**：一次记全 `anchor`（逻辑 px）/ `dpr` / `appUiScale` / 真正投给 native 的**物理** `showAt` 坐标 / `cardCss` / `cap` / native 回报的 `work`+`origin`+`monitorDpr`。那条已排除三个假根因（详见 `docs/bugs/BUG-2372-*.md`），按现有模型算卡片本该就在词下面，需要真实落点数值定位「模型里哪个输入是错的」。

## 验证

- `flutter build windows --debug` → `√ Built ...fushi.exe`（exit 0）
- `flutter analyze`（含 test）→ No issues found
- **守卫变异实测**：把外接矩形改回逐行铺 → 守卫**真红**；恢复后 21/21 绿（不是空壳断言）
- `flutter test test/native test/tools test/build test/lookup test/windows` → **+1708 -6**；6 条红全部是 `TimeoutException after 30s`，落在 git 重的 `bug_tool_*` / `update_manifest_*` 上（本机 1431 refs / 636 worktrees，1700 条并跑时撞单测 30s 上限）。同样这些文件**单跑 exit=0 全绿**（45/45、36/36）。
- 守卫从**固定 2200 字符窗口**改成**结构锚**（块尾 `// Highlight range background.`），否则往块里插几行合法代码就会错位变红。

**缺口**：未在真实游戏上复测原始失败路径，只有编译 + 源码守卫 + 变异实测。

https://claude.ai/code/session_01WmpyozLwKc768SP6zGgAPd