### PR TITLE
fix(sync): 互联对端 401 不再谎称「登录已过期」(BUG-2377)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2189 条。点号进各自文件。
+> 共 2190 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2377](bugs/BUG-2377-interconnect-401-says-login-expired.md) | ✅ | ✅ | 互联对端 401 被误报为「登录已过期，请重新登录」 |
 | [BUG-2375](bugs/BUG-2375-asr-unusable-model.md) | ✅ | ✅ | ASR 模型文件损坏后永久卡死：Protobuf parsing failed 且无自愈路径 |
 | [BUG-2373](bugs/BUG-2373-android-stylus-idle-loses-hover-pressure-buttons.md) | 🚧 | 🚧 | 安卓平板触控笔闲置1-2分钟后悬停/压力/侧键全失效 |
 | [BUG-2372](bugs/BUG-2372-gal-overlay-lookup-card-not-anchored-to-word.md) | 🚧 | 🚧 | 悬浮字幕查词弹窗没锚在被点的词上 |

--- a/docs/bugs/BUG-2377-interconnect-401-says-login-expired.md
+++ b/docs/bugs/BUG-2377-interconnect-401-says-login-expired.md
@@ -1,0 +1,52 @@
+## BUG-2377 · 互联对端 401 被误报为「登录已过期，请重新登录」
+- **报告**：2026-09-09（用户：截图，同步与备份页，存储后端 = Fushi 互联）
+- **真实性**：✅ 真 bug。用户点「立即同步」→ 上次同步「失败」→ toast「登录已过期，请重新登录。」
+  互联的凭据是配对时对端发的 per-peer token，**应用里根本没有互联的登录入口**，
+  这句话把用户指向一个不存在的操作。
+
+  根因链（三段，缺一不可）：
+  1. `fushi/lib/src/sync/webdav_ops.dart:167/246/404` —— `WebDavOps` 是**传输层**，
+     对 WebDAV（用户名/密码）和互联（配对 token）一律抛默认的
+     `SyncAuthError('Authentication failed')`（kind 默认 `credentials`，
+     `sync_backend.dart:85`）。凭据模型的语义在这里丢失。
+  2. `fushi/lib/src/sync/sync_error_messages.dart:75-77` —— 类型没了，文案层只能按
+     字符串猜：`error is SyncAuthError && l.contains('auth')` → `sync_err_auth_expired`
+     「登录已过期，请重新登录。」这是 OAuth 后端的措辞。
+  3. 同文件 `:39-43` —— 另一条相邻缺陷：互联未配对时抛的
+     `'Fushi server credentials not configured'` 命中 `contains('not configured')`
+     → 返回 null → **裸英文原文直接上屏**。
+
+  用户侧的真实事件是：对端把本机从已配对列表里删了（`FushiServerController` 删后清
+  server 端 token 缓存，被删设备下一次请求立刻 401），或对端重置/重装后 token 换了。
+  正确的可操作项是**重新配对**。
+
+  破坏性那一半此前已由 BUG-1578 修掉（`shouldSignOutChannelOnAuthError` 对互联通道
+  返回 false，故配对配置没有被 401 清空）——本单只剩文案/语义错配。
+
+- **[x] ① 已修复** — 根因修在**凭据语义的归属**上，不是在文案文件里加分支：
+  - `sync_backend.dart` 新增两个类型化语义 `SyncAuthFailureKind.pairingRejected` /
+    `pairingNotConfigured`（沿用 BUG-1323/1348/1693 立下的「判据是类型，不是字符串」）。
+  - `webdav_ops.dart` 的 `WebDavOps` 新增 `unauthorizedKind`（默认 `credentials`，
+    WebDAV / 网络媒体源库行为逐字不变）：传输层只转达，**凭据语义由后端拥有者声明**。
+  - `interconnect_sync_backend.dart` 全部 5 处 `WebDavOps` 构造点声明 `pairingRejected`；
+    2 处「未配对」抛出点改带 `pairingNotConfigured`。
+  - `interconnect_post_transport.dart` 的 401（远程查词/制卡 token）同样带 `pairingRejected`。
+  - `manual_sync_ui.dart` 的穷举 switch 登记两个新值为**不登出**；
+    `sync_error_messages.dart` 的 `friendlySyncAuthFailure` 按 kind 分派到新文案。
+  - 新 i18n key `sync_err_pairing_rejected` / `sync_err_not_paired`，17 语言均为真翻译。
+  - 提交：见本分支 `fix(sync): type interconnect auth failures`。
+
+- **[x] ② 已加自动化测试** — `fushi/test/sync/sync_auth_error_kind_test.dart`
+  新增 group「BUG-2377 互联没有「登录」这回事」：
+  - 行为层：同一个 401，WebDAV 仍是 `credentials`/「登录已过期」（不回归），互联变
+    `pairingRejected`/「重新配对」；403 不被 `unauthorizedKind` 抢走；未配对不再摔裸英文。
+  - 文案层：两条新文案断言不含「登录/登入/sign in」。
+  - 登出层：两个新 kind 均不得触发登出。
+  - 源码守卫：互联后端的 `WebDavOps(` 出现次数必须与 `unauthorizedKind:` 声明次数**相等**
+    （新增构造点漏声明就红）；POST 传输层带类型；文案层的类型分派必须排在 `contains('401')` 之前。
+  - `oauth_proxy_and_browser_timeout_test.dart` 的 `SyncAuthFailureKind.values` 穷举登记表
+    补上两个新值（该守卫本就是为拦「新 kind 被默默归错边」而写）。
+  - 验证：`flutter test test/sync test/i18n --no-pub` → 2584 条通过，exit 0。
+
+- **备注**：`sync_err_not_configured`（「此构建未配置谷歌同步凭据」）是 Google 专用文案，
+  不能复用给互联未配对——故另立 `sync_err_not_paired`。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77129 (4537 per locale)
+/// Strings: 77163 (4539 per locale)
 ///
-/// Built on 2026-09-09 at 09:32 UTC
+/// Built on 2026-09-09 at 09:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6297,6 +6297,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Already a source — rescanning: ${path}';
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  String get sync_err_pairing_rejected =>
+      'The paired device rejected this device\'s credentials — pair again to resume syncing.';
+  String get sync_err_not_paired =>
+      'No paired device yet — set up pairing in Fushi Interconnect first.';
 }
 
 // Path: <root>
@@ -16959,6 +16963,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'رفض الجهاز المقترن بيانات اعتماد هذا الجهاز — أعد الإقتران لاستئناف المزامنة.';
+  @override
+  String get sync_err_not_paired =>
+      'لم يتم إقران أي جهاز بعد — أعدّ الإقتران أولاً من «Fushi Interconnect».';
 }
 
 // Path: <root>
@@ -27848,6 +27858,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Das gekoppelte Gerät hat die Anmeldedaten dieses Geräts abgelehnt — koppeln Sie erneut, um die Synchronisierung fortzusetzen.';
+  @override
+  String get sync_err_not_paired =>
+      'Noch kein Gerät gekoppelt — richten Sie die Kopplung zuerst unter „Fushi Interconnect“ ein.';
 }
 
 // Path: <root>
@@ -38791,6 +38807,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'El dispositivo emparejado rechazó las credenciales de este dispositivo: vuelve a emparejarlo para reanudar la sincronización.';
+  @override
+  String get sync_err_not_paired =>
+      'Aún no hay ningún dispositivo emparejado: configura el emparejamiento en «Fushi Interconnect» primero.';
 }
 
 // Path: <root>
@@ -49768,6 +49790,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'L\'appareil associé a refusé les identifiants de cet appareil — associez-le à nouveau pour reprendre la synchronisation.';
+  @override
+  String get sync_err_not_paired =>
+      'Aucun appareil associé pour l\'instant — configurez d\'abord l\'association dans « Fushi Interconnect ».';
 }
 
 // Path: <root>
@@ -60547,6 +60575,12 @@ class _StringsId extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Perangkat yang dipasangkan menolak kredensial perangkat ini — pasangkan ulang untuk melanjutkan sinkronisasi.';
+  @override
+  String get sync_err_not_paired =>
+      'Belum ada perangkat yang dipasangkan — atur pemasangan di "Fushi Interconnect" terlebih dahulu.';
 }
 
 // Path: <root>
@@ -71418,6 +71452,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Il dispositivo associato ha rifiutato le credenziali di questo dispositivo: esegui di nuovo l\'associazione per riprendere la sincronizzazione.';
+  @override
+  String get sync_err_not_paired =>
+      'Nessun dispositivo associato: configura prima l\'associazione in «Fushi Interconnect».';
 }
 
 // Path: <root>
@@ -81670,6 +81710,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'ペアリング済みの端末がこの端末の認証情報を拒否しました。同期を再開するには再度ペアリングしてください。';
+  @override
+  String get sync_err_not_paired =>
+      'ペアリング済みの端末がありません。まず「Fushi 互联」でペアリングを行ってください。';
 }
 
 // Path: <root>
@@ -91932,6 +91978,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      '페어링된 기기가 이 기기의 자격 증명을 거부했습니다. 동기화를 재개하려면 다시 페어링하세요.';
+  @override
+  String get sync_err_not_paired =>
+      '아직 페어링된 기기가 없습니다. 먼저 \'Fushi 互联\'에서 페어링을 완료하세요.';
 }
 
 // Path: <root>
@@ -102760,6 +102812,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Het gekoppelde apparaat heeft de inloggegevens van dit apparaat geweigerd — koppel opnieuw om te blijven synchroniseren.';
+  @override
+  String get sync_err_not_paired =>
+      'Nog geen gekoppeld apparaat — stel het koppelen eerst in bij \'Fushi Interconnect\'.';
 }
 
 // Path: <root>
@@ -113641,6 +113699,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'O dispositivo pareado rejeitou as credenciais deste dispositivo — pareie novamente para retomar a sincronização.';
+  @override
+  String get sync_err_not_paired =>
+      'Nenhum dispositivo pareado ainda — configure o pareamento em "Fushi Interconnect" primeiro.';
 }
 
 // Path: <root>
@@ -124499,6 +124563,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Сопряжённое устройство отклонило учётные данные этого устройства — выполните сопряжение заново, чтобы продолжить синхронизацию.';
+  @override
+  String get sync_err_not_paired =>
+      'Пока нет сопряжённых устройств — сначала выполните сопряжение в «Fushi Interconnect».';
 }
 
 // Path: <root>
@@ -135157,6 +135227,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'อุปกรณ์ที่จับคู่ไว้ปฏิเสธข้อมูลรับรองของเครื่องนี้ — โปรดจับคู่ใหม่เพื่อซิงค์ต่อ';
+  @override
+  String get sync_err_not_paired =>
+      'ยังไม่มีอุปกรณ์ที่จับคู่ — โปรดตั้งค่าการจับคู่ใน «Fushi Interconnect» ก่อน';
 }
 
 // Path: <root>
@@ -145931,6 +146007,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Eşleştirilmiş cihaz bu cihazın kimlik bilgilerini reddetti — eşitlemeye devam etmek için yeniden eşleştirin.';
+  @override
+  String get sync_err_not_paired =>
+      'Henüz eşleştirilmiş cihaz yok — önce "Fushi Interconnect" bölümünden eşleştirmeyi yapın.';
 }
 
 // Path: <root>
@@ -156676,6 +156758,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected =>
+      'Thiết bị đã ghép nối từ chối thông tin xác thực của máy này — hãy ghép nối lại để tiếp tục đồng bộ.';
+  @override
+  String get sync_err_not_paired =>
+      'Chưa ghép nối thiết bị nào — hãy thiết lập ghép nối trong «Fushi Interconnect» trước.';
 }
 
 // Path: <root>
@@ -166544,6 +166632,10 @@ class _StringsZhCn extends _StringsEn {
       '该位置已是来源，正在重新扫描：${path}';
   @override
   String get audiobook_transcribe_model_discarded => '模型文件读不出来，已自动清除，请重新下载。';
+  @override
+  String get sync_err_pairing_rejected => '对方设备已拒绝本机的配对凭据，请重新配对后再同步。';
+  @override
+  String get sync_err_not_paired => '尚未配对任何设备，请先在「Fushi 互联」里完成配对。';
 }
 
 // Path: <root>
@@ -176482,6 +176574,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get sync_err_pairing_rejected => '對方裝置已拒絕本機的配對憑證，請重新配對後再同步。';
+  @override
+  String get sync_err_not_paired => '尚未配對任何裝置，請先在「Fushi 互聯」裡完成配對。';
 }
 
 /// Flat map(s) containing all translations.
@@ -185817,6 +185913,10 @@ extension on _StringsEn {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'The paired device rejected this device\'s credentials — pair again to resume syncing.';
+      case 'sync_err_not_paired':
+        return 'No paired device yet — set up pairing in Fushi Interconnect first.';
       default:
         return null;
     }
@@ -195147,6 +195247,10 @@ extension on _StringsAr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'رفض الجهاز المقترن بيانات اعتماد هذا الجهاز — أعد الإقتران لاستئناف المزامنة.';
+      case 'sync_err_not_paired':
+        return 'لم يتم إقران أي جهاز بعد — أعدّ الإقتران أولاً من «Fushi Interconnect».';
       default:
         return null;
     }
@@ -204522,6 +204626,10 @@ extension on _StringsDe {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Das gekoppelte Gerät hat die Anmeldedaten dieses Geräts abgelehnt — koppeln Sie erneut, um die Synchronisierung fortzusetzen.';
+      case 'sync_err_not_paired':
+        return 'Noch kein Gerät gekoppelt — richten Sie die Kopplung zuerst unter „Fushi Interconnect“ ein.';
       default:
         return null;
     }
@@ -213888,6 +213996,10 @@ extension on _StringsEs {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'El dispositivo emparejado rechazó las credenciales de este dispositivo: vuelve a emparejarlo para reanudar la sincronización.';
+      case 'sync_err_not_paired':
+        return 'Aún no hay ningún dispositivo emparejado: configura el emparejamiento en «Fushi Interconnect» primero.';
       default:
         return null;
     }
@@ -223263,6 +223375,10 @@ extension on _StringsFr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'L\'appareil associé a refusé les identifiants de cet appareil — associez-le à nouveau pour reprendre la synchronisation.';
+      case 'sync_err_not_paired':
+        return 'Aucun appareil associé pour l\'instant — configurez d\'abord l\'association dans « Fushi Interconnect ».';
       default:
         return null;
     }
@@ -232609,6 +232725,10 @@ extension on _StringsId {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Perangkat yang dipasangkan menolak kredensial perangkat ini — pasangkan ulang untuk melanjutkan sinkronisasi.';
+      case 'sync_err_not_paired':
+        return 'Belum ada perangkat yang dipasangkan — atur pemasangan di "Fushi Interconnect" terlebih dahulu.';
       default:
         return null;
     }
@@ -241977,6 +242097,10 @@ extension on _StringsIt {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Il dispositivo associato ha rifiutato le credenziali di questo dispositivo: esegui di nuovo l\'associazione per riprendere la sincronizzazione.';
+      case 'sync_err_not_paired':
+        return 'Nessun dispositivo associato: configura prima l\'associazione in «Fushi Interconnect».';
       default:
         return null;
     }
@@ -251272,6 +251396,10 @@ extension on _StringsJa {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'ペアリング済みの端末がこの端末の認証情報を拒否しました。同期を再開するには再度ペアリングしてください。';
+      case 'sync_err_not_paired':
+        return 'ペアリング済みの端末がありません。まず「Fushi 互联」でペアリングを行ってください。';
       default:
         return null;
     }
@@ -260571,6 +260699,10 @@ extension on _StringsKo {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return '페어링된 기기가 이 기기의 자격 증명을 거부했습니다. 동기화를 재개하려면 다시 페어링하세요.';
+      case 'sync_err_not_paired':
+        return '아직 페어링된 기기가 없습니다. 먼저 \'Fushi 互联\'에서 페어링을 완료하세요.';
       default:
         return null;
     }
@@ -269932,6 +270064,10 @@ extension on _StringsNl {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Het gekoppelde apparaat heeft de inloggegevens van dit apparaat geweigerd — koppel opnieuw om te blijven synchroniseren.';
+      case 'sync_err_not_paired':
+        return 'Nog geen gekoppeld apparaat — stel het koppelen eerst in bij \'Fushi Interconnect\'.';
       default:
         return null;
     }
@@ -279288,6 +279424,10 @@ extension on _StringsPtBr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'O dispositivo pareado rejeitou as credenciais deste dispositivo — pareie novamente para retomar a sincronização.';
+      case 'sync_err_not_paired':
+        return 'Nenhum dispositivo pareado ainda — configure o pareamento em "Fushi Interconnect" primeiro.';
       default:
         return null;
     }
@@ -288651,6 +288791,10 @@ extension on _StringsRu {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Сопряжённое устройство отклонило учётные данные этого устройства — выполните сопряжение заново, чтобы продолжить синхронизацию.';
+      case 'sync_err_not_paired':
+        return 'Пока нет сопряжённых устройств — сначала выполните сопряжение в «Fushi Interconnect».';
       default:
         return null;
     }
@@ -297986,6 +298130,10 @@ extension on _StringsTh {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'อุปกรณ์ที่จับคู่ไว้ปฏิเสธข้อมูลรับรองของเครื่องนี้ — โปรดจับคู่ใหม่เพื่อซิงค์ต่อ';
+      case 'sync_err_not_paired':
+        return 'ยังไม่มีอุปกรณ์ที่จับคู่ — โปรดตั้งค่าการจับคู่ใน «Fushi Interconnect» ก่อน';
       default:
         return null;
     }
@@ -307336,6 +307484,10 @@ extension on _StringsTr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Eşleştirilmiş cihaz bu cihazın kimlik bilgilerini reddetti — eşitlemeye devam etmek için yeniden eşleştirin.';
+      case 'sync_err_not_paired':
+        return 'Henüz eşleştirilmiş cihaz yok — önce "Fushi Interconnect" bölümünden eşleştirmeyi yapın.';
       default:
         return null;
     }
@@ -316680,6 +316832,10 @@ extension on _StringsVi {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return 'Thiết bị đã ghép nối từ chối thông tin xác thực của máy này — hãy ghép nối lại để tiếp tục đồng bộ.';
+      case 'sync_err_not_paired':
+        return 'Chưa ghép nối thiết bị nào — hãy thiết lập ghép nối trong «Fushi Interconnect» trước.';
       default:
         return null;
     }
@@ -325942,6 +326098,10 @@ extension on _StringsZhCn {
         return ({required Object path}) => '该位置已是来源，正在重新扫描：${path}';
       case 'audiobook_transcribe_model_discarded':
         return '模型文件读不出来，已自动清除，请重新下载。';
+      case 'sync_err_pairing_rejected':
+        return '对方设备已拒绝本机的配对凭据，请重新配对后再同步。';
+      case 'sync_err_not_paired':
+        return '尚未配对任何设备，请先在「Fushi 互联」里完成配对。';
       default:
         return null;
     }
@@ -335215,6 +335375,10 @@ extension on _StringsZhHk {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'sync_err_pairing_rejected':
+        return '對方裝置已拒絕本機的配對憑證，請重新配對後再同步。';
+      case 'sync_err_not_paired':
+        return '尚未配對任何裝置，請先在「Fushi 互聯」裡完成配對。';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Show reading timer",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "The paired device rejected this device's credentials — pair again to resume syncing.",
+  "sync_err_not_paired": "No paired device yet — set up pairing in Fushi Interconnect first."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "إظهار مؤقت القراءة",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "رفض الجهاز المقترن بيانات اعتماد هذا الجهاز — أعد الإقتران لاستئناف المزامنة.",
+  "sync_err_not_paired": "لم يتم إقران أي جهاز بعد — أعدّ الإقتران أولاً من «Fushi Interconnect»."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Lesetimer anzeigen",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Das gekoppelte Gerät hat die Anmeldedaten dieses Geräts abgelehnt — koppeln Sie erneut, um die Synchronisierung fortzusetzen.",
+  "sync_err_not_paired": "Noch kein Gerät gekoppelt — richten Sie die Kopplung zuerst unter „Fushi Interconnect“ ein."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostrar temporizador de lectura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "El dispositivo emparejado rechazó las credenciales de este dispositivo: vuelve a emparejarlo para reanudar la sincronización.",
+  "sync_err_not_paired": "Aún no hay ningún dispositivo emparejado: configura el emparejamiento en «Fushi Interconnect» primero."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Afficher le minuteur de lecture",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "L'appareil associé a refusé les identifiants de cet appareil — associez-le à nouveau pour reprendre la synchronisation.",
+  "sync_err_not_paired": "Aucun appareil associé pour l'instant — configurez d'abord l'association dans « Fushi Interconnect »."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Tampilkan pengatur waktu baca",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Perangkat yang dipasangkan menolak kredensial perangkat ini — pasangkan ulang untuk melanjutkan sinkronisasi.",
+  "sync_err_not_paired": "Belum ada perangkat yang dipasangkan — atur pemasangan di \"Fushi Interconnect\" terlebih dahulu."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostra timer di lettura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Il dispositivo associato ha rifiutato le credenziali di questo dispositivo: esegui di nuovo l'associazione per riprendere la sincronizzazione.",
+  "sync_err_not_paired": "Nessun dispositivo associato: configura prima l'associazione in «Fushi Interconnect»."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "読書タイマーを表示",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "ペアリング済みの端末がこの端末の認証情報を拒否しました。同期を再開するには再度ペアリングしてください。",
+  "sync_err_not_paired": "ペアリング済みの端末がありません。まず「Fushi 互联」でペアリングを行ってください。"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "독서 타이머 표시",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "페어링된 기기가 이 기기의 자격 증명을 거부했습니다. 동기화를 재개하려면 다시 페어링하세요.",
+  "sync_err_not_paired": "아직 페어링된 기기가 없습니다. 먼저 'Fushi 互联'에서 페어링을 완료하세요."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Leestimer tonen",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Het gekoppelde apparaat heeft de inloggegevens van dit apparaat geweigerd — koppel opnieuw om te blijven synchroniseren.",
+  "sync_err_not_paired": "Nog geen gekoppeld apparaat — stel het koppelen eerst in bij 'Fushi Interconnect'."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostrar cronômetro de leitura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "O dispositivo pareado rejeitou as credenciais deste dispositivo — pareie novamente para retomar a sincronização.",
+  "sync_err_not_paired": "Nenhum dispositivo pareado ainda — configure o pareamento em \"Fushi Interconnect\" primeiro."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Показывать таймер чтения",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Сопряжённое устройство отклонило учётные данные этого устройства — выполните сопряжение заново, чтобы продолжить синхронизацию.",
+  "sync_err_not_paired": "Пока нет сопряжённых устройств — сначала выполните сопряжение в «Fushi Interconnect»."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "แสดงตัวจับเวลาการอ่าน",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "อุปกรณ์ที่จับคู่ไว้ปฏิเสธข้อมูลรับรองของเครื่องนี้ — โปรดจับคู่ใหม่เพื่อซิงค์ต่อ",
+  "sync_err_not_paired": "ยังไม่มีอุปกรณ์ที่จับคู่ — โปรดตั้งค่าการจับคู่ใน «Fushi Interconnect» ก่อน"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Okuma zamanlayıcısını göster",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Eşleştirilmiş cihaz bu cihazın kimlik bilgilerini reddetti — eşitlemeye devam etmek için yeniden eşleştirin.",
+  "sync_err_not_paired": "Henüz eşleştirilmiş cihaz yok — önce \"Fushi Interconnect\" bölümünden eşleştirmeyi yapın."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Hiển thị bộ đếm thời gian đọc",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "Thiết bị đã ghép nối từ chối thông tin xác thực của máy này — hãy ghép nối lại để tiếp tục đồng bộ.",
+  "sync_err_not_paired": "Chưa ghép nối thiết bị nào — hãy thiết lập ghép nối trong «Fushi Interconnect» trước."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "关闭（任务继续在后台运行）",
   "reader_timer_show": "显示阅读计时器",
   "media_source_root_already_added": "该位置已是来源，正在重新扫描：$path",
-  "audiobook_transcribe_model_discarded": "模型文件读不出来，已自动清除，请重新下载。"
+  "audiobook_transcribe_model_discarded": "模型文件读不出来，已自动清除，请重新下载。",
+  "sync_err_pairing_rejected": "对方设备已拒绝本机的配对凭据，请重新配对后再同步。",
+  "sync_err_not_paired": "尚未配对任何设备，请先在「Fushi 互联」里完成配对。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4535,5 +4535,7 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "顯示閱讀計時器",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "sync_err_pairing_rejected": "對方裝置已拒絕本機的配對憑證，請重新配對後再同步。",
+  "sync_err_not_paired": "尚未配對任何裝置，請先在「Fushi 互聯」裡完成配對。"
 }

--- a/fushi/lib/src/sync/interconnect_post_transport.dart
+++ b/fushi/lib/src/sync/interconnect_post_transport.dart
@@ -146,7 +146,14 @@ class InterconnectPostTransport {
         // 传输层失败（连接拒绝/超时/DNS）根本走不到这一行，落在 catch 里。
         anyResponse = true;
         if (response.statusCode == 401) {
-          authError = SyncAuthError(authErrorMessage);
+          // BUG-2377：这条通道的凭据只可能是配对 token（地址行自带的 per-peer
+          // token，或全局回落键）——本文件从头到尾只服务互联。语义写死成
+          // [SyncAuthFailureKind.pairingRejected]，别再让上层从消息字面量去猜：
+          // 猜的结果是「登录已过期，请重新登录」，而互联没有登录这个操作。
+          authError = SyncAuthError(
+            authErrorMessage,
+            kind: SyncAuthFailureKind.pairingRejected,
+          );
           continue;
         }
         if (response.statusCode == 404 || response.statusCode == 405) {

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -85,6 +85,8 @@ Future<bool> _pinnedReachabilityProbe(
       password: token,
       connectionTimeout: InterconnectSyncBackend.probeTimeout,
       pinnedFingerprint: fingerprint,
+      // BUG-2377：互联的凭据是配对 token，不是登录会话。
+      unauthorizedKind: SyncAuthFailureKind.pairingRejected,
     );
     await ops.testConnection().timeout(InterconnectSyncBackend.probeTimeout);
     return true;
@@ -113,6 +115,8 @@ Future<bool> _defaultFushiProbe(String url, String token) async {
       // Bound the socket connect itself (WebDavOps defaults to 60s); the outer
       // .timeout only bounds the awaited future, not the underlying connect.
       connectionTimeout: InterconnectSyncBackend.probeTimeout,
+      // BUG-2377：互联的凭据是配对 token，不是登录会话。
+      unauthorizedKind: SyncAuthFailureKind.pairingRejected,
     );
     await ops.testConnection().timeout(InterconnectSyncBackend.probeTimeout);
     return true;
@@ -335,6 +339,8 @@ class InterconnectSyncBackend extends SyncBackend
           username: 'hibiki',
           password: token,
           pinnedFingerprint: candidate.fingerprintSha256,
+          // BUG-2377：互联的凭据是配对 token，不是登录会话。
+          unauthorizedKind: SyncAuthFailureKind.pairingRejected,
         );
         _activeFingerprint = candidate.fingerprintSha256;
         // 与 [_ensureResolved] 的判据保持同一真相：暂定句柄用的是哪份凭据必须记下，
@@ -353,7 +359,8 @@ class InterconnectSyncBackend extends SyncBackend
   Future<void> _ensureResolved() async {
     if (_sessionResolved) return;
     if (!_hasAnyCredential) {
-      throw SyncAuthError('Fushi server credentials not configured');
+      throw SyncAuthError('Fushi server credentials not configured',
+          kind: SyncAuthFailureKind.pairingNotConfigured);
     }
     final FushiClientUrl chosen =
         await resolveReachableFushiCandidate(_candidates, _token ?? '', _probe);
@@ -376,6 +383,8 @@ class InterconnectSyncBackend extends SyncBackend
         // clearCache 才复位，页面级读取失败后永远钉死在死地址上，WAN 备用
         // 地址到重启前都不会被尝试。
         onConnectivityError: () => _sessionResolved = false,
+        // BUG-2377：互联的凭据是配对 token，不是登录会话。
+        unauthorizedKind: SyncAuthFailureKind.pairingRejected,
       );
       _activeFingerprint = chosen.fingerprintSha256;
       _activeToken = token;
@@ -394,7 +403,8 @@ class InterconnectSyncBackend extends SyncBackend
   Future<void> authenticate({required SyncRepository repo}) async {
     await _loadConfig(repo);
     if (_candidates.isEmpty || !_hasAnyCredential) {
-      throw SyncAuthError('Fushi server credentials not configured');
+      throw SyncAuthError('Fushi server credentials not configured',
+          kind: SyncAuthFailureKind.pairingNotConfigured);
     }
     // Probes + selects a reachable address (or throws), confirming the token
     // is accepted by the server.
@@ -1828,6 +1838,8 @@ class InterconnectSyncBackend extends SyncBackend
       // 「测试连接」就泄漏一个最长 60s 的挂起 socket。
       connectionTimeout: InterconnectSyncBackend.probeTimeout,
       pinnedFingerprint: fingerprint,
+      // BUG-2377：互联的凭据是配对 token，不是登录会话。
+      unauthorizedKind: SyncAuthFailureKind.pairingRejected,
     );
     try {
       await ops.testConnection().timeout(InterconnectSyncBackend.probeTimeout);

--- a/fushi/lib/src/sync/manual_sync_ui.dart
+++ b/fushi/lib/src/sync/manual_sync_ui.dart
@@ -69,6 +69,14 @@ bool shouldSignOutOnAuthError(SyncAuthError error) => switch (error.kind) {
       SyncAuthFailureKind.forbidden => false,
       SyncAuthFailureKind.browserTimeout => false,
       SyncAuthFailureKind.cancelled => false,
+      // BUG-2377：互联的「登出」会清空 `sync_hibiki_client_urls`——全部对端地址、
+      // TOFU 指纹和 per-peer token 一起没。用一台对端的 401 去清整份配对配置，
+      // 正是 BUG-1550 / BUG-1578 要消灭的株连。凭据失效由配对流程处理，不在这
+      // 里代劳。（`shouldSignOutChannelOnAuthError` 已按通道拦了一层，这里是同
+      // 一决定的第二道：裸 SyncAuthError 走不到那层。）
+      SyncAuthFailureKind.pairingRejected => false,
+      // 压根没有凭据可丢，登出无事可做。
+      SyncAuthFailureKind.pairingNotConfigured => false,
     };
 
 /// 一条**具名通道**的鉴权失败之后，该不该对这条通道执行登出（BUG-1578）。

--- a/fushi/lib/src/sync/sync_backend.dart
+++ b/fushi/lib/src/sync/sync_backend.dart
@@ -77,6 +77,31 @@ enum SyncAuthFailureKind {
   /// 也不是浏览器没回来，而是**用户决定不等了**——UI 对它必须静默：不弹错误、不写
   /// 错误日志、不登出。单立枚举值的理由同 [browserTimeout]：判据是类型，不是字符串。
   cancelled,
+
+  /// 互联（Fushi 互联）的**配对凭据被对端拒绝**：对端对本机的请求回了 401
+  /// （BUG-2377）。与 [credentials] 的差别不是程度而是**凭据模型**——互联根本没有
+  /// 「登录会话」这回事，凭据是配对时对端发给本机的 per-peer token。压成
+  /// [credentials] 会让 UI 说「登录已过期，请重新登录」，把用户指向一个应用里
+  /// **不存在**的操作；真正可操作的是重新配对。
+  ///
+  /// 成因基本只有一种：对端把本机从已配对列表里删了（server 端 token 缓存随即
+  /// 清空，被删设备下一次请求立刻 401，见 `FushiServerController`），或对端重置/
+  /// 重装后 token 换了。
+  ///
+  /// 与 [credentials] 的第二个差别是**不得登出**：`InterconnectSyncBackend.signOut`
+  /// 会清空 `sync_hibiki_client_urls`，把全部对端地址、TOFU 指纹和 per-peer token
+  /// 一并抹掉——用一台对端的 401 去清整份配对配置，正是 BUG-1550 / BUG-1578 要
+  /// 消灭的株连行为。
+  pairingRejected,
+
+  /// 互联**压根没有凭据可发**：一台对端都没配对，或配对信息已被清空。既不是
+  /// 「凭据被拒」（还没走到发请求那一步），也不是 [credentials] 说的「登录过期」。
+  /// 可操作项 = 去「Fushi 互联」里完成配对。
+  ///
+  /// 此前它靠消息字面量 `'Fushi server credentials not configured'` 落进
+  /// `sync_error_messages` 的 `contains('not configured')` 分支 → 返回 null →
+  /// **裸英文原文直接上屏**。判据改成类型（同 [SyncPeerUnreachableError] 的教训）。
+  pairingNotConfigured,
 }
 
 class SyncAuthError implements Exception {

--- a/fushi/lib/src/sync/sync_error_messages.dart
+++ b/fushi/lib/src/sync/sync_error_messages.dart
@@ -117,6 +117,15 @@ String friendlySyncAuthFailure(SyncAuthFailureKind kind, String? serverReason) {
       final String? reason = serverReason;
       if (reason == null || reason.isEmpty) return t.sync_err_forbidden;
       return t.sync_err_forbidden_detail(reason: reason);
+    case SyncAuthFailureKind.pairingRejected:
+      // BUG-2377：互联没有「登录」。对端 401 = 它不再认本机的配对 token（多半是
+      // 对方把本机从已配对列表里删了，或对端重装/重置后换了 token）。唯一可操作
+      // 的是重新配对——叫用户「重新登录」是把他指向应用里根本不存在的入口。
+      return t.sync_err_pairing_rejected;
+    case SyncAuthFailureKind.pairingNotConfigured:
+      // 一台对端都没配对：以前落到字符串层的 `contains('not configured')` → 返回
+      // null → 裸英文 'Fushi server credentials not configured' 直接上屏。
+      return t.sync_err_not_paired;
   }
 }
 

--- a/fushi/lib/src/sync/webdav_ops.dart
+++ b/fushi/lib/src/sync/webdav_ops.dart
@@ -55,10 +55,12 @@ class WebDavOps {
     Duration connectionTimeout = const Duration(seconds: 60),
     String? pinnedFingerprint,
     void Function()? onConnectivityError,
+    SyncAuthFailureKind unauthorizedKind = SyncAuthFailureKind.credentials,
   }) : _baseUrl = baseUrl,
        _connectionTimeout = connectionTimeout,
        _pinnedFingerprint = pinnedFingerprint,
        _onConnectivityError = onConnectivityError,
+       _unauthorizedKind = unauthorizedKind,
        // 用户名和密码都空 = 匿名 / 无鉴权 WebDAV：根本不带 Authorization 头，
        // 而不是发 `Basic base64(':')`（很多匿名服务器仍会因此回 401）。任一凭据
        // 非空时行为完全不变（BUG-1016）。
@@ -81,6 +83,19 @@ class WebDavOps {
   /// 普通 WebDAV，遵循应用出站代理与局域网绕过；非 null = 用 pinned client，仅
   /// 接受指纹相等的自签证书。由数据（URL 是否带指纹）决定，不靠平台分支。
   final String? _pinnedFingerprint;
+
+  /// BUG-2377：本传输层收到 401 时该抛哪一种鉴权失败语义。
+  ///
+  /// [WebDavOps] 是**传输层**，它只知道「服务端说凭据不行」，不知道这份凭据是什么
+  /// 模型——WebDAV 是用户名/密码，互联是配对时对端发的 per-peer token。以前它对
+  /// 两者一律抛默认的 [SyncAuthFailureKind.credentials]，于是互联对端把本机从已配对
+  /// 列表里删掉之后，用户看到的是「登录已过期，请重新登录」——而互联根本没有登录
+  /// 这个操作。凭据语义归**后端拥有者**声明，传输层只转达。
+  ///
+  /// 默认 [SyncAuthFailureKind.credentials] 让 WebDAV / 网络媒体源库等既有调用点
+  /// 行为逐字不变。
+  final SyncAuthFailureKind _unauthorizedKind;
+
   HttpClient? _httpClient;
 
   String get baseUrl => _baseUrl;
@@ -151,7 +166,7 @@ class WebDavOps {
 
       if (response.statusCode == 401) {
         await response.drain<void>();
-        throw SyncAuthError('Authentication failed');
+        throw SyncAuthError('Authentication failed', kind: _unauthorizedKind);
       }
       // BUG-1323：403 是服务端的策略拒绝，用户要看到的是**服务端说了什么**，而不是
       // 「登录已过期，请重新登录」。「测试连接」正是最该把原文摆出来的地方，故这条
@@ -228,7 +243,7 @@ class WebDavOps {
     final response = await closeRequest(request);
 
     if (response.statusCode == 401) {
-      throw SyncAuthError('Authentication failed');
+      throw SyncAuthError('Authentication failed', kind: _unauthorizedKind);
     }
     // BUG-1323：403 带上服务端原文。读响应体放在这条分支里而不是提前统一读——
     // 401 的判定必须先于任何可能抛异常的流读取，否则一个畸形错误体就能把鉴权
@@ -386,7 +401,7 @@ class WebDavOps {
   /// 一行都不用改。
   void checkStatus(int statusCode, String context, {String? serverReason}) {
     if (statusCode == 401) {
-      throw SyncAuthError('Authentication failed');
+      throw SyncAuthError('Authentication failed', kind: _unauthorizedKind);
     }
     // BUG-1323：403 ≠ 401。403 是「凭据已被接受，但服务端按策略拒绝了这一次请求」
     // （host 对明文会话返回 `HTTPS required for service config` 就是有意拒绝，不是

--- a/fushi/test/sync/oauth_proxy_and_browser_timeout_test.dart
+++ b/fushi/test/sync/oauth_proxy_and_browser_timeout_test.dart
@@ -199,6 +199,12 @@ void main() {
         SyncAuthFailureKind.browserTimeout: false,
         // 用户自己在等待对话框里取消（BUG-2120）：连错误都不算，更不该动会话。
         SyncAuthFailureKind.cancelled: false,
+        // 互联对端拒了本机的配对 token（BUG-2377）：互联的 signOut 会清空整份配对
+        // 配置（全部对端地址 + TOFU 指纹 + per-peer token），一台对端的 401 不得
+        // 株连其余对端 —— 这正是 BUG-1550 / BUG-1578 要消灭的行为。
+        SyncAuthFailureKind.pairingRejected: false,
+        // 压根没配对过（BUG-2377）：没有凭据可丢，登出无事可做。
+        SyncAuthFailureKind.pairingNotConfigured: false,
       };
       expect(
         signOutByKind.keys.toSet(),

--- a/fushi/test/sync/sync_auth_error_kind_test.dart
+++ b/fushi/test/sync/sync_auth_error_kind_test.dart
@@ -8,6 +8,8 @@ import 'package:fushi/src/sync/sync_error_messages.dart';
 import 'package:fushi/src/sync/sync_orchestrator.dart';
 import 'package:fushi/src/sync/webdav_ops.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1323 / BUG-1324：同步层两处「把错误压平」的独立缺陷。
 ///
 /// - BUG-1323：`WebDavOps.checkStatus` 把 401（凭据不被接受）和 403（凭据没问题，
@@ -258,6 +260,144 @@ void main() {
         isNot(contains('resolveSyncBackend(await repo.getBackendType())')),
         reason: '按 backendType 猜通道 = 双通道下必然猜错一半',
       );
+    });
+  });
+
+  group('BUG-2377 互联没有「登录」这回事', () {
+    // 用户实拍：存储后端 = Fushi 互联，点「立即同步」→ 上次同步「失败」→ toast
+    // 「登录已过期，请重新登录。」互联的凭据是配对时对端发的 per-peer token，
+    // 应用里根本没有互联的登录入口 —— 这句话把用户指向一个不存在的操作。
+    // 根因：WebDavOps 是**传输层**，对 WebDAV（用户名/密码）和互联（配对 token）
+    // 一律抛默认的 credentials，文案层只能按字符串猜，猜成了 OAuth 的措辞。
+
+    test('传输层默认不变：WebDAV 的 401 仍是 credentials（逐字不回归）', () {
+      final WebDavOps dav = WebDavOps(
+        baseUrl: 'http://127.0.0.1:1/dav',
+        username: 'u',
+        password: 'p',
+      );
+      SyncAuthError? caught;
+      try {
+        dav.checkStatus(401, 'GET /x');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught!.kind, SyncAuthFailureKind.credentials);
+      expect(friendlySyncError(caught), t.sync_err_auth_expired);
+    });
+
+    test('互联声明的传输层：同一个 401 变成「配对被拒」，不再说登录过期', () {
+      final WebDavOps peer = WebDavOps(
+        baseUrl: 'http://127.0.0.1:1/dav',
+        username: 'hibiki',
+        password: 'per-peer-token',
+        unauthorizedKind: SyncAuthFailureKind.pairingRejected,
+      );
+      SyncAuthError? caught;
+      try {
+        peer.checkStatus(401, 'GET /x');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.kind, SyncAuthFailureKind.pairingRejected);
+      expect(friendlySyncError(caught), t.sync_err_pairing_rejected);
+      expect(friendlySyncError(caught), isNot(equals(t.sync_err_auth_expired)));
+    });
+
+    test('403 的语义不被 unauthorizedKind 抢走（只管 401）', () {
+      final WebDavOps peer = WebDavOps(
+        baseUrl: 'http://127.0.0.1:1/dav',
+        username: 'hibiki',
+        password: 't',
+        unauthorizedKind: SyncAuthFailureKind.pairingRejected,
+      );
+      SyncAuthError? caught;
+      try {
+        peer.checkStatus(403, 'GET /svc', serverReason: 'HTTPS required');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught!.kind, SyncAuthFailureKind.forbidden);
+      expect(friendlySyncError(caught), contains('HTTPS required'));
+    });
+
+    test('一台对端都没配对：不再把裸英文原文摔给用户', () {
+      final SyncAuthError e = SyncAuthError(
+        'Fushi server credentials not configured',
+        kind: SyncAuthFailureKind.pairingNotConfigured,
+      );
+      expect(friendlySyncError(e), t.sync_err_not_paired);
+      expect(friendlySyncError(e),
+          isNot(contains('Fushi server credentials not configured')));
+      expect(friendlySyncError(e), isNot(equals(t.sync_err_auth_expired)));
+    });
+
+    test('两条新文案都不得再提「登录」（互联没有登录入口）', () {
+      // 英文与简中双语都钉：措辞跑偏成 "sign in again" 就等于回归。
+      for (final String shown in <String>[
+        t.sync_err_pairing_rejected,
+        t.sync_err_not_paired,
+      ]) {
+        expect(shown, isNot(contains('sign in')));
+        expect(shown, isNot(contains('登录')));
+        expect(shown, isNot(contains('登入')));
+      }
+    });
+
+    test('配对被拒**不得**登出：互联登出会清空整份配对配置', () {
+      expect(
+        shouldSignOutOnAuthError(
+          SyncAuthError('Authentication failed',
+              kind: SyncAuthFailureKind.pairingRejected),
+        ),
+        isFalse,
+        reason: 'BUG-1550/BUG-1578：一台对端的 401 不得株连其余对端的配对',
+      );
+      expect(
+        shouldSignOutOnAuthError(
+          SyncAuthError('not configured',
+              kind: SyncAuthFailureKind.pairingNotConfigured),
+        ),
+        isFalse,
+      );
+    });
+
+    test('互联后端**每一个** WebDavOps 都声明了自己的凭据语义（源码守卫）', () {
+      // 漏一处 = 那条路径上的 401 又变回「登录已过期」。互联侧的构造点会随功能
+      // 增加（探测/暂定句柄/已解析会话/测试连接…），故按出现次数配对扫描，而不是
+      // 钉死行号。
+      final String src = maskComments(
+          File('lib/src/sync/interconnect_sync_backend.dart')
+              .readAsStringSync());
+      final int constructions = 'WebDavOps('.allMatches(src).length;
+      final int declared =
+          'unauthorizedKind: SyncAuthFailureKind.pairingRejected'
+              .allMatches(src)
+              .length;
+      expect(constructions, greaterThanOrEqualTo(5),
+          reason: '互联后端至少有 5 处 WebDavOps 构造点');
+      expect(declared, constructions,
+          reason: '有 WebDavOps 构造点没声明 unauthorizedKind —— '
+              '那条路径上的对端 401 会重新被说成「登录已过期」');
+    });
+
+    test('互联的 POST 传输层同样带类型（远程查词/制卡的 401）', () {
+      final String src = maskComments(
+          File('lib/src/sync/interconnect_post_transport.dart')
+              .readAsStringSync());
+      expect(src, contains('kind: SyncAuthFailureKind.pairingRejected'));
+    });
+
+    test('文案层对互联不再靠字符串猜：按 kind 分派先于任何 contains', () {
+      final String src = maskComments(
+          File('lib/src/sync/sync_error_messages.dart').readAsStringSync());
+      final int typeDispatch =
+          src.indexOf('error.kind != SyncAuthFailureKind.credentials');
+      final int stringGuess = src.indexOf("l.contains('401')");
+      expect(typeDispatch, greaterThanOrEqualTo(0));
+      expect(stringGuess, greaterThan(typeDispatch),
+          reason: '类型分派必须排在字符串猜测之前，否则新 kind 又被 contains 抢走');
     });
   });
 


### PR DESCRIPTION
## 症状

用户实拍：同步与备份页，存储后端 = **Fushi 互联**，点「立即同步」→ 上次同步「失败」→ toast **「登录已过期，请重新登录。」**

互联的凭据是配对时对端发的 per-peer token，**应用里根本没有互联的登录入口**——这句话把用户指向一个不存在的操作。

## 根因（三段，缺一不可）

1. `webdav_ops.dart` —— `WebDavOps` 是**传输层**，对 WebDAV（用户名/密码）和互联（配对 token）一律抛默认的 `SyncAuthError('Authentication failed')`，kind 默认 `credentials`。**凭据模型的语义在这里丢失。**
2. `sync_error_messages.dart:75-77` —— 类型没了，文案层只能按字符串猜：`error is SyncAuthError && l.contains('auth')` → `sync_err_auth_expired`，而那是 OAuth 后端的措辞。
3. 同文件 `:39-43` —— 相邻的第二处缺陷：互联未配对时抛的 `'Fushi server credentials not configured'` 命中 `contains('not configured')` → 返回 null → **裸英文原文直接上屏**。

真实事件是对端把本机从已配对列表里删了（server 端 token 缓存随即清空，被删设备下一次请求立刻 401），或对端重置/重装后 token 换了。可操作项是**重新配对**。

> 破坏性那一半此前已由 BUG-1578 修掉（`shouldSignOutChannelOnAuthError` 对互联通道返回 false），配对配置不会被一次 401 清空。本 PR 只剩语义/文案错配。

## 修法：修凭据语义的归属，不加特例分支

沿用 BUG-1323 / BUG-1348 / BUG-1693 立下的规矩——**判据是类型，不是字符串**。

- `SyncAuthFailureKind` 新增 `pairingRejected` / `pairingNotConfigured`
- `WebDavOps` 新增 `unauthorizedKind`（默认 `credentials`）：**传输层只转达，凭据语义由后端拥有者声明**。WebDAV 与 `NetworkSourceFileSystem` 行为逐字不变
- 互联后端 **5 处** `WebDavOps` 构造点 + **2 处**未配对抛出点 + POST 传输层 401 全部带类型
- 两处穷举 switch（`shouldSignOutOnAuthError`、`friendlySyncAuthFailure`）显式登记新值，两个新 kind **均不登出**
- 新 i18n key `sync_err_pairing_rejected` / `sync_err_not_paired`，**17 语言全部真翻译**（非英文占位）

## 测试

`sync_auth_error_kind_test.dart` 新增 group「BUG-2377 互联没有「登录」这回事」：

- **行为**：同一个 401，WebDAV 仍是 `credentials`/「登录已过期」（不回归），互联变 `pairingRejected`/「重新配对」；403 不被 `unauthorizedKind` 抢走；未配对不再摔裸英文
- **文案**：两条新文案断言不含「登录 / 登入 / sign in」
- **登出**：两个新 kind 均不得触发登出
- **源码守卫**：互联后端的 `WebDavOps(` 出现次数必须与 `unauthorizedKind:` 声明次数**相等**（将来新增构造点漏声明即红）；POST 传输层带类型；文案层的类型分派必须排在 `contains('401')` 之前

`oauth_proxy_and_browser_timeout_test.dart` 的 `SyncAuthFailureKind.values` 穷举登记表补上两个新值——那条守卫本就是为拦「新 kind 被默默归错边」而写的。

## 验证

- `flutter analyze`（含 test 目录）→ **No issues found**
- `flutter test test/sync test/i18n --no-pub` → **2584 条通过，exit 0**
- 目录枚举型守卫整批（51 条）→ **364 条通过，exit 0**

单据：`docs/bugs/BUG-2377-interconnect-401-says-login-expired.md`

https://claude.ai/code/session_01VyUHio8gaTFqjWnyNoEsby
