### PR TITLE
feat(collection): 合集封面/重刮入口 + 删除支持删本地文件（BUG-2374 / BUG-2389）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2374](bugs/BUG-2374-collection-cover-and-rescrape-entries-lost.md) | ✅ | ✅ | 合集丢失设置封面与重新刮削入口 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2374-collection-cover-and-rescrape-entries-lost.md
+++ b/docs/bugs/BUG-2374-collection-cover-and-rescrape-entries-lost.md
@@ -1,0 +1,18 @@
+## BUG-2374 · 合集丢失设置封面与重新刮削入口
+- **报告**：2026-09-09（用户：截图指着视频合集右键菜单问「选封面功能去哪了」，随后追加「现在缺少重新刮削某个合集，还有这些能设置的少了一些东西吧」）
+- **真实性**：✅ 真 bug（两条，一条是回归，一条是从未接线）
+  - **重新刮削合集 = 回归**。`1637876c64`（refactor(video): make AniDB the canonical scraper，2026-08-23）把合集右键的「刮削资料与封面」连同 `_openCollectionCoverMatch`、`showCollectionScrapeDialog`、详情页注入的 `onScrapeCollection` / `onEpisodeScrapeInfo` 一起删光，注释理由是「在线元数据刮削统一从来源页进入」。但来源页的作用域是**扫描根**（`VideoSourceWorkPlanner.plan(source)`），用户手上是**一个刮错的合集**，两者不可互相替代——BUG-1662 当初补这个入口正是因为库页「想重刮某个合集」是断头路。删除后 `video_collection_scrape` 这个 i18n key 在 17 份 json 里成了全仓零引用的孤儿，是回归的物证。
+  - **合集封面 = 从未接线**。`MediaCollections` 有两列封面事实：`coverPath`（合集自有图，schema v61 / BUG-1211）与 `coverSource`（借哪个成员的图）。`coverPath` 只有在线刮削（`video_source_scrape_coordinator.dart:2259`）和番剧下载导入器（`anime_download_importer.dart:140`）会写，`coverSource` 更是只有导入器写，**UI 层零入口**。而视频合集卡渲染把 `coverPath` 排在第一优先（`home_video_page.dart` `_buildCollectionCover`），所以用户既改不了也退不回，只能等刮削刮对。
+  - 根因位置：`fushi/lib/src/pages/implementations/home_video_page.dart` 的 `_showCollectionContextMenu`（`extraListActions` 只剩批量字幕）与 `fushi/lib/src/pages/implementations/media_collection_detail_page.dart` 的 `_buildAppBar` 管理菜单。
+- **[x] ① 已修复** — 两处入口按 canonical 管线补齐，不复活 legacy 刮削路径：
+  - 新增 `MediaCoverService.applyCollectionCover`：落 `video_covers/collections/<id>.jpg`（与导入器写合集海报同目录同命名）→ 写 `coverPath`。走既有的 `applyCoverFile` 收口（原子 .tmp+rename、双键驱逐），并沿用视频侧 `VideoScrapeOperationGate` + `VideoCoverMutationGate` 两把门，与刮削写同一路径时不打架。**不需要**额外的 manual 保护标记：刮削覆盖判据是 `coverPath == null || isUnmodifiedGeneratedArtifact(coverPath)`，后者按 `video_sidecar_artifacts` 的 sha256 登记比对，手选图从不进那张表 → 结构性免疫覆盖。
+  - 新增 `clearCollectionOwnCover`（`collection_asset_reclaim.dart`）：先落库置 null，再把置 null 前的快照交给既有的 `reclaimDeletedCollectionAssets`，**复用同一套三条误删护栏**（路径来自 DB 行、必须 `p.isWithin` 合集封面目录、删行后仍被别的合集引用则保留），最后 `applyCoverRemoval` 驱逐解码缓存。没有第二套删除条件。
+  - 新增 `planScrapeWorkForCollection`（`video_library_scrape_sweep.dart`）：问计划器要同一份计划，按 `stableKey == 'collection:<id>'` 定位作品单元，拿回「来源行 + 作品标题 + 稳定键」。按稳定键而非标题匹配，同名/改名合集都不会认错，也不会撞 `VideoSourceScrapeWorkAmbiguous`。
+  - 库页右键菜单接三项（设置封面 / 恢复默认封面（仅在有自有封面时出现）/ 重新刮削资料与封面）；详情页 AppBar 管理菜单接同样三项。重刮走既有共享入口 `showVideoSourceScrapeManualBindingDialog` 选身份 → `VideoSourceScrapeTaskController.rescrapeWorkWithLookup`，与批次内确认、下载导入后的精确刮削共用同一条 `_store.apply`，不新开绑定保存路径。controller 归 HomePage 持有，详情页经 `VideoWorkDetailPage.onRescrapeCollection` 注入（恢复被删的 `onScrapeCollection` 同型接线），拿不到 controller 时整条菜单项不渲染。
+  - 封面两项只给视频合集：书架与游戏库的合集入口是横排行头、没有封面槽，挂上去点了看不出任何变化。
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/media/media_cover_service_test.dart`：`applyCollectionCover` 落盘路径与写库、**只写 `media_collections` 一行不动任何成员封面**（BUG-1211 语义）、同路径覆盖写后双键驱逐、源文件不可读时抛出且不写库不留 `.tmp`。
+  - `fushi/test/media/collections/collection_asset_reclaim_test.dart`：`clearCollectionOwnCover` 清列+回收文件且合集本身还在、别的合集仍引用同一张图时保留文件、合集封面目录之外的用户图片只解引用绝不删除、无自有封面时空操作。
+  - `fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart`：`planScrapeWorkForCollection` 按 stableKey 命中并带回来源行、同名合集不认错、不在任何本地来源计划里时返回 null。
+  - `fushi/test/pages/collection_detail_scrape_entry_test.dart`：把原来的单向否定守卫升级成**双向**——既钉死 legacy 入口不复活，也钉死没注入 controller 时不渲染重刮项、注入后必须渲染且点击真把当前合集交给注入实现，以及封面项在场 / 未设封面时不显示「恢复默认」。
+- **备注**：原守卫只断言「不得有 legacy 刮削入口」，删入口的那次 refactor 因此畅通无阻——**否定守卫单独存在时，把功能删光也是绿的**。这次一并补上了正向断言。孤儿 key `video_collection_scrape` 已随本次一并删除（`i18n_sync.dart --remove`）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77112 (4536 per locale)
+/// Strings: 77231 (4543 per locale)
 ///
-/// Built on 2026-09-09 at 08:11 UTC
+/// Built on 2026-09-09 at 08:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5164,7 +5164,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_clip_exporting => 'Exporting clip…';
   String get video_collection_no_local_member =>
       'No local video in this collection';
-  String get video_collection_scrape => 'Scrape info & cover';
   String get video_continue_watching => 'Continue watching';
   String get video_control_audio_track => 'Audio track';
   String video_control_custom_action({required Object index}) =>
@@ -6294,6 +6293,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   String get dialog_background_close => 'Close (task keeps running)';
   String get reader_timer_show => 'Show reading timer';
+  String get collection_cover_set => 'Set cover';
+  String get collection_cover_reset => 'Reset to default cover';
+  String get collection_cover_updated => 'Cover updated';
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  String get collection_rescrape_started => 'Rescrape queued';
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -15005,8 +15013,6 @@ class _StringsAr extends _StringsEn {
   String get video_collection_no_local_member =>
       'لا يوجد فيديو محلي في هذه المجموعة';
   @override
-  String get video_collection_scrape => 'كشط المعلومات والغلاف';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'المسار الصوتي';
@@ -16952,6 +16958,23 @@ class _StringsAr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'إظهار مؤقت القراءة';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -25842,8 +25865,6 @@ class _StringsDe extends _StringsEn {
   String get video_collection_no_local_member =>
       'Kein lokales Video in dieser Sammlung';
   @override
-  String get video_collection_scrape => 'Info & Cover scrapen';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Tonspur';
@@ -27837,6 +27858,23 @@ class _StringsDe extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Lesetimer anzeigen';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -36766,8 +36804,6 @@ class _StringsEs extends _StringsEn {
   String get video_collection_no_local_member =>
       'No hay vídeo local en esta colección';
   @override
-  String get video_collection_scrape => 'Obtener info y portada';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Pista de audio';
@@ -38776,6 +38812,23 @@ class _StringsEs extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar temporizador de lectura';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -47723,8 +47776,6 @@ class _StringsFr extends _StringsEn {
   String get video_collection_no_local_member =>
       'Aucune vidéo locale dans cette collection';
   @override
-  String get video_collection_scrape => 'Récupérer infos et couverture';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Piste audio';
@@ -49749,6 +49800,23 @@ class _StringsFr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Afficher le minuteur de lecture';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -58549,8 +58617,6 @@ class _StringsId extends _StringsEn {
   String get video_collection_no_local_member =>
       'Tidak ada video lokal dalam koleksi ini';
   @override
-  String get video_collection_scrape => 'Scrape info & sampul';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Trek audio';
@@ -60524,6 +60590,23 @@ class _StringsId extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Tampilkan pengatur waktu baca';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -69396,8 +69479,6 @@ class _StringsIt extends _StringsEn {
   String get video_collection_no_local_member =>
       'Nessun video locale in questa raccolta';
   @override
-  String get video_collection_scrape => 'Scrape info e copertina';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Traccia audio';
@@ -71391,6 +71472,23 @@ class _StringsIt extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostra timer di lettura';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -79771,8 +79869,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_collection_no_local_member => 'このコレクションにローカル動画がありません';
   @override
-  String get video_collection_scrape => '情報と封面を取得';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => '音声トラック';
@@ -81639,6 +81735,23 @@ class _StringsJa extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '読書タイマーを表示';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -90026,8 +90139,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_collection_no_local_member => '이 컬렉션에 로컬 동영상이 없습니다';
   @override
-  String get video_collection_scrape => '정보 및 표지 스크랩';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => '오디오 트랙';
@@ -91897,6 +92008,23 @@ class _StringsKo extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '독서 타이머 표시';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -100738,8 +100866,6 @@ class _StringsNl extends _StringsEn {
   String get video_collection_no_local_member =>
       'Geen lokale video in deze collectie';
   @override
-  String get video_collection_scrape => 'Info & omslag scrapen';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Audiotrack';
@@ -102721,6 +102847,23 @@ class _StringsNl extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Leestimer tonen';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -111597,8 +111740,6 @@ class _StringsPtBr extends _StringsEn {
   String get video_collection_no_local_member =>
       'Nenhum vídeo local nesta coleção';
   @override
-  String get video_collection_scrape => 'Buscar info e capa';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Faixa de áudio';
@@ -113598,6 +113739,23 @@ class _StringsPtBr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar cronômetro de leitura';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -122449,8 +122607,6 @@ class _StringsRu extends _StringsEn {
   String get video_collection_no_local_member =>
       'Нет локальных видео в этой коллекции';
   @override
-  String get video_collection_scrape => 'Получить информацию и обложку';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Аудиодорожка';
@@ -124452,6 +124608,23 @@ class _StringsRu extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Показывать таймер чтения';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -133159,8 +133332,6 @@ class _StringsTh extends _StringsEn {
   String get video_collection_no_local_member =>
       'ไม่มีวิดีโอในเครื่องในคอลเลกชันนี้';
   @override
-  String get video_collection_scrape => 'สแกนข้อมูลและปก';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'แทร็กเสียง';
@@ -135106,6 +135277,23 @@ class _StringsTh extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'แสดงตัวจับเวลาการอ่าน';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -143901,8 +144089,6 @@ class _StringsTr extends _StringsEn {
   String get video_collection_no_local_member =>
       'Bu koleksiyonda yerel video yok';
   @override
-  String get video_collection_scrape => 'Bilgi ve kapak tara';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Ses izi';
@@ -145876,6 +146062,23 @@ class _StringsTr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Okuma zamanlayıcısını göster';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -154654,8 +154857,6 @@ class _StringsVi extends _StringsEn {
   String get video_collection_no_local_member =>
       'Không có video cục bộ trong bộ sưu tập này';
   @override
-  String get video_collection_scrape => 'Quét thông tin & bìa';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => 'Bản âm thanh';
@@ -156617,6 +156818,23 @@ class _StringsVi extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Hiển thị bộ đếm thời gian đọc';
+  @override
+  String get collection_cover_set => 'Set cover';
+  @override
+  String get collection_cover_reset => 'Reset to default cover';
+  @override
+  String get collection_cover_updated => 'Cover updated';
+  @override
+  String get collection_cover_failed => 'Couldn\'t set the cover';
+  @override
+  String get collection_rescrape => 'Rescrape metadata and cover';
+  @override
+  String get collection_rescrape_not_planned =>
+      'This collection isn\'t in any local video source\'s scrape plan';
+  @override
+  String get collection_rescrape_started => 'Rescrape queued';
+  @override
+  String get collection_rescrape_failed => 'Rescrape failed';
 }
 
 // Path: <root>
@@ -164683,8 +164901,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_collection_no_local_member => '本合集没有本地视频';
   @override
-  String get video_collection_scrape => '刮削资料与封面';
-  @override
   String get video_continue_watching => '继续观看';
   @override
   String get video_control_audio_track => '音轨';
@@ -166482,6 +166698,22 @@ class _StringsZhCn extends _StringsEn {
   String get dialog_background_close => '关闭（任务继续在后台运行）';
   @override
   String get reader_timer_show => '显示阅读计时器';
+  @override
+  String get collection_cover_set => '设置封面';
+  @override
+  String get collection_cover_reset => '恢复默认封面';
+  @override
+  String get collection_cover_updated => '封面已更新';
+  @override
+  String get collection_cover_failed => '封面设置失败';
+  @override
+  String get collection_rescrape => '重新刮削资料与封面';
+  @override
+  String get collection_rescrape_not_planned => '这个合集不在任何本地视频来源的刮削计划里';
+  @override
+  String get collection_rescrape_started => '已开始重新刮削';
+  @override
+  String get collection_rescrape_failed => '重新刮削失败';
 }
 
 // Path: <root>
@@ -174608,8 +174840,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_collection_no_local_member => '本合集沒有本地影片';
   @override
-  String get video_collection_scrape => '刮削資料與封面';
-  @override
   String get video_continue_watching => 'Continue Watching';
   @override
   String get video_control_audio_track => '音軌';
@@ -176416,6 +176646,22 @@ class _StringsZhHk extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '顯示閱讀計時器';
+  @override
+  String get collection_cover_set => '設定封面';
+  @override
+  String get collection_cover_reset => '回復預設封面';
+  @override
+  String get collection_cover_updated => '封面已更新';
+  @override
+  String get collection_cover_failed => '封面設定失敗';
+  @override
+  String get collection_rescrape => '重新刮削資料與封面';
+  @override
+  String get collection_rescrape_not_planned => '這個合集不在任何本機影片來源的刮削計劃裡';
+  @override
+  String get collection_rescrape_started => '已開始重新刮削';
+  @override
+  String get collection_rescrape_failed => '重新刮削失敗';
 }
 
 /// Flat map(s) containing all translations.
@@ -184060,8 +184306,6 @@ extension on _StringsEn {
         return 'Exporting clip…';
       case 'video_collection_no_local_member':
         return 'No local video in this collection';
-      case 'video_collection_scrape':
-        return 'Scrape info & cover';
       case 'video_continue_watching':
         return 'Continue watching';
       case 'video_control_audio_track':
@@ -185748,6 +185992,22 @@ extension on _StringsEn {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Show reading timer';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -193386,8 +193646,6 @@ extension on _StringsAr {
         return 'جارٍ تصدير المقطع…';
       case 'video_collection_no_local_member':
         return 'لا يوجد فيديو محلي في هذه المجموعة';
-      case 'video_collection_scrape':
-        return 'كشط المعلومات والغلاف';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -195075,6 +195333,22 @@ extension on _StringsAr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'إظهار مؤقت القراءة';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -202755,8 +203029,6 @@ extension on _StringsDe {
         return 'Clip wird exportiert…';
       case 'video_collection_no_local_member':
         return 'Kein lokales Video in dieser Sammlung';
-      case 'video_collection_scrape':
-        return 'Info & Cover scrapen';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -204447,6 +204719,22 @@ extension on _StringsDe {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Lesetimer anzeigen';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -212119,8 +212407,6 @@ extension on _StringsEs {
         return 'Exportando fragmento…';
       case 'video_collection_no_local_member':
         return 'No hay vídeo local en esta colección';
-      case 'video_collection_scrape':
-        return 'Obtener info y portada';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -213810,6 +214096,22 @@ extension on _StringsEs {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar temporizador de lectura';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -221490,8 +221792,6 @@ extension on _StringsFr {
         return 'Export de l\'extrait…';
       case 'video_collection_no_local_member':
         return 'Aucune vidéo locale dans cette collection';
-      case 'video_collection_scrape':
-        return 'Récupérer infos et couverture';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -223182,6 +223482,22 @@ extension on _StringsFr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Afficher le minuteur de lecture';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -230835,8 +231151,6 @@ extension on _StringsId {
         return 'Mengekspor klip…';
       case 'video_collection_no_local_member':
         return 'Tidak ada video lokal dalam koleksi ini';
-      case 'video_collection_scrape':
-        return 'Scrape info & sampul';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -232525,6 +232839,22 @@ extension on _StringsId {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Tampilkan pengatur waktu baca';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -240198,8 +240528,6 @@ extension on _StringsIt {
         return 'Esportazione del clip…';
       case 'video_collection_no_local_member':
         return 'Nessun video locale in questa raccolta';
-      case 'video_collection_scrape':
-        return 'Scrape info e copertina';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -241890,6 +242218,22 @@ extension on _StringsIt {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostra timer di lettura';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -249501,8 +249845,6 @@ extension on _StringsJa {
         return 'クリップを書き出し中…';
       case 'video_collection_no_local_member':
         return 'このコレクションにローカル動画がありません';
-      case 'video_collection_scrape':
-        return '情報と封面を取得';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -251182,6 +251524,22 @@ extension on _StringsJa {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '読書タイマーを表示';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -258796,8 +259154,6 @@ extension on _StringsKo {
         return '클립 내보내는 중…';
       case 'video_collection_no_local_member':
         return '이 컬렉션에 로컬 동영상이 없습니다';
-      case 'video_collection_scrape':
-        return '정보 및 표지 스크랩';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -260478,6 +260834,22 @@ extension on _StringsKo {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '독서 타이머 표시';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -268143,8 +268515,6 @@ extension on _StringsNl {
         return 'Fragment exporteren…';
       case 'video_collection_no_local_member':
         return 'Geen lokale video in deze collectie';
-      case 'video_collection_scrape':
-        return 'Info & omslag scrapen';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -269836,6 +270206,22 @@ extension on _StringsNl {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Leestimer tonen';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -277497,8 +277883,6 @@ extension on _StringsPtBr {
         return 'Exportando trecho…';
       case 'video_collection_no_local_member':
         return 'Nenhum vídeo local nesta coleção';
-      case 'video_collection_scrape':
-        return 'Buscar info e capa';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -279189,6 +279573,22 @@ extension on _StringsPtBr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar cronômetro de leitura';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -286859,8 +287259,6 @@ extension on _StringsRu {
         return 'Экспорт фрагмента…';
       case 'video_collection_no_local_member':
         return 'Нет локальных видео в этой коллекции';
-      case 'video_collection_scrape':
-        return 'Получить информацию и обложку';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -288549,6 +288947,22 @@ extension on _StringsRu {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Показывать таймер чтения';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -296193,8 +296607,6 @@ extension on _StringsTh {
         return 'กำลังส่งออกคลิป…';
       case 'video_collection_no_local_member':
         return 'ไม่มีวิดีโอในเครื่องในคอลเลกชันนี้';
-      case 'video_collection_scrape':
-        return 'สแกนข้อมูลและปก';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -297881,6 +298293,22 @@ extension on _StringsTh {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'แสดงตัวจับเวลาการอ่าน';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -305537,8 +305965,6 @@ extension on _StringsTr {
         return 'Kesit dışa aktarılıyor…';
       case 'video_collection_no_local_member':
         return 'Bu koleksiyonda yerel video yok';
-      case 'video_collection_scrape':
-        return 'Bilgi ve kapak tara';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -307228,6 +307654,22 @@ extension on _StringsTr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Okuma zamanlayıcısını göster';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -314881,8 +315323,6 @@ extension on _StringsVi {
         return 'Đang xuất đoạn…';
       case 'video_collection_no_local_member':
         return 'Không có video cục bộ trong bộ sưu tập này';
-      case 'video_collection_scrape':
-        return 'Quét thông tin & bìa';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -316569,6 +317009,22 @@ extension on _StringsVi {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Hiển thị bộ đếm thời gian đọc';
+      case 'collection_cover_set':
+        return 'Set cover';
+      case 'collection_cover_reset':
+        return 'Reset to default cover';
+      case 'collection_cover_updated':
+        return 'Cover updated';
+      case 'collection_cover_failed':
+        return 'Couldn\'t set the cover';
+      case 'collection_rescrape':
+        return 'Rescrape metadata and cover';
+      case 'collection_rescrape_not_planned':
+        return 'This collection isn\'t in any local video source\'s scrape plan';
+      case 'collection_rescrape_started':
+        return 'Rescrape queued';
+      case 'collection_rescrape_failed':
+        return 'Rescrape failed';
       default:
         return null;
     }
@@ -324156,8 +324612,6 @@ extension on _StringsZhCn {
         return '正在导出片段…';
       case 'video_collection_no_local_member':
         return '本合集没有本地视频';
-      case 'video_collection_scrape':
-        return '刮削资料与封面';
       case 'video_continue_watching':
         return '继续观看';
       case 'video_control_audio_track':
@@ -325829,6 +326283,22 @@ extension on _StringsZhCn {
         return '关闭（任务继续在后台运行）';
       case 'reader_timer_show':
         return '显示阅读计时器';
+      case 'collection_cover_set':
+        return '设置封面';
+      case 'collection_cover_reset':
+        return '恢复默认封面';
+      case 'collection_cover_updated':
+        return '封面已更新';
+      case 'collection_cover_failed':
+        return '封面设置失败';
+      case 'collection_rescrape':
+        return '重新刮削资料与封面';
+      case 'collection_rescrape_not_planned':
+        return '这个合集不在任何本地视频来源的刮削计划里';
+      case 'collection_rescrape_started':
+        return '已开始重新刮削';
+      case 'collection_rescrape_failed':
+        return '重新刮削失败';
       default:
         return null;
     }
@@ -333424,8 +333894,6 @@ extension on _StringsZhHk {
         return '正在匯出片段…';
       case 'video_collection_no_local_member':
         return '本合集沒有本地影片';
-      case 'video_collection_scrape':
-        return '刮削資料與封面';
       case 'video_continue_watching':
         return 'Continue Watching';
       case 'video_control_audio_track':
@@ -335099,6 +335567,22 @@ extension on _StringsZhHk {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '顯示閱讀計時器';
+      case 'collection_cover_set':
+        return '設定封面';
+      case 'collection_cover_reset':
+        return '回復預設封面';
+      case 'collection_cover_updated':
+        return '封面已更新';
+      case 'collection_cover_failed':
+        return '封面設定失敗';
+      case 'collection_rescrape':
+        return '重新刮削資料與封面';
+      case 'collection_rescrape_not_planned':
+        return '這個合集不在任何本機影片來源的刮削計劃裡';
+      case 'collection_rescrape_started':
+        return '已開始重新刮削';
+      case 'collection_rescrape_failed':
+        return '重新刮削失敗';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip exported with subtitles: ${path}",
   "video_clip_exporting": "Exporting clip…",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_collection_scrape": "Scrape info & cover",
   "video_continue_watching": "Continue watching",
   "video_control_audio_track": "Audio track",
   "video_control_custom_action": "Shortcut $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Show reading timer"
+  "reader_timer_show": "Show reading timer",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "تم تصدير المقطع مع الترجمات: ${path}",
   "video_clip_exporting": "جارٍ تصدير المقطع…",
   "video_collection_no_local_member": "لا يوجد فيديو محلي في هذه المجموعة",
-  "video_collection_scrape": "كشط المعلومات والغلاف",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "المسار الصوتي",
   "video_control_custom_action": "اختصار $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "إظهار مؤقت القراءة"
+  "reader_timer_show": "إظهار مؤقت القراءة",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip mit Untertiteln exportiert: ${path}",
   "video_clip_exporting": "Clip wird exportiert…",
   "video_collection_no_local_member": "Kein lokales Video in dieser Sammlung",
-  "video_collection_scrape": "Info & Cover scrapen",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Tonspur",
   "video_control_custom_action": "Tastenkürzel $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Lesetimer anzeigen"
+  "reader_timer_show": "Lesetimer anzeigen",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip exportado con subtítulos: ${path}",
   "video_clip_exporting": "Exportando fragmento…",
   "video_collection_no_local_member": "No hay vídeo local en esta colección",
-  "video_collection_scrape": "Obtener info y portada",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Pista de audio",
   "video_control_custom_action": "Atajo $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar temporizador de lectura"
+  "reader_timer_show": "Mostrar temporizador de lectura",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip exporté avec sous-titres : ${path}",
   "video_clip_exporting": "Export de l'extrait…",
   "video_collection_no_local_member": "Aucune vidéo locale dans cette collection",
-  "video_collection_scrape": "Récupérer infos et couverture",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Piste audio",
   "video_control_custom_action": "Raccourci $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Afficher le minuteur de lecture"
+  "reader_timer_show": "Afficher le minuteur de lecture",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Klip diekspor dengan subtitle: ${path}",
   "video_clip_exporting": "Mengekspor klip…",
   "video_collection_no_local_member": "Tidak ada video lokal dalam koleksi ini",
-  "video_collection_scrape": "Scrape info & sampul",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Trek audio",
   "video_control_custom_action": "Pintasan $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Tampilkan pengatur waktu baca"
+  "reader_timer_show": "Tampilkan pengatur waktu baca",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip esportata con sottotitoli: ${path}",
   "video_clip_exporting": "Esportazione del clip…",
   "video_collection_no_local_member": "Nessun video locale in questa raccolta",
-  "video_collection_scrape": "Scrape info e copertina",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Traccia audio",
   "video_control_custom_action": "Scorciatoia $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostra timer di lettura"
+  "reader_timer_show": "Mostra timer di lettura",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "字幕付きクリップをエクスポートしました：${path}",
   "video_clip_exporting": "クリップを書き出し中…",
   "video_collection_no_local_member": "このコレクションにローカル動画がありません",
-  "video_collection_scrape": "情報と封面を取得",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "音声トラック",
   "video_control_custom_action": "ショートカット $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "読書タイマーを表示"
+  "reader_timer_show": "読書タイマーを表示",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "자막 포함 클립 내보내기 완료: ${path}",
   "video_clip_exporting": "클립 내보내는 중…",
   "video_collection_no_local_member": "이 컬렉션에 로컬 동영상이 없습니다",
-  "video_collection_scrape": "정보 및 표지 스크랩",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "오디오 트랙",
   "video_control_custom_action": "단축키 $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "독서 타이머 표시"
+  "reader_timer_show": "독서 타이머 표시",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clip geëxporteerd met ondertitels: ${path}",
   "video_clip_exporting": "Fragment exporteren…",
   "video_collection_no_local_member": "Geen lokale video in deze collectie",
-  "video_collection_scrape": "Info & omslag scrapen",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Audiotrack",
   "video_control_custom_action": "Snelkoppeling $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Leestimer tonen"
+  "reader_timer_show": "Leestimer tonen",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Clipe exportado com legendas: ${path}",
   "video_clip_exporting": "Exportando trecho…",
   "video_collection_no_local_member": "Nenhum vídeo local nesta coleção",
-  "video_collection_scrape": "Buscar info e capa",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Faixa de áudio",
   "video_control_custom_action": "Atalho $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar cronômetro de leitura"
+  "reader_timer_show": "Mostrar cronômetro de leitura",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Клип экспортирован с субтитрами: ${path}",
   "video_clip_exporting": "Экспорт фрагмента…",
   "video_collection_no_local_member": "Нет локальных видео в этой коллекции",
-  "video_collection_scrape": "Получить информацию и обложку",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Аудиодорожка",
   "video_control_custom_action": "Быстрое действие $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Показывать таймер чтения"
+  "reader_timer_show": "Показывать таймер чтения",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "ส่งออกคลิปพร้อมคำบรรยายแล้ว: ${path}",
   "video_clip_exporting": "กำลังส่งออกคลิป…",
   "video_collection_no_local_member": "ไม่มีวิดีโอในเครื่องในคอลเลกชันนี้",
-  "video_collection_scrape": "สแกนข้อมูลและปก",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "แทร็กเสียง",
   "video_control_custom_action": "ทางลัด $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน"
+  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Klip altyazılarla dışa aktarıldı: ${path}",
   "video_clip_exporting": "Kesit dışa aktarılıyor…",
   "video_collection_no_local_member": "Bu koleksiyonda yerel video yok",
-  "video_collection_scrape": "Bilgi ve kapak tara",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Ses izi",
   "video_control_custom_action": "Kısayol $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Okuma zamanlayıcısını göster"
+  "reader_timer_show": "Okuma zamanlayıcısını göster",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "Đã xuất clip kèm phụ đề: ${path}",
   "video_clip_exporting": "Đang xuất đoạn…",
   "video_collection_no_local_member": "Không có video cục bộ trong bộ sưu tập này",
-  "video_collection_scrape": "Quét thông tin & bìa",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "Bản âm thanh",
   "video_control_custom_action": "Phím tắt $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc"
+  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc",
+  "collection_cover_set": "Set cover",
+  "collection_cover_reset": "Reset to default cover",
+  "collection_cover_updated": "Cover updated",
+  "collection_cover_failed": "Couldn't set the cover",
+  "collection_rescrape": "Rescrape metadata and cover",
+  "collection_rescrape_not_planned": "This collection isn't in any local video source's scrape plan",
+  "collection_rescrape_started": "Rescrape queued",
+  "collection_rescrape_failed": "Rescrape failed"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "片段已导出（含字幕）：${path}",
   "video_clip_exporting": "正在导出片段…",
   "video_collection_no_local_member": "本合集没有本地视频",
-  "video_collection_scrape": "刮削资料与封面",
   "video_continue_watching": "继续观看",
   "video_control_audio_track": "音轨",
   "video_control_custom_action": "快捷键 $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。",
   "video_shader_tier_ultra_hint_mobile": "Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。",
   "dialog_background_close": "关闭（任务继续在后台运行）",
-  "reader_timer_show": "显示阅读计时器"
+  "reader_timer_show": "显示阅读计时器",
+  "collection_cover_set": "设置封面",
+  "collection_cover_reset": "恢复默认封面",
+  "collection_cover_updated": "封面已更新",
+  "collection_cover_failed": "封面设置失败",
+  "collection_rescrape": "重新刮削资料与封面",
+  "collection_rescrape_not_planned": "这个合集不在任何本地视频来源的刮削计划里",
+  "collection_rescrape_started": "已开始重新刮削",
+  "collection_rescrape_failed": "重新刮削失败"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3714,7 +3714,6 @@
   "video_clip_exported_with_subtitles": "片段已導出（含字幕）：${path}",
   "video_clip_exporting": "正在匯出片段…",
   "video_collection_no_local_member": "本合集沒有本地影片",
-  "video_collection_scrape": "刮削資料與封面",
   "video_continue_watching": "Continue Watching",
   "video_control_audio_track": "音軌",
   "video_control_custom_action": "快捷鍵 $index",
@@ -4534,5 +4533,13 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "顯示閱讀計時器"
+  "reader_timer_show": "顯示閱讀計時器",
+  "collection_cover_set": "設定封面",
+  "collection_cover_reset": "回復預設封面",
+  "collection_cover_updated": "封面已更新",
+  "collection_cover_failed": "封面設定失敗",
+  "collection_rescrape": "重新刮削資料與封面",
+  "collection_rescrape_not_planned": "這個合集不在任何本機影片來源的刮削計劃裡",
+  "collection_rescrape_started": "已開始重新刮削",
+  "collection_rescrape_failed": "重新刮削失敗"
 }

--- a/fushi/lib/src/media/collections/collection_asset_reclaim.dart
+++ b/fushi/lib/src/media/collections/collection_asset_reclaim.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:fushi/src/media/media_cover_service.dart';
 import 'package:fushi/src/media/video/video_storage.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -84,6 +85,41 @@ Future<int> deleteMediaCollectionWithAssets(
     collectionCoversDirectory: collectionCoversDirectory,
   );
   return removed;
+}
+
+/// 清掉合集**自有**封面，回到自动推导（成员借用链 / canonical 海报）。
+///
+/// 与 [deleteMediaCollectionWithAssets] 的关系：那条是「合集没了，顺手回收它的
+/// 图」，这条是「合集还在，只是不要这张图了」。两者共用**同一套误删护栏**——先把
+/// `coverPath` 置 null，再把置 null 前的快照当作「已删资产」交给
+/// [reclaimDeletedCollectionAssets]。置 null 已经落库，所以那边重查全库时本合集
+/// 不再引用该路径，护栏第 3 条自然放行；而别的合集若碰巧引用同一路径，文件照样
+/// 保留。这就是为什么这里不自己写一遍删除条件。
+///
+/// 顺序不可颠倒：先落库置 null，再删文件。反过来一旦删文件后置 null 失败，DB 就
+/// 指着一个不存在的文件。
+///
+/// 合集还活着、UI 还在画这张图，因此删完必须走
+/// [MediaCoverService.applyCoverRemoval] 双键驱逐解码缓存——否则封面卡会继续画
+/// 一张文件已经不在的图直到重启（BUG-1118 同型）。
+///
+/// 无自有封面时是彻底的空操作（零 IO、零写库）。
+Future<void> clearCollectionOwnCover(
+  FushiDatabase db,
+  int collectionId, {
+  Directory? collectionCoversDirectory,
+}) async {
+  final MediaCollectionRow? snapshot =
+      await db.getMediaCollectionById(collectionId);
+  final String? coverPath = snapshot?.coverPath;
+  if (snapshot == null || coverPath == null || coverPath.isEmpty) return;
+  await db.updateMediaCollectionCoverPath(collectionId, null);
+  await reclaimDeletedCollectionAssets(
+    db,
+    <MediaCollectionRow>[snapshot],
+    collectionCoversDirectory: collectionCoversDirectory,
+  );
+  await MediaCoverService.applyCoverRemoval(destPath: coverPath);
 }
 
 /// 回收 [deletedCollections]（DB 行**已删**的合集快照）各自自有的磁盘资产。

--- a/fushi/lib/src/media/media_cover_service.dart
+++ b/fushi/lib/src/media/media_cover_service.dart
@@ -8,11 +8,15 @@ import 'package:fushi/src/media/video/scraper/scraper_types.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
 import 'package:fushi/src/media/video/video_import_dialog.dart'
     show setVideoCoverFromPickedFile;
+import 'package:fushi/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
 import 'package:fushi/src/media/video/video_storage.dart';
 import 'package:fushi/src/mining/galgame_cover_resolver.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/utils/cover_image.dart';
 import 'package:fushi/src/utils/misc/gallery_image_picker.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
 
 /// 媒体统一路线 P3：三个媒体岛（书 / 视频 / 游戏）封面「选图 → 落盘 → 缓存驱逐」
 /// 的统一服务入口。
@@ -164,6 +168,49 @@ class MediaCoverService {
           pickedPath: pickedPath,
           coversDirectory: covers,
         );
+      });
+    } finally {
+      lease.release();
+    }
+  }
+
+  /// 合集：用用户手选的图片设置**合集自有**封面，返回落盘路径。
+  ///
+  /// 落 `video_covers/collections/<collectionId>.jpg`
+  /// （[VideoStorage.collectionCoversDir] + [videoCoverFileName]，与番剧下载导入
+  /// 器写合集海报**同目录同命名**），再写 [MediaCollections.coverPath]。固定文件
+  /// 名意味着换封面就是同路径覆盖，不留孤儿；扩展名恒 `.jpg` 只是沿用视频封面的
+  /// 命名约定（内容按原字节拷贝、不转码，解码不看扩展名）。
+  ///
+  /// 为什么不需要额外的「手动封面」保护标记（对比 [applyVideoCoverManual] 的
+  /// [CoverOrigin.manual]）：合集封面的刮削覆盖判据是
+  /// `coverPath == null || isUnmodifiedGeneratedArtifact(coverPath)` ——后者按
+  /// `video_sidecar_artifacts` 登记表的 sha256 比对，手选图从不进那张表，因而
+  /// **结构性**不会被在线刮削覆盖。
+  ///
+  /// 与刮削并发的互斥沿用视频侧同一对门：[VideoScrapeOperationGate]（清理期禁写）
+  /// + [VideoCoverMutationGate]（封面写互斥），与
+  /// `video_source_scrape_coordinator` 写同一路径时不打架。
+  /// [collectionCoversDirectory] 是测试接缝。
+  static Future<String> applyCollectionCover({
+    required FushiDatabase database,
+    required int collectionId,
+    required String pickedPath,
+    Directory? collectionCoversDirectory,
+  }) async {
+    final VideoScrapeOperationLease? lease =
+        VideoScrapeOperationGate.tryEnterOperation();
+    if (lease == null) throw StateError('视频刮削资料正在清理');
+    try {
+      return await VideoCoverMutationGate.runExclusive(() async {
+        final Directory covers = collectionCoversDirectory ??
+            await VideoStorage.collectionCoversDir();
+        await covers.create(recursive: true);
+        final String destPath =
+            p.join(covers.path, videoCoverFileName('$collectionId'));
+        await applyCoverFile(source: File(pickedPath), destPath: destPath);
+        await database.updateMediaCollectionCoverPath(collectionId, destPath);
+        return destPath;
       });
     } finally {
       lease.release();

--- a/fushi/lib/src/media/video/metadata/video_library_scrape_sweep.dart
+++ b/fushi/lib/src/media/video/metadata/video_library_scrape_sweep.dart
@@ -34,6 +34,40 @@ class VideoPendingScrapeWork {
   final VideoSourceScrapeWork work;
 }
 
+/// 在所有本地视频来源的刮削计划里定位某个合集对应的作品单元。
+///
+/// 「重新刮削这个合集」需要的三样东西——来源行、作品标题、稳定键——只有计划器
+/// 知道：合集本身不记 sourceId（成员才记），而作品单元是计划器按「合集 = 一个
+/// 剧集作品」现推出来的。所以入口不是「查一张表」，而是「问计划器要同一份计划」，
+/// 与自动补刮、待确认队列、批次刮削看到的作品定义**逐字节同源**。
+///
+/// 按 [VideoSourceScrapeWork.stableKey]（`collection:<id>`）匹配而不是按标题：
+/// 同名合集、改过名的合集都不会认错，也不会撞
+/// [VideoSourceScrapeWorkAmbiguous]。
+///
+/// 找不到返回 null——合集成员全是远端占位、来源已删、或该来源是目录分组模式
+/// （计划器对它返回空计划）时都会这样，调用方需要给出可见提示而不是静默失败。
+Future<VideoPendingScrapeWork?> planScrapeWorkForCollection(
+  FushiDatabase database,
+  int collectionId,
+) async {
+  final String stableKey = 'collection:$collectionId';
+  final List<SourceLibraryRow> sources =
+      (await database.getMediaSourcesByKind('video'))
+          .where((SourceLibraryRow source) => source.transport == 'local')
+          .toList(growable: false);
+  for (final SourceLibraryRow source in sources) {
+    final List<VideoSourceScrapeWork> works =
+        await VideoSourceWorkPlanner(database).plan(source);
+    for (final VideoSourceScrapeWork work in works) {
+      if (work.stableKey == stableKey) {
+        return VideoPendingScrapeWork(source: source, work: work);
+      }
+    }
+  }
+  return null;
+}
+
 /// 自动补刮调度器。生命周期跟随 HomePage 的刮削 controller。
 class VideoLibraryScrapeSweep {
   VideoLibraryScrapeSweep({

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -51,6 +51,8 @@ import 'package:fushi/src/media/video/video_library_overview.dart';
 import 'package:fushi/src/media/video/video_library_section.dart';
 import 'package:fushi/src/media/video/metadata/video_scrape_operation_gate.dart';
 import 'package:fushi/src/media/video/metadata/video_library_scrape_sweep.dart';
+import 'package:fushi/src/media/video/metadata/video_source_scrape_run_detail_dialog.dart'
+    show showVideoSourceScrapeManualBindingDialog;
 import 'package:fushi/src/media/video/metadata/video_source_scrape_task.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi/src/media/video/video_storage.dart';
@@ -6250,8 +6252,29 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         }
       },
       deleteMembersCheckboxLabel: t.delete_collection_also_videos,
-      // 视频合集特有项只保留批量字幕；在线元数据刮削统一从来源页进入。
+      // 视频合集特有项：封面 / 重刮 / 批量字幕。
+      //
+      // 封面两项只给视频合集：书架与游戏库的合集入口是横排行头，根本没有封面槽，
+      // 挂上去点了也看不出任何变化。「恢复默认」只在真有自有封面时出现——没有
+      // 可恢复的东西就不该占一行菜单。
       extraListActions: <DialogListAction>[
+        DialogListAction(
+          label: t.collection_cover_set,
+          icon: Icons.image_outlined,
+          onPressed: () => _setCollectionCover(collection),
+        ),
+        if (collection.coverPath?.isNotEmpty ?? false)
+          DialogListAction(
+            label: t.collection_cover_reset,
+            icon: Icons.undo_outlined,
+            onPressed: () => _resetCollectionCover(collection),
+          ),
+        if (widget.scrapeTaskController != null)
+          DialogListAction(
+            label: t.collection_rescrape,
+            icon: Icons.image_search,
+            onPressed: () => _rescrapeCollection(collection),
+          ),
         DialogListAction(
           label: t.video_jimaku_batch_title,
           icon: Icons.subtitles_outlined,
@@ -6259,6 +6282,114 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         )
       ],
     );
+  }
+
+  /// 合集右键「设置封面」：选图 → 落 `video_covers/collections/<id>.jpg` → 写
+  /// `media_collections.cover_path` → 刷新。
+  ///
+  /// 合集封面在此之前**没有任何用户入口**：`coverPath` 只有在线刮削和番剧下载
+  /// 导入器会写，`coverSource`（借哪个成员的图）更是只有导入器写。用户既改不了
+  /// 也退不回，只能等刮削刮对。
+  ///
+  /// 手选的图不会被后续刮削顶掉：刮削覆盖判据是「coverPath 为空，或该文件是
+  /// sidecar 登记表里 sha256 未变的生成产物」，手选图从不进那张登记表。
+  Future<void> _setCollectionCover(MediaCollectionRow collection) async {
+    final File? picked = await MediaCoverService.pickCoverImage();
+    if (picked == null) return;
+    try {
+      await MediaCoverService.applyCollectionCover(
+        database: ref.read(appProvider).database,
+        collectionId: collection.id,
+        pickedPath: picked.path,
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance.log('video.setCollectionCover', e, stack);
+      FushiToast.show(
+        msg: t.collection_cover_failed,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    _refresh();
+    FushiToast.show(
+      msg: t.collection_cover_updated,
+      severity: ToastSeverity.success,
+    );
+  }
+
+  /// 合集右键「恢复默认封面」：清 `coverPath` + 回收那张图（与删合集共用同一套
+  /// 误删护栏，见 [clearCollectionOwnCover]），封面回落成员借用链 / canonical 海报。
+  Future<void> _resetCollectionCover(MediaCollectionRow collection) async {
+    await clearCollectionOwnCover(
+      ref.read(appProvider).database,
+      collection.id,
+    );
+    _refresh();
+  }
+
+  /// 合集右键「重新刮削资料与封面」：手动指定作品身份 → 走 canonical 来源刮削
+  /// 管线重刮这一个合集。
+  ///
+  /// 这个入口在 `1637876c64`（AniDB canonical 重构）里连同旧 TMDB 版
+  /// `showCollectionScrapeDialog` 一起被删掉，理由是「在线元数据刮削统一从来源页
+  /// 进入」。但来源页的作用域是**扫描根**，用户手上是**一个刮错的合集**，两者不
+  /// 可互相替代——BUG-1662 当初补这个入口正是因为「想重刮某个合集」在库页是断头
+  /// 路。这里按 canonical 管线接回来，不复活旧刮削路径。
+  ///
+  /// 三个必需事实（来源行 / 作品标题 / 稳定键）全部问计划器要
+  /// （[planScrapeWorkForCollection]），与自动补刮、待确认队列同源；按
+  /// `collection:<id>` 匹配，改过名或同名合集都不会认错。落库走
+  /// [VideoSourceScrapeTaskController.rescrapeWorkWithLookup]——与批次内确认、
+  /// 下载导入后的精确刮削共用同一条 `_store.apply`，不新开第二套绑定保存。
+  Future<void> _rescrapeCollection(MediaCollectionRow collection) async {
+    final VideoSourceScrapeTaskController? controller =
+        widget.scrapeTaskController;
+    if (controller == null) return;
+    final FushiDatabase db = ref.read(appProvider).database;
+    final VideoPendingScrapeWork? planned =
+        await planScrapeWorkForCollection(db, collection.id);
+    if (!mounted) return;
+    if (planned == null) {
+      FushiToast.show(
+        msg: t.collection_rescrape_not_planned,
+        severity: ToastSeverity.info,
+      );
+      return;
+    }
+    final VideoSourceScrapeConfirmationCandidate? candidate =
+        await showVideoSourceScrapeManualBindingDialog(
+      context: context,
+      controller: controller,
+      source: planned.source,
+      workTitle: planned.work.title,
+      workStableKey: planned.work.stableKey,
+    );
+    if (candidate == null || !mounted) return;
+    FushiToast.show(
+      msg: t.collection_rescrape_started,
+      severity: ToastSeverity.info,
+    );
+    try {
+      await controller.rescrapeWorkWithLookup(
+        source: planned.source,
+        workTitle: planned.work.title,
+        workStableKey: planned.work.stableKey,
+        lookup: candidate.lookup,
+      );
+    } on VideoSourceScrapeCancelled {
+      // 用户在任务面板撤回了尚未执行的绑定，不是失败。
+      return;
+    } on Object catch (e, stack) {
+      ErrorLogService.instance.log('video.rescrapeCollection', e, stack);
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.collection_rescrape_failed,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    if (!mounted) return;
+    _refresh();
   }
 
   /// 合集右键「为合集获取字幕」：与合集详情页 AppBar 同一 [SubtitleWorkbenchPage]
@@ -6352,6 +6483,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
               await repo.compactAfterVideoDeleteBestEffort();
             }
           },
+          // 详情页的「重新刮削资料与封面」：controller 归 HomePage，注入库页同一
+          // 条实现，合集语境下的重刮不再是断头路（BUG-1662 入口的 canonical 复位）。
+          onRescrapeCollection:
+              widget.scrapeTaskController == null ? null : _rescrapeCollection,
         ),
       ),
     );

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/media/collections/collection_asset_reclaim.dart';
 import 'package:fushi/src/media/collections/collection_continue.dart';
 import 'package:fushi/src/media/collections/collection_episode_slot.dart';
+import 'package:fushi/src/media/media_cover_service.dart';
 import 'package:fushi/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
 import 'package:fushi/src/media/collections/collection_relation.dart';
@@ -68,6 +69,7 @@ class MediaCollectionDetailPage extends StatefulWidget {
     this.remote,
     required this.onChanged,
     this.onDeleteMembersMedia,
+    this.onRescrapeCollection,
     super.key,
   });
 
@@ -101,6 +103,11 @@ class MediaCollectionDetailPage extends StatefulWidget {
   /// app 拥有副本（封面/字幕），**保留用户原始视频文件**（导入时只存路径从不复制）。
   /// null = 详情页不提供该选项（确认框不显示复选框），退回纯解链删除。
   final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
+
+  /// 「重新刮削资料与封面」：由库页注入（刮削 controller 的生命周期归 HomePage，
+  /// 详情页不自己造）。null = 当前装配拿不到 controller，菜单项整条不渲染。
+  final Future<void> Function(MediaCollectionRow collection)?
+      onRescrapeCollection;
 
   @override
   State<MediaCollectionDetailPage> createState() =>
@@ -675,6 +682,49 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 「按季排序」：按文件名重排全表（季→集→标题，PV/特典殿后）并落盘。季 tab
   /// **展示**本身是派生的、进页面即生效，本动作只负责把落盘全序也整理成分季连续
   /// （单季合集执行后无可见变化，幂等）。
+  /// 当前合集行：`_collectionRow` 是 [_reload] 重取的最新快照，
+  /// `widget.collection` 只是进页那一刻的副本（刮削会改写 name / coverPath）。
+  MediaCollectionRow get _collection => _collectionRow ?? widget.collection;
+
+  /// AppBar「设置封面」：选图 → 落 `video_covers/collections/<id>.jpg` → 写
+  /// `media_collections.cover_path`。与库页合集右键同一条
+  /// [MediaCoverService.applyCollectionCover]，不另开落盘路径。
+  Future<void> _setCover() async {
+    final File? picked = await MediaCoverService.pickCoverImage();
+    if (picked == null) return;
+    try {
+      await MediaCoverService.applyCollectionCover(
+        database: widget.database,
+        collectionId: widget.collection.id,
+        pickedPath: picked.path,
+      );
+    } on Object catch (e, stack) {
+      ErrorLogService.instance.log('collectionDetail.setCover', e, stack);
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.collection_cover_failed,
+        severity: ToastSeverity.error,
+      );
+      return;
+    }
+    if (!mounted) return;
+    await _reload();
+    widget.onChanged();
+    FushiToast.show(
+      msg: t.collection_cover_updated,
+      severity: ToastSeverity.success,
+    );
+  }
+
+  /// AppBar「恢复默认封面」：清 `coverPath` + 回收那张图（与删合集共用同一套误删
+  /// 护栏，见 [clearCollectionOwnCover]），封面回落成员借用链 / canonical 海报。
+  Future<void> _resetCover() async {
+    await clearCollectionOwnCover(widget.database, widget.collection.id);
+    if (!mounted) return;
+    await _reload();
+    widget.onChanged();
+  }
+
   Future<void> _sortBySeason() async {
     if (_slots.isEmpty) return;
     final CollectionSeasonRegroup<CollectionEpisodeSlot> regroup =
@@ -1798,10 +1848,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                 final VideoMetadataCreditSummary credit = credits[index];
                 final String? path = credit.person.profilePath;
                 final String? url = credit.person.profileUrl;
-                final ImageProvider? image = path != null &&
-                        File(path).existsSync()
-                    ? FileImage(File(path))
-                    : (url == null ? null : AppCachedHttpImage(url));
+                final ImageProvider? image =
+                    path != null && File(path).existsSync()
+                        ? FileImage(File(path))
+                        : (url == null ? null : AppCachedHttpImage(url));
                 return SizedBox(
                   key: ValueKey<String>(
                       'video-work-credit-${credit.person.personKey}-$index'),
@@ -2366,6 +2416,16 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
 
   Future<void> _handleManageAction(_CollectionManageAction action) async {
     switch (action) {
+      case _CollectionManageAction.setCover:
+        await _setCover();
+        return;
+      case _CollectionManageAction.resetCover:
+        await _resetCover();
+        return;
+      case _CollectionManageAction.rescrape:
+        await widget.onRescrapeCollection?.call(_collection);
+        if (mounted) await _reload();
+        return;
       case _CollectionManageAction.sortBySeason:
         await _sortBySeason();
         return;
@@ -2447,6 +2507,25 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               unawaited(_handleManageAction(action)),
           itemBuilder: (BuildContext context) =>
               <PopupMenuEntry<_CollectionManageAction>>[
+            _manageMenuItem(
+              _CollectionManageAction.setCover,
+              Icons.image_outlined,
+              t.collection_cover_set,
+            ),
+            if (_collection.coverPath?.isNotEmpty ?? false)
+              _manageMenuItem(
+                _CollectionManageAction.resetCover,
+                Icons.undo_outlined,
+                t.collection_cover_reset,
+              ),
+            // 重刮入口只在库页注入了 controller 时存在（详情页不自造 controller）。
+            if (widget.onRescrapeCollection != null)
+              _manageMenuItem(
+                _CollectionManageAction.rescrape,
+                Icons.image_search,
+                t.collection_rescrape,
+              ),
+            const PopupMenuDivider(),
             _manageMenuItem(
               _CollectionManageAction.sortBySeason,
               Icons.segment,
@@ -2583,6 +2662,9 @@ enum _EpisodeMenuAction {
 }
 
 enum _CollectionManageAction {
+  setCover,
+  resetCover,
+  rescrape,
   sortBySeason,
   subtitles,
   renameEpisodes,

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -38,6 +38,7 @@ class VideoWorkDetailPage extends StatelessWidget {
     required this.onChanged,
     this.remote,
     this.onDeleteMembersMedia,
+    this.onRescrapeCollection,
     super.key,
   });
 
@@ -55,6 +56,11 @@ class VideoWorkDetailPage extends StatelessWidget {
   final CollectionRemoteContext? remote;
 
   final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
+
+  /// 透传给合集详情页的「重新刮削资料与封面」（刮削 controller 归 HomePage，
+  /// 由库页注入）。null = 不渲染该菜单项。
+  final Future<void> Function(MediaCollectionRow collection)?
+      onRescrapeCollection;
 
   @override
   Widget build(BuildContext context) {
@@ -108,6 +114,7 @@ class VideoWorkDetailPage extends StatelessWidget {
             },
             onChanged: onChanged,
             onDeleteMembersMedia: onDeleteMembersMedia,
+            onRescrapeCollection: onRescrapeCollection,
           );
         },
       );

--- a/fushi/test/media/collections/collection_asset_reclaim_test.dart
+++ b/fushi/test/media/collections/collection_asset_reclaim_test.dart
@@ -45,6 +45,10 @@ Future<File> _giveCover(
 }
 
 void main() {
+  // clearCollectionOwnCover 会驱逐解码缓存（PaintingBinding.imageCache），
+  // 没有 binding 直接抛 "Binding has not yet been initialized"。
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('deleteMediaCollectionWithAssets', () {
     test('回收被删合集自己的封面文件，同时删掉 DB 行', () async {
       final FushiDatabase db = await _openDb();
@@ -250,6 +254,69 @@ void main() {
       final int reclaimAt = body.indexOf('reclaimDeletedCollectionAssets(');
       expect(txEnd >= 0 && reclaimAt > txEnd, isTrue,
           reason: '文件 IO 必须落在 db.transaction 之后，不能在事务里做');
+    });
+  });
+
+  group('clearCollectionOwnCover', () {
+    test('清掉自有封面：coverPath 置 null 且文件被回收，合集本身还在', () async {
+      final FushiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int id = await db.createMediaCollection('A');
+      final File cover = await _giveCover(db, covers, id);
+      expect(cover.existsSync(), isTrue);
+
+      await clearCollectionOwnCover(db, id, collectionCoversDirectory: covers);
+
+      final MediaCollectionRow? row = await db.getMediaCollectionById(id);
+      expect(row, isNotNull, reason: '恢复默认封面绝不能把合集本身删掉');
+      expect(row!.coverPath, isNull);
+      expect(cover.existsSync(), isFalse,
+          reason: '清掉的自有封面不回收就是泄漏——gcOrphanCovers 扫不到这个子目录');
+    });
+
+    test('别的合集仍引用同一张图时保留文件，只清本合集的 coverPath', () async {
+      final FushiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int a = await db.createMediaCollection('A');
+      final int b = await db.createMediaCollection('B');
+      final File shared = await _giveCover(db, covers, a);
+      await db.updateMediaCollectionCoverPath(b, shared.path);
+
+      await clearCollectionOwnCover(db, a, collectionCoversDirectory: covers);
+
+      expect((await db.getMediaCollectionById(a))!.coverPath, isNull);
+      expect((await db.getMediaCollectionById(b))!.coverPath, shared.path);
+      expect(shared.existsSync(), isTrue, reason: '还有合集指着这张图，删了就是误删——护栏第 3 条');
+    });
+
+    test('目录外的用户图片只解引用，绝不删除', () async {
+      final FushiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final Directory outside =
+          await Directory.systemTemp.createTemp('outside_cover_');
+      addTearDown(() async {
+        if (await outside.exists()) await outside.delete(recursive: true);
+      });
+      final File userImage = File(p.join(outside.path, 'my.jpg'));
+      await userImage.writeAsBytes(<int>[0xFF, 0xD8, 0xFF]);
+      final int id = await db.createMediaCollection('A');
+      await db.updateMediaCollectionCoverPath(id, userImage.path);
+
+      await clearCollectionOwnCover(db, id, collectionCoversDirectory: covers);
+
+      expect((await db.getMediaCollectionById(id))!.coverPath, isNull);
+      expect(userImage.existsSync(), isTrue,
+          reason: '合集封面目录之外的文件是用户自己的，任何情况下都不许删');
+    });
+
+    test('本来就没有自有封面时是彻底的空操作', () async {
+      final FushiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int id = await db.createMediaCollection('A');
+
+      await clearCollectionOwnCover(db, id, collectionCoversDirectory: covers);
+
+      expect((await db.getMediaCollectionById(id))!.coverPath, isNull);
     });
   });
 }

--- a/fushi/test/media/media_cover_service_test.dart
+++ b/fushi/test/media/media_cover_service_test.dart
@@ -435,4 +435,104 @@ void main() {
       await expectBothCoverKeysEvicted(filename);
     });
   });
+
+  group('applyCollectionCover（video_covers/collections/<id>.jpg）', () {
+    late FushiDatabase db;
+
+    setUp(() {
+      db = FushiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+    });
+
+    test('落盘到合集封面目录并写 media_collections.cover_path', () async {
+      final int id = await db.createMediaCollection('Show');
+      final Directory covers = Directory(p.join(tempDir.path, 'collections'));
+      final File source = writePng(tempDir, 'poster.png');
+
+      final String saved = await MediaCoverService.applyCollectionCover(
+        database: db,
+        collectionId: id,
+        pickedPath: source.path,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(saved, p.join(covers.path, videoCoverFileName('$id')));
+      expect(File(saved).existsSync(), isTrue);
+      expect((await db.getMediaCollectionById(id))!.coverPath, saved,
+          reason: '只落盘不写库 = 用户换了封面但界面永远看不到');
+    });
+
+    test('只写 media_collections 一行，一个成员的封面都不动（BUG-1211）', () async {
+      final int id = await db.createMediaCollection('Show');
+      await db.upsertVideoBook(
+        VideoBooksCompanion(
+          bookUid: const Value('video/e1'),
+          title: const Value('E1'),
+          videoPath: const Value('/v/e1.mkv'),
+          coverPath: const Value('/covers/e1.jpg'),
+        ),
+      );
+      await db.addToCollection(id, MediaKind.video, 'video/e1');
+      final Directory covers = Directory(p.join(tempDir.path, 'collections2'));
+
+      await MediaCoverService.applyCollectionCover(
+        database: db,
+        collectionId: id,
+        pickedPath: writePng(tempDir, 'poster2.png').path,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(
+        (await db.getVideoBookByBookUid('video/e1'))!.coverPath,
+        '/covers/e1.jpg',
+        reason: '「匹配的是合集的封面，谁说应用到本机里面的视频了」——BUG-1211',
+      );
+    });
+
+    test('换封面是同路径覆盖写，落盘后双键驱逐解码缓存', () async {
+      final int id = await db.createMediaCollection('Show');
+      final Directory covers = Directory(p.join(tempDir.path, 'collections3'));
+      final String saved = await MediaCoverService.applyCollectionCover(
+        database: db,
+        collectionId: id,
+        pickedPath: writePng(tempDir, 'a.png').path,
+        collectionCoversDirectory: covers,
+      );
+      await populateBothCoverKeys(saved);
+
+      final String again = await MediaCoverService.applyCollectionCover(
+        database: db,
+        collectionId: id,
+        pickedPath: writePng(tempDir, 'b.png').path,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(again, saved, reason: '文件名恒为 <id>.jpg，换图不留孤儿');
+      await expectBothCoverKeysEvicted(saved);
+    });
+
+    test('源文件不可读时抛出，且不写库、不留 .tmp', () async {
+      final int id = await db.createMediaCollection('Show');
+      final Directory covers = Directory(p.join(tempDir.path, 'collections4'));
+
+      await expectLater(
+        MediaCoverService.applyCollectionCover(
+          database: db,
+          collectionId: id,
+          pickedPath: p.join(tempDir.path, 'missing.png'),
+          collectionCoversDirectory: covers,
+        ),
+        throwsA(isA<Object>()),
+      );
+
+      expect((await db.getMediaCollectionById(id))!.coverPath, isNull,
+          reason: '写盘失败还写库 = DB 指着一个不存在的文件');
+      expect(
+        covers
+            .listSync()
+            .where((FileSystemEntity e) => e.path.contains('.tmp')),
+        isEmpty,
+      );
+    });
+  });
 }

--- a/fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart
+++ b/fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart
@@ -184,13 +184,11 @@ void main() {
 
       await repo.setVideoLibraryAutoBackfillScrape(false);
       expect(repo.videoLibraryAutoBackfillScrape, isFalse);
-      expect(repo.videoAutoScrape, isTrue,
-          reason: '关掉补刮不得连带改动旧的本地封面 sweep 开关');
+      expect(repo.videoAutoScrape, isTrue, reason: '关掉补刮不得连带改动旧的本地封面 sweep 开关');
 
       await repo.setVideoAutoScrape(false);
       await repo.setVideoLibraryAutoBackfillScrape(true);
-      expect(repo.videoAutoScrape, isFalse,
-          reason: '两个键必须是两份独立状态，不是同一个键的两个名字');
+      expect(repo.videoAutoScrape, isFalse, reason: '两个键必须是两份独立状态，不是同一个键的两个名字');
       expect(repo.videoLibraryAutoBackfillScrape, isTrue);
 
       await repo.loadFromDb();
@@ -282,5 +280,54 @@ void main() {
       pending.map((VideoPendingScrapeWork e) => e.work.title),
       <String>['Unscraped Movie'],
     );
+  });
+
+  group('planScrapeWorkForCollection（「重刮这一个合集」的定位入口）', () {
+    /// 建一个多成员合集并返回 id —— 计划器只把**多成员**合集当剧集作品单元。
+    Future<int> addCollection(String name, int sourceId,
+        {required List<String> uids}) async {
+      for (final String uid in uids) {
+        await addVideo(uid, 'D:/A/$uid.mkv', sourceId, title: uid);
+      }
+      final int id = await db.createMediaCollection(name);
+      for (final String uid in uids) {
+        await db.addToCollection(id, MediaKind.video, uid);
+      }
+      return id;
+    }
+
+    test('按 stableKey 命中该合集的作品单元，并带回它所属的来源行', () async {
+      final int sourceId = await addSource('D:/A');
+      final int id =
+          await addCollection('Show', sourceId, uids: <String>['s-e1', 's-e2']);
+
+      final VideoPendingScrapeWork? planned =
+          await planScrapeWorkForCollection(db, id);
+
+      expect(planned, isNotNull);
+      expect(planned!.source.id, sourceId);
+      expect(planned.work.stableKey, 'collection:$id');
+      expect(planned.work.collection?.id, id);
+    });
+
+    test('同名合集不会认错——匹配的是 stableKey 不是标题', () async {
+      final int sourceId = await addSource('D:/A');
+      final int first =
+          await addCollection('Show', sourceId, uids: <String>['a-e1', 'a-e2']);
+      final int second =
+          await addCollection('Show', sourceId, uids: <String>['b-e1', 'b-e2']);
+
+      expect(
+          (await planScrapeWorkForCollection(db, first))!.work.collection?.id,
+          first);
+      expect(
+          (await planScrapeWorkForCollection(db, second))!.work.collection?.id,
+          second);
+    });
+
+    test('合集不在任何本地来源的计划里时返回 null（调用方据此给可见提示）', () async {
+      final int orphan = await db.createMediaCollection('No members');
+      expect(await planScrapeWorkForCollection(db, orphan), isNull);
+    });
   });
 }

--- a/fushi/test/pages/collection_detail_scrape_entry_test.dart
+++ b/fushi/test/pages/collection_detail_scrape_entry_test.dart
@@ -9,7 +9,13 @@ import 'package:fushi/src/pages/implementations/media_collection_detail_page.dar
 import 'package:fushi_core/fushi_core.dart';
 
 /// legacy cover scraper 已退出生产 UI：合集详情的管理菜单和集卡菜单都不得再
-/// 暴露旧在线匹配/重刮入口；canonical 刮削统一从媒体来源页发起。
+/// 暴露旧在线匹配/重刮入口（旧 TMDB 标题匹配 `showCollectionScrapeDialog`）。
+///
+/// 但「不得走 legacy」 ≠ 「合集不能重刮」：`1637876c64` 把 legacy 入口删掉时
+/// **连带删光了合集语境下的一切重刮入口**，用户手上一个刮错的合集在库页和详情页
+/// 都成了断头路（来源页的作用域是扫描根，替代不了「重刮这一个合集」）。所以本
+/// 守卫是双向的：既钉死 legacy 不复活，也钉死 canonical 入口必须在场——只有否定
+/// 断言的守卫，被人把功能整个删光时照样是绿的（BUG-2374）。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -55,7 +61,10 @@ void main() {
     ];
   }
 
-  Widget buildApp() => TranslationProvider(
+  Widget buildApp({
+    Future<void> Function(MediaCollectionRow collection)? onRescrapeCollection,
+  }) =>
+      TranslationProvider(
         child: MaterialApp(
           home: MediaCollectionDetailPage(
             database: db,
@@ -74,6 +83,7 @@ void main() {
             ],
             onOpenEpisode: (VideoBookRow _) {},
             onChanged: () {},
+            onRescrapeCollection: onRescrapeCollection,
           ),
         ),
       );
@@ -99,8 +109,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('合集管理菜单不暴露 legacy 刮削入口', (WidgetTester tester) async {
+  testWidgets('没有刮削 controller 时不渲染任何重刮入口', (WidgetTester tester) async {
     useSurface(tester);
+    // 不注入 onRescrapeCollection = 拿不到刮削 controller 的装配，此时菜单里
+    // 一条重刮入口都不该有。
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
@@ -108,11 +120,53 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text(t.video_collection_scrape),
+      find.text(t.collection_rescrape),
       findsNothing,
-      reason: '合集在线刮削必须从来源页进入，详情页不得再走 legacy 标题匹配',
+      reason: '没有 controller 就渲染重刮入口 = 点了必然什么都不发生',
     );
     expect(find.text(t.collection_sort_by_season), findsOneWidget);
+  });
+
+  testWidgets('注入 controller 后管理菜单必须有 canonical 重刮入口',
+      (WidgetTester tester) async {
+    useSurface(tester);
+    final List<int> rescraped = <int>[];
+    await tester.pumpWidget(buildApp(
+      onRescrapeCollection: (MediaCollectionRow collection) async =>
+          rescraped.add(collection.id),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_horiz));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(t.collection_rescrape),
+      findsOneWidget,
+      reason: '「重刮这一个合集」是 BUG-1662 的诉求，来源页的扫描根作用域替代不了',
+    );
+
+    await tester.tap(find.text(t.collection_rescrape));
+    await tester.pumpAndSettle();
+    expect(rescraped, <int>[collectionId],
+        reason: '菜单项必须真的把当前合集交给注入的重刮实现，不能只是长得像');
+  });
+
+  testWidgets('管理菜单提供合集封面设置，且未设封面时不显示恢复默认', (WidgetTester tester) async {
+    useSurface(tester);
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_horiz));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.collection_cover_set), findsOneWidget,
+        reason: '合集封面此前没有任何用户入口，只有刮削和下载导入会写');
+    expect(
+      find.text(t.collection_cover_reset),
+      findsNothing,
+      reason: 'coverPath 为空时没有可恢复的东西，不该占一行菜单',
+    );
   });
 
   testWidgets('集卡菜单不暴露 legacy 条目信息重刮入口', (WidgetTester tester) async {


### PR DESCRIPTION
两条用户报告的合集缺口，同属「合集这条路径没接上单卡早就有的能力」。

---

## ① BUG-2374：补回合集设置封面与重新刮削入口

用户从截图指出视频合集右键菜单里「选封面」没了，追问后又指出「缺少重新刮削某个合集」。两条独立缺口，一条回归一条从未接线。

**重新刮削合集 = 回归。** `1637876c64`（refactor(video): make AniDB the canonical scraper）删 legacy TMDB 刮削时，把合集语境下的所有重刮入口一起删光，理由写的是「在线元数据刮削统一从来源页进入」。但来源页的作用域是**扫描根**（`VideoSourceWorkPlanner.plan(source)`），用户手上是**一个刮错的合集**——BUG-1662 当初补这个入口正是因为库页「想重刮某个合集」是断头路。物证：`video_collection_scrape` 这个 i18n key 删除后成了全仓零引用的孤儿。

**合集封面 = 从未接线。** `media_collections.cover_path`（合集自有图，v61/BUG-1211）只有刮削和番剧下载导入器会写，`coverSource` 更是只有导入器写，**UI 层零入口**；而合集卡渲染把 `coverPath` 排第一优先。用户既改不了也退不回。

改动：库页右键与详情页管理菜单两处同源，补「设置封面 / 恢复默认封面（仅在真有自有封面时出现）/ 重新刮削资料与封面」。

- `MediaCoverService.applyCollectionCover`：落 `video_covers/collections/<id>.jpg`（与导入器写合集海报同目录同命名），走既有 `applyCoverFile` 收口 + 视频侧两把互斥门。**不需要**额外 manual 保护标记：刮削覆盖判据按 `video_sidecar_artifacts` 的 sha256 登记比对，手选图从不进那张表 → 结构性免疫覆盖。
- `clearCollectionOwnCover`：先落库置 null，再把快照交给既有的 `reclaimDeletedCollectionAssets`，**复用删合集同一套三条误删护栏**，不写第二套删除条件。
- `planScrapeWorkForCollection`：问计划器要同一份计划，按 `stableKey == 'collection:<id>'` 定位（同名/改名合集都不会认错）。重刮走既有共享入口 `showVideoSourceScrapeManualBindingDialog` → `rescrapeWorkWithLookup`，与批次内确认共用同一条 `_store.apply`。

守卫升级为双向：`collection_detail_scrape_entry_test.dart` 原来只断言「不得有 legacy 入口」——所以当初把功能整个删光时它照样是绿的。

---

## ② BUG-2389：合集/系列删除支持「同时删除本地文件」

用户：「系列右键不能删除本地文件」。属实，且是结构性的。

- **单卡**删除 → `showDeleteScopeConfirm` 有「同时删除本地文件」勾选 → `deleteVideoBooksWithDecision`。
- **合集/系列卡**右键删除 → 确认框只有一个「同时删除其中的视频」勾选，执行时裸调 `repo.deleteVideoBookAndReclaimAssets(uid, compactDatabase: false)`，**不传 `deleteLocalFiles`**。所以无论怎么勾，磁盘上的原始视频一个都不会少。合集详情页同病。

改动：

- `FushiDestructiveConfirmDialog` 支持**二级勾选**：只在一级勾上后渲染、缩进一档；一级取消时二级**一并归零**（否则勾了「删文件」再取消「删条目」，状态会留着，下次勾回一级就带上一个用户没再确认过的破坏性选项）。结果对象的 `nestedChecked` 语义蕴含 `checked`。
- **视频合集删成员改走 `deleteVideoBooksWithDecision`**。这是根因的关键：裸调仓库方法不只是少传一个 bool——它同时少了 `MediaHandleRegistry.releaseHolding`（Windows 上不放句柄 `File.delete()` 直接 errno 32，用户看到「删除成功」而盘上一个文件没少）与 `prepareVideoDownloadJobsForLocalDelete`（正在做种的文件不先标 skip，种子会因「文件缺失」被整个停掉）。
- 勾选只在**真有本机文件的成员**存在时摆出；删不掉的原件经 `reportLocalFileDeleteFailures` 如实上报。
- 一级文案去掉「（保留你的原始视频文件）」那半句（17 份 json，各语言主干本身是地道翻译，只摘掉括号说明）——二级勾选出现后那半句会说谎。
- 书架 / 游戏库**行为零变化**：不注入二级文案，回调恒收到 false。

---

## 一处自查

②的过程中发现 ① **漏跑了「目录枚举型守卫」整批**，`legacy_video_scrape_surface_guard_test.dart` 因此变红——不是功能问题，是①的新方法**文档注释**里写了已退役符号名 `showCollectionScrapeDialog`，而那条守卫按字面量扫 `lib/` 全树、不区分注释与代码。已改注释（不放宽守卫），并补跑整批 51 条。

## 验证

- `flutter analyze`（含 test 目录）：No issues found.
- 目录枚举型守卫整批 51 条：**368 tests PASSED**（基线 362 + 本次新增 4 + 2 条 develop 期间漂移）。
- 定向测试：合集菜单 / 合集详情 / 封面服务 / 回收 / 刮削定位 / legacy 守卫共 **75 tests PASSED**（退出码 0，非 `| tail` 判绿）。
- 未做真机验证。改的是菜单接线、确认框状态机与删除路径接线，单测覆盖了真实文件系统、真实 DB 与弹窗交互；「删本地文件」这一维的磁盘行为由既有的 `deleteVideoBooksWithDecision` 链路负责，本 PR 没有改它。
