### PR TITLE
feat: 下载相关界面支持多选批量操作（六处）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77112 (4536 per locale)
+/// Strings: 77180 (4540 per locale)
 ///
-/// Built on 2026-09-09 at 08:11 UTC
+/// Built on 2026-09-09 at 09:04 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6294,6 +6294,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   String get dialog_background_close => 'Close (task keeps running)';
   String get reader_timer_show => 'Show reading timer';
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  String download_batch_failed({required Object n}) => '${n} failed';
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -16952,6 +16958,16 @@ class _StringsAr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'إظهار مؤقت القراءة';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -27837,6 +27853,16 @@ class _StringsDe extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Lesetimer anzeigen';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -38776,6 +38802,16 @@ class _StringsEs extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar temporizador de lectura';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -49749,6 +49785,16 @@ class _StringsFr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Afficher le minuteur de lecture';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -60524,6 +60570,16 @@ class _StringsId extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Tampilkan pengatur waktu baca';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -71391,6 +71447,16 @@ class _StringsIt extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostra timer di lettura';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -81639,6 +81705,16 @@ class _StringsJa extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '読書タイマーを表示';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -91897,6 +91973,16 @@ class _StringsKo extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '독서 타이머 표시';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -102721,6 +102807,16 @@ class _StringsNl extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Leestimer tonen';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -113598,6 +113694,16 @@ class _StringsPtBr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Mostrar cronômetro de leitura';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -124452,6 +124558,16 @@ class _StringsRu extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Показывать таймер чтения';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -135106,6 +135222,16 @@ class _StringsTh extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'แสดงตัวจับเวลาการอ่าน';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -145876,6 +146002,16 @@ class _StringsTr extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Okuma zamanlayıcısını göster';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -156617,6 +156753,16 @@ class _StringsVi extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => 'Hiển thị bộ đếm thời gian đọc';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 // Path: <root>
@@ -166482,6 +166628,14 @@ class _StringsZhCn extends _StringsEn {
   String get dialog_background_close => '关闭（任务继续在后台运行）';
   @override
   String get reader_timer_show => '显示阅读计时器';
+  @override
+  String download_batch_done({required Object n}) => '已处理 ${n} 项';
+  @override
+  String download_batch_unsupported({required Object n}) => '${n} 项不支持此操作';
+  @override
+  String download_batch_failed({required Object n}) => '${n} 项失败';
+  @override
+  String download_batch_delete_confirm({required Object n}) => '删除 ${n} 个下载任务？';
 }
 
 // Path: <root>
@@ -176416,6 +176570,16 @@ class _StringsZhHk extends _StringsEn {
   String get dialog_background_close => 'Close (task keeps running)';
   @override
   String get reader_timer_show => '顯示閱讀計時器';
+  @override
+  String download_batch_done({required Object n}) => '${n} task(s) processed';
+  @override
+  String download_batch_unsupported({required Object n}) =>
+      '${n} skipped (not supported)';
+  @override
+  String download_batch_failed({required Object n}) => '${n} failed';
+  @override
+  String download_batch_delete_confirm({required Object n}) =>
+      'Delete ${n} download task(s)?';
 }
 
 /// Flat map(s) containing all translations.
@@ -185748,6 +185912,14 @@ extension on _StringsEn {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Show reading timer';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -195075,6 +195247,14 @@ extension on _StringsAr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'إظهار مؤقت القراءة';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -204447,6 +204627,14 @@ extension on _StringsDe {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Lesetimer anzeigen';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -213810,6 +213998,14 @@ extension on _StringsEs {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar temporizador de lectura';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -223182,6 +223378,14 @@ extension on _StringsFr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Afficher le minuteur de lecture';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -232525,6 +232729,14 @@ extension on _StringsId {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Tampilkan pengatur waktu baca';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -241890,6 +242102,14 @@ extension on _StringsIt {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostra timer di lettura';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -251182,6 +251402,14 @@ extension on _StringsJa {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '読書タイマーを表示';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -260478,6 +260706,14 @@ extension on _StringsKo {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '독서 타이머 표시';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -269836,6 +270072,14 @@ extension on _StringsNl {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Leestimer tonen';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -279189,6 +279433,14 @@ extension on _StringsPtBr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Mostrar cronômetro de leitura';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -288549,6 +288801,14 @@ extension on _StringsRu {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Показывать таймер чтения';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -297881,6 +298141,14 @@ extension on _StringsTh {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'แสดงตัวจับเวลาการอ่าน';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -307228,6 +307496,14 @@ extension on _StringsTr {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Okuma zamanlayıcısını göster';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -316569,6 +316845,14 @@ extension on _StringsVi {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return 'Hiển thị bộ đếm thời gian đọc';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }
@@ -325829,6 +326113,14 @@ extension on _StringsZhCn {
         return '关闭（任务继续在后台运行）';
       case 'reader_timer_show':
         return '显示阅读计时器';
+      case 'download_batch_done':
+        return ({required Object n}) => '已处理 ${n} 项';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} 项不支持此操作';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} 项失败';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => '删除 ${n} 个下载任务？';
       default:
         return null;
     }
@@ -335099,6 +335391,14 @@ extension on _StringsZhHk {
         return 'Close (task keeps running)';
       case 'reader_timer_show':
         return '顯示閱讀計時器';
+      case 'download_batch_done':
+        return ({required Object n}) => '${n} task(s) processed';
+      case 'download_batch_unsupported':
+        return ({required Object n}) => '${n} skipped (not supported)';
+      case 'download_batch_failed':
+        return ({required Object n}) => '${n} failed';
+      case 'download_batch_delete_confirm':
+        return ({required Object n}) => 'Delete ${n} download task(s)?';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Show reading timer"
+  "reader_timer_show": "Show reading timer",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "إظهار مؤقت القراءة"
+  "reader_timer_show": "إظهار مؤقت القراءة",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Lesetimer anzeigen"
+  "reader_timer_show": "Lesetimer anzeigen",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar temporizador de lectura"
+  "reader_timer_show": "Mostrar temporizador de lectura",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Afficher le minuteur de lecture"
+  "reader_timer_show": "Afficher le minuteur de lecture",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Tampilkan pengatur waktu baca"
+  "reader_timer_show": "Tampilkan pengatur waktu baca",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostra timer di lettura"
+  "reader_timer_show": "Mostra timer di lettura",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "読書タイマーを表示"
+  "reader_timer_show": "読書タイマーを表示",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "독서 타이머 표시"
+  "reader_timer_show": "독서 타이머 표시",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Leestimer tonen"
+  "reader_timer_show": "Leestimer tonen",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Mostrar cronômetro de leitura"
+  "reader_timer_show": "Mostrar cronômetro de leitura",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Показывать таймер чтения"
+  "reader_timer_show": "Показывать таймер чтения",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน"
+  "reader_timer_show": "แสดงตัวจับเวลาการอ่าน",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Okuma zamanlayıcısını göster"
+  "reader_timer_show": "Okuma zamanlayıcısını göster",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc"
+  "reader_timer_show": "Hiển thị bộ đếm thời gian đọc",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。",
   "video_shader_tier_ultra_hint_mobile": "Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。",
   "dialog_background_close": "关闭（任务继续在后台运行）",
-  "reader_timer_show": "显示阅读计时器"
+  "reader_timer_show": "显示阅读计时器",
+  "download_batch_done": "已处理 $n 项",
+  "download_batch_unsupported": "$n 项不支持此操作",
+  "download_batch_failed": "$n 项失败",
+  "download_batch_delete_confirm": "删除 $n 个下载任务？"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4534,5 +4534,9 @@
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
   "dialog_background_close": "Close (task keeps running)",
-  "reader_timer_show": "顯示閱讀計時器"
+  "reader_timer_show": "顯示閱讀計時器",
+  "download_batch_done": "$n task(s) processed",
+  "download_batch_unsupported": "$n skipped (not supported)",
+  "download_batch_failed": "$n failed",
+  "download_batch_delete_confirm": "Delete $n download task(s)?"
 }

--- a/fushi/lib/src/media/discovery/discovery_download_tasks_section.dart
+++ b/fushi/lib/src/media/discovery/discovery_download_tasks_section.dart
@@ -141,8 +141,14 @@ class DiscoveryDownloadTasksSection extends ConsumerWidget {
       id: id,
       title: task.item.title,
       createdAt: task.createdAt,
-      onRetry: _canRetry(task) ? () => queue.retry(task) : null,
-      onClear: task.isFinished ? () => queue.remove(task) : null,
+      // 直链队列同样是单跑道内存队列：无调度优先级、无暂停态（续传靠 retry 走
+      // ResumableDownloader 的 Range）。删除只能移出列表——文件删除被显式关掉
+      // （见本文件 offerDeleteFiles: false 处的说明），故只填 clear 不填 delete。
+      actions: DownloadTaskActions(
+        retry: _canRetry(task) ? () async => queue.retry(task) : null,
+        clear: task.isFinished ? () async => queue.remove(task) : null,
+        cancel: task.isFinished ? null : () async => queue.cancel(task),
+      ),
       kind: switch (task.item.kind) {
         DiscoveryMediaKind.novel => DownloadTaskKind.novel,
         DiscoveryMediaKind.audiobook => DownloadTaskKind.audiobook,

--- a/fushi/lib/src/media/downloads/download_batch.dart
+++ b/fushi/lib/src/media/downloads/download_batch.dart
@@ -1,0 +1,127 @@
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/downloads/download_task_entry.dart';
+
+/// 可以对一批选中任务执行的动作。
+///
+/// 与 [DownloadTaskActions] 的槽位一一对应；不含 setPriority（它还要带一个档位
+/// 参数，走单独入口）与 reveal（批量打开 N 个文件管理器窗口是骚扰不是便利）。
+enum DownloadBatchAction { pause, resume, retry, cancel, clear, delete }
+
+/// 一次批量操作的结果。
+///
+/// [unsupported] 与 [failed] 是**两回事**：前者是这条任务的来源根本没有这个动作
+/// （单跑道队列没有暂停、mokuro 删不了磁盘文件），后者是支持但执行时出错。混成
+/// 一个数字会让用户以为「失败了、再试一次就好」，而实际上再试一百次也一样。
+class DownloadBatchOutcome {
+  const DownloadBatchOutcome({
+    this.done = 0,
+    this.unsupported = 0,
+    this.failed = 0,
+  });
+
+  /// 真正执行成功的条数。
+  final int done;
+
+  /// 因来源不支持该动作被跳过的条数。
+  final int unsupported;
+
+  /// 支持该动作但执行时抛错的条数。
+  final int failed;
+
+  int get total => done + unsupported + failed;
+
+  bool get isEmpty => total == 0;
+}
+
+/// 取一条任务在某个批量动作下的执行体；来源不支持该动作时返回 null。
+///
+/// [deleteFiles] 只对 [DownloadBatchAction.delete] 有意义，由调用方在弹过**一次**
+/// 确认框之后定死，逐条复用。
+Future<void> Function()? downloadTaskBatchCallable(
+  DownloadTaskEntry task,
+  DownloadBatchAction action, {
+  bool deleteFiles = false,
+}) {
+  final DownloadTaskActions actions = task.actions;
+  return switch (action) {
+    DownloadBatchAction.pause => actions.pause,
+    DownloadBatchAction.resume => actions.resume,
+    DownloadBatchAction.retry => actions.retry,
+    DownloadBatchAction.cancel => actions.cancel,
+    DownloadBatchAction.clear => actions.clear,
+    DownloadBatchAction.delete => actions.delete == null
+        ? null
+        : () => actions.delete!(deleteFiles: deleteFiles),
+  };
+}
+
+/// 选中集里有几条真的支持这个动作——按钮的可用态判据。
+///
+/// 一条都不支持时按钮直接禁用：摆一个点下去只会弹「0 条已处理」的按钮，比没有
+/// 这个按钮更糟。
+int countDownloadTasksSupporting(
+  Iterable<DownloadTaskEntry> tasks,
+  DownloadBatchAction action,
+) {
+  int count = 0;
+  for (final DownloadTaskEntry task in tasks) {
+    if (downloadTaskBatchCallable(task, action) != null) count++;
+  }
+  return count;
+}
+
+/// 对一批任务串行执行同一个动作。
+///
+/// **串行而非并发**：这些动作最终落到 torrent 后端与 SQLite 上，并发只会把「一批
+/// 操作」变成「一批竞态」（同一后端的暂停/恢复、同一张表的生命周期 CAS）；顺序
+/// 执行也让结果计数与用户看到的列表顺序对得上。
+///
+/// **单条抛错不中断整批**：一条失败就整批停下，用户既不知道做成了几条，也不知道
+/// 从哪条开始没做——那比部分成功更难收拾。错误计入 [DownloadBatchOutcome.failed]。
+Future<DownloadBatchOutcome> runDownloadTaskBatch({
+  required Iterable<DownloadTaskEntry> tasks,
+  required DownloadBatchAction action,
+  bool deleteFiles = false,
+  void Function(Object error, StackTrace stackTrace)? onError,
+}) async {
+  int done = 0;
+  int unsupported = 0;
+  int failed = 0;
+  for (final DownloadTaskEntry task in tasks) {
+    final Future<void> Function()? callable = downloadTaskBatchCallable(
+      task,
+      action,
+      deleteFiles: deleteFiles,
+    );
+    if (callable == null) {
+      unsupported++;
+      continue;
+    }
+    try {
+      await callable();
+      done++;
+    } on Object catch (error, stackTrace) {
+      failed++;
+      onError?.call(error, stackTrace);
+    }
+  }
+  return DownloadBatchOutcome(
+    done: done,
+    unsupported: unsupported,
+    failed: failed,
+  );
+}
+
+/// 批量结果的用户可见描述：只拼非零的段，用 ' · ' 连接。
+///
+/// 「不支持」与「失败」分开说，因为用户的下一步动作不同：前者再点一百次也一样，
+/// 后者值得重试。三段全为零时返回空串，调用方据此不弹提示。
+String describeDownloadBatchOutcome(DownloadBatchOutcome outcome) {
+  final List<String> parts = <String>[
+    if (outcome.done > 0) t.download_batch_done(n: outcome.done),
+    if (outcome.unsupported > 0)
+      t.download_batch_unsupported(n: outcome.unsupported),
+    if (outcome.failed > 0) t.download_batch_failed(n: outcome.failed),
+  ];
+  return parts.join(' · ');
+}

--- a/fushi/lib/src/media/downloads/download_task_browser.dart
+++ b/fushi/lib/src/media/downloads/download_task_browser.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/utils.dart';
@@ -288,23 +290,23 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                     }),
                   ),
                 if (visible.any(
-                  (DownloadTaskEntry task) => task.onRetry != null,
+                  (DownloadTaskEntry task) => task.actions.retry != null,
                 ))
                   TextButton(
                     onPressed: () {
                       for (final DownloadTaskEntry task in visible) {
-                        task.onRetry?.call();
+                        unawaited(task.actions.retry?.call() ?? Future<void>.value());
                       }
                     },
                     child: Text(t.retry),
                   ),
                 if (visible.any(
-                  (DownloadTaskEntry task) => task.onClear != null,
+                  (DownloadTaskEntry task) => task.actions.clear != null,
                 ))
                   TextButton(
                     onPressed: () {
                       for (final DownloadTaskEntry task in visible) {
-                        task.onClear?.call();
+                        unawaited(task.actions.clear?.call() ?? Future<void>.value());
                       }
                     },
                     child: Text(t.download_clear_finished),

--- a/fushi/lib/src/media/downloads/download_task_browser.dart
+++ b/fushi/lib/src/media/downloads/download_task_browser.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/media_search_text.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/media/downloads/download_batch.dart';
+import 'package:fushi/src/media/downloads/download_task_delete_confirm.dart';
 import 'package:fushi/src/media/downloads/download_task_entry.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 
 enum DownloadTaskSort { created, title, progress, status }
 
@@ -92,12 +95,205 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
   bool _reverse = false;
   bool _collapseAll = false;
   final Map<String, bool> _expandedGroups = <String, bool>{};
+  bool _selectionMode = false;
+  /// 选中的任务 id。可见集合会随筛选 / 刷新变化，所以每次真正执行前都拿当前
+  /// 可见列表与它取交集（见 [_selectedVisible]）——不这么做，批量动作会作用在
+  /// 用户已经看不见、甚至已经不存在的条目上。
+  final Set<String> _selectedIds = <String>{};
 
   @override
   void dispose() {
     _search.dispose();
     _searchFocus.dispose();
     super.dispose();
+  }
+
+  /// 选中集与**当前可见列表**的交集，按可见顺序排列。
+  ///
+  /// 选中集是纯 id，可见集合却会随筛选、搜索、分组折叠与后台刷新变化。批量动作
+  /// 一律作用于这个交集：既避免动到用户已经筛掉的条目，也天然剔掉已经消失的
+  /// 幽灵 id（任务跑完被清出列表、直链/mokuro 的自增 id 随进程重启作废）。
+  List<DownloadTaskEntry> _selectedVisible(List<DownloadTaskEntry> visible) {
+    return visible
+        .where((DownloadTaskEntry task) => _selectedIds.contains(task.id))
+        .toList();
+  }
+
+  void _exitSelection() {
+    setState(() {
+      _selectionMode = false;
+      _selectedIds.clear();
+    });
+  }
+
+  void _toggleTask(String id) {
+    setState(() {
+      if (!_selectedIds.remove(id)) _selectedIds.add(id);
+    });
+  }
+
+  /// 批量执行一个动作。
+  ///
+  /// 目标集在 await 之前就用 [List.of] 定死：执行期间列表会因后台刷新重建，跨
+  /// await 两侧各读一次会让「报告里的条数」和「真正动过的条目」对不上。
+  Future<void> _runBatch(
+    List<DownloadTaskEntry> visible,
+    DownloadBatchAction action, {
+    bool deleteFiles = false,
+  }) async {
+    final List<DownloadTaskEntry> targets = List<DownloadTaskEntry>.of(
+      _selectedVisible(visible),
+    );
+    if (targets.isEmpty) return;
+    final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
+      tasks: targets,
+      action: action,
+      deleteFiles: deleteFiles,
+    );
+    if (!mounted) return;
+    setState(() {
+      // 已处理的条目退出选中：留着会让下一次批量重复作用在它们身上。
+      for (final DownloadTaskEntry task in targets) {
+        _selectedIds.remove(task.id);
+      }
+      if (_selectedIds.isEmpty) _selectionMode = false;
+    });
+    final String message = describeDownloadBatchOutcome(outcome);
+    if (message.isEmpty) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  /// 批量删除：整批只问一次「要不要连文件一起删」。
+  Future<void> _confirmBatchDelete(List<DownloadTaskEntry> visible) async {
+    final List<DownloadTaskEntry> targets = _selectedVisible(visible);
+    if (targets.isEmpty) return;
+    // 「同时删除文件」只在选中集里真有条目兑现得了时才摆出来——mokuro / 直链
+    // 只能把条目移出列表，勾了也删不掉盘上的东西。
+    final bool offerDeleteFiles = targets.any(
+      (DownloadTaskEntry task) => task.actions.delete != null,
+    );
+    final bool? deleteFiles = await showDownloadTaskDeleteConfirm(
+      context,
+      title: '',
+      message: t.download_batch_delete_confirm(n: targets.length),
+      keySuffix: 'batch',
+      offerDeleteFiles: offerDeleteFiles,
+    );
+    if (deleteFiles == null || !mounted) return;
+    await _runBatch(
+      visible,
+      DownloadBatchAction.delete,
+      deleteFiles: deleteFiles,
+    );
+  }
+
+  /// 选择态下的一行：勾选框 + 原卡片。
+  ///
+  /// 卡片被 [IgnorePointer] 罩住，整行点击一律翻转选中——选择态里卡片自带的
+  /// 重试 / 删除按钮必须让位，否则「想勾第三条」会变成「把第三条删了」。
+  Widget _selectableRow(DownloadTaskEntry task) {
+    final bool selected = _selectedIds.contains(task.id);
+    return InkWell(
+      key: ValueKey<String>('download-entry-select-${task.id}'),
+      onTap: () => _toggleTask(task.id),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Checkbox(
+            value: selected,
+            onChanged: (_) => _toggleTask(task.id),
+          ),
+          Expanded(
+            child: IgnorePointer(child: task.builder(context)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 底部批量操作栏。动作按钮按「选中集里有几条真支持它」决定可用态。
+  Widget _buildBatchBar(List<DownloadTaskEntry> visible) {
+    final List<DownloadTaskEntry> selected = _selectedVisible(visible);
+    final ThemeData theme = Theme.of(context);
+    Widget action({
+      required String id,
+      required IconData icon,
+      required String tooltip,
+      required DownloadBatchAction batchAction,
+      VoidCallback? onTap,
+      Color? enabledColor,
+    }) {
+      final bool enabled =
+          countDownloadTasksSupporting(selected, batchAction) > 0;
+      return FushiIconButton(
+        key: ValueKey<String>('download-batch-$id'),
+        enabled: enabled,
+        tooltip: tooltip,
+        icon: icon,
+        enabledColor: enabledColor,
+        onTap: onTap ?? () => unawaited(_runBatch(visible, batchAction)),
+      );
+    }
+
+    return BatchActionBar(
+      selectedCount: selected.length,
+      onSelectAll: () => setState(
+        () => _selectedIds.addAll(
+          visible.map((DownloadTaskEntry task) => task.id),
+        ),
+      ),
+      onInvertSelection: () => setState(() {
+        final Set<String> next = <String>{
+          for (final DownloadTaskEntry task in visible)
+            if (!_selectedIds.contains(task.id)) task.id,
+        };
+        _selectedIds
+          ..clear()
+          ..addAll(next);
+      }),
+      actions: <Widget>[
+        action(
+          id: 'resume',
+          icon: Icons.play_arrow,
+          tooltip: t.download_task_resume,
+          batchAction: DownloadBatchAction.resume,
+        ),
+        action(
+          id: 'pause',
+          icon: Icons.pause,
+          tooltip: t.download_task_pause,
+          batchAction: DownloadBatchAction.pause,
+        ),
+        action(
+          id: 'retry',
+          icon: Icons.refresh,
+          tooltip: t.retry,
+          batchAction: DownloadBatchAction.retry,
+        ),
+        action(
+          id: 'cancel',
+          icon: Icons.close,
+          tooltip: t.dialog_cancel,
+          batchAction: DownloadBatchAction.cancel,
+        ),
+        action(
+          id: 'clear',
+          icon: Icons.playlist_remove,
+          tooltip: t.download_clear_finished,
+          batchAction: DownloadBatchAction.clear,
+        ),
+        action(
+          id: 'delete',
+          icon: Icons.delete_outline,
+          tooltip: t.download_task_delete,
+          batchAction: DownloadBatchAction.delete,
+          enabledColor: theme.colorScheme.error,
+          onTap: () => unawaited(_confirmBatchDelete(visible)),
+        ),
+      ],
+    );
   }
 
   String _sortLabel(DownloadTaskSort value) => switch (value) {
@@ -277,6 +473,20 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                       setState(() => _grouping = value),
                   icon: Icons.folder_copy_outlined,
                 ),
+                FushiIconButton(
+                  key: const ValueKey<String>('download-task-select-mode'),
+                  tooltip: _selectionMode ? t.dialog_cancel : t.batch_select,
+                  icon: _selectionMode
+                      ? Icons.close
+                      : Icons.checklist_outlined,
+                  onTap: () {
+                    if (_selectionMode) {
+                      _exitSelection();
+                    } else {
+                      setState(() => _selectionMode = true);
+                    }
+                  },
+                ),
                 if (_grouping != DownloadTaskGrouping.none)
                   FushiIconButton(
                     key: const ValueKey<String>('download-task-collapse-all'),
@@ -346,7 +556,9 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                       return Padding(
                         key: ValueKey<String>('download-entry-${row.id}'),
                         padding: const EdgeInsets.only(bottom: 8),
-                        child: row.builder(context),
+                        child: _selectionMode
+                            ? _selectableRow(row)
+                            : row.builder(context),
                       );
                     }
                     final MapEntry<String, List<DownloadTaskEntry>> group =
@@ -376,6 +588,7 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                   },
                 ),
         ),
+        if (_selectionMode) _buildBatchBar(visible),
       ],
     );
   }

--- a/fushi/lib/src/media/downloads/download_task_browser.dart
+++ b/fushi/lib/src/media/downloads/download_task_browser.dart
@@ -96,6 +96,10 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
   bool _collapseAll = false;
   final Map<String, bool> _expandedGroups = <String, bool>{};
   bool _selectionMode = false;
+  /// 整批执行中：期间禁掉全部批量按钮。没有这道锁，连点两下就是整批跑两遍
+  /// （同一 hash 被 addTorrent 两次 / 对已删条目再删一遍），也把 runDownloadTaskBatch
+  /// 的串行保证在整批层面破掉了。
+  bool _batchRunning = false;
   /// 选中的任务 id。可见集合会随筛选 / 刷新变化，所以每次真正执行前都拿当前
   /// 可见列表与它取交集（见 [_selectedVisible]）——不这么做，批量动作会作用在
   /// 用户已经看不见、甚至已经不存在的条目上。
@@ -108,13 +112,18 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
     super.dispose();
   }
 
-  /// 选中集与**当前可见列表**的交集，按可见顺序排列。
+  /// 选中集与**屏幕上真正渲染出来的行**的交集，按渲染顺序排列。
   ///
-  /// 选中集是纯 id，可见集合却会随筛选、搜索、分组折叠与后台刷新变化。批量动作
-  /// 一律作用于这个交集：既避免动到用户已经筛掉的条目，也天然剔掉已经消失的
-  /// 幽灵 id（任务跑完被清出列表、直链/mokuro 的自增 id 随进程重启作废）。
-  List<DownloadTaskEntry> _selectedVisible(List<DownloadTaskEntry> visible) {
-    return visible
+  /// 传进来的必须是 rows 里的 entry（见 build 末尾的 `_visibleEntries`），**不是**
+  /// 筛选后的全集 `visible`：分组折叠时被收起来的成员仍在 `visible` 里，拿它当域
+  /// 会让「全选 → 删除」把用户根本没看见的条目连同磁盘文件一起删掉——确认框写
+  /// 「删除 15 个」而屏幕上只有 3 张卡。
+  ///
+  /// 选中集是纯 id，渲染集合会随筛选、搜索、分组折叠与后台刷新变化，所以每次都
+  /// 现取交集：既避免动到用户看不见的条目，也天然剔掉已经消失的幽灵 id（任务跑完
+  /// 被清出列表、直链/mokuro 的自增 id 随进程重启作废）。
+  List<DownloadTaskEntry> _selectedVisible(List<DownloadTaskEntry> rendered) {
+    return rendered
         .where((DownloadTaskEntry task) => _selectedIds.contains(task.id))
         .toList();
   }
@@ -132,31 +141,38 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
     });
   }
 
-  /// 批量执行一个动作。
+  /// 批量执行一个动作（目标集已定死）。
   ///
-  /// 目标集在 await 之前就用 [List.of] 定死：执行期间列表会因后台刷新重建，跨
-  /// await 两侧各读一次会让「报告里的条数」和「真正动过的条目」对不上。
-  Future<void> _runBatch(
-    List<DownloadTaskEntry> visible,
+  /// [targets] 由调用方在**任何 await 之前**取好并定死：执行期间列表会因后台刷新
+  /// 重建，跨 await 两侧各求一次交集会让「确认框里的 N」和「真正动过的条目」对不上。
+  Future<void> _runBatchOn(
+    List<DownloadTaskEntry> targets,
     DownloadBatchAction action, {
     bool deleteFiles = false,
   }) async {
-    final List<DownloadTaskEntry> targets = List<DownloadTaskEntry>.of(
-      _selectedVisible(visible),
-    );
-    if (targets.isEmpty) return;
-    final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
-      tasks: targets,
-      action: action,
-      deleteFiles: deleteFiles,
-    );
+    if (targets.isEmpty || _batchRunning) return;
+    setState(() => _batchRunning = true);
+    DownloadBatchOutcome outcome = const DownloadBatchOutcome();
+    try {
+      outcome = await runDownloadTaskBatch(
+        tasks: targets,
+        action: action,
+        deleteFiles: deleteFiles,
+        // 失败条目只在计数里体现是不够的：没有 stack trace 就没法查根因。
+        onError: (Object error, StackTrace stackTrace) => debugPrint(
+          '[fushi-downloads] batch ${action.name} failed: $error\n$stackTrace',
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _batchRunning = false);
+    }
     if (!mounted) return;
     setState(() {
       // 已处理的条目退出选中：留着会让下一次批量重复作用在它们身上。
       for (final DownloadTaskEntry task in targets) {
         _selectedIds.remove(task.id);
       }
-      if (_selectedIds.isEmpty) _selectionMode = false;
+      _pruneSelection();
     });
     final String message = describeDownloadBatchOutcome(outcome);
     if (message.isEmpty) return;
@@ -165,14 +181,33 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
     );
   }
 
+  /// 剔掉选中集里已经不存在的 id，并在真的空了之后退出选择态。
+  ///
+  /// 判据用**任务全集**而不是当前渲染集：被搜索或折叠暂时藏起来的选中项还活着，
+  /// 拿渲染集判会让批量栏卡在「已选 0」——全部按钮禁用、看着像卡死，清空搜索后
+  /// 那几条又带着选中态冒出来。
+  void _pruneSelection() {
+    final Set<String> alive = <String>{
+      for (final DownloadTaskEntry task in widget.tasks) task.id,
+    };
+    _selectedIds.removeWhere((String id) => !alive.contains(id));
+    if (_selectedIds.isEmpty) _selectionMode = false;
+  }
+
   /// 批量删除：整批只问一次「要不要连文件一起删」。
-  Future<void> _confirmBatchDelete(List<DownloadTaskEntry> visible) async {
-    final List<DownloadTaskEntry> targets = _selectedVisible(visible);
+  ///
+  /// 目标集在弹确认框**之前**就定死并一路带到执行：确认框可能停留好几秒，期间
+  /// 后台轮询会重建列表，跨 await 重算一次交集会让确认框里的 N 与实际删除量对不上，
+  /// 甚至对已经消失的条目调 delete。
+  Future<void> _confirmBatchDelete(List<DownloadTaskEntry> rendered) async {
+    final List<DownloadTaskEntry> targets = List<DownloadTaskEntry>.of(
+      _selectedVisible(rendered),
+    );
     if (targets.isEmpty) return;
     // 「同时删除文件」只在选中集里真有条目兑现得了时才摆出来——mokuro / 直链
-    // 只能把条目移出列表，勾了也删不掉盘上的东西。
+    // 只能把条目移出列表，勾了也删不掉盘上的东西（与单条删除确认框同一纪律）。
     final bool offerDeleteFiles = targets.any(
-      (DownloadTaskEntry task) => task.actions.delete != null,
+      (DownloadTaskEntry task) => task.actions.deletesFiles,
     );
     final bool? deleteFiles = await showDownloadTaskDeleteConfirm(
       context,
@@ -182,8 +217,8 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
       offerDeleteFiles: offerDeleteFiles,
     );
     if (deleteFiles == null || !mounted) return;
-    await _runBatch(
-      visible,
+    await _runBatchOn(
+      targets,
       DownloadBatchAction.delete,
       deleteFiles: deleteFiles,
     );
@@ -206,7 +241,12 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
             onChanged: (_) => _toggleTask(task.id),
           ),
           Expanded(
-            child: IgnorePointer(child: task.builder(context)),
+            // IgnorePointer 只挡指针。卡片里的重试/删除是真正可聚焦的按钮，光挡
+            // 指针的话手柄/键盘用户方向键仍会走进去，按 Enter 直接删任务——
+            // 「想勾第三条变成把第三条删了」在键盘路径上照样成立。
+            child: ExcludeFocus(
+              child: IgnorePointer(child: task.builder(context)),
+            ),
           ),
         ],
       ),
@@ -214,8 +254,11 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
   }
 
   /// 底部批量操作栏。动作按钮按「选中集里有几条真支持它」决定可用态。
-  Widget _buildBatchBar(List<DownloadTaskEntry> visible) {
-    final List<DownloadTaskEntry> selected = _selectedVisible(visible);
+  ///
+  /// [rendered] 必须是屏幕上真正渲染出来的行（rows 里的 entry），不是筛选后的
+  /// 全集——分组折叠时被收起来的成员不该被「全选」卷进来。
+  Widget _buildBatchBar(List<DownloadTaskEntry> rendered) {
+    final List<DownloadTaskEntry> selected = _selectedVisible(rendered);
     final ThemeData theme = Theme.of(context);
     Widget action({
       required String id,
@@ -226,6 +269,7 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
       Color? enabledColor,
     }) {
       final bool enabled =
+          !_batchRunning &&
           countDownloadTasksSupporting(selected, batchAction) > 0;
       return FushiIconButton(
         key: ValueKey<String>('download-batch-$id'),
@@ -233,7 +277,13 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
         tooltip: tooltip,
         icon: icon,
         enabledColor: enabledColor,
-        onTap: onTap ?? () => unawaited(_runBatch(visible, batchAction)),
+        onTap: onTap ??
+            () => unawaited(
+                  _runBatchOn(
+                    List<DownloadTaskEntry>.of(selected),
+                    batchAction,
+                  ),
+                ),
       );
     }
 
@@ -241,12 +291,12 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
       selectedCount: selected.length,
       onSelectAll: () => setState(
         () => _selectedIds.addAll(
-          visible.map((DownloadTaskEntry task) => task.id),
+          rendered.map((DownloadTaskEntry task) => task.id),
         ),
       ),
       onInvertSelection: () => setState(() {
         final Set<String> next = <String>{
-          for (final DownloadTaskEntry task in visible)
+          for (final DownloadTaskEntry task in rendered)
             if (!_selectedIds.contains(task.id)) task.id,
         };
         _selectedIds
@@ -290,7 +340,7 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
           tooltip: t.download_task_delete,
           batchAction: DownloadBatchAction.delete,
           enabledColor: theme.colorScheme.error,
-          onTap: () => unawaited(_confirmBatchDelete(visible)),
+          onTap: () => unawaited(_confirmBatchDelete(rendered)),
         ),
       ],
     );
@@ -499,26 +549,37 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                       _expandedGroups.clear();
                     }),
                   ),
+                // 这两个「对可见集合全体执行」的入口与多选批量走同一个串行执行器：
+                // 逐条 fire-and-forget 会把 40 条重试变成 40 路并发打向同一后端，
+                // 且任何一条抛错都是没人接的 async 异常。
                 if (visible.any(
                   (DownloadTaskEntry task) => task.actions.retry != null,
                 ))
                   TextButton(
-                    onPressed: () {
-                      for (final DownloadTaskEntry task in visible) {
-                        unawaited(task.actions.retry?.call() ?? Future<void>.value());
-                      }
-                    },
+                    key: const ValueKey<String>('download-task-retry-visible'),
+                    onPressed: _batchRunning
+                        ? null
+                        : () => unawaited(
+                              _runBatchOn(
+                                List<DownloadTaskEntry>.of(visible),
+                                DownloadBatchAction.retry,
+                              ),
+                            ),
                     child: Text(t.retry),
                   ),
                 if (visible.any(
                   (DownloadTaskEntry task) => task.actions.clear != null,
                 ))
                   TextButton(
-                    onPressed: () {
-                      for (final DownloadTaskEntry task in visible) {
-                        unawaited(task.actions.clear?.call() ?? Future<void>.value());
-                      }
-                    },
+                    key: const ValueKey<String>('download-task-clear-visible'),
+                    onPressed: _batchRunning
+                        ? null
+                        : () => unawaited(
+                              _runBatchOn(
+                                List<DownloadTaskEntry>.of(visible),
+                                DownloadBatchAction.clear,
+                              ),
+                            ),
                     child: Text(t.download_clear_finished),
                   ),
                 Text(
@@ -588,7 +649,8 @@ class _DownloadTaskBrowserState extends State<DownloadTaskBrowser> {
                   },
                 ),
         ),
-        if (_selectionMode) _buildBatchBar(visible),
+        if (_selectionMode)
+          _buildBatchBar(rows.whereType<DownloadTaskEntry>().toList()),
       ],
     );
   }

--- a/fushi/lib/src/media/downloads/download_task_delete_confirm.dart
+++ b/fushi/lib/src/media/downloads/download_task_delete_confirm.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+import 'package:fushi/src/utils/misc/show_app_dialog.dart';
+
+/// 下载任务「删除任务」确认框：正文 + 「同时删除已下载文件」勾选框。返回 null=取消，
+/// 否则为勾选值。v78 任务面板与旧番剧计划面板共用，两处口径一致；测试按
+/// `video-download-job-delete-files-<keySuffix>` / `…-confirm-<keySuffix>` 定位。
+///
+/// [offerDeleteFiles]=false 时不渲染勾选框、恒返回 false：删已下载的数据只能由下载
+/// 后端执行，本机没有可用后端时那个勾选框兑现不了（与两个删除确认框「兑现不了就不
+/// 显示」同一纪律）。
+///
+/// [message] 用于批量删除：整批只问一次，正文是「删除 N 个下载任务？」而不是
+/// 单条的「删除《标题》的下载任务？」。给了 [message] 就不再用 [title] 拼正文。
+Future<bool?> showDownloadTaskDeleteConfirm(
+  BuildContext context, {
+  required String title,
+  required String keySuffix,
+  bool offerDeleteFiles = true,
+  String? message,
+}) {
+  bool deleteFiles = false;
+  return showAppDialog<bool>(
+    context: context,
+    builder: (BuildContext dialogContext) => StatefulBuilder(
+      builder: (
+        BuildContext context,
+        void Function(void Function()) setDialogState,
+      ) =>
+          AlertDialog(
+        title: Text(t.download_task_delete),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(message ?? t.download_task_delete_confirm(title: title)),
+            if (offerDeleteFiles) ...<Widget>[
+              const SizedBox(height: 12),
+              // 共享 MD3 行 + 裸 [Checkbox] 作 leading，整行 onTap 翻转——等价旧
+              // CheckboxListTile 的取值/回调/标题，但行高与内边距走设计令牌。
+              //
+              // 这里刻意**不**换成两个删除确认框用的 [DeleteConfirmCheckboxRow]：
+              // 那个行基于 `AdaptiveSettingsRow`，内部有 `LayoutBuilder`，而
+              // `AlertDialog` 会对 content 做 intrinsic 测量——
+              // 「LayoutBuilder does not support returning intrinsic dimensions」
+              // 直接崩。两个删除确认框用的是 `FushiModalSheetFrame`，不测 intrinsic。
+              // 要统一得先把本弹窗换成同一个 frame，那是另一件事。
+              FushiListItem(
+                key: ValueKey<String>(
+                  'video-download-job-delete-files-$keySuffix',
+                ),
+                density: FushiListDensity.compact,
+                padding: EdgeInsets.zero,
+                onTap: () => setDialogState(
+                  () => deleteFiles = !deleteFiles,
+                ),
+                leading: Checkbox(
+                  value: deleteFiles,
+                  onChanged: (bool? value) => setDialogState(
+                    () => deleteFiles = value ?? false,
+                  ),
+                ),
+                title: Text(t.download_task_delete_files),
+              ),
+            ],
+          ],
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text(t.dialog_cancel),
+          ),
+          FilledButton(
+            key: ValueKey<String>(
+              'video-download-job-delete-confirm-$keySuffix',
+            ),
+            onPressed: () => Navigator.pop(
+              dialogContext,
+              offerDeleteFiles && deleteFiles,
+            ),
+            child: Text(t.dialog_delete),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/fushi/lib/src/media/downloads/download_task_entry.dart
+++ b/fushi/lib/src/media/downloads/download_task_entry.dart
@@ -12,6 +12,62 @@ enum DownloadTaskStatus {
   cancelled,
 }
 
+/// 一条任务支持的动作集合。
+///
+/// 槽位为 null 表示**该来源根本没有这个概念**，而不是「此刻不可用」——统一列表里
+/// 四类任务的能力天然不齐：任务级优先级只有 video job 的持久化调度器有；
+/// mokuro 与直链是单跑道内存队列，一次只跑一个、无调度器、连暂停态都不存在，
+/// 所以既没有 [setPriority] 也没有 [resume]（它们的「续传」是 retry 走 Range，
+/// 语义上是重跑而非恢复）。
+///
+/// 「打开所在位置」刻意**不在**本集合里：批量 reveal 会一次弹出 N 个文件管理器
+/// 窗口，那是骚扰不是便利。它天生是单条动作，留在各来源的卡片上。
+///
+/// 批量操作按这些槽位过滤选中集：不支持某动作的条目原样跳过并计入结果报告，
+/// 而不是让按钮凭空消失或整批失败。
+class DownloadTaskActions {
+  const DownloadTaskActions({
+    this.pause,
+    this.cancel,
+    this.resume,
+    this.retry,
+    this.clear,
+    this.delete,
+    this.setPriority,
+  });
+
+  /// 不支持任何动作（默认值）。
+  static const DownloadTaskActions none = DownloadTaskActions();
+
+  /// 暂停：**可恢复**地中止，已下载的数据留着，之后由 [resume] 原地接上。
+  ///
+  /// video job 侧的 `cancelJob` 就是这个语义（名为 cancel 实为 pause：它不删已
+  /// 下载数据、底层调 pauseTorrent，且 `resumeJob` 只接受被它停下的任务；
+  /// `cancelled` 是冻结的 DB 生命周期值，不追改）。
+  final Future<void> Function()? pause;
+
+  /// 取消：**不可恢复**地中止，之后只能靠 [retry] 重跑。
+  /// 与 [pause] 是两种语义，不要合并——mokuro / 直链只有这一种。
+  final Future<void> Function()? cancel;
+
+  /// 从 [pause] 的暂停态原地恢复。Range 断点续传不算——那属于 [retry]。
+  final Future<void> Function()? resume;
+
+  /// 失败 / 已取消后重跑（多数来源即断点续传）。
+  final Future<void> Function()? retry;
+
+  /// 仅把条目移出列表，不动已落盘文件。
+  final Future<void> Function()? clear;
+
+  /// 删除任务；[deleteFiles] 为 true 时连带删除已落盘文件。
+  /// 来源做不到连带删文件时不提供本槽位，只提供 [clear]——把「移出列表」伪装成
+  /// 「删除」会让用户以为磁盘已经清干净了。
+  final Future<void> Function({required bool deleteFiles})? delete;
+
+  /// 设置任务级调度优先级（1 高 / 0 普通 / -1 低）。
+  final Future<void> Function(int priority)? setPriority;
+}
+
 class DownloadTaskEntry {
   const DownloadTaskEntry({
     required this.id,
@@ -19,8 +75,7 @@ class DownloadTaskEntry {
     required this.kind,
     required this.status,
     required this.builder,
-    this.onRetry,
-    this.onClear,
+    this.actions = DownloadTaskActions.none,
     this.createdAt,
     this.progress,
     this.collectionKey,
@@ -28,8 +83,8 @@ class DownloadTaskEntry {
     this.searchTerms = const <String>[],
   });
 
-  final VoidCallback? onRetry;
-  final VoidCallback? onClear;
+  /// 本条任务支持的动作，由产生它的来源填充。
+  final DownloadTaskActions actions;
 
   final String id;
   final String title;
@@ -43,5 +98,5 @@ class DownloadTaskEntry {
   final WidgetBuilder builder;
 }
 
-typedef DownloadTasksBuilder =
-    Widget Function(BuildContext context, List<DownloadTaskEntry> tasks);
+typedef DownloadTasksBuilder = Widget Function(
+    BuildContext context, List<DownloadTaskEntry> tasks);

--- a/fushi/lib/src/media/downloads/download_task_entry.dart
+++ b/fushi/lib/src/media/downloads/download_task_entry.dart
@@ -33,6 +33,7 @@ class DownloadTaskActions {
     this.retry,
     this.clear,
     this.delete,
+    this.deletesFiles = false,
     this.setPriority,
   });
 
@@ -63,6 +64,14 @@ class DownloadTaskActions {
   /// 来源做不到连带删文件时不提供本槽位，只提供 [clear]——把「移出列表」伪装成
   /// 「删除」会让用户以为磁盘已经清干净了。
   final Future<void> Function({required bool deleteFiles})? delete;
+
+  /// [delete] 这一次**真的能删掉磁盘文件**吗。
+  ///
+  /// 与「有没有 delete 槽位」是两回事：torrent 侧删数据只能由下载后端执行，后端
+  /// 没配好时槽位仍在（计划行照样删得掉），但 deleteFiles 参数会被丢弃。UI 据此
+  /// 决定要不要摆出「同时删除已下载文件」勾选框——兑现不了就不显示，否则用户勾了
+  /// 以为盘清干净了，而几十 GB 还在，且再没有第二次机会发现。
+  final bool deletesFiles;
 
   /// 设置任务级调度优先级（1 高 / 0 普通 / -1 低）。
   final Future<void> Function(int priority)? setPriority;

--- a/fushi/lib/src/media/manga/online/mokuro_moe_tasks_section.dart
+++ b/fushi/lib/src/media/manga/online/mokuro_moe_tasks_section.dart
@@ -125,8 +125,15 @@ class MokuroMoeTasksSection extends ConsumerWidget {
       id: id,
       title: task.title,
       createdAt: task.createdAt,
-      onRetry: _canRetry(task) ? () => queue.retry(task) : null,
-      onClear: task.isFinished ? () => queue.removeFinished(task) : null,
+      // mokuro 队列是单跑道内存队列：没有调度优先级、没有暂停态（cancel 后
+      // retry 走 Range 续传，语义是重跑不是恢复），任务上也没有落盘路径可 reveal。
+      actions: DownloadTaskActions(
+        retry: _canRetry(task) ? () async => queue.retry(task) : null,
+        clear: task.isFinished
+            ? () async => queue.removeFinished(task)
+            : null,
+        cancel: task.isFinished ? null : () async => queue.cancel(task),
+      ),
       kind: DownloadTaskKind.manga,
       status: switch (task.status) {
         MokuroMoeTaskStatus.queued => DownloadTaskStatus.queued,

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -2405,6 +2405,44 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// addTorrent 顺序/首尾块优先），成功后计划复位 downloading（重置计时，
   /// torrent-missing 超时从头算）。addTorrent 报失败但种子已在后端列表
   /// （入库失败类重试的常态——重复添加被后端拒绝）也算在下，交回轮询重走完成流程。
+  /// 批量路径专用的暂停/恢复：失败**抛错**而不是弹 SnackBar。
+  ///
+  /// _togglePausePlan 在后端拒绝时只 _snack 一句就 return，对单条是合适的，但批量
+  /// 走它会变成「先排队弹 10 条『操作失败』，最后再弹一条『已处理 10 项』」——
+  /// 既刷屏又把失败计数骗成 0。抛出来交给 runDownloadTaskBatch 聚合。
+  Future<void> _batchPausePlan(
+    AnimeDownloadPlan plan, {
+    required bool pause,
+  }) async {
+    if (!await _ensureBackendReady()) {
+      throw StateError('torrent backend unavailable');
+    }
+    final AppModel appModel = ref.read(appProvider);
+    final TorrentBackend backend = appModel.createTorrentBackend(
+      effectiveTorrentConfig(appModel.qbConnectionConfig),
+    );
+    try {
+      if (backend is! TorrentPauseBackend) {
+        throw StateError('backend does not support pause control');
+      }
+      final bool ok = pause
+          ? await backend.pauseTorrent(plan.id)
+          : await backend.resumeTorrent(plan.id);
+      if (!ok) throw StateError('backend rejected pause/resume');
+    } finally {
+      backend.close();
+    }
+    await _reloadPlans();
+  }
+
+  /// 批量路径专用的重试：后端没准备好时抛错而不是静默 return。
+  Future<void> _batchRetryPlan(AnimeDownloadPlan plan) async {
+    if (!await _ensureBackendReady()) {
+      throw StateError('torrent backend unavailable');
+    }
+    await _retryPlan(plan);
+  }
+
   /// 统一下载列表里一条 legacy 计划支持的批量动作。
   ///
   /// 四项在服务层本来就齐（pauseTorrent/resumeTorrent、_retryPlan 重新 addTorrent、
@@ -2415,6 +2453,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     AnimeDownloadPlan plan,
     DownloadTaskStats? stats,
   ) {
+    final AppModel appModel = ref.read(appProvider);
     final bool imported = plan.status == AnimeDownloadPlan.statusImported;
     final bool failed = plan.status == AnimeDownloadPlan.statusFailed;
     final TorrentDisplayStatus? observed = stats == null
@@ -2423,16 +2462,28 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     final bool paused = observed == TorrentDisplayStatus.paused;
     // 后端不支持暂停控制时两个槽位都留 null——摆出来点了没反应比没有更糟。
     final bool pauseCapable = _pauseCapable;
+    // 计划仓库没装配（Profile 切换中 / 初始化未完成）时 _deletePlanResolved 会
+    // 静默 return，批量却会把它记成「已处理」。删不了就别填槽位。
+    final bool canDelete = appModel.animeDownloadPlanStore != null;
+    // 删磁盘数据只能由下载后端执行，判据与单条删除确认框逐字一致。
+    final bool canDeleteFiles = canDelete &&
+        appModel.animeDownloadService != null &&
+        effectiveTorrentConfig(appModel.qbConnectionConfig).isConfigured;
     return DownloadTaskActions(
+      // pause / resume 都排除 failed：卡片上的暂停/恢复只在 downloading 时渲染
+      // （见 _buildPlanRowInner），批量比卡片宽会变成「卡片上没有、批量却能做」。
       pause: pauseCapable && !imported && !failed && !paused
-          ? () => _togglePausePlan(plan, pause: true)
+          ? () => _batchPausePlan(plan, pause: true)
           : null,
-      resume: pauseCapable && !imported && paused
-          ? () => _togglePausePlan(plan, pause: false)
+      resume: pauseCapable && !imported && !failed && paused
+          ? () => _batchPausePlan(plan, pause: false)
           : null,
-      retry: failed ? () => _retryPlan(plan) : null,
-      delete: ({required bool deleteFiles}) =>
-          _deletePlanResolved(plan, deleteFiles: deleteFiles),
+      retry: failed ? () => _batchRetryPlan(plan) : null,
+      delete: canDelete
+          ? ({required bool deleteFiles}) =>
+              _deletePlanResolved(plan, deleteFiles: deleteFiles)
+          : null,
+      deletesFiles: canDeleteFiles,
     );
   }
 

--- a/fushi/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/fushi/lib/src/pages/implementations/anime_download_dialog.dart
@@ -145,6 +145,7 @@ DownloadTaskEntry animeDownloadTaskEntry({
   required WidgetBuilder builder,
   double? progress,
   DownloadTaskStats? stats,
+  DownloadTaskActions actions = DownloadTaskActions.none,
 }) {
   final DownloadTaskKind kind = switch (plan.contentKind) {
     AnimeDownloadPlan.kindGame => DownloadTaskKind.game,
@@ -180,6 +181,7 @@ DownloadTaskEntry animeDownloadTaskEntry({
     collectionKey: collectionKey,
     collectionTitle: collectionKey == null ? null : plan.seriesTitle,
     searchTerms: <String>[plan.torrentTitle, plan.qbCategory],
+    actions: actions,
     builder: builder,
   );
 }
@@ -1106,10 +1108,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// 删除旧番剧计划：与 v78 任务面板同一确认框（正文 + 「同时删除已下载文件」）。
   /// 以前这里没有确认框、也从不删文件；勾选后经后端 `removeTorrent(deleteFiles)` 删
   /// 数据，并把已入库、指向这些文件的视频行一并清掉（否则库里留下一排打不开的壳）。
+  /// 单条删除：弹确认框问「要不要连文件一起删」，再走 [_deletePlanResolved]。
   Future<void> _deletePlan(AnimeDownloadPlan plan) async {
     final AppModel appModel = ref.read(appProvider);
-    final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
-    if (store == null) return;
+    if (appModel.animeDownloadPlanStore == null) return;
     final AnimeDownloadService? service = appModel.animeDownloadService;
     // 「同时删除已下载文件」只在真兑现得了时才摆出来：删数据只能由下载后端执行，
     // 没有 service 或后端没配好时勾了也只会静默丢弃（与两个删除确认框里
@@ -1123,6 +1125,19 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       offerDeleteFiles: canDeleteFiles,
     );
     if (deleteFiles == null || !mounted) return;
+    await _deletePlanResolved(plan, deleteFiles: deleteFiles);
+  }
+
+  /// 删除的执行体：**不弹任何确认框**，[deleteFiles] 由调用方定好。
+  /// 批量删除对一整批只问一次，之后逐条走这里。
+  Future<void> _deletePlanResolved(
+    AnimeDownloadPlan plan, {
+    required bool deleteFiles,
+  }) async {
+    final AppModel appModel = ref.read(appProvider);
+    final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
+    if (store == null) return;
+    final AnimeDownloadService? service = appModel.animeDownloadService;
     if (service == null) {
       await store.delete(plan.id);
     } else {
@@ -2390,6 +2405,37 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// addTorrent 顺序/首尾块优先），成功后计划复位 downloading（重置计时，
   /// torrent-missing 超时从头算）。addTorrent 报失败但种子已在后端列表
   /// （入库失败类重试的常态——重复添加被后端拒绝）也算在下，交回轮询重走完成流程。
+  /// 统一下载列表里一条 legacy 计划支持的批量动作。
+  ///
+  /// 四项在服务层本来就齐（pauseTorrent/resumeTorrent、_retryPlan 重新 addTorrent、
+  /// deletePlan 含 deleteFiles），此前只是 [DownloadTaskEntry] 上没有槽位可填。
+  /// 不填 setPriority：torrent 后端只有**文件级** priority，没有任务级调度优先级，
+  /// 硬凑一个只会让批量「设为高优先级」对 legacy 行静默无效。
+  DownloadTaskActions _planActions(
+    AnimeDownloadPlan plan,
+    DownloadTaskStats? stats,
+  ) {
+    final bool imported = plan.status == AnimeDownloadPlan.statusImported;
+    final bool failed = plan.status == AnimeDownloadPlan.statusFailed;
+    final TorrentDisplayStatus? observed = stats == null
+        ? null
+        : torrentDisplayStatusFor(stats.state);
+    final bool paused = observed == TorrentDisplayStatus.paused;
+    // 后端不支持暂停控制时两个槽位都留 null——摆出来点了没反应比没有更糟。
+    final bool pauseCapable = _pauseCapable;
+    return DownloadTaskActions(
+      pause: pauseCapable && !imported && !failed && !paused
+          ? () => _togglePausePlan(plan, pause: true)
+          : null,
+      resume: pauseCapable && !imported && paused
+          ? () => _togglePausePlan(plan, pause: false)
+          : null,
+      retry: failed ? () => _retryPlan(plan) : null,
+      delete: ({required bool deleteFiles}) =>
+          _deletePlanResolved(plan, deleteFiles: deleteFiles),
+    );
+  }
+
   Future<void> _retryPlan(AnimeDownloadPlan plan) async {
     if (!await _ensureBackendReady()) return;
     final AppModel appModel = ref.read(appProvider);
@@ -2746,6 +2792,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               plan: plan,
               progress: progress[plan.id],
               stats: stats[plan.id],
+              // torrent 侧四项服务层本来就有，此前只是 Entry 上没有槽位可填，
+              // 于是统一列表里的 legacy 行既进不了批量重试也进不了批量清理。
+              // 优先级不填：后端只有文件级 priority，没有任务级调度优先级。
+              actions: _planActions(plan, stats[plan.id]),
               builder: (BuildContext context) => DownloadTaskCard(
                 key: ValueKey<String>('legacy-plan:${plan.id}'),
                 taskId: 'legacy-plan:${plan.id.trim().toLowerCase()}',

--- a/fushi/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/fushi/lib/src/pages/implementations/custom_fonts_page.dart
@@ -11,6 +11,7 @@ import 'package:fushi/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:fushi/src/models/app_font_loader.dart';
 import 'package:fushi/src/reader/font_catalog.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/utils.dart';
 import 'package:fushi/src/utils/net/app_user_agent.dart';
@@ -218,8 +219,9 @@ int _nextCatalogFontId(List<CustomFontCatalogRow> rows) {
   return next;
 }
 
-class _RecommendedFont {
-  _RecommendedFont({
+@visibleForTesting
+class RecommendedFont {
+  RecommendedFont({
     required this.name,
     required this.nameJa,
     required this.urls,
@@ -242,9 +244,10 @@ class _RecommendedFont {
 //
 // jsDelivr 对整个包 >50MB 的目录会整目录 403（例如 notoserifsc），这类只能
 // 走 GitHub raw；GitHub raw 无此限制，对 CJK 大字体统一补一条兜底直链。
-List<_RecommendedFont> get _recommendedFonts => [
+@visibleForTesting
+List<RecommendedFont> get recommendedFontsCatalog => [
   // ── 推荐首选 ──
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Klee One',
     nameJa: 'クレー One',
     urls: [
@@ -256,7 +259,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     description: t.font_desc_klee_one,
   ),
   // ── CJK 覆盖（日中韩通用，不会缺字） ──
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Sans JP',
     nameJa: 'Noto Sans 日本語',
     urls: [
@@ -267,7 +270,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_noto_sans_jp,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Serif JP',
     nameJa: 'Noto Serif 日本語',
     urls: [
@@ -278,7 +281,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_noto_serif_jp,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Sans SC',
     nameJa: 'Noto Sans 简体中文',
     urls: [
@@ -289,7 +292,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_noto_sans_sc,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Serif SC',
     nameJa: 'Noto Serif 简体中文',
     // jsDelivr 整目录 >50MB → notoserifsc 直接 403，只能走 GitHub raw。
@@ -300,7 +303,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_noto_serif_sc,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Sans TC',
     nameJa: 'Noto Sans 繁體中文',
     urls: [
@@ -311,7 +314,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_noto_sans_tc,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Noto Serif TC',
     nameJa: 'Noto Serif 繁體中文',
     urls: [
@@ -323,7 +326,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     description: t.font_desc_noto_serif_tc,
   ),
   // ── 日语特色字体（风格独特，建议搭配 Noto Sans JP 做回退） ──
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Shippori Mincho',
     nameJa: 'しっぽり明朝',
     urls: [
@@ -333,7 +336,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_shippori_mincho,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Zen Old Mincho',
     nameJa: '禅オールド明朝',
     urls: [
@@ -343,7 +346,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_zen_old_mincho,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Zen Maru Gothic',
     nameJa: '禅丸ゴシック',
     urls: [
@@ -353,7 +356,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_zen_maru_gothic,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'M PLUS Rounded 1c',
     nameJa: 'M PLUS Rounded 1c',
     urls: [
@@ -363,7 +366,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_mplus_rounded_1c,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Hina Mincho',
     nameJa: 'ひな明朝',
     urls: [
@@ -373,7 +376,7 @@ List<_RecommendedFont> get _recommendedFonts => [
     license: 'OFL 1.1',
     description: t.font_desc_hina_mincho,
   ),
-  _RecommendedFont(
+  RecommendedFont(
     name: 'Zen Kaku Gothic New',
     nameJa: '禅角ゴシック New',
     urls: [
@@ -963,36 +966,29 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
     }
   }
 
-  Future<void> _downloadUrl(
+  /// 一次字体下载的结果。[importedCount] > 0 即成功；[error] 非空说明失败，
+  /// [cancelled] 是用户主动取消（既不算成功也不该报错）。
+  ///
+  /// 执行体不弹任何 toast / 对话框，就是为了让批量下载能把 N 条结果聚合成一句话。
+  ///
+  /// 批量下载真正要避开的是旧实现里「每条各弹一个 barrierDismissible:false +
+  /// PopScope(canPop:false) 的独占模态框」——那种框在下载期间把整个 UI 锁死，
+  /// 连着下 5 个字体就是连着锁 5 次，中途还没法看进度到哪了。
+  ///
+  /// 执行体的取消由调用方持有 [cancelToken]：批量时一次取消应当停掉整批。
+
+  /// 下载执行体：**不碰 Navigator、不弹 toast**，只跑「多源回退下载 → 校验 →
+  /// 解包/落库」。UI 由调用方负责。
+  Future<_FontDownloadResult> _runFontDownload(
     String url, {
-    String? displayName,
+    required ValueNotifier<double?> progressNotifier,
+    required CancelToken cancelToken,
     List<String> mirrorUrls = const [],
     String? overrideName,
   }) async {
     final allUrls = [url, ...mirrorUrls];
     final ts = DateTime.now().millisecondsSinceEpoch;
     final tempPath = p.join(_fontsDir.path, '_tmp_$ts');
-    final progressNotifier = ValueNotifier<double?>(null);
-    final cancelToken = CancelToken();
-
-    if (mounted) {
-      showAppDialog(
-        context: context,
-        barrierDismissible: false,
-        builder: (ctx) => PopScope(
-          canPop: false,
-          child: CustomFontDownloadProgressDialog(
-            title: displayName ?? t.custom_fonts_downloading,
-            progressNotifier: progressNotifier,
-            onCancel: () {
-              cancelToken.cancel();
-              Navigator.pop(ctx);
-            },
-          ),
-        ),
-      );
-    }
-
     try {
       // BUG-1498：字体全在 cdn.jsdelivr.net / raw.githubusercontent.com /
       // fonts.google.com 上，原先是裸 `Dio(...)`（`findProxy` 为 null，连 HTTPS_PROXY
@@ -1060,8 +1056,6 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
         throw Exception(err.toString());
       }
 
-      if (mounted) Navigator.pop(context);
-
       final tempFile = File(tempPath);
       final fileName = _fileNameFromUrl(downloadedUrl);
       int count = 0;
@@ -1086,11 +1080,77 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
         );
       }
       if (await tempFile.exists()) await tempFile.delete();
+      return _FontDownloadResult(importedCount: count);
+    } on DioError catch (e, stack) {
+      final f = File(tempPath);
+      if (await f.exists()) await f.delete();
+      if (e.type == DioErrorType.cancel) {
+        return const _FontDownloadResult(cancelled: true);
+      }
+      debugPrint(
+        '[fushi-fonts] DioError: type=${e.type} '
+        'status=${e.response?.statusCode} msg=${e.message}',
+      );
+      debugPrint('[fushi-fonts] stack: $stack');
+      return _FontDownloadResult(error: e.type.name);
+    } catch (e, stack) {
+      final f = File(tempPath);
+      if (await f.exists()) await f.delete();
+      debugPrint('[fushi-fonts] download failed: $e');
+      debugPrint('[fushi-fonts] stack: $stack');
+      return _FontDownloadResult(error: '$e');
+    }
+  }
 
-      if (count > 0) {
+  /// 单条下载：独占进度框 + 逐条 toast，行为与重构前一致。
+  Future<void> _downloadUrl(
+    String url, {
+    String? displayName,
+    List<String> mirrorUrls = const [],
+    String? overrideName,
+  }) async {
+    final progressNotifier = ValueNotifier<double?>(null);
+    final cancelToken = CancelToken();
+    if (mounted) {
+      showAppDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (ctx) => PopScope(
+          canPop: false,
+          child: CustomFontDownloadProgressDialog(
+            title: displayName ?? t.custom_fonts_downloading,
+            progressNotifier: progressNotifier,
+            onCancel: () {
+              cancelToken.cancel();
+              Navigator.pop(ctx);
+            },
+          ),
+        ),
+      );
+    }
+    try {
+      final _FontDownloadResult result = await _runFontDownload(
+        url,
+        progressNotifier: progressNotifier,
+        cancelToken: cancelToken,
+        mirrorUrls: mirrorUrls,
+        overrideName: overrideName,
+      );
+      // 取消时进度框已被 onCancel 关掉，别再 pop 一次——那会连着把字体页也弹掉。
+      if (mounted && !result.cancelled) Navigator.pop(context);
+      if (result.cancelled) return;
+      if (result.error != null) {
+        FushiToast.show(
+          msg: '${t.custom_fonts_download_failed}: ${result.error}',
+          toastLength: Toast.LENGTH_LONG,
+          severity: ToastSeverity.error,
+        );
+        return;
+      }
+      if (result.importedCount > 0) {
         await _save();
         FushiToast.show(
-          msg: t.custom_fonts_imported_count(count: count),
+          msg: t.custom_fonts_imported_count(count: result.importedCount),
           severity: ToastSeverity.success,
         );
       } else {
@@ -1099,33 +1159,6 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
           severity: ToastSeverity.error,
         );
       }
-    } on DioError catch (e, stack) {
-      if (mounted) Navigator.pop(context);
-      if (e.type != DioErrorType.cancel) {
-        debugPrint(
-          '[fushi-fonts] DioError: type=${e.type} '
-          'status=${e.response?.statusCode} msg=${e.message}',
-        );
-        debugPrint('[fushi-fonts] stack: $stack');
-        FushiToast.show(
-          msg: '${t.custom_fonts_download_failed}: ${e.type.name}',
-          toastLength: Toast.LENGTH_LONG,
-          severity: ToastSeverity.error,
-        );
-      }
-      final f = File(tempPath);
-      if (await f.exists()) await f.delete();
-    } catch (e, stack) {
-      if (mounted) Navigator.pop(context);
-      debugPrint('[fushi-fonts] download failed: $e');
-      debugPrint('[fushi-fonts] stack: $stack');
-      FushiToast.show(
-        msg: '${t.custom_fonts_download_failed}: $e',
-        toastLength: Toast.LENGTH_LONG,
-        severity: ToastSeverity.error,
-      );
-      final f = File(tempPath);
-      if (await f.exists()) await f.delete();
     } finally {
       progressNotifier.dispose();
     }
@@ -1153,13 +1186,88 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
     await _downloadUrl(url);
   }
 
-  Future<void> _downloadRecommendedFont(_RecommendedFont font) async {
-    await _downloadUrl(
-      font.urls.first,
-      displayName: font.name,
-      mirrorUrls: font.urls.skip(1).toList(),
-      overrideName: font.name,
+  /// 批量下载推荐字体：**一个**进度框跑完整批，逐条串行。
+  ///
+  /// 串行而非并发：每条都要落到同一个字体目录、跑同一套解包与 _save() 落库，
+  /// 并发只会让临时文件与 catalog 写入互相踩。
+  ///
+  /// 一条失败不中断整批（网络抽风是常态，一条挂掉不该把其余六条也废掉），
+  /// 结果聚合成一句 toast；中途取消则停掉整批——用户点的是「取消」不是「跳过」。
+  Future<void> _downloadRecommendedFonts(List<RecommendedFont> fonts) async {
+    final progressNotifier = ValueNotifier<double?>(null);
+    final cancelToken = CancelToken();
+    final ValueNotifier<String> titleNotifier = ValueNotifier<String>(
+      fonts.first.name,
     );
+    if (mounted) {
+      showAppDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (ctx) => PopScope(
+          canPop: false,
+          child: ValueListenableBuilder<String>(
+            valueListenable: titleNotifier,
+            builder: (BuildContext context, String title, _) =>
+                CustomFontDownloadProgressDialog(
+              title: title,
+              progressNotifier: progressNotifier,
+              onCancel: () {
+                cancelToken.cancel();
+                Navigator.pop(ctx);
+              },
+            ),
+          ),
+        ),
+      );
+    }
+    int imported = 0;
+    int failed = 0;
+    bool cancelled = false;
+    try {
+      for (int i = 0; i < fonts.length; i++) {
+        final RecommendedFont font = fonts[i];
+        titleNotifier.value = fonts.length > 1
+            ? '${font.name}  (${i + 1}/${fonts.length})'
+            : font.name;
+        progressNotifier.value = null;
+        final _FontDownloadResult result = await _runFontDownload(
+          font.urls.first,
+          progressNotifier: progressNotifier,
+          cancelToken: cancelToken,
+          mirrorUrls: font.urls.skip(1).toList(),
+          overrideName: font.name,
+        );
+        if (result.cancelled) {
+          cancelled = true;
+          break;
+        }
+        if (result.error != null || result.importedCount == 0) {
+          failed++;
+          continue;
+        }
+        imported += result.importedCount;
+      }
+      // 取消时进度框已被 onCancel 关掉，别再 pop 一次。
+      if (mounted && !cancelled) Navigator.pop(context);
+      if (imported > 0) await _save();
+      if (!mounted) return;
+      if (imported > 0) {
+        FushiToast.show(
+          msg: t.custom_fonts_imported_count(count: imported),
+          severity: ToastSeverity.success,
+        );
+      }
+      if (failed > 0) {
+        FushiToast.show(
+          msg: '${t.custom_fonts_download_failed}: $failed',
+          toastLength: Toast.LENGTH_LONG,
+          severity: ToastSeverity.error,
+        );
+      }
+    } finally {
+      progressNotifier.dispose();
+      titleNotifier.dispose();
+    }
   }
 
   // HBK-AUDIT-109: one canonical dedupe key (the display name) shared by both
@@ -1172,15 +1280,15 @@ class _CustomFontsPageState extends BasePageState<CustomFontsPage> {
   Future<void> _openRecommended() async {
     await _fontsReady;
     if (!mounted) return;
-    final font = await Navigator.push<_RecommendedFont>(
+    final fonts = await Navigator.push<List<RecommendedFont>>(
       context,
       adaptivePageRoute(
         context: context,
-        builder: (_) => _RecommendedFontsPage(alreadyAdded: _addedFontNames),
+        builder: (_) => RecommendedFontsPage(alreadyAdded: _addedFontNames),
       ),
     );
-    if (font == null || !mounted) return;
-    await _downloadRecommendedFont(font);
+    if (fonts == null || fonts.isEmpty || !mounted) return;
+    await _downloadRecommendedFonts(fonts);
   }
 
   Future<void> _addSystemFont() async {
@@ -1502,31 +1610,108 @@ class _CustomFontUrlImportDialogState extends State<CustomFontUrlImportDialog> {
   }
 }
 
-class _RecommendedFontsPage extends StatelessWidget {
-  const _RecommendedFontsPage({required this.alreadyAdded});
+/// 一次字体下载的结果：导入了几个字面、是否被取消、失败原因。
+class _FontDownloadResult {
+  const _FontDownloadResult({
+    this.importedCount = 0,
+    this.error,
+    this.cancelled = false,
+  });
+
+  final int importedCount;
+  final String? error;
+  final bool cancelled;
+
+  bool get succeeded => error == null && !cancelled && importedCount > 0;
+}
+
+/// 推荐字体页：**默认就是多选**，不设「进入选择态」开关。
+///
+/// 这个页面唯一的用途就是挑字体下载，再要求先点一下「选择」纯属多余一步；词典
+/// 下载弹窗也是同样形态（进去就是勾选列表），两处保持一致。
+///
+/// 返回 `List<RecommendedFont>`（取消为 null）。旧实现是 `Navigator.pop(context, font)`
+/// 单值返回，选一个字体就把整页弹掉，想再下一个得重新进来——这正是要改掉的。
+@visibleForTesting
+class RecommendedFontsPage extends StatefulWidget {
+  const RecommendedFontsPage({required this.alreadyAdded, super.key});
   final Set<String> alreadyAdded;
+
+  @override
+  State<RecommendedFontsPage> createState() => _RecommendedFontsPageState();
+}
+
+class _RecommendedFontsPageState extends State<RecommendedFontsPage> {
+  final Set<String> _selected = <String>{};
+
+  bool _isAdded(RecommendedFont font) => widget.alreadyAdded.any(
+        (String name) => name.toLowerCase() == font.name.toLowerCase(),
+      );
+
+  /// 可勾选域：已装的不参与全选，与词典下载弹窗同判据——已经有的再下一遍只是
+  /// 白跑一趟下载 + 导入。
+  List<RecommendedFont> get _selectable =>
+      recommendedFontsCatalog.where((f) => !_isAdded(f)).toList();
+
+  void _toggle(RecommendedFont font) {
+    setState(() {
+      if (!_selected.remove(font.name)) _selected.add(font.name);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme scheme = Theme.of(context).colorScheme;
+    final List<RecommendedFont> selectable = _selectable;
     return AdaptiveSettingsScaffold(
       title: Text(t.custom_fonts_recommended),
+      bottom: _selected.isEmpty
+          ? null
+          : BatchActionBar(
+              selectedCount: _selected.length,
+              onSelectAll: () => setState(
+                () => _selected.addAll(selectable.map((f) => f.name)),
+              ),
+              onInvertSelection: () => setState(() {
+                final Set<String> next = <String>{
+                  for (final RecommendedFont font in selectable)
+                    if (!_selected.contains(font.name)) font.name,
+                };
+                _selected
+                  ..clear()
+                  ..addAll(next);
+              }),
+              actions: <Widget>[
+                FushiIconButton(
+                  key: const ValueKey<String>('recommended-fonts-download'),
+                  tooltip: t.dialog_import,
+                  icon: Icons.download_outlined,
+                  onTap: () => Navigator.pop(
+                    context,
+                    <RecommendedFont>[
+                      for (final RecommendedFont font in recommendedFontsCatalog)
+                        if (_selected.contains(font.name)) font,
+                    ],
+                  ),
+                ),
+              ],
+            ),
       children: [
         AdaptiveSettingsSection(
-          children: _recommendedFonts.map((font) {
-            final bool added = alreadyAdded.any(
-              (String name) => name.toLowerCase() == font.name.toLowerCase(),
-            );
+          children: recommendedFontsCatalog.map((font) {
+            final bool added = _isAdded(font);
+            final bool selected = _selected.contains(font.name);
             return AdaptiveSettingsRow(
+              key: ValueKey<String>('recommended-font-${font.name}'),
               title: font.name,
               subtitle: '${font.nameJa}\n${font.description}',
               icon: Icons.font_download_outlined,
+              onTap: added ? null : () => _toggle(font),
               trailing: added
                   ? Icon(Icons.check, color: scheme.outline)
-                  : IconButton.filledTonal(
-                      icon: const Icon(Icons.download_outlined, size: 20),
-                      tooltip: t.dialog_import,
-                      onPressed: () => Navigator.pop(context, font),
+                  : Checkbox(
+                      value: selected,
+                      onChanged: (_) => _toggle(font),
                     ),
             );
           }).toList(),

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -102,6 +102,226 @@ bool? dictionaryCategoryCheckState({
   return null;
 }
 
+/// 推荐词典目录的勾选列表：顶部「已选 N · 全选 · 反选」+ 按分类折叠的三态勾选。
+///
+/// 从 `_showDownloadSelectionDialog` 的内联闭包里抽出来，是为了让「全选只作用于
+/// 可勾选域」「分类三态」这些接线能被真的测到——判据的纯函数好测，但按钮接错域
+/// （比如把已安装项也算进全选）编译期看不出来，只有 widget 用例拦得住。
+@visibleForTesting
+class DictionaryCatalogSelectionList extends StatelessWidget {
+  const DictionaryCatalogSelectionList({
+    required this.workingCatalog,
+    required this.byCategory,
+    required this.recIndex,
+    required this.installedIndices,
+    required this.checked,
+    required this.expandedCategories,
+    required this.onCheckedChanged,
+    required this.onExpansionChanged,
+    super.key,
+  });
+
+  final List<RecommendedDictionary> workingCatalog;
+  final Map<DictionaryCategory, List<RecommendedDictionary>> byCategory;
+  final Map<RecommendedDictionary, int> recIndex;
+  final Set<int> installedIndices;
+  final Set<int> checked;
+  final Set<DictionaryCategory> expandedCategories;
+  final ValueChanged<Set<int>> onCheckedChanged;
+  final void Function(DictionaryCategory cat, bool expanded) onExpansionChanged;
+
+  String _categoryLabel(DictionaryCategory cat) => switch (cat) {
+    DictionaryCategory.jaEn => t.dict_category_ja_en,
+    DictionaryCategory.jaJa => t.dict_category_ja_ja,
+    DictionaryCategory.jaOther => t.dict_category_ja_other,
+    DictionaryCategory.grammar => t.dict_category_grammar,
+    DictionaryCategory.kanji => t.dict_category_kanji,
+    DictionaryCategory.frequency => t.dict_category_frequency,
+    DictionaryCategory.names => t.dict_category_names,
+    DictionaryCategory.supplementary => t.dict_category_supplementary,
+    DictionaryCategory.bilingual => t.dict_category_bilingual,
+    DictionaryCategory.monolingual => t.dict_category_monolingual,
+  };
+
+  void _toggleOne(int idx, bool value) {
+    final Set<int> next = Set<int>.of(checked);
+    if (value) {
+      next.add(idx);
+    } else {
+      next.remove(idx);
+    }
+    onCheckedChanged(next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextTheme textTheme = theme.textTheme;
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    // 47 条目录 + 分类折叠下，逐条点是唯一的入口太贵：全选 / 反选一律只作用于
+    // **可勾选域**（已装的不参与，见 [selectableDictionaryIndices]）。
+    final Set<int> selectable = selectableDictionaryIndices(
+      catalogLength: workingCatalog.length,
+      installedIndices: installedIndices,
+    );
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Text(
+              t.batch_selected_count(n: checked.length),
+              style: textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const Spacer(),
+            TextButton(
+              key: const ValueKey<String>('dict-download-select-all'),
+              onPressed: selectable.isEmpty
+                  ? null
+                  : () => onCheckedChanged(Set<int>.of(selectable)),
+              child: Text(t.batch_select_all),
+            ),
+            TextButton(
+              key: const ValueKey<String>('dict-download-invert-selection'),
+              onPressed: selectable.isEmpty
+                  ? null
+                  : () => onCheckedChanged(selectable.difference(checked)),
+              child: Text(t.batch_invert_selection),
+            ),
+          ],
+        ),
+        SizedBox(height: tokens.spacing.gap),
+        for (final DictionaryCategory cat in DictionaryCategory.values)
+          if (byCategory.containsKey(cat))
+            _buildCategoryTile(
+              context: context,
+              theme: theme,
+              textTheme: textTheme,
+              tokens: tokens,
+              cat: cat,
+              items: byCategory[cat]!,
+              expanded: expandedCategories.contains(cat),
+            ),
+      ],
+    );
+  }
+
+  Widget _buildCategoryTile({
+    required BuildContext context,
+    required ThemeData theme,
+    required TextTheme textTheme,
+    required FushiDesignTokens tokens,
+    required DictionaryCategory cat,
+    required List<RecommendedDictionary> items,
+    required bool expanded,
+  }) {
+    // 本类的可勾选下标（已装的不算），三态框与「本类全选」同域。
+    final Set<int> categoryIndices = <int>{
+      for (final RecommendedDictionary rec in items)
+        if (recIndex[rec] != null && !installedIndices.contains(recIndex[rec]))
+          recIndex[rec]!,
+    };
+    return Padding(
+      padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+      child: FushiCard(
+        padding: EdgeInsets.zero,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            FushiListItem(
+              minHeight: 52,
+              leading: Checkbox(
+                key: ValueKey<String>(
+                  'dict-download-category-check-${cat.name}',
+                ),
+                tristate: true,
+                value: dictionaryCategoryCheckState(
+                  categoryIndices: categoryIndices,
+                  checked: checked,
+                ),
+                onChanged: categoryIndices.isEmpty
+                    ? null
+                    : (bool? value) {
+                        final Set<int> next = Set<int>.of(checked);
+                        if (value ?? false) {
+                          next.addAll(categoryIndices);
+                        } else {
+                          next.removeAll(categoryIndices);
+                        }
+                        onCheckedChanged(next);
+                      },
+              ),
+              title: Text(
+                _categoryLabel(cat),
+                style: textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              trailing: Icon(
+                expanded ? Icons.expand_less : Icons.expand_more,
+                color: tokens.surfaces.onVariant,
+              ),
+              onTap: () => onExpansionChanged(cat, !expanded),
+            ),
+            if (expanded)
+              for (final RecommendedDictionary rec in items)
+                _buildDictCheckbox(
+                  theme: theme,
+                  textTheme: textTheme,
+                  tokens: tokens,
+                  rec: rec,
+                ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDictCheckbox({
+    required ThemeData theme,
+    required TextTheme textTheme,
+    required FushiDesignTokens tokens,
+    required RecommendedDictionary rec,
+  }) {
+    // HBK-AUDIT-110: O(1) lookup from a precomputed map instead of the former
+    // per-checkbox catalog.indexOf(rec) linear scan on every rebuild.
+    final int idx = recIndex[rec] ?? -1;
+    final bool installed = installedIndices.contains(idx);
+    final bool selected = checked.contains(idx);
+    return FushiListItem(
+      key: ValueKey<String>('dict-download-entry-${rec.name}'),
+      minHeight: 68,
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.rowHorizontal - tokens.spacing.gap / 2,
+        vertical: tokens.spacing.gap,
+      ),
+      selected: selected,
+      onTap: () => _toggleOne(idx, !selected),
+      leading: Checkbox(
+        value: selected,
+        onChanged: (bool? value) => _toggleOne(idx, value ?? false),
+      ),
+      title: Text(
+        rec.name,
+        style: textTheme.bodyMedium?.copyWith(
+          color: installed ? theme.colorScheme.onSurfaceVariant : null,
+          fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+        ),
+      ),
+      subtitle: Text(
+        installed
+            ? '${t.dict_download_installed}  ${rec.sizeEstimate}'
+            : '${rec.description}  ${rec.sizeEstimate}',
+        style: textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
 class DictionaryDialogPage extends BasePage {
   /// Create an instance of this page.
   const DictionaryDialogPage({
@@ -683,31 +903,6 @@ class _DictionaryDialogPageState extends BasePageState {
     _importDictionaryPaths(importPaths);
   }
 
-  String _categoryLabel(DictionaryCategory cat) {
-    switch (cat) {
-      case DictionaryCategory.jaEn:
-        return t.dict_category_ja_en;
-      case DictionaryCategory.jaJa:
-        return t.dict_category_ja_ja;
-      case DictionaryCategory.jaOther:
-        return t.dict_category_ja_other;
-      case DictionaryCategory.grammar:
-        return t.dict_category_grammar;
-      case DictionaryCategory.kanji:
-        return t.dict_category_kanji;
-      case DictionaryCategory.frequency:
-        return t.dict_category_frequency;
-      case DictionaryCategory.names:
-        return t.dict_category_names;
-      case DictionaryCategory.supplementary:
-        return t.dict_category_supplementary;
-      case DictionaryCategory.bilingual:
-        return t.dict_category_bilingual;
-      case DictionaryCategory.monolingual:
-        return t.dict_category_monolingual;
-    }
-  }
-
   bool _isDictInstalled(RecommendedDictionary rec) {
     return appModel.dictionaries.any((d) {
       final String base = DictionaryRepository.baseName(d.name);
@@ -822,84 +1017,26 @@ class _DictionaryDialogPageState extends BasePageState {
                       },
                     ),
                     SizedBox(height: tokens.spacing.gap),
-                    // 47 条目录 + 分类折叠下，逐条点是唯一的入口太贵：全选 /
-                    // 反选一律只作用于**可勾选域**（已装的不参与，见
-                    // [selectableDictionaryIndices]）。
-                    Builder(
-                      builder: (BuildContext ctx) {
-                        final Set<int> selectable = selectableDictionaryIndices(
-                          catalogLength: workingCatalog.length,
-                          installedIndices: installedIndices,
-                        );
-                        return Row(
-                          children: <Widget>[
-                            Text(
-                              t.batch_selected_count(n: checked.length),
-                              style: textTheme.bodyMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const Spacer(),
-                            TextButton(
-                              key: const ValueKey<String>(
-                                  'dict-download-select-all'),
-                              onPressed: selectable.isEmpty
-                                  ? null
-                                  : () => setDialogState(
-                                      () => checked = Set<int>.of(selectable)),
-                              child: Text(t.batch_select_all),
-                            ),
-                            TextButton(
-                              key: const ValueKey<String>(
-                                  'dict-download-invert-selection'),
-                              onPressed: selectable.isEmpty
-                                  ? null
-                                  : () => setDialogState(() =>
-                                      checked = selectable.difference(checked)),
-                              child: Text(t.batch_invert_selection),
-                            ),
-                          ],
-                        );
-                      },
+                    DictionaryCatalogSelectionList(
+                      workingCatalog: workingCatalog,
+                      byCategory: byCategory,
+                      recIndex: recIndex,
+                      installedIndices: installedIndices,
+                      checked: checked,
+                      expandedCategories: expandedCategories,
+                      onCheckedChanged: (Set<int> next) =>
+                          setDialogState(() => checked = next),
+                      onExpansionChanged: (
+                        DictionaryCategory cat,
+                        bool expanded,
+                      ) => setDialogState(() {
+                        if (expanded) {
+                          expandedCategories.add(cat);
+                        } else {
+                          expandedCategories.remove(cat);
+                        }
+                      }),
                     ),
-                    SizedBox(height: tokens.spacing.gap),
-                    for (final cat in DictionaryCategory.values)
-                      if (byCategory.containsKey(cat))
-                        _buildCategoryTile(
-                          cat: cat,
-                          items: byCategory[cat]!,
-                          recIndex: recIndex,
-                          checked: checked,
-                          installedIndices: installedIndices,
-                          expanded: expandedCategories.contains(cat),
-                          onExpansionChanged: (bool expanded) {
-                            setDialogState(() {
-                              if (expanded) {
-                                expandedCategories.add(cat);
-                              } else {
-                                expandedCategories.remove(cat);
-                              }
-                            });
-                          },
-                          onChanged: (int idx, bool val) {
-                            setDialogState(() {
-                              if (val) {
-                                checked.add(idx);
-                              } else {
-                                checked.remove(idx);
-                              }
-                            });
-                          },
-                          onToggleCategory: (Set<int> indices, bool val) {
-                            setDialogState(() {
-                              if (val) {
-                                checked.addAll(indices);
-                              } else {
-                                checked.removeAll(indices);
-                              }
-                            });
-                          },
-                        ),
                   ],
                 ),
               ),
@@ -954,115 +1091,6 @@ class _DictionaryDialogPageState extends BasePageState {
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildCategoryTile({
-    required DictionaryCategory cat,
-    required List<RecommendedDictionary> items,
-    required Map<RecommendedDictionary, int> recIndex,
-    required Set<int> checked,
-    required Set<int> installedIndices,
-    required bool expanded,
-    required ValueChanged<bool> onExpansionChanged,
-    required void Function(int idx, bool val) onChanged,
-    required void Function(Set<int> indices, bool val) onToggleCategory,
-  }) {
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    final Set<int> categoryIndices = <int>{
-      for (final RecommendedDictionary rec in items)
-        if (recIndex[rec] != null && !installedIndices.contains(recIndex[rec]))
-          recIndex[rec]!,
-    };
-    return Padding(
-      padding: EdgeInsets.only(bottom: tokens.spacing.gap),
-      child: FushiCard(
-        padding: EdgeInsets.zero,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            FushiListItem(
-              minHeight: 52,
-              // 本类的可勾选下标（已装的不算），三态框与「本类全选」同域。
-              leading: Checkbox(
-                key: ValueKey<String>('dict-download-category-check-${cat.name}'),
-                tristate: true,
-                value: dictionaryCategoryCheckState(
-                  categoryIndices: categoryIndices,
-                  checked: checked,
-                ),
-                onChanged: categoryIndices.isEmpty
-                    ? null
-                    : (bool? value) =>
-                        onToggleCategory(categoryIndices, value ?? false),
-              ),
-              title: Text(
-                _categoryLabel(cat),
-                style: textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              trailing: Icon(
-                expanded ? Icons.expand_less : Icons.expand_more,
-                color: tokens.surfaces.onVariant,
-              ),
-              onTap: () => onExpansionChanged(!expanded),
-            ),
-            if (expanded)
-              for (final rec in items)
-                _buildDictCheckbox(
-                  rec: rec,
-                  recIndex: recIndex,
-                  checked: checked,
-                  installedIndices: installedIndices,
-                  onChanged: onChanged,
-                ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDictCheckbox({
-    required RecommendedDictionary rec,
-    required Map<RecommendedDictionary, int> recIndex,
-    required Set<int> checked,
-    required Set<int> installedIndices,
-    required void Function(int idx, bool val) onChanged,
-  }) {
-    // HBK-AUDIT-110: O(1) lookup from a precomputed map instead of the former
-    // per-checkbox catalog.indexOf(rec) linear scan on every rebuild.
-    final int idx = recIndex[rec] ?? -1;
-    final bool installed = installedIndices.contains(idx);
-    final bool selected = checked.contains(idx);
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    return FushiListItem(
-      minHeight: 68,
-      padding: EdgeInsets.symmetric(
-        horizontal: tokens.spacing.rowHorizontal - tokens.spacing.gap / 2,
-        vertical: tokens.spacing.gap,
-      ),
-      selected: selected,
-      onTap: () => onChanged(idx, !selected),
-      leading: Checkbox(
-        value: selected,
-        onChanged: (bool? value) => onChanged(idx, value ?? false),
-      ),
-      title: Text(
-        rec.name,
-        style: textTheme.bodyMedium?.copyWith(
-          color: installed ? theme.colorScheme.onSurfaceVariant : null,
-          fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-        ),
-      ),
-      subtitle: Text(
-        installed
-            ? '${t.dict_download_installed}  ${rec.sizeEstimate}'
-            : '${rec.description}  ${rec.sizeEstimate}',
-        style: textTheme.bodySmall?.copyWith(
-          color: theme.colorScheme.onSurfaceVariant,
-        ),
-      ),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -69,6 +69,39 @@ void enterDictionaryImportStage({
 }
 
 /// Page used for managing installed dictionaries.
+/// 推荐词典下载弹窗的「可勾选下标域」：catalog 全体减去已安装项。
+///
+/// 全选 / 反选 / 分类三态一律以此为域，与默认勾选同判据（
+/// `defaultSelectionForLearningLang` 的结果也要 `.difference(installedIndices)`）：
+/// 已装的词典再下一遍只会走一趟无谓的下载 + 导入，把它们算进「全选」等于把
+/// 47 条目录里最贵的那部分默认塞给用户。
+@visibleForTesting
+Set<int> selectableDictionaryIndices({
+  required int catalogLength,
+  required Set<int> installedIndices,
+}) {
+  return <int>{
+    for (int i = 0; i < catalogLength; i++)
+      if (!installedIndices.contains(i)) i,
+  };
+}
+
+/// 分类头三态勾选框的值：全选 true / 全不选 false / 部分 null。
+///
+/// [categoryIndices] 只应传本类的**可勾选**下标；本类全是已安装项时传空集，
+/// 调用方据此把勾选框禁用（无可选项时 true/false 都是谎话）。
+@visibleForTesting
+bool? dictionaryCategoryCheckState({
+  required Set<int> categoryIndices,
+  required Set<int> checked,
+}) {
+  if (categoryIndices.isEmpty) return false;
+  final int hit = categoryIndices.where(checked.contains).length;
+  if (hit == 0) return false;
+  if (hit == categoryIndices.length) return true;
+  return null;
+}
+
 class DictionaryDialogPage extends BasePage {
   /// Create an instance of this page.
   const DictionaryDialogPage({
@@ -789,6 +822,47 @@ class _DictionaryDialogPageState extends BasePageState {
                       },
                     ),
                     SizedBox(height: tokens.spacing.gap),
+                    // 47 条目录 + 分类折叠下，逐条点是唯一的入口太贵：全选 /
+                    // 反选一律只作用于**可勾选域**（已装的不参与，见
+                    // [selectableDictionaryIndices]）。
+                    Builder(
+                      builder: (BuildContext ctx) {
+                        final Set<int> selectable = selectableDictionaryIndices(
+                          catalogLength: workingCatalog.length,
+                          installedIndices: installedIndices,
+                        );
+                        return Row(
+                          children: <Widget>[
+                            Text(
+                              t.batch_selected_count(n: checked.length),
+                              style: textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const Spacer(),
+                            TextButton(
+                              key: const ValueKey<String>(
+                                  'dict-download-select-all'),
+                              onPressed: selectable.isEmpty
+                                  ? null
+                                  : () => setDialogState(
+                                      () => checked = Set<int>.of(selectable)),
+                              child: Text(t.batch_select_all),
+                            ),
+                            TextButton(
+                              key: const ValueKey<String>(
+                                  'dict-download-invert-selection'),
+                              onPressed: selectable.isEmpty
+                                  ? null
+                                  : () => setDialogState(() =>
+                                      checked = selectable.difference(checked)),
+                              child: Text(t.batch_invert_selection),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                    SizedBox(height: tokens.spacing.gap),
                     for (final cat in DictionaryCategory.values)
                       if (byCategory.containsKey(cat))
                         _buildCategoryTile(
@@ -813,6 +887,15 @@ class _DictionaryDialogPageState extends BasePageState {
                                 checked.add(idx);
                               } else {
                                 checked.remove(idx);
+                              }
+                            });
+                          },
+                          onToggleCategory: (Set<int> indices, bool val) {
+                            setDialogState(() {
+                              if (val) {
+                                checked.addAll(indices);
+                              } else {
+                                checked.removeAll(indices);
                               }
                             });
                           },
@@ -883,8 +966,14 @@ class _DictionaryDialogPageState extends BasePageState {
     required bool expanded,
     required ValueChanged<bool> onExpansionChanged,
     required void Function(int idx, bool val) onChanged,
+    required void Function(Set<int> indices, bool val) onToggleCategory,
   }) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final Set<int> categoryIndices = <int>{
+      for (final RecommendedDictionary rec in items)
+        if (recIndex[rec] != null && !installedIndices.contains(recIndex[rec]))
+          recIndex[rec]!,
+    };
     return Padding(
       padding: EdgeInsets.only(bottom: tokens.spacing.gap),
       child: FushiCard(
@@ -894,6 +983,19 @@ class _DictionaryDialogPageState extends BasePageState {
           children: [
             FushiListItem(
               minHeight: 52,
+              // 本类的可勾选下标（已装的不算），三态框与「本类全选」同域。
+              leading: Checkbox(
+                key: ValueKey<String>('dict-download-category-check-${cat.name}'),
+                tristate: true,
+                value: dictionaryCategoryCheckState(
+                  categoryIndices: categoryIndices,
+                  checked: checked,
+                ),
+                onChanged: categoryIndices.isEmpty
+                    ? null
+                    : (bool? value) =>
+                        onToggleCategory(categoryIndices, value ?? false),
+              ),
               title: Text(
                 _categoryLabel(cat),
                 style: textTheme.titleSmall?.copyWith(

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -101,6 +101,7 @@ import 'package:fushi/src/sync/jellyfin_video_client.dart'
     show JellyfinServerConfig, JellyfinVideoClient;
 import 'package:fushi/src/sync/sync_repository.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 import 'package:fushi/src/utils/components/batch_tag_dialog_frame.dart';
 import 'package:fushi/src/utils/cover_image.dart';
 import 'package:fushi/src/pages/implementations/collection_name_dialog.dart';
@@ -6626,10 +6627,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   /// 批量操作栏（底部，仅选择态显示）：选中计数 + 全选 / 反选 + 打标签 + 删除。
-  /// 与书架 [reader_fushi_history_page._buildBatchActionBar] 对齐。
+  /// chrome 收敛到共享 [BatchActionBar]（与书架同一实现），本页只提供动作按钮与可用态。
   Widget _buildBatchActionBar() {
     final ThemeData theme = Theme.of(context);
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     // 块2/3/4：计数与按钮可用态涵盖散卡选中集 + 合集选中集。
     final int selectedCount =
         _selectedUids.length + _selectedCollectionIds.length;
@@ -6642,64 +6642,36 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           looseCount: _selectedUids.length,
         ) !=
         CombineTier.noop;
-    return Material(
-      elevation: 6,
-      color: theme.colorScheme.surfaceContainer,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: tokens.spacing.card - tokens.spacing.gap / 2,
-            vertical: tokens.spacing.gap,
-          ),
-          child: Row(
-            children: <Widget>[
-              Text(
-                t.batch_selected_count(n: selectedCount),
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              SizedBox(width: tokens.spacing.gap),
-              TextButton(
-                onPressed: _selectAllVisible,
-                child: Text(t.batch_select_all),
-              ),
-              TextButton(
-                onPressed: _invertSelection,
-                child: Text(t.batch_invert_selection),
-              ),
-              const Spacer(),
-              FushiIconButton(
-                key: const ValueKey<String>('home_video_batch_combine'),
-                enabled: canCombine,
-                onTap: _batchCombineIntoSeries,
-                // 组合成系列用 playlist_add，与页头「收藏夹」入口的
-                // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
-                icon: Icons.playlist_add,
-                tooltip: t.combine_into_series,
-              ),
-              SizedBox(width: tokens.spacing.gap / 2),
-              FushiIconButton(
-                // 打标签只作用于散卡媒体（合集无直接标签），故按散卡选中集可用态。
-                enabled: _selectedUids.isNotEmpty,
-                onTap: _batchShowTagPicker,
-                icon: Icons.sell_outlined,
-                tooltip: t.tag_label,
-              ),
-              SizedBox(width: tokens.spacing.gap / 2),
-              FushiIconButton(
-                key: const ValueKey<String>('home_video_batch_delete'),
-                enabled: hasSelection,
-                onTap: _batchDeleteConfirm,
-                icon: Icons.delete_outline,
-                tooltip: t.dialog_delete,
-                enabledColor: theme.colorScheme.error,
-              ),
-            ],
-          ),
+    return BatchActionBar(
+      selectedCount: selectedCount,
+      onSelectAll: _selectAllVisible,
+      onInvertSelection: _invertSelection,
+      actions: <Widget>[
+        FushiIconButton(
+          key: const ValueKey<String>('home_video_batch_combine'),
+          enabled: canCombine,
+          onTap: _batchCombineIntoSeries,
+          // 组合成系列用 playlist_add，与页头「收藏夹」入口的
+          // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
+          icon: Icons.playlist_add,
+          tooltip: t.combine_into_series,
         ),
-      ),
+        FushiIconButton(
+          // 打标签只作用于散卡媒体（合集无直接标签），故按散卡选中集可用态。
+          enabled: _selectedUids.isNotEmpty,
+          onTap: _batchShowTagPicker,
+          icon: Icons.sell_outlined,
+          tooltip: t.tag_label,
+        ),
+        FushiIconButton(
+          key: const ValueKey<String>('home_video_batch_delete'),
+          enabled: hasSelection,
+          onTap: _batchDeleteConfirm,
+          icon: Icons.delete_outline,
+          tooltip: t.dialog_delete,
+          enabledColor: theme.colorScheme.error,
+        ),
+      ],
     );
   }
 

--- a/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/fushi/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -79,7 +79,10 @@ class JimakuSubtitleDialog extends StatelessWidget {
         debugInitialCandidates: debugInitialCandidates,
         debugInitialSeriesMatches: debugInitialSeriesMatches,
         debugInitialSeriesLookupFailed: debugInitialSeriesLookupFailed,
-        onDownloaded: (String path) => Navigator.pop(context, path),
+        // 这个存量对话框壳仍是单值出口（调用方只应用一条）：多选下载时
+        // 取第一条，其余已落盘、由字幕轨列表承载。
+        onDownloaded: (List<String> paths) =>
+            Navigator.pop(context, paths.isEmpty ? null : paths.first),
         onCancel: () => Navigator.pop(context),
       ),
     );

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -98,6 +98,7 @@ import 'package:fushi/src/sync/sync_progress_banner.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
 import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/utils.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 import 'package:fushi/src/utils/components/batch_tag_dialog_frame.dart';
 import 'package:fushi/src/utils/cover_image.dart';
 

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -435,7 +435,6 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
   }
 
   Widget _buildBatchActionBar() {
-    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     // 块2/3/4：计数与按钮可用态涵盖散卡选中集 + 合集选中集。
     final int selectedCount =
         _selectedKeys.length + _selectedCollectionIds.length;
@@ -448,77 +447,36 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
           looseCount: _selectedKeys.length,
         ) !=
         CombineTier.noop;
-
-    // 全 app elevation 0 纪律：去阴影改上边框分隔（巡检 PR-3）；窄屏 + 大字体下
-    // 「已选 N / 全选 / 反选」改 Wrap 自动换行（旧 Row 全员不可收缩必溢出）。
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainer,
-        border: Border(
-          top: BorderSide(color: theme.colorScheme.outlineVariant),
+    return BatchActionBar(
+      selectedCount: selectedCount,
+      onSelectAll: _selectAll,
+      onInvertSelection: _invertSelection,
+      actions: <Widget>[
+        FushiIconButton(
+          key: const ValueKey<String>('reader_shelf_batch_combine'),
+          enabled: canCombine,
+          onTap: _batchCombineIntoSeries,
+          // 组合成系列用 playlist_add，与页头「收藏夹」入口的
+          // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
+          icon: Icons.playlist_add,
+          tooltip: t.combine_into_series,
         ),
-      ),
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: tokens.spacing.card - tokens.spacing.gap / 2,
-            vertical: tokens.spacing.gap,
-          ),
-          child: Row(
-            children: [
-              Expanded(
-                child: Wrap(
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  spacing: tokens.spacing.gap,
-                  children: <Widget>[
-                    Text(
-                      t.batch_selected_count(n: selectedCount),
-                      style: textTheme.bodyMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    TextButton(
-                      onPressed: _selectAll,
-                      child: Text(t.batch_select_all),
-                    ),
-                    TextButton(
-                      onPressed: _invertSelection,
-                      child: Text(t.batch_invert_selection),
-                    ),
-                  ],
-                ),
-              ),
-              FushiIconButton(
-                key: const ValueKey<String>('reader_shelf_batch_combine'),
-                enabled: canCombine,
-                onTap: _batchCombineIntoSeries,
-                // 组合成系列用 playlist_add，与页头「收藏夹」入口的
-                // collections_bookmark_outlined 区分开（二者语义无关，避免同图标歧义）。
-                icon: Icons.playlist_add,
-                tooltip: t.combine_into_series,
-              ),
-              SizedBox(width: tokens.spacing.gap / 2),
-              FushiIconButton(
-                // 打标签只作用于散卡媒体（合集无直接标签），故按散卡选中集可用态。
-                enabled: _selectedKeys.isNotEmpty,
-                onTap: _batchShowTagPicker,
-                icon: Icons.sell_outlined,
-                tooltip: t.tag_label,
-              ),
-              SizedBox(width: tokens.spacing.gap / 2),
-              FushiIconButton(
-                key: const ValueKey<String>('reader_shelf_batch_delete'),
-                enabled: hasSelection,
-                onTap: _batchDeleteConfirm,
-                icon: Icons.delete_outline,
-                tooltip: t.dialog_delete,
-                enabledColor: theme.colorScheme.error,
-              ),
-            ],
-          ),
+        FushiIconButton(
+          // 打标签只作用于散卡媒体（合集无直接标签），故按散卡选中集可用态。
+          enabled: _selectedKeys.isNotEmpty,
+          onTap: _batchShowTagPicker,
+          icon: Icons.sell_outlined,
+          tooltip: t.tag_label,
         ),
-      ),
+        FushiIconButton(
+          key: const ValueKey<String>('reader_shelf_batch_delete'),
+          enabled: hasSelection,
+          onTap: _batchDeleteConfirm,
+          icon: Icons.delete_outline,
+          tooltip: t.dialog_delete,
+          enabledColor: theme.colorScheme.error,
+        ),
+      ],
     );
   }
 

--- a/fushi/lib/src/pages/implementations/subtitle_search_panel.dart
+++ b/fushi/lib/src/pages/implementations/subtitle_search_panel.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
@@ -255,6 +256,28 @@ const ValueKey<String> kSubtitleNoticeBannerKey = ValueKey<String>(
   'jimaku-notice-banner',
 );
 
+/// 在 [directory] 下为 [fileName] 取一个**不会覆盖已有文件**的落盘路径。
+///
+/// 已存在时依次试 `name (2).srt`、`name (3).srt`……批量下载多条候选时，不同
+/// provider、不同版本组常常给出一模一样的文件名（`[Group] Show - 01.srt`），
+/// 直接写进去就是后一条把前一条盖掉——用户以为下了 5 条，盘上只剩 1 条，而且
+/// 盖掉的那几条永远不会有人发现。
+///
+/// 批量落盘路径（[runSubtitleBatch]）早就踩过同一个坑，用的是 bookUid 前缀；
+/// 这里是「同一集的多个候选」，没有 bookUid 可用，故按序号消歧。
+@visibleForTesting
+String uniqueSubtitleDestination(String directory, String fileName) {
+  final String ext = p.extension(fileName);
+  final String stem = p.basenameWithoutExtension(fileName);
+  String candidate = p.join(directory, fileName);
+  int counter = 2;
+  while (File(candidate).existsSync()) {
+    candidate = p.join(directory, '$stem ($counter)$ext');
+    counter++;
+  }
+  return candidate;
+}
+
 class SubtitleSearchPanel extends StatefulWidget {
   const SubtitleSearchPanel({
     required this.onDownloaded,
@@ -278,7 +301,11 @@ class SubtitleSearchPanel extends StatefulWidget {
 
   /// 下载落盘成功后的回调（绝对路径）。对话框壳用它 `Navigator.pop`，全屏工作台
   /// 用它把路径带回播放页——面板自己**不**碰 Navigator。
-  final void Function(String path) onDownloaded;
+  /// 下载完成后回调，参数是**本次落盘的全部字幕绝对路径**，按用户勾选顺序。
+  ///
+  /// 单选时就是一条。多选时调用方负责「全部登记进字幕轨列表、只应用第一条」——
+  /// 单值契约表达不了这件事，所以这里收的是 List。
+  final void Function(List<String> paths) onDownloaded;
 
   /// 「取消」按钮回调；null = 不渲染取消按钮（宿主自己有返回入口，如 AppBar）。
   final VoidCallback? onCancel;
@@ -367,6 +394,30 @@ class _SubtitleSearchPanelState extends State<SubtitleSearchPanel>
   AniListFailureKind? _seriesLookupKind;
   String? _busyName; // 正在下载的文件名
   String? _busySourceKey; // 正在下载的候选 identityKey（版本卡视图用）
+
+  /// 已勾选的候选，按点选顺序（下载与「应用第一条」都按这个顺序）。
+  final List<VideoSubtitleCandidate> _selectedCandidates =
+      <VideoSubtitleCandidate>[];
+
+  bool get _multiSelecting => _selectedCandidates.isNotEmpty;
+
+  Set<String> get _selectedIdentityKeys => <String>{
+        for (final VideoSubtitleCandidate c in _selectedCandidates)
+          c.identityKey,
+      };
+
+  void _toggleCandidate(VideoSubtitleCandidate candidate) {
+    setState(() {
+      final int at = _selectedCandidates.indexWhere(
+        (VideoSubtitleCandidate c) => c.identityKey == candidate.identityKey,
+      );
+      if (at >= 0) {
+        _selectedCandidates.removeAt(at);
+      } else {
+        _selectedCandidates.add(candidate);
+      }
+    });
+  }
   List<JimakuCandidate> _candidates = const <JimakuCandidate>[];
 
   /// true = 平铺文件列表（旧视图）；false（默认）= 版本卡视图。候选缺 source
@@ -830,6 +881,60 @@ class _SubtitleSearchPanelState extends State<SubtitleSearchPanel>
 
   /// 下载真实来源候选（文件视图与版本卡视图共用）：registry 按 providerId
   /// 分派，落盘后 pop 回本地路径。
+  /// 批量下载已勾选的字幕：串行，落盘路径逐条去重，最后一次性回调。
+  ///
+  /// 串行而非并发：OpenSubtitles 只是**读取并上报**配额与 429（客户端没有任何
+  /// 限流器、也没有按 Retry-After 等待的代码），并发下载一勾十条就是主动撞配额；
+  /// 顺序执行还让「应用第一条」有确定含义。
+  ///
+  /// 一条失败不中断整批（某个 provider 挂了不该把其余的也废掉），失败条数汇总到
+  /// 错误提示里；一条都没成功时不回调，避免调用方拿着空列表去「应用第一条」。
+  Future<void> _downloadSelected() async {
+    final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
+    if (registry == null || _selectedCandidates.isEmpty) return;
+    final List<VideoSubtitleCandidate> targets =
+        List<VideoSubtitleCandidate>.of(_selectedCandidates);
+    final List<String> saved = <String>[];
+    int failed = 0;
+    for (final VideoSubtitleCandidate source in targets) {
+      if (!mounted) return;
+      setState(() {
+        _busyName = source.fileName;
+        _busySourceKey = source.identityKey;
+        _error = null;
+      });
+      try {
+        final VideoSubtitleDownload download = await registry.download(source);
+        if (download.bytes.isEmpty) {
+          failed++;
+          continue;
+        }
+        final Directory dir = Directory(widget.saveDirectory);
+        if (!dir.existsSync()) dir.createSync(recursive: true);
+        final String dest = uniqueSubtitleDestination(
+          dir.path,
+          safeSubtitleFileName(download.fileName),
+        );
+        await File(dest).writeAsBytes(download.bytes);
+        saved.add(dest);
+      } on Object catch (error) {
+        failed++;
+        debugPrint('[fushi-subtitle] batch download failed: $error');
+      }
+    }
+    if (!mounted) return;
+    setState(() {
+      _busyName = null;
+      _busySourceKey = null;
+    });
+    if (saved.isEmpty) {
+      _showError(t.video_jimaku_download_failed);
+      return;
+    }
+    if (failed > 0) _showError(t.download_batch_failed(n: failed));
+    widget.onDownloaded(saved);
+  }
+
   Future<void> _downloadSource(VideoSubtitleCandidate source) async {
     final VideoSubtitleRegistry? registry = widget.subtitleRegistry?.call();
     if (registry == null) return;
@@ -848,13 +953,13 @@ class _SubtitleSearchPanelState extends State<SubtitleSearchPanel>
       if (!dir.existsSync()) dir.createSync(recursive: true);
       // BUG-1845：文件名来自远端 provider，只取安全叶名——`../` / `..\` 不得逃出
       // [SubtitleSearchPanel.saveDirectory]。
-      final String dest = p.join(
+      final String dest = uniqueSubtitleDestination(
         dir.path,
         safeSubtitleFileName(download.fileName),
       );
       await File(dest).writeAsBytes(download.bytes);
       if (!mounted) return;
-      widget.onDownloaded(dest);
+      widget.onDownloaded(<String>[dest]);
     } on Object catch (error) {
       // BUG-1844：401（key 过期）/ 429（限流）/ 404（文件下架）对用户是完全不同的三
       // 件事，一律显示「下载失败」等于什么都没说。
@@ -1259,6 +1364,8 @@ class _SubtitleSearchPanelState extends State<SubtitleSearchPanel>
         requestedEpisode: int.tryParse(_episodeCtrl.text.trim()),
         busyIdentityKey: _busySourceKey,
         onPickCandidate: _busyName == null ? _downloadSource : null,
+        selectedIdentityKeys: _selectedIdentityKeys,
+        onToggleCandidate: _busyName == null ? _toggleCandidate : null,
         probedLanguages: _probedGroupLanguages,
       );
     }
@@ -1342,6 +1449,41 @@ class _SubtitleSearchPanelState extends State<SubtitleSearchPanel>
             },
           ),
         ),
+        // 勾了字幕才出现的批量栏：本面板的主操作仍是「搜索」，多选是叠加能力，
+        // 没勾东西时不该占掉本来就紧张的固定高（窄机横屏正文只剩百来 dp）。
+        if (_multiSelecting)
+          BatchActionBar(
+            selectedCount: _selectedCandidates.length,
+            onSelectAll: () => setState(() {
+              _selectedCandidates
+                ..clear()
+                ..addAll(_candidates
+                    .map((JimakuCandidate c) => c.source)
+                    .whereType<VideoSubtitleCandidate>());
+            }),
+            onInvertSelection: () => setState(() {
+              final Set<String> current = _selectedIdentityKeys;
+              final List<VideoSubtitleCandidate> next =
+                  <VideoSubtitleCandidate>[
+                for (final JimakuCandidate c in _candidates)
+                  if (c.source != null &&
+                      !current.contains(c.source!.identityKey))
+                    c.source!,
+              ];
+              _selectedCandidates
+                ..clear()
+                ..addAll(next);
+            }),
+            actions: <Widget>[
+              FushiIconButton(
+                key: const ValueKey<String>('subtitle-batch-download'),
+                enabled: _busyName == null,
+                tooltip: t.video_jimaku_batch_download,
+                icon: Icons.download_outlined,
+                onTap: () => unawaited(_downloadSelected()),
+              ),
+            ],
+          ),
         const SizedBox(height: 8),
         // 底部固定操作栏：「取消」+「搜索」。搜索是本面板唯一主操作，必须在不随
         // 正文滚动的槽位——它此前跟着输入框放在筛选面板（可滚区）里，iPhone 横屏

--- a/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
+++ b/fushi/lib/src/pages/implementations/subtitle_version_group_list.dart
@@ -22,6 +22,8 @@ class SubtitleVersionGroupList extends StatefulWidget {
     required this.requestedEpisode,
     required this.busyIdentityKey,
     required this.onPickCandidate,
+    this.selectedIdentityKeys = const <String>{},
+    this.onToggleCandidate,
     this.probedLanguages = const <String, SubtitleContentLanguage>{},
     super.key,
   });
@@ -36,6 +38,12 @@ class SubtitleVersionGroupList extends StatefulWidget {
 
   /// 用户最终选定某个文件（下载动作由宿主执行）。null = 全部禁用。
   final void Function(VideoSubtitleCandidate candidate)? onPickCandidate;
+
+  /// 已勾选的候选 identityKey。非空时列表进入多选态：点行只勾选，不再直接下载。
+  final Set<String> selectedIdentityKeys;
+
+  /// 勾选/取消一个候选；null = 不支持多选。
+  final void Function(VideoSubtitleCandidate candidate)? onToggleCandidate;
 
   /// 正文语言探测结果（group.key → 检测值）：文件名认不出语言的组，宿主可
   /// 后台探测正文后回填，本组件只展示（`正文：简体中文`），不参与分组。
@@ -245,6 +253,14 @@ class _SubtitleVersionGroupListState extends State<SubtitleVersionGroupList> {
     ];
     return FushiListItem(
       key: ValueKey<String>('subtitle-file-${candidate.identityKey}'),
+      leading: widget.onToggleCandidate == null
+          ? null
+          : Checkbox(
+              value: widget.selectedIdentityKeys.contains(
+                candidate.identityKey,
+              ),
+              onChanged: (_) => widget.onToggleCandidate!(candidate),
+            ),
       density: FushiListDensity.compact,
       padding: const EdgeInsets.symmetric(horizontal: 4),
       selected: highlight,

--- a/fushi/lib/src/pages/implementations/subtitle_workbench_page.dart
+++ b/fushi/lib/src/pages/implementations/subtitle_workbench_page.dart
@@ -137,11 +137,15 @@ class SubtitleWorkbenchPage extends StatefulWidget {
 
   final SubtitleWorkbenchScope initialScope;
 
-  /// 推整页路由。返回「本集」作用域下载落盘的字幕绝对路径（用户直接返回为 null）。
+  /// 推整页路由。返回「本集」作用域下载落盘的**全部**字幕绝对路径，按用户勾选
+  /// 顺序（用户直接返回为 null）。
+  ///
+  /// 多选下载完成后由调用方「全部登记进字幕轨列表、只应用第一条」——单值返回
+  /// 表达不了这件事，所以这里是 List。
   ///
   /// `fullscreenDialog` + root navigator：播放页全屏态自建的路由在 root 上，工作台
   /// 必须盖在它之上；关闭后由调用方归还播放器焦点。
-  static Future<String?> open(
+  static Future<List<String>?> open(
     BuildContext context, {
     required SubtitleWorkbenchHost host,
     required String saveDirectory,
@@ -149,8 +153,8 @@ class SubtitleWorkbenchPage extends StatefulWidget {
     SubtitleCollectionSpec? collection,
     SubtitleWorkbenchScope initialScope = SubtitleWorkbenchScope.episode,
   }) {
-    return Navigator.of(context, rootNavigator: true).push<String>(
-      MaterialPageRoute<String>(
+    return Navigator.of(context, rootNavigator: true).push<List<String>>(
+      MaterialPageRoute<List<String>>(
         fullscreenDialog: true,
         builder: (_) => SubtitleWorkbenchPage(
           host: host,
@@ -196,7 +200,8 @@ class _SubtitleWorkbenchPageState extends State<SubtitleWorkbenchPage> {
       initialPreferredLanguage: host.preferredLanguageFor(spec.seriesKey),
       onPreferredLanguageChanged: (String lang) =>
           host.setPreferredLanguage(spec.seriesKey, lang),
-      onDownloaded: (String path) => Navigator.of(context).pop(path),
+      onDownloaded: (List<String> paths) =>
+          Navigator.of(context).pop(paths),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:crypto/crypto.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/media_extensions.dart';
@@ -647,7 +648,26 @@ class _VideoResourceSearchSurfaceState
   VideoMetadataMediaKind _manualMediaKind = VideoMetadataMediaKind.tv;
   String _manualProvider = 'anidb';
   ProviderBatchResult<VideoResourceCandidate>? _result;
-  VideoResourceCandidate? _selected;
+  /// 已选中的候选，按点选顺序（入队顺序就按这个走，与用户看到的顺序一致）。
+  ///
+  /// 只有**下载模式**才可能多于一条：订阅是「一条规则跟一个 release 模板」，
+  /// 多选在那里没有意义，所以订阅模式下选新的直接替换旧的（见 [_select]）。
+  /// 用一个集合而不是「单值 + 集合」两份状态，是为了不再有两处要同步。
+  final List<VideoResourceCandidate> _selectedCandidates =
+      <VideoResourceCandidate>[];
+
+  VideoResourceCandidate? get _selected =>
+      _selectedCandidates.isEmpty ? null : _selectedCandidates.last;
+
+  bool _isSelected(VideoResourceCandidate candidate) =>
+      _selectedCandidates.any(
+        (VideoResourceCandidate c) => c.identityKey == candidate.identityKey,
+      );
+
+  Set<String> get _selectedIdentityKeys => <String>{
+        for (final VideoResourceCandidate c in _selectedCandidates)
+          c.identityKey,
+      };
   int? _sourceId;
   VideoDownloadSubtitlePolicy _subtitlePolicy =
       VideoDownloadSubtitlePolicy.bestEffort;
@@ -714,7 +734,7 @@ class _VideoResourceSearchSurfaceState
       ++_generation;
       _loading = false;
       _result = null;
-      _selected = null;
+      _selectedCandidates.clear();
       _strictConfirmed = false;
     });
   }
@@ -765,7 +785,7 @@ class _VideoResourceSearchSurfaceState
     final int generation = ++_generation;
     setState(() {
       _loading = true;
-      _selected = null;
+      _selectedCandidates.clear();
       _strictConfirmed = false;
     });
     final ProviderBatchResult<VideoResourceCandidate> result =
@@ -784,9 +804,26 @@ class _VideoResourceSearchSurfaceState
 
   void _select(VideoResourceCandidate candidate) {
     setState(() {
-      _selected = candidate;
       _strictConfirmed = false;
-      final int? episode = episodeNumberFromReleaseTitle(candidate.title);
+      if (widget.subscription) {
+        // 订阅只跟一条模板：选新的直接替换，不累积。
+        _selectedCandidates
+          ..clear()
+          ..add(candidate);
+      } else if (!_selectedCandidates.remove(
+        _selectedCandidates.firstWhereOrNull(
+          (VideoResourceCandidate c) =>
+              c.identityKey == candidate.identityKey,
+        ),
+      )) {
+        _selectedCandidates.add(candidate);
+      }
+      // 起始集号只对订阅有意义，且要跟着「当前这一条」走；下载模式多选时用最后
+      // 点的那条填，反正提交时不读它。
+      final VideoResourceCandidate? current = _selected;
+      final int? episode = current == null
+          ? null
+          : episodeNumberFromReleaseTitle(current.title);
       _startAfterController.text = episode?.toString() ?? '';
     });
   }
@@ -800,21 +837,27 @@ class _VideoResourceSearchSurfaceState
 
   Future<void> _submit() async {
     final VideoMediaReference? media = _media;
-    final VideoResourceCandidate? resource = _selected;
     final MediaSourceRow? source = _source;
-    if (media == null || resource == null || source == null || _submitting) {
+    // 目标集在任何 await 之前定死：提交期间搜索结果会被刷新重建，跨 await 重读
+    // 会让「按钮上写的 N」与实际入队条数对不上。
+    final List<VideoResourceCandidate> resources =
+        List<VideoResourceCandidate>.of(_selectedCandidates);
+    if (media == null || resources.isEmpty || source == null || _submitting) {
       return;
     }
-    final VideoDiscoveryDownloadSelection download =
+    VideoDiscoveryDownloadSelection downloadFor(
+      VideoResourceCandidate resource,
+    ) =>
         VideoDiscoveryDownloadSelection(
-      media: media,
-      resource: resource,
-      source: source,
-      subtitlePolicy: _subtitlePolicy,
-    );
+          media: media,
+          resource: resource,
+          source: source,
+          subtitlePolicy: _subtitlePolicy,
+        );
     setState(() => _submitting = true);
     try {
       if (widget.subscription) {
+        final VideoResourceCandidate resource = resources.first;
         final StrictVideoSubscriptionFilter? filter =
             deriveStrictVideoSubscriptionFilter(resource);
         if (filter == null || !_strictConfirmed) return;
@@ -823,13 +866,31 @@ class _VideoResourceSearchSurfaceState
             : int.tryParse(_startAfterController.text.trim());
         await widget.onSubscriptionSubmit!(
           VideoDiscoverySubscriptionSelection(
-            download: download,
+            download: downloadFor(resource),
             filter: filter,
             startAfterEpisode: startAfter,
           ),
         );
       } else {
-        await widget.onSubmit!(download);
+        // 串行：入队最终落到同一张 video_download_jobs 表，并发只会把一批提交
+        // 变成一批竞态。首条失败直接抛给下面的 catch（后端不可用 / 没配好这类
+        // 前置问题对整批都成立，逐条重复报 N 次没有意义）；后续条目的失败聚合成
+        // 一句，不让一条挂掉把其余的也废掉。
+        int failed = 0;
+        for (int i = 0; i < resources.length; i++) {
+          try {
+            await widget.onSubmit!(downloadFor(resources[i]));
+          } on Object catch (error, stackTrace) {
+            if (i == 0) rethrow;
+            failed++;
+            debugPrint(
+              '[fushi-discovery] batch enqueue failed: $error\n$stackTrace',
+            );
+          }
+        }
+        if (failed > 0 && mounted) {
+          _showSubmitFailure(t.download_batch_failed(n: failed), null);
+        }
       }
       if (mounted) widget.onClose?.call();
     } on VideoDownloadBackendUnavailable catch (error) {
@@ -1042,7 +1103,7 @@ class _VideoResourceSearchSurfaceState
                   setState(() {
                     _manualMediaKind = value;
                     _result = null;
-                    _selected = null;
+                    _selectedCandidates.clear();
                     _strictConfirmed = false;
                   });
                 },
@@ -1076,7 +1137,7 @@ class _VideoResourceSearchSurfaceState
                     setState(() {
                       _manualProvider = value;
                       _result = null;
-                      _selected = null;
+                      _selectedCandidates.clear();
                     });
                   },
                 );
@@ -1169,7 +1230,13 @@ class _VideoResourceSearchSurfaceState
                 label: Text(
                   widget.subscription
                       ? t.video_discovery_subscribe
-                      : t.dialog_done,
+                      : _selectedCandidates.length > 1
+                          // 选了多条时按钮上直接写清楚这一下会入队几条，
+                          // 免得用户以为只下最后点的那一条。
+                          ? t.batch_selected_count(
+                              n: _selectedCandidates.length,
+                            )
+                          : t.dialog_done,
                 ),
               ),
             ],
@@ -1182,7 +1249,7 @@ class _VideoResourceSearchSurfaceState
   bool _canSubmit(StrictVideoSubscriptionFilter? filter) =>
       !_loading &&
       !_submitting &&
-      _selected != null &&
+      _selectedCandidates.isNotEmpty &&
       _source != null &&
       (!widget.subscription || (filter != null && _strictConfirmed));
 
@@ -1240,7 +1307,8 @@ class _VideoResourceSearchSurfaceState
             Expanded(
               child: VideoResourceVersionGroupList(
                 groups: buildVideoResourceVersionGroups(result.items),
-                selectedIdentityKey: _selected?.identityKey,
+                selectedIdentityKeys: _selectedIdentityKeys,
+                multiSelect: !widget.subscription,
                 onSelect: _select,
                 compact: !widget.pageMode,
               ),
@@ -1308,10 +1376,17 @@ class _VideoResourceSearchSurfaceState
           density: widget.pageMode
               ? FushiListDensity.standard
               : FushiListDensity.compact,
-          selected: identical(_selected, candidate),
-          leading: Icon(candidate.trusted
-              ? Icons.verified_rounded
-              : Icons.cloud_download_outlined),
+          selected: _isSelected(candidate),
+          // 下载模式给勾选框（可多选整季分集）；订阅模式仍是单选，摆勾选框会
+          // 让人以为能订阅一批。
+          leading: widget.subscription
+              ? Icon(candidate.trusted
+                  ? Icons.verified_rounded
+                  : Icons.cloud_download_outlined)
+              : Checkbox(
+                  value: _isSelected(candidate),
+                  onChanged: (_) => _select(candidate),
+                ),
           onTap: () => _select(candidate),
         );
       },

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -388,6 +388,8 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
           ? null
           : ({required bool deleteFiles}) =>
               onDelete(job, deleteFiles: deleteFiles),
+      // durable pipeline 的 deleteJob 自己会去后端摘种子删数据，能删。
+      deletesFiles: onDelete != null,
       setPriority: onSetPriority != null && videoDownloadJobCanSetPriority(job)
           ? (int priority) => onSetPriority(job, priority)
           : null,

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -28,6 +28,28 @@ typedef VideoDownloadJobAction = Future<void> Function(
   VideoDownloadJobRow job,
 );
 
+/// 能否重试：只有真失败 / 需要处理的任务能重跑；legacy 导入报告不是可重跑任务。
+bool videoDownloadJobCanRetry(VideoDownloadJobRow job) =>
+    job.resourceProvider != 'legacy-import-report' &&
+    (job.lifecycle == VideoDownloadJobLifecycle.needsAttention ||
+        job.lifecycle == VideoDownloadJobLifecycle.failed);
+
+/// 能否恢复：`cancelled` 是**用户暂停**这一生命周期的冻结 DB 值（见
+/// `VideoDownloadPipelineService.cancelJob`：它不删已下载数据、底层调
+/// pauseTorrent），所以「已暂停」才是它的真实语义。
+bool videoDownloadJobCanResume(VideoDownloadJobRow job) =>
+    job.lifecycle == VideoDownloadJobLifecycle.cancelled;
+
+/// 能否暂停：只有正在跑的任务。对应 `cancelJob`（名为 cancel 实为 pause）。
+bool videoDownloadJobCanPause(VideoDownloadJobRow job) =>
+    job.lifecycle == VideoDownloadJobLifecycle.active;
+
+/// 优先级只对「还会被取走」的任务有意义。已完成 / 已暂停的任务调了也不会重新
+/// 排队，露出来只会让人以为能插队。
+bool videoDownloadJobCanSetPriority(VideoDownloadJobRow job) =>
+    job.lifecycle == VideoDownloadJobLifecycle.active ||
+    job.lifecycle == VideoDownloadJobLifecycle.needsAttention;
+
 typedef VideoDownloadJobLocationLoader = Future<String?> Function(
   VideoDownloadJobRow job,
 );
@@ -412,6 +434,39 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
     }
   }
 
+  /// 统一列表里一条 video job 支持的批量动作。
+  ///
+  /// 可用判据一律复用卡片同款纯函数（videoDownloadJobCan*），不在这里抄第二份——
+  /// 两份判据必然漂移，最后表现为「卡片上有按钮、批量却跳过它」。
+  ///
+  /// 这里直连注入的回调、不经 [_runAction]：那层的 busy 门与逐条 SnackBar 是
+  /// **单条**语义，批量有自己的进度与聚合报告，套上去会让一批操作弹出一串错误条。
+  DownloadTaskActions _entryActions(VideoDownloadJobRow job) {
+    final VideoDownloadJobAction? onPause = widget.onCancel;
+    final VideoDownloadJobAction? onResume = widget.onResume;
+    final VideoDownloadJobAction? onRetry = widget.onRetry;
+    final VideoDownloadJobDeleteAction? onDelete = widget.onDelete;
+    final VideoDownloadJobPriorityAction? onSetPriority = widget.onSetPriority;
+    return DownloadTaskActions(
+      pause: onPause != null && videoDownloadJobCanPause(job)
+          ? () => onPause(job)
+          : null,
+      resume: onResume != null && videoDownloadJobCanResume(job)
+          ? () => onResume(job)
+          : null,
+      retry: onRetry != null && videoDownloadJobCanRetry(job)
+          ? () => onRetry(job)
+          : null,
+      delete: onDelete == null
+          ? null
+          : ({required bool deleteFiles}) =>
+              onDelete(job, deleteFiles: deleteFiles),
+      setPriority: onSetPriority != null && videoDownloadJobCanSetPriority(job)
+          ? (int priority) => onSetPriority(job, priority)
+          : null,
+    );
+  }
+
   Future<void> _runAction(
     VideoDownloadJobRow job,
     VideoDownloadJobAction action,
@@ -637,6 +692,7 @@ class _VideoDownloadJobsPanelState extends State<VideoDownloadJobsPanel> {
       additionalTasks: widget.additionalTasks,
       metricsLoader: widget.metricsLoader,
       selectedSizeLoader: widget.selectedSizeLoader,
+      actionsFor: _entryActions,
       itemBuilder: (
         BuildContext context,
         VideoDownloadJobRow job,
@@ -719,9 +775,13 @@ class _VideoDownloadJobList extends StatefulWidget {
     required this.metricsLoader,
     required this.selectedSizeLoader,
     required this.itemBuilder,
+    required this.actionsFor,
     required this.unified,
     required this.additionalTasks,
   });
+
+  /// 统一列表里一条 video job 支持的批量动作，由 panel 按注入的回调组装。
+  final DownloadTaskActions Function(VideoDownloadJobRow job) actionsFor;
 
   final bool unified;
   final List<DownloadTaskEntry> additionalTasks;
@@ -860,6 +920,7 @@ class _VideoDownloadJobListState extends State<_VideoDownloadJobList> {
             if (job.resourceTitle != null) job.resourceTitle!,
             job.resourceProvider,
           ],
+          actions: widget.actionsFor(job),
           builder: (BuildContext context) => widget.itemBuilder(
             context,
             job,
@@ -927,20 +988,13 @@ class _VideoDownloadJobCard extends StatelessWidget {
   final String Function(String lifecycle)? lifecycleLabel;
   final String Function(String stage)? stageLabel;
 
-  bool get _canRetry =>
-      job.resourceProvider != 'legacy-import-report' &&
-      (job.lifecycle == VideoDownloadJobLifecycle.needsAttention ||
-          job.lifecycle == VideoDownloadJobLifecycle.failed);
+  bool get _canRetry => videoDownloadJobCanRetry(job);
 
-  bool get _canResume => job.lifecycle == VideoDownloadJobLifecycle.cancelled;
+  bool get _canResume => videoDownloadJobCanResume(job);
 
-  bool get _canCancel => job.lifecycle == VideoDownloadJobLifecycle.active;
+  bool get _canCancel => videoDownloadJobCanPause(job);
 
-  /// 优先级只对「还会被取走」的任务有意义。已完成 / 已取消的任务调了也不会重新
-  /// 排队，露出来只会让人以为能插队。
-  bool get _canSetPriority =>
-      job.lifecycle == VideoDownloadJobLifecycle.active ||
-      job.lifecycle == VideoDownloadJobLifecycle.needsAttention;
+  bool get _canSetPriority => videoDownloadJobCanSetPriority(job);
 
   /// 数值 -> 档位名。非三档的历史值（理论上不会有，但 DB 不拦）按最接近的一档
   /// 显示，不显示裸数字——用户看到 `优先级 · 7` 只会困惑。

--- a/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
+++ b/fushi/lib/src/pages/implementations/video_download_jobs_panel.dart
@@ -4,6 +4,7 @@ import 'package:fushi/src/media/downloads/download_task_browser.dart';
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/src/media/downloads/download_task_delete_confirm.dart';
 import 'package:flutter/services.dart';
 import 'package:fushi_core/fushi_core.dart'
     show
@@ -23,6 +24,12 @@ import 'package:fushi/src/media/video/download/video_download_pipeline_service.d
     show downloadOnlyKindOfOrganizationPolicy;
 import 'package:fushi/src/utils/misc/reveal_in_file_manager.dart';
 import 'package:fushi/utils.dart';
+
+// 确认框已迁到 media/downloads 共享层（browser 也要用它做批量删除，
+// 而 panel 自己 import 了 browser——留在这里会构成循环 import）。
+// 窄 show 的 re-export 让三个既有 import 点不必改动。
+export 'package:fushi/src/media/downloads/download_task_delete_confirm.dart'
+    show showDownloadTaskDeleteConfirm;
 
 typedef VideoDownloadJobAction = Future<void> Function(
   VideoDownloadJobRow job,
@@ -53,86 +60,6 @@ bool videoDownloadJobCanSetPriority(VideoDownloadJobRow job) =>
 typedef VideoDownloadJobLocationLoader = Future<String?> Function(
   VideoDownloadJobRow job,
 );
-
-/// 下载任务「删除任务」确认框：正文 + 「同时删除已下载文件」勾选框。返回 null=取消，
-/// 否则为勾选值。v78 任务面板与旧番剧计划面板共用，两处口径一致；测试按
-/// `video-download-job-delete-files-<keySuffix>` / `…-confirm-<keySuffix>` 定位。
-///
-/// [offerDeleteFiles]=false 时不渲染勾选框、恒返回 false：删已下载的数据只能由下载
-/// 后端执行，本机没有可用后端时那个勾选框兑现不了（与两个删除确认框「兑现不了就不
-/// 显示」同一纪律）。
-Future<bool?> showDownloadTaskDeleteConfirm(
-  BuildContext context, {
-  required String title,
-  required String keySuffix,
-  bool offerDeleteFiles = true,
-}) {
-  bool deleteFiles = false;
-  return showAppDialog<bool>(
-    context: context,
-    builder: (BuildContext dialogContext) => StatefulBuilder(
-      builder: (
-        BuildContext context,
-        void Function(void Function()) setDialogState,
-      ) =>
-          AlertDialog(
-        title: Text(t.download_task_delete),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(t.download_task_delete_confirm(title: title)),
-            if (offerDeleteFiles) ...<Widget>[
-              const SizedBox(height: 12),
-              // 共享 MD3 行 + 裸 [Checkbox] 作 leading，整行 onTap 翻转——等价旧
-              // CheckboxListTile 的取值/回调/标题，但行高与内边距走设计令牌。
-              //
-              // 这里刻意**不**换成两个删除确认框用的 [DeleteConfirmCheckboxRow]：
-              // 那个行基于 `AdaptiveSettingsRow`，内部有 `LayoutBuilder`，而
-              // `AlertDialog` 会对 content 做 intrinsic 测量——
-              // 「LayoutBuilder does not support returning intrinsic dimensions」
-              // 直接崩。两个删除确认框用的是 `FushiModalSheetFrame`，不测 intrinsic。
-              // 要统一得先把本弹窗换成同一个 frame，那是另一件事。
-              FushiListItem(
-                key: ValueKey<String>(
-                  'video-download-job-delete-files-$keySuffix',
-                ),
-                density: FushiListDensity.compact,
-                padding: EdgeInsets.zero,
-                onTap: () => setDialogState(
-                  () => deleteFiles = !deleteFiles,
-                ),
-                leading: Checkbox(
-                  value: deleteFiles,
-                  onChanged: (bool? value) => setDialogState(
-                    () => deleteFiles = value ?? false,
-                  ),
-                ),
-                title: Text(t.download_task_delete_files),
-              ),
-            ],
-          ],
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: Text(t.dialog_cancel),
-          ),
-          FilledButton(
-            key: ValueKey<String>(
-              'video-download-job-delete-confirm-$keySuffix',
-            ),
-            onPressed: () => Navigator.pop(
-              dialogContext,
-              offerDeleteFiles && deleteFiles,
-            ),
-            child: Text(t.dialog_delete),
-          ),
-        ],
-      ),
-    ),
-  );
-}
 
 typedef VideoDownloadJobDeleteAction = Future<void> Function(
   VideoDownloadJobRow job, {

--- a/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/subtitle.part.dart
@@ -1157,7 +1157,7 @@ extension _VideoSubtitle on _VideoFushiPageState {
     final SubtitleSearchSeed seed = await _buildJimakuSeed(query);
     final SubtitleCollectionSpec? collection = await _subtitleCollectionSpec();
     if (!context.mounted) return;
-    final String? downloaded = await SubtitleWorkbenchPage.open(
+    final List<String>? downloadedPaths = await SubtitleWorkbenchPage.open(
       context,
       host: AppSubtitleWorkbenchHost(appModel),
       saveDirectory: saveDir,
@@ -1172,7 +1172,18 @@ extension _VideoSubtitle on _VideoFushiPageState {
     );
     // 工作台内含联网搜索/下载，会夺焦；关闭后把焦点还给 Video。
     _focusOwnership.reclaim(FocusReclaimCause.overlayClosed);
-    if (downloaded == null || !context.mounted) return;
+    if (downloadedPaths == null ||
+        downloadedPaths.isEmpty ||
+        !context.mounted) {
+      return;
+    }
+    // 多选下载：**全部**登记进字幕轨列表，只把第一条（用户最先勾的那条）应用为
+    // 当前字幕。其余就在轨列表里等着切——一次下 5 条却只有 1 条能找得到，等于
+    // 另外 4 条白下了。
+    for (final String extra in downloadedPaths.skip(1)) {
+      _registerImportedSubtitleSource(extra);
+    }
+    final String downloaded = downloadedPaths.first;
     if (_isRemote) {
       // 远端：内存应用，不写本地 DB（_applyRemoteSubtitle 自带 cue 为空时的失败提示
       // + 成功 OSD），不叠加额外提示。

--- a/fushi/lib/src/pages/implementations/video_resource_version_group_list.dart
+++ b/fushi/lib/src/pages/implementations/video_resource_version_group_list.dart
@@ -13,16 +13,21 @@ import 'package:fushi/utils.dart';
 class VideoResourceVersionGroupList extends StatefulWidget {
   const VideoResourceVersionGroupList({
     required this.groups,
-    required this.selectedIdentityKey,
+    required this.selectedIdentityKeys,
     required this.onSelect,
+    this.multiSelect = false,
     this.compact = false,
     super.key,
   });
 
   final List<VideoResourceVersionGroup> groups;
 
-  /// 当前选中发布的 identityKey（外层 `_selected`）；null = 未选。
-  final String? selectedIdentityKey;
+  /// 当前选中发布的 identityKey 集合（外层选中集）；空集 = 未选。
+  final Set<String> selectedIdentityKeys;
+
+  /// 是否允许多选（下载模式）。订阅是「一条规则跟一个 release 模板」，多选在那里
+  /// 没有意义，所以订阅模式传 false：不摆勾选框、点卡仍是「挑一条」。
+  final bool multiSelect;
 
   final void Function(VideoResourceCandidate candidate)? onSelect;
 
@@ -45,6 +50,10 @@ class _VideoResourceVersionGroupListState
   }
 
   void _onCardTap(VideoResourceVersionGroup group) {
+    // 点卡仍走「这组里唯一合理的那条」：对单成员组它就是那一条，对能唯一确定的
+    // 组（整季包 / 集号精确命中）也是用户要的默认，挑不出来才展开手选。多选并不
+    // 改变这条快捷路径——多选模式下 onSelect 本身是 toggle，点第二下即取消；
+    // 想挑分集照旧展开后逐行勾。
     final VideoResourceCandidate? picked = pickResourceVersionCandidate(group);
     if (picked != null && widget.onSelect != null) {
       widget.onSelect!(picked);
@@ -52,6 +61,14 @@ class _VideoResourceVersionGroupListState
     }
     _toggleExpanded(group.key);
   }
+
+  /// 本组里已被选中的成员数——多选时卡片上直接写出来，免得折起来后看不见。
+  int _selectedCountIn(VideoResourceVersionGroup group) => group.members
+      .where(
+        (VideoResourceCandidate member) =>
+            widget.selectedIdentityKeys.contains(member.identityKey),
+      )
+      .length;
 
   String _relativeLabel(DateTime at) {
     final ActivityRelativeTime rel = activityRelativeTime(
@@ -97,12 +114,8 @@ class _VideoResourceVersionGroupListState
 
   Widget _buildCard(ThemeData theme, VideoResourceVersionGroup group) {
     final bool expanded = _expanded.contains(group.key);
-    final bool containsSelection =
-        widget.selectedIdentityKey != null &&
-        group.members.any(
-          (VideoResourceCandidate member) =>
-              member.identityKey == widget.selectedIdentityKey,
-        );
+    final int selectedInGroup = _selectedCountIn(group);
+    final bool containsSelection = selectedInGroup > 0;
     return FushiCard(
       key: ValueKey<String>('resource-version-${group.key}'),
       padding: const EdgeInsets.all(12),
@@ -195,7 +208,13 @@ class _VideoResourceVersionGroupListState
           ? FushiListDensity.compact
           : FushiListDensity.standard,
       padding: const EdgeInsets.symmetric(horizontal: 4),
-      selected: widget.selectedIdentityKey == member.identityKey,
+      selected: widget.selectedIdentityKeys.contains(member.identityKey),
+      leading: widget.multiSelect && widget.onSelect != null
+          ? Checkbox(
+              value: widget.selectedIdentityKeys.contains(member.identityKey),
+              onChanged: (_) => widget.onSelect!(member),
+            )
+          : null,
       onTap: widget.onSelect == null ? null : () => widget.onSelect!(member),
       title: Text(
         member.title,

--- a/fushi/lib/src/utils/components/batch_action_bar.dart
+++ b/fushi/lib/src/utils/components/batch_action_bar.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
+
+/// 批量操作栏：多选态下钉在页面底部的那条「已选 N · 全选 · 反选 · 若干动作」。
+///
+/// 视频库页与书架页原本各写一份近逐字重复的实现，且已经漂移出真实差异——书架侧按
+/// 「全 app elevation 0」纪律换成了上边框分隔，并把左侧三件套改 [Wrap] 以免窄屏 +
+/// 大字体下 [Row] 全员不可收缩必溢出；视频侧仍停在 `Material(elevation: 6)` + 裸
+/// [Row]。本组件取书架侧（较新、已修溢出）的形态作为唯一实现，后续新增多选表面
+/// （下载任务、资源选集、字幕候选等）一律复用，不再各写一份。
+///
+/// 只封装容器 chrome 与左侧三件套；右侧动作按钮由各表面自行构造后经 [actions] 注入
+/// ——动作的可用态判据（能否组合、能否删除、选中集是否跨类型）是各域的业务语义，
+/// 塞进共享组件只会变成一堆 bool 开关。
+class BatchActionBar extends StatelessWidget {
+  const BatchActionBar({
+    required this.selectedCount,
+    required this.onSelectAll,
+    required this.onInvertSelection,
+    required this.actions,
+    super.key,
+  });
+
+  /// 当前选中总数，渲染为 `t.batch_selected_count`。
+  final int selectedCount;
+
+  /// 「全选」：各表面按自己的可见集合语义实现（只选可见项，不含被筛选隐藏的）。
+  final VoidCallback onSelectAll;
+
+  /// 「反选」：同样以可见集合为域。
+  final VoidCallback onInvertSelection;
+
+  /// 右侧动作按钮，按给出顺序排布，之间自动插入半个 gap 间隔。
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    final double gap = tokens.spacing.gap;
+    final List<Widget> trailing = <Widget>[];
+    for (int i = 0; i < actions.length; i++) {
+      if (i > 0) {
+        trailing.add(SizedBox(width: gap / 2));
+      }
+      trailing.add(actions[i]);
+    }
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainer,
+        border: Border(
+          top: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.card - gap / 2,
+            vertical: gap,
+          ),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: gap,
+                  children: <Widget>[
+                    Text(
+                      t.batch_selected_count(n: selectedCount),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: onSelectAll,
+                      child: Text(t.batch_select_all),
+                    ),
+                    TextButton(
+                      onPressed: onInvertSelection,
+                      child: Text(t.batch_invert_selection),
+                    ),
+                  ],
+                ),
+              ),
+              ...trailing,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/utils/components/settings_shared.dart
+++ b/fushi/lib/src/utils/components/settings_shared.dart
@@ -66,12 +66,17 @@ class AdaptiveSettingsScaffold extends StatelessWidget {
     super.key,
     this.actions,
     this.padding,
+    this.bottom,
   });
 
   final Widget title;
   final List<Widget> children;
   final List<Widget>? actions;
   final EdgeInsetsGeometry? padding;
+
+  /// 钉在列表下方、不随内容滚动的一条（多选态的批量操作栏用）。为空时布局与
+  /// 加它之前逐字相同。
+  final Widget? bottom;
 
   @override
   Widget build(BuildContext context) {
@@ -86,36 +91,52 @@ class AdaptiveSettingsScaffold extends StatelessWidget {
         );
 
     if (cupertino) {
+      final Widget scroll = CustomScrollView(
+        slivers: <Widget>[
+          CupertinoSliverNavigationBar(
+            largeTitle: title,
+            trailing: actions != null && actions!.isNotEmpty
+                ? Row(mainAxisSize: MainAxisSize.min, children: actions!)
+                : null,
+          ),
+          SliverPadding(
+            padding: listPadding,
+            sliver: SliverList(
+              delegate: SliverChildListDelegate(children),
+            ),
+          ),
+        ],
+      );
       return CupertinoPageScaffold(
         backgroundColor: CupertinoColors.systemGroupedBackground.resolveFrom(
           context,
         ),
-        child: CustomScrollView(
-          slivers: <Widget>[
-            CupertinoSliverNavigationBar(
-              largeTitle: title,
-              trailing: actions != null && actions!.isNotEmpty
-                  ? Row(mainAxisSize: MainAxisSize.min, children: actions!)
-                  : null,
-            ),
-            SliverPadding(
-              padding: listPadding,
-              sliver: SliverList(
-                delegate: SliverChildListDelegate(children),
+        child: bottom == null
+            ? scroll
+            : Column(
+                children: <Widget>[
+                  Expanded(child: scroll),
+                  bottom!,
+                ],
               ),
-            ),
-          ],
-        ),
       );
     }
 
+    final Widget list = ListView(
+      padding: listPadding,
+      children: children,
+    );
     return FushiToolScaffold.customTitle(
       title: title,
       actions: actions ?? const <Widget>[],
-      body: ListView(
-        padding: listPadding,
-        children: children,
-      ),
+      body: bottom == null
+          ? list
+          : Column(
+              children: <Widget>[
+                Expanded(child: list),
+                bottom!,
+              ],
+            ),
     );
   }
 }

--- a/fushi/test/media/downloads/download_batch_test.dart
+++ b/fushi/test/media/downloads/download_batch_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/downloads/download_batch.dart';
+import 'package:fushi/src/media/downloads/download_task_entry.dart';
+
+DownloadTaskEntry _task(String id, DownloadTaskActions actions) {
+  return DownloadTaskEntry(
+    id: id,
+    title: id,
+    kind: DownloadTaskKind.video,
+    status: DownloadTaskStatus.active,
+    actions: actions,
+    builder: (_) => const SizedBox.shrink(),
+  );
+}
+
+void main() {
+  group('runDownloadTaskBatch', () {
+    test('不支持该动作的条目计入 unsupported，不算失败', () async {
+      final List<String> ran = <String>[];
+      final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
+        tasks: <DownloadTaskEntry>[
+          _task('a', DownloadTaskActions(retry: () async => ran.add('a'))),
+          _task('b', DownloadTaskActions.none),
+          _task('c', DownloadTaskActions(retry: () async => ran.add('c'))),
+        ],
+        action: DownloadBatchAction.retry,
+      );
+      expect(ran, <String>['a', 'c']);
+      expect(outcome.done, 2);
+      expect(outcome.unsupported, 1);
+      expect(outcome.failed, 0);
+    });
+
+    test('单条抛错不中断整批，其余照常执行', () async {
+      final List<String> ran = <String>[];
+      final List<Object> errors = <Object>[];
+      final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
+        tasks: <DownloadTaskEntry>[
+          _task('a', DownloadTaskActions(cancel: () async => ran.add('a'))),
+          _task(
+            'boom',
+            DownloadTaskActions(cancel: () async => throw StateError('boom')),
+          ),
+          _task('c', DownloadTaskActions(cancel: () async => ran.add('c'))),
+        ],
+        action: DownloadBatchAction.cancel,
+        onError: (Object error, StackTrace _) => errors.add(error),
+      );
+      expect(ran, <String>['a', 'c'], reason: '中间那条炸了不该拦住后面的');
+      expect(outcome.done, 2);
+      expect(outcome.failed, 1);
+      expect(outcome.unsupported, 0);
+      expect(errors, hasLength(1));
+    });
+
+    test('串行执行：下一条开始前上一条必须已经结束', () async {
+      int running = 0;
+      int maxConcurrent = 0;
+      Future<void> body() async {
+        running++;
+        maxConcurrent = running > maxConcurrent ? running : maxConcurrent;
+        await Future<void>.delayed(Duration.zero);
+        running--;
+      }
+
+      await runDownloadTaskBatch(
+        tasks: <DownloadTaskEntry>[
+          for (int i = 0; i < 4; i++)
+            _task('t$i', DownloadTaskActions(pause: body)),
+        ],
+        action: DownloadBatchAction.pause,
+      );
+      expect(maxConcurrent, 1,
+          reason: '并发会把一批操作变成一批竞态（同后端暂停/同表生命周期 CAS）');
+    });
+
+    test('deleteFiles 透传到每一条的 delete', () async {
+      final List<bool> seen = <bool>[];
+      await runDownloadTaskBatch(
+        tasks: <DownloadTaskEntry>[
+          _task(
+            'a',
+            DownloadTaskActions(
+              delete: ({required bool deleteFiles}) async =>
+                  seen.add(deleteFiles),
+            ),
+          ),
+          _task(
+            'b',
+            DownloadTaskActions(
+              delete: ({required bool deleteFiles}) async =>
+                  seen.add(deleteFiles),
+            ),
+          ),
+        ],
+        action: DownloadBatchAction.delete,
+        deleteFiles: true,
+      );
+      expect(seen, <bool>[true, true]);
+    });
+
+    test('空集返回空结果', () async {
+      final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
+        tasks: const <DownloadTaskEntry>[],
+        action: DownloadBatchAction.retry,
+      );
+      expect(outcome.isEmpty, isTrue);
+    });
+
+    test('pause 不会顶替 cancel：只有 cancel 的条目按不支持跳过', () async {
+      final DownloadBatchOutcome outcome = await runDownloadTaskBatch(
+        tasks: <DownloadTaskEntry>[
+          _task('queue-like', DownloadTaskActions(cancel: () async {})),
+        ],
+        action: DownloadBatchAction.pause,
+      );
+      expect(outcome.done, 0);
+      expect(outcome.unsupported, 1);
+    });
+  });
+
+  group('countDownloadTasksSupporting', () {
+    test('数的是真支持该动作的条数（按钮可用态判据）', () {
+      final List<DownloadTaskEntry> tasks = <DownloadTaskEntry>[
+        _task('a', DownloadTaskActions(retry: () async {})),
+        _task('b', DownloadTaskActions(clear: () async {})),
+        _task('c', DownloadTaskActions(retry: () async {})),
+      ];
+      expect(
+        countDownloadTasksSupporting(tasks, DownloadBatchAction.retry),
+        2,
+      );
+      expect(
+        countDownloadTasksSupporting(tasks, DownloadBatchAction.clear),
+        1,
+      );
+      expect(
+        countDownloadTasksSupporting(tasks, DownloadBatchAction.pause),
+        0,
+        reason: '一条都不支持时按钮必须禁用，否则点下去只会弹「0 条已处理」',
+      );
+    });
+  });
+}

--- a/fushi/test/media/downloads/download_queue_entries_test.dart
+++ b/fushi/test/media/downloads/download_queue_entries_test.dart
@@ -128,8 +128,8 @@ void main() {
         isTrue,
       );
       expect(entries!.first.createdAt, greaterThanOrEqualTo(before));
-      expect(entries!.first.onClear, isNull);
-      expect(entries!.first.onRetry, isNull);
+      expect(entries!.first.actions.clear, isNull);
+      expect(entries!.first.actions.retry, isNull);
       final String originalId = entries!.last.id;
       final int? originalCreatedAt = entries!.last.createdAt;
       queue.tasks.last.status = DiscoveryDownloadStatus.failed;
@@ -148,8 +148,8 @@ void main() {
           },
         ),
       );
-      expect(entries!.last.onRetry, isNotNull);
-      entries!.last.onClear!();
+      expect(entries!.last.actions.retry, isNotNull);
+      await entries!.last.actions.clear!();
       await tester.pump();
       expect(queue.tasks, hasLength(3));
       expect(queue.tasks.first.status, DiscoveryDownloadStatus.running);

--- a/fushi/test/media/downloads/download_task_actions_test.dart
+++ b/fushi/test/media/downloads/download_task_actions_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/downloads/download_task_entry.dart';
+import 'package:fushi/src/pages/implementations/video_download_jobs_panel.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 统一下载列表把四类任务归一成 [DownloadTaskEntry]，但它们的能力天然不齐。
+/// 这批用例钉住的是「谁有什么」这个契约本身——批量操作按 [DownloadTaskActions]
+/// 的槽位过滤选中集，槽位填错的后果是按钮点了静默无效，而不是编译期错误。
+void main() {
+  VideoDownloadJobRow job(
+    String lifecycle, {
+    String resourceProvider = 'nyaa:default',
+  }) =>
+      VideoDownloadJobRow(
+        jobId: 'job-$lifecycle',
+        resourceProvider: resourceProvider,
+        selectedResourceId: 'resource',
+        magnetUri: null,
+        resourceTitle: null,
+        torrentHash: null,
+        metadataProvider: null,
+        externalId: null,
+        mediaKind: 'tv',
+        discoveryCategory: null,
+        title: 'title',
+        year: null,
+        season: null,
+        coverUrl: null,
+        backendKind: 'embedded',
+        backendTaskId: null,
+        backendProfileId: 'default',
+        fingerprint: 'embedded-test',
+        category: 'fushi-video',
+        targetSourceId: null,
+        collectionId: null,
+        organizationPolicy: 'library',
+        subtitlePolicy: 'bestEffort',
+        observedSavePath: null,
+        targetRelativeRoot: null,
+        lifecycle: lifecycle,
+        stage: VideoDownloadJobStage.download,
+        stageProgress: 0.4,
+        priority: 0,
+        attemptCount: 0,
+        maxAttempts: 3,
+        nextAttemptAt: null,
+        claimedBy: null,
+        claimExpiresAt: null,
+        lastError: null,
+        createdAt: 1,
+        updatedAt: 2,
+        completedAt: null,
+      );
+
+  group('video job 动作判据', () {
+    test('重试只对 failed / needsAttention 开放', () {
+      expect(videoDownloadJobCanRetry(job(VideoDownloadJobLifecycle.failed)),
+          isTrue);
+      expect(
+        videoDownloadJobCanRetry(job(VideoDownloadJobLifecycle.needsAttention)),
+        isTrue,
+      );
+      expect(
+        videoDownloadJobCanRetry(job(VideoDownloadJobLifecycle.active)),
+        isFalse,
+      );
+      expect(
+        videoDownloadJobCanRetry(job(VideoDownloadJobLifecycle.completed)),
+        isFalse,
+      );
+    });
+
+    test('legacy 导入报告不是可重跑任务', () {
+      expect(
+        videoDownloadJobCanRetry(
+          job(
+            VideoDownloadJobLifecycle.failed,
+            resourceProvider: 'legacy-import-report',
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('cancelled 是「用户已暂停」：能恢复、不能再暂停', () {
+      final VideoDownloadJobRow paused =
+          job(VideoDownloadJobLifecycle.cancelled);
+      expect(videoDownloadJobCanResume(paused), isTrue);
+      expect(videoDownloadJobCanPause(paused), isFalse);
+    });
+
+    test('只有正在跑的任务能暂停', () {
+      expect(
+        videoDownloadJobCanPause(job(VideoDownloadJobLifecycle.active)),
+        isTrue,
+      );
+      expect(
+        videoDownloadJobCanPause(job(VideoDownloadJobLifecycle.completed)),
+        isFalse,
+      );
+      expect(
+        videoDownloadJobCanResume(job(VideoDownloadJobLifecycle.active)),
+        isFalse,
+      );
+    });
+
+    test('优先级只对还会被取走的任务有意义', () {
+      expect(
+        videoDownloadJobCanSetPriority(job(VideoDownloadJobLifecycle.active)),
+        isTrue,
+      );
+      expect(
+        videoDownloadJobCanSetPriority(
+          job(VideoDownloadJobLifecycle.needsAttention),
+        ),
+        isTrue,
+      );
+      expect(
+        videoDownloadJobCanSetPriority(
+          job(VideoDownloadJobLifecycle.completed),
+        ),
+        isFalse,
+        reason: '已完成的任务设优先级不会重新排队，露出来只会让人以为能插队',
+      );
+      expect(
+        videoDownloadJobCanSetPriority(
+          job(VideoDownloadJobLifecycle.cancelled),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('DownloadTaskActions 契约', () {
+    test('默认不支持任何动作', () {
+      const DownloadTaskActions actions = DownloadTaskActions.none;
+      expect(actions.pause, isNull);
+      expect(actions.cancel, isNull);
+      expect(actions.resume, isNull);
+      expect(actions.retry, isNull);
+      expect(actions.clear, isNull);
+      expect(actions.delete, isNull);
+      expect(actions.setPriority, isNull);
+    });
+
+    test('entry 默认带 none，不必逐个来源显式传', () {
+      final DownloadTaskEntry entry = DownloadTaskEntry(
+        id: 'x',
+        title: 'x',
+        kind: DownloadTaskKind.video,
+        status: DownloadTaskStatus.active,
+        builder: (_) => const SizedBox.shrink(),
+      );
+      expect(identical(entry.actions, DownloadTaskActions.none), isTrue);
+    });
+
+    test('pause 与 cancel 是两个槽位，不可互相顶替', () {
+      // 单跑道内存队列（mokuro / 直链）只有不可恢复的 cancel；torrent 侧才有
+      // 可恢复的 pause。把两者合成一个槽位会让「继续」对前者静默无效。
+      final DownloadTaskActions queueLike = DownloadTaskActions(
+        cancel: () async {},
+        retry: () async {},
+        clear: () async {},
+      );
+      expect(queueLike.pause, isNull);
+      expect(queueLike.resume, isNull);
+      expect(queueLike.setPriority, isNull, reason: '单跑道队列没有调度器，优先级无从谈起');
+    });
+
+    test('只提供 clear 的来源不得被当成能删文件', () {
+      final DownloadTaskActions clearOnly = DownloadTaskActions(
+        clear: () async {},
+      );
+      expect(clearOnly.delete, isNull, reason: '把「移出列表」伪装成「删除」会让用户以为磁盘已经清干净了');
+    });
+  });
+}

--- a/fushi/test/pages/custom_fonts_dialog_page_test.dart
+++ b/fushi/test/pages/custom_fonts_dialog_page_test.dart
@@ -4,6 +4,7 @@ import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/pages/implementations/custom_fonts_page.dart';
 import 'package:fushi/src/reader/font_catalog.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
 import 'package:fushi/src/utils/components/fushi_icon_button.dart';
 
 void main() {
@@ -294,4 +295,173 @@ void main() {
       );
     },
   );
+
+  group('推荐字体页多选', () {
+    Future<List<RecommendedFont>?> openPage(
+      WidgetTester tester, {
+      Set<String> alreadyAdded = const <String>{},
+    }) async {
+      List<RecommendedFont>? result;
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: Center(
+                child: TextButton(
+                  key: const ValueKey<String>('open'),
+                  onPressed: () async {
+                    result = await Navigator.push<List<RecommendedFont>>(
+                      context,
+                      MaterialPageRoute<List<RecommendedFont>>(
+                        builder: (_) =>
+                            RecommendedFontsPage(alreadyAdded: alreadyAdded),
+                      ),
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const ValueKey<String>('open')));
+      await tester.pumpAndSettle();
+      return result;
+    }
+
+    testWidgets('进页就是勾选列表，没选东西时不显示批量栏', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(900, 1400);
+      addTearDown(tester.view.reset);
+
+      await openPage(tester);
+      expect(find.byType(Checkbox), findsWidgets);
+      expect(
+        find.byType(BatchActionBar),
+        findsNothing,
+        reason: '一条都没勾时底栏是多余的',
+      );
+    });
+
+    testWidgets('勾选多条后一次返回全部选中项（不再选一个就把整页弹掉）', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(900, 1400);
+      addTearDown(tester.view.reset);
+
+      List<RecommendedFont>? picked;
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: Center(
+                child: TextButton(
+                  key: const ValueKey<String>('open'),
+                  onPressed: () async {
+                    picked = await Navigator.push<List<RecommendedFont>>(
+                      context,
+                      MaterialPageRoute<List<RecommendedFont>>(
+                        builder: (_) => const RecommendedFontsPage(
+                          alreadyAdded: <String>{},
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const ValueKey<String>('open')));
+      await tester.pumpAndSettle();
+
+      final List<RecommendedFont> catalog = recommendedFontsCatalog;
+      for (final RecommendedFont font in <RecommendedFont>[
+        catalog[0],
+        catalog[1],
+      ]) {
+        await tester.tap(
+          find.byKey(ValueKey<String>('recommended-font-${font.name}')),
+        );
+        await tester.pumpAndSettle();
+      }
+      expect(find.byType(BatchActionBar), findsOneWidget);
+      expect(find.text(t.batch_selected_count(n: 2)), findsOneWidget);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('recommended-fonts-download')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(picked, isNotNull);
+      expect(
+        picked!.map((RecommendedFont f) => f.name).toList(),
+        <String>[catalog[0].name, catalog[1].name],
+      );
+    });
+
+    testWidgets('已添加的字体不可勾选，也不被「全选」卷进来', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(900, 1400);
+      addTearDown(tester.view.reset);
+
+      final List<RecommendedFont> catalog = recommendedFontsCatalog;
+      final String addedName = catalog.first.name;
+      List<RecommendedFont>? picked;
+      await tester.pumpWidget(
+        buildApp(
+          Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: Center(
+                child: TextButton(
+                  key: const ValueKey<String>('open'),
+                  onPressed: () async {
+                    picked = await Navigator.push<List<RecommendedFont>>(
+                      context,
+                      MaterialPageRoute<List<RecommendedFont>>(
+                        builder: (_) => RecommendedFontsPage(
+                          alreadyAdded: <String>{addedName},
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const ValueKey<String>('open')));
+      await tester.pumpAndSettle();
+
+      // 先勾一条别的把批量栏叫出来，再点全选。
+      await tester.tap(
+        find.byKey(ValueKey<String>('recommended-font-${catalog[1].name}')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('recommended-fonts-download')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(picked, isNotNull);
+      expect(
+        picked!.any((RecommendedFont f) => f.name == addedName),
+        isFalse,
+        reason: '已装的再下一遍只是白跑一趟下载 + 导入',
+      );
+      expect(picked!.length, catalog.length - 1);
+    });
+  });
 }

--- a/fushi/test/pages/dictionary_download_dialog_test.dart
+++ b/fushi/test/pages/dictionary_download_dialog_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/models/dictionary_download_controller.dart';
 import 'package:fushi/src/pages/implementations/dictionary_dialog_page.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
 import 'package:fushi/src/utils/misc/show_app_dialog.dart';
 
 void main() {
@@ -317,6 +318,307 @@ void main() {
         ),
         isTrue,
       );
+    });
+  });
+
+  group('目录勾选列表的真实接线', () {
+    RecommendedDictionary rec(String name, DictionaryCategory cat) =>
+        RecommendedDictionary(
+          name: name,
+          url: 'https://example.invalid/$name.zip',
+          description: 'desc',
+          matchPrefix: name,
+          category: cat,
+          sizeEstimate: '~1 MB',
+          langCode: 'en',
+        );
+
+    /// 三条：两条 jaEn、一条 kanji；下标即 catalog 顺序。
+    final List<RecommendedDictionary> catalog = <RecommendedDictionary>[
+      rec('Alpha', DictionaryCategory.jaEn),
+      rec('Beta', DictionaryCategory.jaEn),
+      rec('Gamma', DictionaryCategory.kanji),
+    ];
+
+    Future<Set<int>> pumpList(
+      WidgetTester tester, {
+      required Set<int> checked,
+      Set<int> installed = const <int>{},
+    }) async {
+      Set<int> current = Set<int>.of(checked);
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) =>
+                    SingleChildScrollView(
+                  child: DictionaryCatalogSelectionList(
+                    workingCatalog: catalog,
+                    byCategory: <DictionaryCategory,
+                        List<RecommendedDictionary>>{
+                      DictionaryCategory.jaEn: <RecommendedDictionary>[
+                        catalog[0],
+                        catalog[1],
+                      ],
+                      DictionaryCategory.kanji: <RecommendedDictionary>[
+                        catalog[2],
+                      ],
+                    },
+                    recIndex: <RecommendedDictionary, int>{
+                      catalog[0]: 0,
+                      catalog[1]: 1,
+                      catalog[2]: 2,
+                    },
+                    installedIndices: installed,
+                    checked: current,
+                    expandedCategories: <DictionaryCategory>{
+                      DictionaryCategory.jaEn,
+                      DictionaryCategory.kanji,
+                    },
+                    onCheckedChanged: (Set<int> next) =>
+                        setState(() => current = next),
+                    onExpansionChanged: (_, __) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return current;
+    }
+
+    testWidgets('点「全选」勾上全部未安装项，已安装的不进选中集', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(900, 1400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      Set<int> current = <int>{};
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) =>
+                    SingleChildScrollView(
+                  child: DictionaryCatalogSelectionList(
+                    workingCatalog: catalog,
+                    byCategory: <DictionaryCategory,
+                        List<RecommendedDictionary>>{
+                      DictionaryCategory.jaEn: <RecommendedDictionary>[
+                        catalog[0],
+                        catalog[1],
+                      ],
+                      DictionaryCategory.kanji: <RecommendedDictionary>[
+                        catalog[2],
+                      ],
+                    },
+                    recIndex: <RecommendedDictionary, int>{
+                      catalog[0]: 0,
+                      catalog[1]: 1,
+                      catalog[2]: 2,
+                    },
+                    installedIndices: const <int>{1},
+                    checked: current,
+                    expandedCategories: <DictionaryCategory>{
+                      DictionaryCategory.jaEn,
+                      DictionaryCategory.kanji,
+                    },
+                    onCheckedChanged: (Set<int> next) =>
+                        setState(() => current = next),
+                    onExpansionChanged: (_, __) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('dict-download-select-all')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        current,
+        <int>{0, 2},
+        reason: '已安装的 1 号再下一遍只是白跑一趟下载 + 导入',
+      );
+      expect(find.text(t.batch_selected_count(n: 2)), findsOneWidget);
+    });
+
+    testWidgets('分类三态框勾上 → 只勾本类；再点 → 只清本类', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(900, 1400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      Set<int> current = <int>{2};
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) =>
+                    SingleChildScrollView(
+                  child: DictionaryCatalogSelectionList(
+                    workingCatalog: catalog,
+                    byCategory: <DictionaryCategory,
+                        List<RecommendedDictionary>>{
+                      DictionaryCategory.jaEn: <RecommendedDictionary>[
+                        catalog[0],
+                        catalog[1],
+                      ],
+                      DictionaryCategory.kanji: <RecommendedDictionary>[
+                        catalog[2],
+                      ],
+                    },
+                    recIndex: <RecommendedDictionary, int>{
+                      catalog[0]: 0,
+                      catalog[1]: 1,
+                      catalog[2]: 2,
+                    },
+                    installedIndices: const <int>{},
+                    checked: current,
+                    expandedCategories: <DictionaryCategory>{
+                      DictionaryCategory.jaEn,
+                      DictionaryCategory.kanji,
+                    },
+                    onCheckedChanged: (Set<int> next) =>
+                        setState(() => current = next),
+                    onExpansionChanged: (_, __) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('dict-download-category-check-jaEn'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(current, <int>{2, 0, 1},
+          reason: '本类全选不该动别的分类里已经勾上的 2 号');
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('dict-download-category-check-jaEn'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(current, <int>{2}, reason: '再点一次只清本类');
+    });
+
+    testWidgets('全部已安装时全选/反选禁用，分类三态框也点不动', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(900, 1400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await pumpList(
+        tester,
+        checked: const <int>{},
+        installed: const <int>{0, 1, 2},
+      );
+
+      expect(
+        tester
+            .widget<TextButton>(
+              find.byKey(const ValueKey<String>('dict-download-select-all')),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        tester
+            .widget<TextButton>(
+              find.byKey(
+                const ValueKey<String>('dict-download-invert-selection'),
+              ),
+            )
+            .onPressed,
+        isNull,
+      );
+      expect(
+        tester
+            .widget<Checkbox>(
+              find.byKey(
+                const ValueKey<String>('dict-download-category-check-jaEn'),
+              ),
+            )
+            .onChanged,
+        isNull,
+        reason: '本类全已安装时说「已全选」是谎话，框必须点不动',
+      );
+    });
+
+    testWidgets('反选只在可勾选域内翻转', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(900, 1400);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      Set<int> current = <int>{0};
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setState) =>
+                    SingleChildScrollView(
+                  child: DictionaryCatalogSelectionList(
+                    workingCatalog: catalog,
+                    byCategory: <DictionaryCategory,
+                        List<RecommendedDictionary>>{
+                      DictionaryCategory.jaEn: <RecommendedDictionary>[
+                        catalog[0],
+                        catalog[1],
+                      ],
+                      DictionaryCategory.kanji: <RecommendedDictionary>[
+                        catalog[2],
+                      ],
+                    },
+                    recIndex: <RecommendedDictionary, int>{
+                      catalog[0]: 0,
+                      catalog[1]: 1,
+                      catalog[2]: 2,
+                    },
+                    installedIndices: const <int>{2},
+                    checked: current,
+                    expandedCategories: <DictionaryCategory>{
+                      DictionaryCategory.jaEn,
+                      DictionaryCategory.kanji,
+                    },
+                    onCheckedChanged: (Set<int> next) =>
+                        setState(() => current = next),
+                    onExpansionChanged: (_, __) {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('dict-download-invert-selection')),
+      );
+      await tester.pumpAndSettle();
+      expect(current, <int>{1},
+          reason: '已安装的 2 号既不在原选中集也不该被反选带出来');
     });
   });
 }

--- a/fushi/test/pages/dictionary_download_dialog_test.dart
+++ b/fushi/test/pages/dictionary_download_dialog_test.dart
@@ -232,4 +232,91 @@ void main() {
       expect(tester.takeException(), isNull);
     });
   });
+
+  group('批量勾选：全选 / 反选 / 分类三态的可勾选域', () {
+    test('可勾选域 = catalog 全体减去已安装项', () {
+      expect(
+        selectableDictionaryIndices(
+          catalogLength: 5,
+          installedIndices: <int>{1, 3},
+        ),
+        <int>{0, 2, 4},
+      );
+    });
+
+    test('全部已安装时可勾选域为空（全选/反选按钮据此禁用）', () {
+      expect(
+        selectableDictionaryIndices(
+          catalogLength: 3,
+          installedIndices: <int>{0, 1, 2},
+        ),
+        isEmpty,
+      );
+    });
+
+    test('没有已安装项时可勾选域是整份 catalog', () {
+      expect(
+        selectableDictionaryIndices(
+          catalogLength: 3,
+          installedIndices: const <int>{},
+        ),
+        <int>{0, 1, 2},
+      );
+    });
+
+    test('反选只在可勾选域内翻转，已安装项不会被卷进来', () {
+      final Set<int> selectable = selectableDictionaryIndices(
+        catalogLength: 5,
+        installedIndices: <int>{1},
+      );
+      final Set<int> checked = <int>{0, 2};
+      expect(selectable.difference(checked), <int>{3, 4},
+          reason: '已安装的 1 号既不在原选中集也不该被反选带出来');
+    });
+
+    test('分类三态：全选 true / 全不选 false / 部分 null', () {
+      expect(
+        dictionaryCategoryCheckState(
+          categoryIndices: <int>{1, 2, 3},
+          checked: <int>{1, 2, 3},
+        ),
+        isTrue,
+      );
+      expect(
+        dictionaryCategoryCheckState(
+          categoryIndices: <int>{1, 2, 3},
+          checked: <int>{9},
+        ),
+        isFalse,
+      );
+      expect(
+        dictionaryCategoryCheckState(
+          categoryIndices: <int>{1, 2, 3},
+          checked: <int>{2},
+        ),
+        isNull,
+      );
+    });
+
+    test('分类可勾选域为空时给 false 而非 true（勾选框同时被禁用）', () {
+      expect(
+        dictionaryCategoryCheckState(
+          categoryIndices: const <int>{},
+          checked: <int>{1, 2},
+        ),
+        isFalse,
+        reason: '本类全已安装时说「已全选」是谎话，且此时勾选框不可点',
+      );
+    });
+
+    test('选中集含本类之外的下标不影响本类三态判定', () {
+      expect(
+        dictionaryCategoryCheckState(
+          categoryIndices: <int>{1, 2},
+          checked: <int>{1, 2, 7, 8},
+        ),
+        isTrue,
+      );
+    });
+  });
 }

--- a/fushi/test/pages/dictionary_download_dialog_test.dart
+++ b/fushi/test/pages/dictionary_download_dialog_test.dart
@@ -372,7 +372,7 @@ void main() {
                     },
                     installedIndices: installed,
                     checked: current,
-                    expandedCategories: <DictionaryCategory>{
+                    expandedCategories: const <DictionaryCategory>{
                       DictionaryCategory.jaEn,
                       DictionaryCategory.kanji,
                     },
@@ -424,7 +424,7 @@ void main() {
                     },
                     installedIndices: const <int>{1},
                     checked: current,
-                    expandedCategories: <DictionaryCategory>{
+                    expandedCategories: const <DictionaryCategory>{
                       DictionaryCategory.jaEn,
                       DictionaryCategory.kanji,
                     },
@@ -487,7 +487,7 @@ void main() {
                     },
                     installedIndices: const <int>{},
                     checked: current,
-                    expandedCategories: <DictionaryCategory>{
+                    expandedCategories: const <DictionaryCategory>{
                       DictionaryCategory.jaEn,
                       DictionaryCategory.kanji,
                     },
@@ -597,7 +597,7 @@ void main() {
                     },
                     installedIndices: const <int>{2},
                     checked: current,
-                    expandedCategories: <DictionaryCategory>{
+                    expandedCategories: const <DictionaryCategory>{
                       DictionaryCategory.jaEn,
                       DictionaryCategory.kanji,
                     },

--- a/fushi/test/pages/download_task_browser_test.dart
+++ b/fushi/test/pages/download_task_browser_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:ui' as ui;
 
@@ -565,6 +566,282 @@ void main() {
       await enterSelection(tester);
       await tester.tap(find.text(t.batch_select_all));
       await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('多选批量：审查发现的回归', () {
+    DownloadTaskEntry entry(
+      String id, {
+      required DownloadTaskActions actions,
+      String? collectionKey,
+    }) => DownloadTaskEntry(
+      id: id,
+      title: id,
+      kind: DownloadTaskKind.video,
+      status: DownloadTaskStatus.active,
+      actions: actions,
+      collectionKey: collectionKey,
+      collectionTitle: collectionKey,
+      builder: (BuildContext context) => DownloadTaskCard(
+        key: ValueKey<String>(id),
+        taskId: id,
+        title: id,
+        status: 'x',
+        details: Text('details-$id'),
+      ),
+    );
+
+    Future<void> enterSelection(WidgetTester tester) async {
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-task-select-mode')),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('折叠分组里的成员不被「全选」卷进来', (WidgetTester tester) async {
+      _viewport(tester, const Size(900, 900));
+      final List<String> cleared = <String>[];
+      DownloadTaskEntry member(String id, String group) => entry(
+        id,
+        collectionKey: group,
+        actions: DownloadTaskActions(clear: () async => cleared.add(id)),
+      );
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          member('shown', 'group-a'),
+          member('hidden-1', 'group-b'),
+          member('hidden-2', 'group-b'),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      // 折叠 group-b：它的两个成员不再渲染。
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-group-collection:group-b')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey<String>('hidden-1')), findsNothing);
+
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-clear')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        cleared,
+        <String>['shown'],
+        reason: '屏幕上看不见的条目被批量删掉，用户没有任何机会发现',
+      );
+    });
+
+    testWidgets('没有条目真能删文件时不摆出「同时删除文件」勾选框', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          entry(
+            'no-file-delete',
+            actions: DownloadTaskActions(
+              delete: ({required bool deleteFiles}) async {},
+              // deletesFiles 默认 false：槽位在（条目删得掉），但盘上的数据删不掉。
+            ),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-delete')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.download_task_delete_files), findsNothing,
+          reason: '兑现不了就不显示：勾了以为盘清干净了，而数据还在');
+      expect(
+        find.textContaining(t.download_batch_delete_confirm(n: 1)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('确认框取消 → 一条都不删', (WidgetTester tester) async {
+      _viewport(tester, const Size(900, 900));
+      int deleted = 0;
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          entry(
+            'a',
+            actions: DownloadTaskActions(
+              delete: ({required bool deleteFiles}) async => deleted++,
+              deletesFiles: true,
+            ),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-delete')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.dialog_cancel).last);
+      await tester.pumpAndSettle();
+
+      expect(deleted, 0);
+    });
+
+    testWidgets('勾了「同时删除文件」→ 每条 delete 都收到 true', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      final List<bool> seen = <bool>[];
+      DownloadTaskEntry deletable(String id) => entry(
+        id,
+        actions: DownloadTaskActions(
+          delete: ({required bool deleteFiles}) async => seen.add(deleteFiles),
+          deletesFiles: true,
+        ),
+      );
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[deletable('a'), deletable('b')]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-delete')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.download_task_delete_files));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.dialog_delete).last);
+      await tester.pumpAndSettle();
+
+      expect(seen, <bool>[true, true]);
+    });
+
+    testWidgets('批量执行期间按钮禁用（连点不会跑两遍）', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      int runs = 0;
+      final Completer<void> hold = Completer<void>();
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          entry(
+            'slow',
+            actions: DownloadTaskActions(
+              retry: () async {
+                runs++;
+                await hold.future;
+              },
+            ),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-retry')),
+      );
+      await tester.pump();
+      expect(
+        tester
+            .widget<FushiIconButton>(
+              find.byKey(const ValueKey<String>('download-batch-retry')),
+            )
+            .enabled,
+        isFalse,
+        reason: '整批跑着的时候再点一下就是整批跑两遍',
+      );
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-retry')),
+        warnIfMissed: false,
+      );
+      await tester.pump();
+      hold.complete();
+      await tester.pumpAndSettle();
+      expect(runs, 1);
+    });
+
+    testWidgets('选择态下卡片按钮连焦点都拿不到（手柄/键盘路径）', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      int cardTaps = 0;
+      final FocusNode cardButtonFocus = FocusNode();
+      addTearDown(cardButtonFocus.dispose);
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          DownloadTaskEntry(
+            id: 'trap',
+            title: 'trap',
+            kind: DownloadTaskKind.video,
+            status: DownloadTaskStatus.active,
+            builder: (BuildContext context) => TextButton(
+              focusNode: cardButtonFocus,
+              onPressed: () => cardTaps++,
+              child: const Text('danger'),
+            ),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+
+      // IgnorePointer 只挡指针；焦点要靠 ExcludeFocus 才拦得住。
+      cardButtonFocus.requestFocus();
+      await tester.pumpAndSettle();
+      expect(
+        cardButtonFocus.hasFocus,
+        isFalse,
+        reason: '焦点能落进卡片按钮的话，方向键走过去按 Enter 就把任务删了',
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pumpAndSettle();
+      expect(cardTaps, 0);
+    });
+
+    testWidgets('360 宽下批量栏真的渲染出来且六个动作都在', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(360, 720));
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          entry('a', actions: DownloadTaskActions(retry: () async {})),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BatchActionBar), findsOneWidget);
+      for (final String id in <String>[
+        'resume',
+        'pause',
+        'retry',
+        'cancel',
+        'clear',
+        'delete',
+      ]) {
+        expect(
+          find.byKey(ValueKey<String>('download-batch-$id')),
+          findsOneWidget,
+        );
+      }
       expect(tester.takeException(), isNull);
     });
   });

--- a/fushi/test/pages/download_task_browser_test.dart
+++ b/fushi/test/pages/download_task_browser_test.dart
@@ -9,6 +9,8 @@ import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/media/downloads/download_task_browser.dart';
 import 'package:fushi/src/media/downloads/download_task_card.dart';
 import 'package:fushi/src/media/downloads/download_task_entry.dart';
+import 'package:fushi/src/utils/components/batch_action_bar.dart';
+import 'package:fushi/src/utils/components/fushi_icon_button.dart';
 
 DownloadTaskEntry _task(
   String id, {
@@ -352,6 +354,218 @@ void main() {
       } finally {
         image.dispose();
       }
+    });
+  });
+
+  group('多选批量操作', () {
+    DownloadTaskEntry actionable(
+      String id, {
+      required DownloadTaskActions actions,
+    }) => DownloadTaskEntry(
+      id: id,
+      title: id,
+      kind: DownloadTaskKind.video,
+      status: DownloadTaskStatus.active,
+      actions: actions,
+      builder: (BuildContext context) => DownloadTaskCard(
+        key: ValueKey<String>(id),
+        taskId: id,
+        title: id,
+        status: 'x',
+        details: Text('details-$id'),
+      ),
+    );
+
+    Future<void> enterSelection(WidgetTester tester) async {
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-task-select-mode')),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('默认不在选择态；点「选择」才出现勾选框与操作栏', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[_task('a'), _task('b')]),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(BatchActionBar), findsNothing);
+      expect(find.byType(Checkbox), findsNothing);
+
+      await enterSelection(tester);
+      expect(find.byType(BatchActionBar), findsOneWidget);
+      expect(find.byType(Checkbox), findsNWidgets(2));
+    });
+
+    testWidgets('选择态下点整行只切换选中，不触发卡片自身的按钮', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      int cardTaps = 0;
+      final DownloadTaskEntry trap = DownloadTaskEntry(
+        id: 'trap',
+        title: 'trap',
+        kind: DownloadTaskKind.video,
+        status: DownloadTaskStatus.active,
+        builder: (BuildContext context) => TextButton(
+          key: const ValueKey<String>('trap-button'),
+          onPressed: () => cardTaps++,
+          child: const Text('danger'),
+        ),
+      );
+      await tester.pumpWidget(_host(<DownloadTaskEntry>[trap]));
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+
+      // warnIfMissed: false 是**被测行为本身**：选择态下 IgnorePointer 罩住卡片，
+      // 这一 tap 打不到按钮才是对的，命中了反而说明回归了。
+      await tester.tap(
+        find.byKey(const ValueKey<String>('trap-button')),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+      expect(cardTaps, 0, reason: '选择态里卡片按钮必须让位，否则勾选会变成删除');
+      expect(
+        tester.widget<Checkbox>(find.byType(Checkbox)).value,
+        isTrue,
+        reason: '这一下应该被算作「勾选这一行」',
+      );
+    });
+
+    testWidgets('批量重试只作用于支持重试的条目，不支持的单独计数', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      final List<String> retried = <String>[];
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          actionable(
+            'has-retry',
+            actions: DownloadTaskActions(
+              retry: () async => retried.add('has-retry'),
+            ),
+          ),
+          actionable('no-retry', actions: DownloadTaskActions.none),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-retry')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(retried, <String>['has-retry']);
+      expect(find.textContaining(t.download_batch_done(n: 1)), findsOneWidget);
+      expect(
+        find.textContaining(t.download_batch_unsupported(n: 1)),
+        findsOneWidget,
+        reason: '「不支持」要和「失败」分开说：再点一百次也一样',
+      );
+    });
+
+    testWidgets('选中集里没有条目支持某动作时按钮禁用', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          actionable(
+            'only-clear',
+            actions: DownloadTaskActions(clear: () async {}),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<FushiIconButton>(
+              find.byKey(const ValueKey<String>('download-batch-clear')),
+            )
+            .enabled,
+        isTrue,
+      );
+      expect(
+        tester
+            .widget<FushiIconButton>(
+              find.byKey(const ValueKey<String>('download-batch-pause')),
+            )
+            .enabled,
+        isFalse,
+        reason: '单跑道队列没有暂停态，摆一个点了没反应的按钮比没有更糟',
+      );
+    });
+
+    testWidgets('全选 / 反选以当前可见集合为域（被搜索筛掉的不算）', (
+      WidgetTester tester,
+    ) async {
+      _viewport(tester, const Size(900, 900));
+      final List<String> cleared = <String>[];
+      DownloadTaskEntry clearable(String id) => DownloadTaskEntry(
+        id: id,
+        title: id,
+        kind: DownloadTaskKind.video,
+        status: DownloadTaskStatus.active,
+        actions: DownloadTaskActions(clear: () async => cleared.add(id)),
+        builder: (BuildContext context) => DownloadTaskCard(
+          key: ValueKey<String>(id),
+          taskId: id,
+          title: id,
+          status: 'x',
+          details: Text('details-$id'),
+        ),
+      );
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[clearable('alpha'), clearable('beta')]),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('download-task-search')),
+        'alpha',
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey<String>('download-batch-clear')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        cleared,
+        <String>['alpha'],
+        reason: '被搜索筛掉的 beta 不该被「全选」卷进来',
+      );
+    });
+
+    testWidgets('批量操作栏在 360 逻辑像素宽不溢出', (WidgetTester tester) async {
+      _viewport(tester, const Size(360, 720));
+      await tester.pumpWidget(
+        _host(<DownloadTaskEntry>[
+          actionable(
+            'a',
+            actions: DownloadTaskActions(
+              retry: () async {},
+              clear: () async {},
+            ),
+          ),
+        ]),
+      );
+      await tester.pumpAndSettle();
+      await enterSelection(tester);
+      await tester.tap(find.text(t.batch_select_all));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
     });
   });
 }

--- a/fushi/test/pages/subtitle_multi_download_test.dart
+++ b/fushi/test/pages/subtitle_multi_download_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/subtitle_search_panel.dart';
+import 'package:path/path.dart' as p;
+
+/// 多选下载字幕时最容易悄悄丢东西的一环：不同 provider、不同版本组常常给出
+/// 一模一样的文件名，裸写就是后一条把前一条盖掉——用户以为下了 5 条，盘上只剩
+/// 1 条，而且被盖掉的那几条永远不会有人发现。
+void main() {
+  late Directory dir;
+
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('fushi_subtitle_dest_test');
+  });
+
+  tearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+
+  test('目录里没有同名文件时原样落盘', () {
+    final String dest = uniqueSubtitleDestination(dir.path, 'Show - 01.srt');
+    expect(p.basename(dest), 'Show - 01.srt');
+    expect(p.dirname(dest), dir.path);
+  });
+
+  test('同名已存在时加序号，不覆盖已有文件', () {
+    File(p.join(dir.path, 'Show - 01.srt')).writeAsStringSync('first');
+    final String dest = uniqueSubtitleDestination(dir.path, 'Show - 01.srt');
+    expect(p.basename(dest), 'Show - 01 (2).srt');
+    expect(
+      File(p.join(dir.path, 'Show - 01.srt')).readAsStringSync(),
+      'first',
+      reason: '已有的那条必须原封不动',
+    );
+  });
+
+  test('连续多条同名依次让位，一条都不丢', () {
+    final List<String> written = <String>[];
+    for (int i = 0; i < 4; i++) {
+      final String dest = uniqueSubtitleDestination(dir.path, 'Same.srt');
+      File(dest).writeAsStringSync('body-$i');
+      written.add(dest);
+    }
+    expect(written.toSet(), hasLength(4), reason: '四条各占一个路径');
+    expect(
+      written.map((String f) => p.basename(f)).toList(),
+      <String>['Same.srt', 'Same (2).srt', 'Same (3).srt', 'Same (4).srt'],
+    );
+    for (int i = 0; i < 4; i++) {
+      expect(File(written[i]).readAsStringSync(), 'body-$i');
+    }
+  });
+
+  test('保留扩展名，序号加在主干名后面', () {
+    File(p.join(dir.path, 'a.ass')).writeAsStringSync('x');
+    expect(
+      p.basename(uniqueSubtitleDestination(dir.path, 'a.ass')),
+      'a (2).ass',
+    );
+  });
+
+  test('无扩展名的文件也能消歧', () {
+    File(p.join(dir.path, 'noext')).writeAsStringSync('x');
+    expect(
+      p.basename(uniqueSubtitleDestination(dir.path, 'noext')),
+      'noext (2)',
+    );
+  });
+}

--- a/fushi/test/pages/subtitle_version_group_list_test.dart
+++ b/fushi/test/pages/subtitle_version_group_list_test.dart
@@ -200,4 +200,113 @@ void main() {
     expect(find.byType(JimakuCandidateList), findsOneWidget,
         reason: '文件视图开关切回旧平铺列表');
   });
+
+  group('多选勾选', () {
+    Future<void> pumpMultiSelect(
+      WidgetTester tester, {
+      required List<SubtitleVersionGroup> groups,
+      required Set<String> selected,
+      required void Function(VideoSubtitleCandidate) onToggle,
+    }) async {
+      tester.view.physicalSize = const Size(1000, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: SubtitleVersionGroupList(
+              groups: groups,
+              requestedEpisode: null,
+              busyIdentityKey: null,
+              onPickCandidate: (_) {},
+              selectedIdentityKeys: selected,
+              onToggleCandidate: onToggle,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('没接多选回调时不摆勾选框（存量单选路径不变）', (
+      WidgetTester tester,
+    ) async {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        _seasonPack(),
+      );
+      await pumpList(tester, groups: groups, onPick: (_) {});
+      final SubtitleVersionGroup group = groups.first;
+      await tester.tap(
+        find.byKey(ValueKey<String>('subtitle-version-${group.key}')),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(Checkbox), findsNothing);
+    });
+
+    testWidgets('接了多选回调后每个文件行带勾选框，点它只勾选不下载', (
+      WidgetTester tester,
+    ) async {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        _seasonPack(),
+      );
+      final List<String> toggled = <String>[];
+      await pumpMultiSelect(
+        tester,
+        groups: groups,
+        selected: const <String>{},
+        onToggle: (VideoSubtitleCandidate c) => toggled.add(c.identityKey),
+      );
+      final SubtitleVersionGroup group = groups.firstWhere(
+        (SubtitleVersionGroup g) => g.members.length > 1,
+      );
+      await tester.tap(
+        find.byKey(ValueKey<String>('subtitle-version-${group.key}')),
+      );
+      await tester.pumpAndSettle();
+
+      final VideoSubtitleCandidate member = group.members.first;
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(
+            ValueKey<String>('subtitle-file-${member.identityKey}'),
+          ),
+          matching: find.byType(Checkbox),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(toggled, <String>[member.identityKey]);
+    });
+
+    testWidgets('已勾选的条目勾选框呈选中态', (WidgetTester tester) async {
+      final List<SubtitleVersionGroup> groups = buildSubtitleVersionGroups(
+        _seasonPack(),
+      );
+      final SubtitleVersionGroup group = groups.firstWhere(
+        (SubtitleVersionGroup g) => g.members.length > 1,
+      );
+      final VideoSubtitleCandidate member = group.members.first;
+      await pumpMultiSelect(
+        tester,
+        groups: groups,
+        selected: <String>{member.identityKey},
+        onToggle: (_) {},
+      );
+      await tester.tap(
+        find.byKey(ValueKey<String>('subtitle-version-${group.key}')),
+      );
+      await tester.pumpAndSettle();
+
+      final Checkbox box = tester.widget<Checkbox>(
+        find.descendant(
+          of: find.byKey(
+            ValueKey<String>('subtitle-file-${member.identityKey}'),
+          ),
+          matching: find.byType(Checkbox),
+        ),
+      );
+      expect(box.value, isTrue);
+    });
+  });
 }

--- a/fushi/test/pages/video_resource_version_group_list_test.dart
+++ b/fushi/test/pages/video_resource_version_group_list_test.dart
@@ -293,4 +293,150 @@ void main() {
     );
     expect(submit.onPressed, isNotNull, reason: '提示后应允许用户重试');
   });
+
+  testWidgets('展开后可勾选多集，提交按钮写出条数', (WidgetTester tester) async {
+    await pumpSurface(tester);
+    final List<VideoResourceVersionGroup> groups =
+        buildVideoResourceVersionGroups(_items());
+    final VideoResourceVersionGroup sp = groups.firstWhere(
+      (VideoResourceVersionGroup group) => group.releaseGroup == 'SubsPlease',
+    );
+    await tester.tap(
+      find.byKey(ValueKey<String>('resource-version-${sp.key}')),
+    );
+    await tester.pumpAndSettle();
+
+    for (final VideoResourceCandidate member in sp.members.take(2)) {
+      await tester.tap(
+        find.byKey(ValueKey<String>('resource-release-${member.identityKey}')),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    expect(
+      find.text(t.batch_selected_count(n: 2)),
+      findsOneWidget,
+      reason: '选了多条时按钮上要写清这一下会入队几条',
+    );
+    final FilledButton submit = tester.widget<FilledButton>(
+      find.byKey(const ValueKey<String>('video-resource-submit')),
+    );
+    expect(submit.onPressed, isNotNull);
+  });
+
+  testWidgets('再点一次取消勾选；全部取消后不能提交', (WidgetTester tester) async {
+    await pumpSurface(tester);
+    final List<VideoResourceVersionGroup> groups =
+        buildVideoResourceVersionGroups(_items());
+    final VideoResourceVersionGroup movie = groups.firstWhere(
+      (VideoResourceVersionGroup group) => group.releaseGroup == 'Erai-raws',
+    );
+    final Finder card = find.byKey(
+      ValueKey<String>('resource-version-${movie.key}'),
+    );
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.byKey(const ValueKey<String>('video-resource-submit')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.byKey(const ValueKey<String>('video-resource-submit')),
+          )
+          .onPressed,
+      isNull,
+      reason: '一条都没选还能提交的话，点下去只会入队 0 条',
+    );
+  });
+
+  testWidgets('多选提交把每一条都入队，顺序与勾选顺序一致', (
+    WidgetTester tester,
+  ) async {
+    final List<String> enqueued = <String>[];
+    await pumpSurface(
+      tester,
+      onSubmit: (VideoDiscoveryDownloadSelection selection) async =>
+          enqueued.add(selection.resource.identityKey),
+    );
+    final List<VideoResourceVersionGroup> groups =
+        buildVideoResourceVersionGroups(_items());
+    final VideoResourceVersionGroup sp = groups.firstWhere(
+      (VideoResourceVersionGroup group) => group.releaseGroup == 'SubsPlease',
+    );
+    await tester.tap(
+      find.byKey(ValueKey<String>('resource-version-${sp.key}')),
+    );
+    await tester.pumpAndSettle();
+
+    final List<VideoResourceCandidate> picked = sp.members.take(2).toList();
+    for (final VideoResourceCandidate member in picked) {
+      await tester.tap(
+        find.byKey(ValueKey<String>('resource-release-${member.identityKey}')),
+      );
+      await tester.pumpAndSettle();
+    }
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-resource-submit')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      enqueued,
+      picked.map((VideoResourceCandidate c) => c.identityKey).toList(),
+    );
+  });
+
+  testWidgets('订阅模式仍是单选：选新的替换旧的，不摆勾选框', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(1100, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: VideoDiscoverySubscriptionPage(
+              item: _item(),
+              registry: VideoResourceRegistry(<VideoResourceProvider>[
+                _SeededProvider(_items()),
+              ]),
+              sources: const <MediaSourceRow>[
+                MediaSourceRow(
+                  videoGroupingMode: 'series',
+                  id: 1,
+                  label: 'videos',
+                  mediaKind: 'video',
+                  transport: 'local',
+                  rootPath: r'D:\media',
+                  mediaCount: 0,
+                  recursive: true,
+                  sortOrder: 0,
+                  createdAt: 1,
+                ),
+              ],
+              onSubmit: (_) async {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(Checkbox),
+      findsNothing,
+      reason: '订阅是一条规则跟一个 release 模板，摆勾选框会让人以为能订阅一批',
+    );
+  });
 }

--- a/fushi/test/settings/md3_design_system_static_test.dart
+++ b/fushi/test/settings/md3_design_system_static_test.dart
@@ -2012,8 +2012,19 @@ void main() {
       source.length,
     );
 
+    // 批量操作栏的 chrome（含全部间距）已收敛到共享 [BatchActionBar]，所以令牌
+    // 用法要到那份实现里断言；调用点只剩动作按钮，仍不得出现硬编码间距。
+    // 钉的是「批量操作栏不许硬编码间距」这个不变式，不是它写在哪个函数里。
+    final String sharedBar = File(
+      'lib/src/utils/components/batch_action_bar.dart',
+    ).readAsStringSync();
+    expect(sharedBar, contains('FushiDesignTokens'));
+    expect(sharedBar, contains('tokens.spacing'));
+    expect(sharedBar, isNot(contains('const SizedBox(height: 12)')));
+    expect(sharedBar, isNot(contains('const SizedBox(width: 12)')));
+    expect(sharedBar, isNot(contains('const SizedBox(width: 8)')));
+
     for (final String section in <String>[
-      batchActionBar,
       placeholder,
       batchTagIntentRow,
     ]) {
@@ -2029,7 +2040,14 @@ void main() {
         ),
       );
     }
-    expect(batchActionBar, isNot(contains('const SizedBox(width: 4)')));
+    for (final String forbidden in <String>[
+      'const SizedBox(width: 4)',
+      'const SizedBox(width: 8)',
+      'const SizedBox(width: 12)',
+      'const SizedBox(height: 12)',
+    ]) {
+      expect(batchActionBar, isNot(contains(forbidden)));
+    }
     expect(
       source,
       isNot(contains('padding: const EdgeInsets.all(24)')),


### PR DESCRIPTION
给六处下载相关界面加多选批量操作。

## 交付方式的偏差（先说明）

原计划是「分 6 批、每批合完再做下一批」。实际是连续作业一口气做完的，所以落在**同一个分支上的 9 个可独立回滚的提交**，而不是 6 个 PR。每个提交都自带验证结论，想拆开合也拆得动。

## 各批

| 提交 | 内容 |
|---|---|
| `574a210` | 抽出共享 `BatchActionBar`（视频库页与书架页各写一份、已漂移；顺带修掉视频侧窄屏溢出隐患） |
| `3f23e2b` | 词典下载弹窗（47 条目录）加全选/反选 + 分类三态勾选 |
| `31b4098` | 统一四类下载任务的动作能力模型 `DownloadTaskActions` |
| `1564317` | 下载任务页多选批量继续/暂停/重试/取消/移出/删除 |
| `7549901` | MD3 守卫改成钉不变式而不是钉写法 |
| `9a00164` | 推荐字体页多选批量下载 |
| `ccc3bd7` | 修代码审查查出的一批问题（见下） |
| `b8b753b` | 资源搜索多选选集，一次入队多条 |
| `c69d559` | 字幕候选多选批量下载 |

## 顺带修好的既有 bug

- 下载页顶栏的「全部重试 / 清理已完成」此前对 **video job 和 legacy 计划一直是静默无效的**——那两条路径压根没填 `onRetry`/`onClear`。
- 字幕单条下载用裸远端文件名落盘，同名字幕会互相覆盖（多选下这会变成静默丢文件）。

## 代码审查查出并已修的问题

两条会真删错东西：

1. **「全选」把折叠分组里看不见的任务卷进来**：按类型分组、折叠 manga 组（12 条）后全选删除，确认框写「删除 15 个」而屏幕上只有 3 张卡，那 12 条连同磁盘文件一起没了。
2. **legacy 的 delete 槽位无条件填充**：store 未装配时静默返回却报「已处理 8 项」；「同时删除文件」在后端没配好时照样弹出、勾了被丢弃且无警告——用户没有第二次机会发现盘上几十 GB 还在。为此给 `DownloadTaskActions` 加了 `deletesFiles` 声明位（「这次真的删得掉文件吗」与「有没有 delete 槽位」是两回事）。

其余：批量按钮无 in-flight 锁（连点跑两遍）、顶栏改 async 后变 N 路并发 + 吞错、`IgnorePointer` 只挡指针不挡焦点（手柄/键盘仍能按 Enter 删任务）、`onError` 从不传导致失败无 stack trace、确认框跨 await 重算目标集、legacy resume 判据比卡片宽、legacy 动作永不抛错导致失败计数恒为 0。

## 刻意没做的

- **ASR 模型区不加多选**：总共 9 个语言包、用户通常只装 1~2 个，而且每行本来就是独立下载流、能连着点几个并发下。加多选是给不存在的问题加复杂度。
- **manga / 直链任务不加优先级与暂停**：它们是单跑道内存队列（一次跑一个、无调度器、无暂停态），加优先级要重写队列模型，而单跑道下「优先级」本身没有意义。
- **批量「打开所在位置」不做**：会一次弹出 N 个文件管理器窗口，是骚扰不是便利，它天生是单条动作。
- **资源批量入队不额外查历史重复**：`enqueue()` 路径本来就不查重（只有 `enqueueManual` 查），那是被既有测试钉住的语义，不在这里改。

## 验证

- `flutter analyze` 全量 0 issue。
- 51 条目录枚举型守卫整批全绿（192 + 176）。
- 下载 / 词典 / 设置 / 焦点 / i18n 回归 1307 条，字幕域 110 + 85 条，资源发现域全绿。
- 新增测试覆盖：批量执行器语义、动作能力契约、选择态 UI、折叠分组不被卷入、删除文件勾选框兑现不了就不显示、连点不跑两遍、焦点拿不到卡片按钮、词典全选/分类三态接线、字幕落盘防覆盖、资源多选逐条入队。

已知无关红：`anidb_udp_file_client_test` 的 real UDP 用例在本机超时（收 0 字节）。本分支改动文件与 AniDB / 网络层零交集，属本机 UDP 环境问题。

真机验证未做。

https://claude.ai/code/session_012LXPi6sv4zBFbLXVi2ZocV
