### PR TITLE
fix(asr): 模型文件装不起来时退回下载态，不再甩 protobuf 报错（BUG-2375）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2375](bugs/BUG-2375-asr-unusable-model.md) | ✅ | ✅ | ASR 模型文件损坏后永久卡死：Protobuf parsing failed 且无自愈路径 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2375-asr-unusable-model.md
+++ b/docs/bugs/BUG-2375-asr-unusable-model.md
@@ -1,0 +1,38 @@
+## BUG-2375 · ASR 模型文件损坏后永久卡死：Protobuf parsing failed 且无自愈路径
+- **报告**：2026-09-09（用户：截图，设备端语音转录弹层）
+- **真实性**：✅ 真 bug。根因 `packages/asr_core/lib/src/asr/asr_model_manifest.dart:1096`（上游 `hajisensai/fushi-subtitles`）的 `isAsrModelFileReady` 只判「存在且非空」，坏档永远被判为已就绪
+- **[x] ① 已修复** — 上游 PR [#9](https://github.com/hajisensai/fushi-subtitles/pull/9)（merge commit `b8a7b76`）：`AsrEngineLoader._openManifestSession` 在建会话失败时用 `isOnnxUnreadableModelFailure` 分类，命中「文件读不出图」的标记就删掉该文件并抛 `AsrModelFileUnusableException`；本仓 bump 钉定 sha + `asr_transcribe_sheet.dart` 的 `_failWith` 把这类失败退回既有的「需要下载」阶段
+- **[x] ② 已加自动化测试** — 上游 `packages/asr_core/test/asr/asr_model_file_unusable_test.dart`（6 条：用户报障原文分类、三种 ORT 实测原文、EP/显存类失败的负向判定、坏档从磁盘消失且不牵连同目录其它文件）
+- **备注**：
+
+### 现象
+
+转录弹层里只有一句，重试同样复现：
+
+```
+转录失败: Bad state: PlatformException(ORT_ERROR, Load model from
+D:\hibiki\support\asr_models\reazonspeech-k2-v2\encoder-epoch-99-avg-1.onnx
+failed:Protobuf parsing failed., false, null)
+```
+
+### 定性证据
+
+本机 onnxruntime 1.22 实测四种情形（错误串来自 ORT C++ 核心，FFI 与插件两个宿主一致）：
+
+| 文件状态 | ORT 报错 |
+|---|---|
+| 不存在 | `NO_SUCHFILE ... File doesn't exist` |
+| 0 字节 | `ModelProto does not have a graph` |
+| **被截断 / 内容不是 onnx** | **`INVALID_PROTOBUF ... Protobuf parsing failed`** ← 与报障逐字一致 |
+
+所以那份 encoder **存在、非空、内容是残档**。
+
+### 根因
+
+不在下载器：`ModelFileDownloader._finalizePart` 在 rename 前的长度校验是严的，坏档是**转正之后**才产生的（写盘中断、外部截断、断电后 NTFS 内容 NUL 化）。真正的问题是这种档没有出路——`isAsrModelFileReady` 判「存在且非空」，坏档永远满足它：设置页显示已下载、`downloadAll` 当就绪跳过、转录每次在同一处炸，用户除了手删整个模型目录没有别的办法，而错误文本里没有任何提示指向那里。
+
+`Bad state:` 前缀来自 `asr_transcribe_isolate.dart:215`——整本转录跑在后台 isolate，错误跨边界被统一压成 `StateError(文本)`，所以 UI 侧只能按文本识别，不能按异常类型。
+
+### 刻意没做的事
+
+**没有**把 `isAsrModelFileReady` 改成按清单 `expectedBytes` 强校验。清单字节数会因上游重新导出而过期，强校验会把「长度不符但确实跑得起来」的旧档误判成缺失，逼用户重下几百 MB（原注释里已写明这条宽松语义是故意的）。长度只作为异常上的诊断字段，不参与判定。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77112 (4536 per locale)
+/// Strings: 77129 (4537 per locale)
 ///
-/// Built on 2026-09-09 at 08:11 UTC
+/// Built on 2026-09-09 at 08:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6294,6 +6294,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   String get dialog_background_close => 'Close (task keeps running)';
   String get reader_timer_show => 'Show reading timer';
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -16952,6 +16954,9 @@ class _StringsAr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'إظهار مؤقت القراءة';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -27837,6 +27842,9 @@ class _StringsDe extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Lesetimer anzeigen';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -38776,6 +38784,9 @@ class _StringsEs extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar temporizador de lectura';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -49749,6 +49760,9 @@ class _StringsFr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Afficher le minuteur de lecture';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -60524,6 +60538,9 @@ class _StringsId extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Tampilkan pengatur waktu baca';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -71391,6 +71408,9 @@ class _StringsIt extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostra timer di lettura';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -81639,6 +81659,9 @@ class _StringsJa extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '読書タイマーを表示';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -91897,6 +91920,9 @@ class _StringsKo extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '독서 타이머 표시';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -102721,6 +102747,9 @@ class _StringsNl extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Leestimer tonen';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -113598,6 +113627,9 @@ class _StringsPtBr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar cronômetro de leitura';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -124452,6 +124484,9 @@ class _StringsRu extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Показывать таймер чтения';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -135106,6 +135141,9 @@ class _StringsTh extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'แสดงตัวจับเวลาการอ่าน';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -145876,6 +145914,9 @@ class _StringsTr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Okuma zamanlayıcısını göster';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -156617,6 +156658,9 @@ class _StringsVi extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Hiển thị bộ đếm thời gian đọc';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 // Path: <root>
@@ -166482,6 +166526,8 @@ class _StringsZhCn extends _StringsEn {
   String get dialog_background_close => '关闭（任务继续在后台运行）';
   @override
   String get reader_timer_show => '显示阅读计时器';
+  @override
+  String get audiobook_transcribe_model_discarded => '模型文件读不出来，已自动清除，请重新下载。';
 }
 
 // Path: <root>
@@ -176416,6 +176462,9 @@ class _StringsZhHk extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '顯示閱讀計時器';
+  @override
+  String get audiobook_transcribe_model_discarded =>
+      'The model file could not be read and was removed. Download it again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -185748,6 +185797,8 @@ extension on _StringsEn {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Show reading timer';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -195075,6 +195126,8 @@ extension on _StringsAr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'إظهار مؤقت القراءة';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -204447,6 +204500,8 @@ extension on _StringsDe {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Lesetimer anzeigen';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -213810,6 +213865,8 @@ extension on _StringsEs {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar temporizador de lectura';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -223182,6 +223239,8 @@ extension on _StringsFr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Afficher le minuteur de lecture';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -232525,6 +232584,8 @@ extension on _StringsId {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Tampilkan pengatur waktu baca';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -241890,6 +241951,8 @@ extension on _StringsIt {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostra timer di lettura';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -251182,6 +251245,8 @@ extension on _StringsJa {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '読書タイマーを表示';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -260478,6 +260543,8 @@ extension on _StringsKo {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '독서 타이머 표시';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -269836,6 +269903,8 @@ extension on _StringsNl {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Leestimer tonen';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -279189,6 +279258,8 @@ extension on _StringsPtBr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar cronômetro de leitura';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -288549,6 +288620,8 @@ extension on _StringsRu {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Показывать таймер чтения';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -297881,6 +297954,8 @@ extension on _StringsTh {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'แสดงตัวจับเวลาการอ่าน';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -307228,6 +307303,8 @@ extension on _StringsTr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Okuma zamanlayıcısını göster';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -316569,6 +316646,8 @@ extension on _StringsVi {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Hiển thị bộ đếm thời gian đọc';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }
@@ -325829,6 +325908,8 @@ extension on _StringsZhCn {
         return '关闭（任务继续在后台运行）';
       case 'reader_timer_show':
         return '显示阅读计时器';
+      case 'audiobook_transcribe_model_discarded':
+        return '模型文件读不出来，已自动清除，请重新下载。';
       default:
         return null;
     }
@@ -335099,6 +335180,8 @@ extension on _StringsZhHk {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '顯示閱讀計時器';
+      case 'audiobook_transcribe_model_discarded':
+        return 'The model file could not be read and was removed. Download it again.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Show reading timer"
+  "reader_timer_show": "Show reading timer",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "إظهار مؤقت القراءة"
+  "reader_timer_show": "إظهار مؤقت القراءة",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Lesetimer anzeigen"
+  "reader_timer_show": "Lesetimer anzeigen",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar temporizador de lectura"
+  "reader_timer_show": "Mostrar temporizador de lectura",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Afficher le minuteur de lecture"
+  "reader_timer_show": "Afficher le minuteur de lecture",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Tampilkan pengatur waktu baca"
+  "reader_timer_show": "Tampilkan pengatur waktu baca",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostra timer di lettura"
+  "reader_timer_show": "Mostra timer di lettura",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "読書タイマーを表示"
+  "reader_timer_show": "読書タイマーを表示",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "독서 타이머 표시"
+  "reader_timer_show": "독서 타이머 표시",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Leestimer tonen"
+  "reader_timer_show": "Leestimer tonen",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar cronômetro de leitura"
+  "reader_timer_show": "Mostrar cronômetro de leitura",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Показывать таймер чтения"
+  "reader_timer_show": "Показывать таймер чтения",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน"
+  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Okuma zamanlayıcısını göster"
+  "reader_timer_show": "Okuma zamanlayıcısını göster",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc"
+  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。",
   "video_shader_tier_ultra_hint_mobile": "Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。",
   "dialog_background_close": "关闭（任务继续在后台运行）",
-  "reader_timer_show": "显示阅读计时器"
+  "reader_timer_show": "显示阅读计时器",
+  "audiobook_transcribe_model_discarded": "模型文件读不出来，已自动清除，请重新下载。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4534,5 +4534,6 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "顯示閱讀計時器"
+  "reader_timer_show": "顯示閱讀計時器",
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
 }

--- a/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
+++ b/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
@@ -271,6 +271,10 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
   String? _finishedSrt;
   String? _error;
 
+  /// 本轮里引擎丢弃过一个读不出图的模型文件（见 [_failWith]）。只用来在「需要
+  /// 下载」那一阶段多说一句为什么又要下载，不参与阶段判定。
+  bool _modelDiscarded = false;
+
   // 下载进度。
   int _downloadReceived = 0;
   int _downloadTotal = 0;
@@ -349,11 +353,37 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() {
-        _phase = _Phase.error;
-        _error = '$e';
-      });
+      _failWith(e);
     }
+  }
+
+  /// 失败的统一落点：先分辨「模型文件本身读不出图」这一类。
+  ///
+  /// 引擎判定某个清单文件装不起来时会把它删掉再抛
+  /// `AsrModelFileUnusableException`（上游 fushi_asr_core）。但整本转录跑在后台
+  /// isolate，错误跨边界只剩字符串——`asr_transcribe_isolate.dart` 统一压成
+  /// `StateError(文本)`，用户从前看到的 `Bad state: PlatformException(ORT_ERROR,
+  /// ... Protobuf parsing failed)` 就是这么来的——所以这里只能按文本判据识别，
+  /// 用的是上游那个纯函数。
+  ///
+  /// 识别到就**直接重新规划**，不为这条路径新造阶段：坏档已经不在磁盘上，
+  /// `plan.modelReady` 自然是 false，界面落回既有的「需要下载」阶段，那儿本来
+  /// 就有下载按钮和进度条，用户点一下就把模型重新取回来了。
+  ///
+  /// 一轮里只自愈一次（[_modelDiscarded] 兼作闸门）：`_refreshPlan` 失败时也走
+  /// 这里，两边互相调用，不设闸门的话「规划本身报同类错误」会转成死循环。第二
+  /// 次就老老实实落错误态，把原文给出去。
+  void _failWith(Object error) {
+    final String text = '$error';
+    if (!_modelDiscarded && isOnnxUnreadableModelFailure(text)) {
+      _modelDiscarded = true;
+      _refreshPlan();
+      return;
+    }
+    setState(() {
+      _phase = _Phase.error;
+      _error = text;
+    });
   }
 
   void _startDownload() {
@@ -386,10 +416,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
       },
       onError: (Object e, StackTrace _) {
         if (!mounted) return;
-        setState(() {
-          _phase = _Phase.error;
-          _error = '$e';
-        });
+        _failWith(e);
       },
       onDone: () {
         if (!mounted) return;
@@ -450,10 +477,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
         onError: (Object e, StackTrace _) async {
           await _releaseRunning();
           if (!mounted) return;
-          setState(() {
-            _phase = _Phase.error;
-            _error = '$e';
-          });
+          _failWith(e);
         },
         onDone: () async {
           await _releaseRunning();
@@ -461,10 +485,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
       );
     } catch (e) {
       if (!mounted) return;
-      setState(() {
-        _phase = _Phase.error;
-        _error = '$e';
-      });
+      _failWith(e);
     }
   }
 
@@ -550,6 +571,13 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
             size: FushiByteFormat.bytes(plan?.bytesToDownload),
           ),
         );
+        // 是「装不起来被清掉」才退回下载的，得说清楚——否则用户刚下完的模型又
+        // 要求下载一遍，看起来像下载没生效。
+        if (_modelDiscarded) {
+          sb
+            ..writeln()
+            ..write(t.audiobook_transcribe_model_discarded);
+        }
         _appendProbeHint(sb, plan);
         return sb.toString();
       case _Phase.downloading:

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
   # 字幕重定时（拿 ASR 转录当参照修好已有字幕的时间轴）。与 fushi_asr_core 同仓同 sha。
   #
   # 只依赖 fushi_asr_core，**不含** ONNX 后端：算法那半边住在 fushi_asr 包里的话会
@@ -28,7 +28,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_subtitles
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
   archive: ^3.6.1
   async_zip: ^0.1.0
   basic_utils: ^5.7.0

--- a/fushi/test/media/audiobook/asr_transcribe_sheet_test.dart
+++ b/fushi/test/media/audiobook/asr_transcribe_sheet_test.dart
@@ -94,6 +94,10 @@ class _FakeService extends AsrTranscriptionService {
 
   /// 非 null 时 plan 报「EP 探测失败」（模拟有 GPU 的机器探测抛错被推荐成 CPU）。
   final String? probeError;
+
+  /// 非 null 时 `start` 抛它。装模型文件读不出图那条路径：引擎在 load 阶段把坏
+  /// 档删掉再抛，所以抛之前 `ready` 归 false——与真实时序一致。
+  Object? startError;
   int downloadCalls = 0;
   int discardCalls = 0;
   final List<AsrLanguage> planLanguages = <AsrLanguage>[];
@@ -174,6 +178,12 @@ class _FakeService extends AsrTranscriptionService {
   }) async {
     lastStartLanguage = language;
     lastStartPreference = preference;
+    final Object? failure = startError;
+    if (failure != null) {
+      // 引擎判定坏档时是「先删文件、再抛」，所以下一次 plan 必然未就绪。
+      ready = false;
+      Error.throwWithStackTrace(failure, StackTrace.current);
+    }
     final AsrEngineSessions sessions = AsrEngineSessions(
       encoder: _NoopSession(),
       decoder: _NoopSession(),
@@ -639,5 +649,57 @@ void main() {
     await tester.tap(find.widgetWithText(TextButton, t.cancel));
     await tester.pumpAndSettle();
     expect(result, isNull);
+  });
+
+  // BUG-2375：模型文件被截断/内容不是 onnx 时 ORT 报 `Protobuf parsing failed`，
+  // 而整本转录跑在后台 isolate，错误跨边界只剩字符串（`Bad state: ...`），所以
+  // 这里的判据只能按文本走。引擎已经把坏档删掉，界面必须退回「需要下载」并说明
+  // 原因——从前是停在错误态、把那句 protobuf 原文甩给用户，重试永远同一个错。
+  testWidgets('模型读不出图：退回下载态并说明模型已被清除', (WidgetTester tester) async {
+    final _FakeService service = _FakeService(ready: true, jobsDir: tmp)
+      ..startError = StateError(
+        'PlatformException(ORT_ERROR, Load model from '
+        r'D:\hibiki\support\asr_models\reazonspeech-k2-v2\'
+        'encoder-epoch-99-avg-1.onnx failed:Protobuf parsing failed., '
+        'false, null)',
+      );
+    await tester.pumpWidget(wrap(service, (String? _) {}));
+    await tester.tap(find.byKey(const ValueKey<String>('open')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.widgetWithText(FilledButton, t.audiobook_transcribe_start),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.widgetWithText(FilledButton, t.audiobook_transcribe_model_download),
+      findsOneWidget,
+      reason: '坏档已被删，界面该落回既有的下载阶段',
+    );
+    expect(
+      find.textContaining(t.audiobook_transcribe_model_discarded),
+      findsOneWidget,
+      reason: '不说一句为什么，用户会以为刚下好的模型没生效',
+    );
+  });
+
+  testWidgets('非坏档失败仍停在错误态，不谎报模型被清除', (WidgetTester tester) async {
+    final _FakeService service = _FakeService(ready: true, jobsDir: tmp)
+      ..startError = StateError('cuda out of memory');
+    await tester.pumpWidget(wrap(service, (String? _) {}));
+    await tester.tap(find.byKey(const ValueKey<String>('open')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.widgetWithText(FilledButton, t.audiobook_transcribe_start),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('cuda out of memory'), findsOneWidget);
+    expect(
+      find.textContaining(t.audiobook_transcribe_model_discarded),
+      findsNothing,
+    );
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,8 +885,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/asr_core"
-      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
-      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
+      resolved-ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"
@@ -894,8 +894,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/asr_subtitles"
-      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
-      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
+      resolved-ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,7 +145,7 @@ dependency_overrides:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: b8a7b76016dd0b7eb55671bbe8b4e054af965d64
 
 # Melos 7 的配置位置就是这里（7.0 起 melos.yaml 被废弃）。包列表不再重复声明：
 # 成员由上面的 workspace: 决定，melos 直接读它。


### PR DESCRIPTION
修 BUG-2375。用户点转录只看到一句，重试永远同一个错：

```
转录失败: Bad state: PlatformException(ORT_ERROR, Load model from
D:\hibiki\support\asr_models\reazonspeech-k2-v2\encoder-epoch-99-avg-1.onnx
failed:Protobuf parsing failed., false, null)
```

## 定性证据

本机 onnxruntime 1.22 实测四种情形（错误串出自 ORT C++ 核心，FFI 与插件两个宿主一致）：

| 文件状态 | ORT 报错 |
|---|---|
| 不存在 | `NO_SUCHFILE ... File doesn't exist` |
| 0 字节 | `ModelProto does not have a graph` |
| **被截断 / 内容不是 onnx** | **`INVALID_PROTOBUF ... Protobuf parsing failed`** ← 与报障逐字一致 |

所以那份 encoder 存在、非空、内容是残档。

## 根因

不在下载器（`_finalizePart` 在 rename 前的长度校验是严的），坏档是**转正之后**产生的。问题是这种档没有出路：`isAsrModelFileReady` 判「存在且非空」，坏档永远满足它——设置页显示已下载、`downloadAll` 当就绪跳过、转录每次在同一处炸，用户除了手删整个模型目录没有别的办法，而错误文本里没有任何提示指向那里。

`Bad state:` 前缀来自 `asr_transcribe_isolate.dart:215`：整本转录跑在后台 isolate，错误跨边界被统一压成 `StateError(文本)`，所以 UI 只能按文本识别，不能按异常类型。

## 改动

**上游** `hajisensai/fushi-subtitles` PR #9（已合并，merge commit `b8a7b76`；本 PR 把三处钉定 sha 一起 bump——`fushi/pubspec.yaml` 两条 + 根 `pubspec.yaml` 的 override，注释要求它们逐字一致）：引擎建会话失败时先分类，只有命中「文件读不出图」的标记才判坏档，删掉那个文件并抛 `AsrModelFileUnusableException`；EP / 显存 / 运行时类失败原样抛出，一个文件都不删。

**本仓**：转录弹层四个失败落点收敛到 `_failWith`，按上游那个纯函数做文本判据。识别到就直接重新规划——坏档已不在磁盘上，`plan.modelReady` 自然为 false，界面落回**既有的**「需要下载」阶段，不为这条路径新造阶段；再加一句 i18n 说明模型是被清除了，否则用户会以为刚下好的模型没生效。`_modelDiscarded` 兼作闸门，一轮只自愈一次，避免 `_failWith` ↔ `_refreshPlan` 互调成死循环。

## 刻意没做的事

**没有**把 `isAsrModelFileReady` 改成按清单 `expectedBytes` 强校验。清单字节数会因上游重新导出而过期，强校验会把「长度不符但确实跑得起来」的旧档误判成缺失，逼用户重下几百 MB（原注释里已写明这条宽松语义是故意的）。长度只作为异常上的诊断字段，不参与判定。

## 验证

- `flutter analyze`（含 test）：**No issues found**
- `flutter test test/i18n test/media/audiobook`：**1090 passed**，退出码 0
- `flutter test test/media/audiobook/asr_transcribe_sheet_test.dart`：**17 passed**，退出码 0（含本 PR 新增 2 条，日志确认执行）
- 上游 `dart test`（asr_core 全量）：**338 passed**，退出码 0；新增 6 条单测

https://claude.ai/code/session_01JrooMsYHt7muUsZvtnUWLd
