### PR TITLE
fix(video): 播放返回只刷该刷的，不再拖起全库封面回填（BUG-2376）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2179 条。点号进各自文件。
+> 共 2180 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2376](bugs/BUG-2376-video-exit-refresh-lag.md) | ✅ | ✅ | 从视频退出后库页刷新卡顿 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |
 | [BUG-2361](bugs/BUG-2361-siglus-eightarg-lookup-no-hit.md) | ✅ | ✅ | 八参数Siglus捕获台词后点击正文直接推进且无查词命中 |
 | [BUG-2360](bugs/BUG-2360-siglus-child-delayed-attach.md) | ✅ | ✅ | Siglus启动器子进程绕过延迟附着并抢先LE初始化 |

--- a/docs/bugs/BUG-2376-video-exit-refresh-lag.md
+++ b/docs/bugs/BUG-2376-video-exit-refresh-lag.md
@@ -1,0 +1,55 @@
+## BUG-2376 · 从视频退出后库页刷新卡顿
+- **报告**：2026-09-09（用户：「现在每次从视频里退出来都会卡一两秒」）
+- **真实性**：⚠️ 部分证实。**测到过**最坏单帧 1848ms 的停顿，时间线与库页封面回填重合；
+  但**无法稳定复现**，故 1~2 秒的用户现象不能算已定位到唯一根因。
+  - 停顿位置：`fushi/lib/src/pages/implementations/home_video_page.dart` 的 `_open()`
+    从播放器 `await` 返回后调用的 `_refresh()`（旧代码 `home_video_page.dart:1968`），
+    而不是视频页销毁或退全屏。
+  - 已实测**排除**的三条：
+    - 退出汇聚点 `_handleBackOrExit` / `exitAfterPersist`：pop 无条件同步，落库 fire-and-forget。
+    - 视频页 `dispose()` + 原生 mpv/纹理拆除：探针实测 `backPressed→disposeBegin` 374ms
+      （路由转场动画），`disposeBegin→disposeEnd` **5ms**；pop 后最坏单帧 131ms。
+    - `_loadLibraryMapsInner` 的 14 条全表读：真实 1024 部库上 **35~151ms**
+      （离线基准 `flutter test` 直连生产库副本），09-07 `2fb9e0641a` 新增的
+      `db.allVideoBooks()` + `getMediaSourcesByKind('video')` 两条只占 ~12ms。
+  - 停顿签名：帧计时 `build=37ms raster=2ms total=774ms`——build 与 raster 都不慢，
+    **慢的是帧根本没被服务**，即 UI isolate 的事件循环被非帧工作堵住。空窗期内唯一在跑的
+    是 `_maybeBackfillCovers()`（`home_video_page.dart` 内）：`listAll()` 再读一遍全表，
+    然后逐行同步 `File.existsSync()`（1024 次）、候选行同步 `statSync()`、每个候选一次
+    同步 64KB 头部读（判据在 `fushi/lib/src/media/video/video_cover_extractor.dart:358`）
+    并串行 spawn ffmpeg——**全部压在 UI isolate 上，快速跳过分支整段不 await 让出**。
+  - **无法复现的原因（重要）**：历次最坏帧 1848 → 1366 → 1115 → 780 → 226 → 249ms
+    单调下降，是操作系统页缓存在一轮轮跑之间被焐热。首次触碰那 1024 个封面文件与候选
+    视频时是真实首次磁盘 IO。试过「先真播 33 秒再退出」以冲掉页缓存（本机内存大，未奏效），
+    也试过两次独立冷跑，均未再现。
+  - **未被排除的候选**：全部测量都在**离屏集成 runner + debug 构建**里做的，窗口在屏外且
+    `WS_EX_NOACTIVATE`，没有真实 DWM 合成、没有真正的原生全屏。因此
+    `fushi/windows/runner/win32_window.cpp:683-700` 退全屏时 `SetWindowPlacement` +
+    `ShowWindow(SW_MAXIMIZE)` 的两次 WM_SIZE（embedder 每次阻塞平台线程等一帧新内容），
+    以及 HDR 直通下 `hdr_video_host_window.cpp:134-142` 的 `SetMainTransparency(false)`
+    强制 DWM 全窗重合成，**结构上就测不到**，只是没被测到、不是被排除。
+- **[x] ① 已修复（部分：把已证实的无效功从退出路径上摘掉）** —
+  新增 `_refreshAfterPlayback()` 只给 `_open()` 用：只重读书架 `listForShelf()` +
+  「最近观看」两张表（`_loadWatchRecency()`）。看完一个视频只可能改动 `video_books`
+  那一行与 `StudyClock` 写的 `study_segments`；合集 / 来源 / 刮削资料 / 元数据作品·图片·
+  分集·花絮 / 媒体图组这十二张表播放页一行都不写（换音轨只动
+  `media_collections.audio_track_id`，库页不渲染它，且有 `watchCollectionTablesChanged`
+  流兜底），因此全量重算在这条路径上是纯无效功。封面回填是「给缺封面的存量行补抽帧」的
+  后台产线，播放不产生新的缺封面行，其真正触发时机（新行入库）由 `watchVideoBookUids`
+  流 → `_onVideoUidsChanged` → `_refresh()` 覆盖，入口另有 `initState` 与下拉刷新
+  （后者还会先清失败记账重试），从退出路径摘掉不会让任何条目永久漏掉。
+  `_refresh()` 本体与其余 9 个调用点原样不动。
+  顺带修掉一个真 bug：`_maybeBackfillCovers` 的节流重列写成
+  `setState(() => _future = widget.repo.listForShelf())`，箭头体把赋值结果（一个 Future）
+  当闭包返回值交给 `setState`，**debug 断言「setState() callback argument returned a
+  Future」当场抛出、整个回填循环被掀掉**（实测探针 `backfill.threw`），release 因断言被
+  编译掉而侥幸跑通——于是「封面回填在 debug 下根本不工作」长期无人发现。改块体。
+- **[x] ② 已加自动化测试** — `fushi/test/tools/load_paths_perf_guard_test.dart`
+  新增两条守卫：`cover backfill never hands setState a closure returning a Future`
+  与 `returning from the player does not rerun the whole library load`（后者同时钉住
+  窄重载与全量重载共用 `_buildWatchRecency` 这一单一真相源，以及两条路径各记各的代）。
+  原先按字面量钉死那行 `setState` 的断言改为钉「几次重列」的不变式。
+- **备注**：用户现象是否已消失**未经真机确认**——本机所有测量都无法再现 1~2 秒，
+  离屏 runner 也够不到真实窗口/全屏/DWM 那一层。下一步最省事的判别是问用户一句：
+  **窗口模式（不进全屏）退出还卡不卡**——不卡则元凶是退全屏的 Win32 几何握手
+  （上面「未被排除的候选」第一条），卡则回到本条已摘掉的那批 UI isolate 同步 IO。

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -154,6 +154,53 @@ typedef _VideoTagChip = ({String label, Color? color});
 /// 标签：视频书与书架（EPUB/SRT）**共用同一套标签系统**（共享 `BookTags` 标签池
 /// + `video_book_tag_mappings` 映射）。顶部有标签筛选栏（共享 [selectedTagIdsProvider]，
 /// 与书架联动），卡片渲染所挂标签，长按弹菜单（编辑标签 / 设置封面 / 删除）。
+/// 「最近观看时刻」的两份映射：按 bookUid 键控的当前口径，以及迁移遗留 NULL-uid
+/// 行按 title 的回退口径。
+class _WatchRecency {
+  const _WatchRecency({required this.byUid, required this.legacyByTitle});
+
+  final Map<String, DateTime> byUid;
+  final Map<String, DateTime> legacyByTitle;
+}
+
+/// watch-stats 全量行 + `study_segments` 最近时刻 → 「最近观看」两份映射。
+///
+/// UI v2 Phase B / v39：v39 新行按 bookUid 键控；迁移遗留 NULL-uid 行按 title 建
+/// 回退映射。v92 起 `video_watch_statistics` 冻结为 legacy 只读（历史数据还在），
+/// 新的观看只写 `study_segments`：两处的 (uid, 时刻) 一起喂 [latestWatchAtByKey]，
+/// 同 uid 取最大，任一来源缺席都不影响另一来源。
+///
+/// 无身份判定 NULL 与 '' 都算（review4-9/review2-10：与统计页展示、删除谓词同一
+/// 判据）——'' 行进不了任何书架条目的 uid 匹配，落 title 回退才不会让该视频从
+/// 「最近观看」消失。
+///
+/// 抽成独立函数是因为它有两个调用者：全量的 [_HomeVideoPageState._loadLibraryMapsInner]
+/// 与播放返回后的窄刷新 [_HomeVideoPageState._loadWatchRecency]。两条路径必须给出
+/// 逐字节相同的映射，否则「继续观看」的排序会随刷新来路漂移。
+_WatchRecency _buildWatchRecency(
+  List<VideoWatchStatisticRow> watchRows,
+  Map<String, int> segmentEndAtByUid,
+) {
+  return _WatchRecency(
+    byUid: latestWatchAtByKey(
+      <(String, int)>[
+        for (final VideoWatchStatisticRow r in watchRows)
+          if (r.bookUid case final String uid when uid.isNotEmpty)
+            (uid, r.lastModified),
+        for (final MapEntry<String, int> e in segmentEndAtByUid.entries)
+          if (e.key.isNotEmpty) (e.key, e.value),
+      ],
+    ),
+    legacyByTitle: latestWatchAtByKey(
+      <(String, int)>[
+        for (final VideoWatchStatisticRow r in watchRows)
+          if (r.bookUid == null || r.bookUid!.isEmpty)
+            (r.title, r.lastModified),
+      ],
+    ),
+  );
+}
+
 class HomeVideoPage extends BaseModuleTabPage {
   const HomeVideoPage({
     required this.repo,
@@ -636,6 +683,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 一次性预取库页排序/分组所需映射：合集字典、折叠归属、组内 sortIndex、
   /// watch-stats 最近观看，外加偏好里的排序方式。
+  /// [_loadWatchRecency] 的记代，与 [_libraryMapsRequestGeneration] 相互独立。
+  int _watchRecencyRequestGeneration = 0;
+
   Future<void> _loadLibraryMaps() async {
     final int requestGeneration = ++_libraryMapsRequestGeneration;
     try {
@@ -651,6 +701,62 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       }
       rethrow;
     }
+  }
+
+  /// 「从播放器返回」专用的窄刷新。
+  ///
+  /// 看完一个视频只可能改动两处：那本书自己的 `video_books` 行（断点 / 完成时刻 /
+  /// 字幕源 / 音轨 / 延迟，以及资源缺失时的删行）和 [StudyClock] 写的
+  /// `study_segments`。合集、来源、刮削资料、元数据作品/图片/分集/花絮、媒体图组
+  /// 这十二张表播放页一行都不写（换音轨只动 `media_collections.audio_track_id`，
+  /// 库页不渲染它，且有 `watchCollectionTablesChanged` 流兜底），因此
+  /// [_loadLibraryMaps] 的整套重算在这条路径上是纯无效功。
+  ///
+  /// 更要紧的是 [_maybeBackfillCovers]：那是「给缺封面的存量行补抽帧」的后台产线，
+  /// 全库扫描 + 逐行同步 stat + 每个候选一次同步 64KB 头部探测（判据在
+  /// `video_cover_extractor.dart`）+ 串行 ffmpeg 子进程，全部压在 UI isolate 上。播放
+  /// 一个视频**不会产生新的缺封面行**（播放页零 `video_books` 插入），所以它挂在
+  /// 这条交互路径上从头到尾都是空转——实测就是它把「每次退出卡一两秒」顶了起来。
+  /// 它的真正触发时机（新行入库）由 `watchVideoBookUids` 流 → [_onVideoUidsChanged]
+  /// → [_refresh] 覆盖，入口还有 [initState] 与下拉刷新（后者还会先清失败记账重试），
+  /// 少跑这一次不会让任何条目永久漏掉。
+  ///
+  /// 只给 [_open] 用。[_refresh] 的其余调用点（uid 集合变化、外部刷新信号、刮削表
+  /// 变化、导入、标签、删除、改名、设封面…）确实需要全量重算，不要把它们并过来。
+  void _refreshAfterPlayback() {
+    setState(() {
+      // TODO-1255：书架展示走 listForShelf（自愈数据根迁移遗弃的封面路径）。
+      _future = widget.repo.listForShelf();
+    });
+    unawaited(_loadWatchRecency());
+  }
+
+  /// [_refreshAfterPlayback] 的映射侧：只重读喂「最近观看」的那两张表。
+  ///
+  /// 与 [_loadLibraryMapsInner] 各自记代（generation），互不取消：全量重载在途时
+  /// 发起窄重载不会把前者的结果丢掉（那会让其余十几个映射永远停在旧值）。两条路径
+  /// 读的是同一批行、经同一个 [_buildWatchRecency] 聚合，后落地者覆盖前者是等价的。
+  Future<void> _loadWatchRecency() async {
+    final int requestGeneration = ++_watchRecencyRequestGeneration;
+    final FushiDatabase db = ref.read(appProvider).database;
+    final Future<List<VideoWatchStatisticRow>> watchRowsF =
+        db.getAllVideoWatchStatistics();
+    final Future<Map<String, int>> segmentEndAtByUidF =
+        db.getLatestStudyEndAtByMedia(kActivityMediaVideo);
+    // 先挂上监听再逐个 await：某个查询失败时另一个的错误不会成为无人接的异常。
+    await Future.wait<Object?>(<Future<Object?>>[
+      watchRowsF,
+      segmentEndAtByUidF,
+    ]);
+    final _WatchRecency recency = _buildWatchRecency(
+      await watchRowsF,
+      await segmentEndAtByUidF,
+    );
+    if (!mounted || requestGeneration != _watchRecencyRequestGeneration) return;
+    setState(() {
+      _watchAtByUid = recency.byUid;
+      _legacyWatchAtByTitle = recency.legacyByTitle;
+    });
   }
 
   Future<void> _loadLibraryMapsInner(int requestGeneration) async {
@@ -727,27 +833,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     // v92 起 `video_watch_statistics` 冻结为 legacy 只读（历史数据还在），新的
     // 观看只写 `study_segments`：两处的 (uid, 时刻) 一起喂 latestWatchAtByKey，
     // 同 uid 取最大，任一来源缺席都不影响另一来源。
-    final List<VideoWatchStatisticRow> watchRows = await watchRowsF;
-    final Map<String, int> segmentEndAtByUid = await segmentEndAtByUidF;
-    // 无身份判定 NULL 与 '' 都算（review4-9/review2-10：与统计页展示、删除谓词
-    // 同一判据）——'' 行进不了任何书架条目的 uid 匹配，落 title 回退才不会让该
-    // 视频从「最近观看」消失。
-    final Map<String, DateTime> watchByUid = latestWatchAtByKey(
-      <(String, int)>[
-        for (final VideoWatchStatisticRow r in watchRows)
-          if (r.bookUid case final String uid when uid.isNotEmpty)
-            (uid, r.lastModified),
-        for (final MapEntry<String, int> e in segmentEndAtByUid.entries)
-          if (e.key.isNotEmpty) (e.key, e.value),
-      ],
+    final _WatchRecency recency = _buildWatchRecency(
+      await watchRowsF,
+      await segmentEndAtByUidF,
     );
-    final Map<String, DateTime> legacyByTitle = latestWatchAtByKey(
-      <(String, int)>[
-        for (final VideoWatchStatisticRow r in watchRows)
-          if (r.bookUid == null || r.bookUid!.isEmpty)
-            (r.title, r.lastModified),
-      ],
-    );
+    final Map<String, DateTime> watchByUid = recency.byUid;
+    final Map<String, DateTime> legacyByTitle = recency.legacyByTitle;
     // TODO-2486：刮削资料批量预取——条目 airDate 派生年份（年份筛选）、合集资料
     // （hero 轮播）。批量 DAO 全表一次拉，替代逐本/逐合集查询的 N+1。
     final List<VideoScrapeMetaRow> scrapeRows = await scrapeRowsF;
@@ -978,7 +1069,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       }
       lastShelfRefreshAt = now;
       shelfDirty = false;
-      setState(() => _future = widget.repo.listForShelf());
+      // 必须用块体：箭头体会把赋值结果（一个 Future）当闭包返回值交给 setState，
+      // debug 断言「setState() callback argument returned a Future」当场抛出，
+      // 整个回填循环从这里被掀掉——release 因断言被编译掉而侥幸跑通，于是这条
+      // 只在 debug 生效的失效路径长期没人发现（封面回填在 debug 下根本不工作）。
+      setState(() {
+        _future = widget.repo.listForShelf();
+      });
     }
 
     try {
@@ -1965,7 +2062,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     // 从播放器返回后刷新：继续观看 hero / 概览统计 / 卡片观看进度行都依赖
     // lastPositionMs 与 watch-stats，播完不刷会展示陈旧数据（对抗审查确认）。
-    if (mounted) _refresh();
+    // 走窄刷新——理由与边界见 [_refreshAfterPlayback]。
+    if (mounted) _refreshAfterPlayback();
   }
 
   Future<void> _openRemote(

--- a/fushi/test/pages/home_video_refresh_remote_guard_test.dart
+++ b/fushi/test/pages/home_video_refresh_remote_guard_test.dart
@@ -50,8 +50,10 @@ void main() {
     );
   });
 
-  test('从播放器返回后的刷新是本地 _refresh()（不带 remote）', () {
-    // _open() 返回后刷新继续观看 hero / 进度，只需本地。
+  test('从播放器返回后的刷新不碰远端清单（BUG-2376 后改走窄刷新）', () {
+    // _open() 返回后刷新继续观看 hero / 进度，只需本地。BUG-2376 起这条路径从
+    // 全量 `_refresh()` 收窄为 `_refreshAfterPlayback()`（只重读书架 + 最近观看），
+    // 本守卫钉的是「不重拉远端」这个不变式，不是当年那一行的写法。
     expect(
       src.contains('从播放器返回后刷新'),
       isTrue,
@@ -60,7 +62,7 @@ void main() {
     final int anchor = src.indexOf('从播放器返回后刷新');
     final String tail = src.substring(anchor, anchor + 300);
     expect(
-      tail.contains('if (mounted) _refresh();'),
+      tail.contains('if (mounted) _refreshAfterPlayback();'),
       isTrue,
       reason: '播放器返回只刷本地，不得传 remote: true',
     );
@@ -68,6 +70,16 @@ void main() {
       tail.contains('_refresh(remote: true)'),
       isFalse,
       reason: '播放器返回不得重拉远端清单',
+    );
+    // 窄刷新自身也不得碰远端 future——远端清单不因本地播放而变。
+    final int narrow = src.indexOf('void _refreshAfterPlayback() {');
+    expect(narrow, isNonNegative, reason: '找不到 _refreshAfterPlayback');
+    final int narrowEnd = src.indexOf('\n  }\n', narrow);
+    final String narrowBody = src.substring(narrow, narrowEnd);
+    expect(
+      narrowBody.contains('_remoteFuture'),
+      isFalse,
+      reason: '窄刷新不得重换远端 future（回归即恢复 BUG-894 的闪空重拉）',
     );
   });
 

--- a/fushi/test/tools/load_paths_perf_guard_test.dart
+++ b/fushi/test/tools/load_paths_perf_guard_test.dart
@@ -41,14 +41,55 @@ void main() {
       final String body =
           methodBody(page, 'Future<void> _maybeBackfillCovers() async {');
       expect(body.contains('refreshShelfThrottled('), isTrue);
-      // 直接重列只允许出现一次——在节流闭包里；循环体里不得再裸调。
+      // 直接重列只允许出现一次——在节流闭包里；循环体里不得再裸调。钉的是「几次
+      // 重列」这个不变式，不是那行的写法（写法从箭头体改成了块体，见下一条）。
       expect(
-          'setState(() => _future = widget.repo.listForShelf())'
-              .allMatches(body)
-              .length,
+          'widget.repo.listForShelf()'.allMatches(body).length,
           1,
           reason: '每张封面一次全库重列 + 整页重建');
       expect(page.contains('_coverBackfillRefreshInterval'), isTrue);
+    });
+
+    test('cover backfill never hands setState a closure returning a Future',
+        () {
+      final String body =
+          methodBody(page, 'Future<void> _maybeBackfillCovers() async {');
+      // `setState(() => _future = ...)` 的箭头体会把赋值结果（Future）当返回值
+      // 交给 setState，debug 断言当场抛出并掀掉整个回填循环；release 因断言被
+      // 编译掉而侥幸跑通，于是这条失效路径只在 debug 生效、长期无人发现。
+      expect(body.contains('setState(() => _future'), isFalse,
+          reason: 'setState() callback argument returned a Future');
+    });
+
+    test('returning from the player does not rerun the whole library load', () {
+      final String open = methodBody(
+          page, 'Future<void> _open(VideoBookRow book, {int? playlistCollectionId}) async {');
+      expect(open.contains('_refreshAfterPlayback()'), isTrue,
+          reason: '播放返回必须走窄刷新');
+      expect(open.contains('_refresh()'), isFalse,
+          reason: '全量 _refresh 会重算 12 张与观看无关的表并拖起封面回填产线');
+
+      final String narrow =
+          methodBody(page, 'void _refreshAfterPlayback() {');
+      expect(narrow.contains('widget.repo.listForShelf()'), isTrue,
+          reason: '断点 / 完成时刻 / 字幕源 / 音轨都在 video_books 上');
+      expect(narrow.contains('_loadWatchRecency()'), isTrue,
+          reason: 'study_segments 驱动的「最近观看」会变');
+      expect(narrow.contains('_maybeBackfillCovers('), isFalse,
+          reason: '播放不产生新的缺封面行，回填是后台产线不该压在退出这一帧上');
+      expect(narrow.contains('_loadLibraryMaps('), isFalse,
+          reason: '合集 / 刮削 / 元数据播放页一行都不写');
+
+      // 窄重载与全量重载必须给出同一份「最近观看」映射，否则排序随刷新来路漂移。
+      final String recency =
+          methodBody(page, 'Future<void> _loadWatchRecency() async {');
+      expect(recency.contains('_buildWatchRecency('), isTrue);
+      final String full = methodBody(
+          page, 'Future<void> _loadLibraryMapsInner(int requestGeneration)');
+      expect(full.contains('_buildWatchRecency('), isTrue);
+      // 两条路径各记各的代，互不取消。
+      expect(recency.contains('_watchRecencyRequestGeneration'), isTrue);
+      expect(full.contains('_libraryMapsRequestGeneration'), isTrue);
     });
 
     test('_loadLibraryMapsInner issues its table reads concurrently', () {


### PR DESCRIPTION
## 问题

用户报「现在每次从视频里退出来都会卡一两秒」。

## 定位（实测，非推断）

在真实规模库（生产库副本，1024 部视频）上用离屏集成 runner + 探针分账：

| 路径 | 实测 | 结论 |
|---|---|---|
| 退出汇聚点 `_handleBackOrExit` / `exitAfterPersist` | pop 无条件同步，落库 fire-and-forget | 排除 |
| 视频页 `dispose()` + 原生 mpv/纹理拆除 | `disposeBegin→disposeEnd` **5ms**；pop 后最坏单帧 131ms | 排除 |
| `_loadLibraryMapsInner` 的 14 条全表读 | **35~151ms**（09-07 新增的两条只占 ~12ms） | 排除 |
| 退出后 `_refresh()` 的异步尾巴 | **最坏单帧 1848ms** | ✅ 命中 |

停顿签名：帧计时 `build=37ms raster=2ms total=774ms`——build 与 raster 都不慢，慢的是**帧根本没被服务**，即 UI isolate 的事件循环被非帧工作堵住。空窗期内唯一在跑的是 `_maybeBackfillCovers()`：`listAll()` 再读一遍全表，然后逐行同步 `existsSync()`（1024 次）、候选行同步 `statSync()`、每个候选一次同步 64KB 头部读，并串行 spawn ffmpeg——全部压在 UI isolate 上，快速跳过分支整段不 await 让出。

## 改动

1. **新增 `_refreshAfterPlayback()` 只给 `_open()` 用**：只重读书架 `listForShelf()` + 「最近观看」两张表。看完一个视频只可能改动 `video_books` 那一行与 `StudyClock` 写的 `study_segments`；合集 / 来源 / 刮削资料 / 元数据作品·图片·分集·花絮 / 媒体图组这十二张表播放页一行都不写（换音轨只动 `media_collections.audio_track_id`，库页不渲染它），且各自有 Drift 变更流兜底。封面回填是「给缺封面的存量行补抽帧」的后台产线，播放不产生新的缺封面行，其真正触发时机（新行入库）由 `watchVideoBookUids` 流覆盖，入口另有 `initState` 与下拉刷新（后者还会先清失败记账重试）。`_refresh()` 本体与其余 9 个调用点不动。
2. **修一个真 bug**：`setState(() => _future = widget.repo.listForShelf())` 的箭头体把赋值结果（一个 Future）当闭包返回值交给 `setState`，debug 断言「setState() callback argument returned a Future」当场抛出、整个回填循环被掀掉；release 因断言被编译掉而侥幸跑通——**封面回填在 debug 构建下根本不工作**，这条只在 debug 生效的失效路径长期无人发现。改块体。
3. **`_buildWatchRecency` 单一真相源**：全量与窄重载共用，保证两条路径给出相同映射（否则「继续观看」排序会随刷新来路漂移）；两条路径各记各的代、互不取消。

## 验证

- `flutter analyze`（含 test 目录）零问题。
- 引用 `home_video_page` 的 **75 个测试文件、536 条全绿**（退出码 0，非管道假绿）。
- 两条按旧写法字面量钉死的守卫改成钉不变式；新增三条守卫（setState 不得收 Future / 播放返回不得重跑全量加载与回填 / 窄刷新不碰远端）。

## ⚠️ 未决，请勿当作已确诊

1~2 秒的用户现象**无法稳定复现**：历次最坏帧 1848 → 1366 → 1115 → 780 → 226 → 249ms 单调下降，是操作系统页缓存被一轮轮焐热。试过「先真播 33 秒冲掉缓存再退出」与两次独立冷跑，均未再现。

且**全部测量都在离屏 runner + debug 构建**里做的（窗口屏外 + `WS_EX_NOACTIVATE`，无真实 DWM 合成、无真正原生全屏），所以 `fushi/windows/runner/win32_window.cpp:683-700` 退全屏时 `SetWindowPlacement` + `ShowWindow(SW_MAXIMIZE)` 的两次 WM_SIZE（embedder 每次阻塞平台线程等一帧新内容），以及 HDR 直通下 `hdr_video_host_window.cpp:134-142` 的 `SetMainTransparency(false)`，**结构上就测不到——只是没被测到，不是被排除**。

最省事的下一步判别：**窗口模式（不进全屏）退出还卡不卡**。不卡则元凶是退全屏的 Win32 几何握手；卡则回到本 PR 已摘掉的那批 UI isolate 同步 IO。

详见 `docs/bugs/BUG-2376`。

https://claude.ai/code/session_012xNarBBurxnZCWAuLEmrKH
