### PR TITLE
fix(anki): AnkiDroid 建牌组失败不再被吞成成功，一键创建 Lapis 不再改选用户自己的牌组（BUG-2380）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2189 条。点号进各自文件。
+> 共 2190 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2380](bugs/BUG-2380-ankidroid-create-deck-silent-failure.md) | ✅ | ✅ | AnkiDroid 建牌组/笔记类型失败被吞成成功，一键创建 Lapis 改选用户自己的牌组 |
 | [BUG-2375](bugs/BUG-2375-asr-unusable-model.md) | ✅ | ✅ | ASR 模型文件损坏后永久卡死：Protobuf parsing failed 且无自愈路径 |
 | [BUG-2373](bugs/BUG-2373-android-stylus-idle-loses-hover-pressure-buttons.md) | 🚧 | 🚧 | 安卓平板触控笔闲置1-2分钟后悬停/压力/侧键全失效 |
 | [BUG-2372](bugs/BUG-2372-gal-overlay-lookup-card-not-anchored-to-word.md) | 🚧 | 🚧 | 悬浮字幕查词弹窗没锚在被点的词上 |

--- a/docs/bugs/BUG-2380-ankidroid-create-deck-silent-failure.md
+++ b/docs/bugs/BUG-2380-ankidroid-create-deck-silent-failure.md
@@ -1,0 +1,65 @@
+## BUG-2380 · AnkiDroid 建牌组/笔记类型失败被吞成成功，一键创建 Lapis 改选用户自己的牌组
+- **报告**：2026-09-09（用户：旧人间，QQ 群）
+- **真实性**：✅ 真 bug。根因两段，都在「创建失败」这条路径上被静默吞掉：
+  - `fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java:360`（修前）
+    裸调 `api.addNewDeck(deckName)` 后**丢掉返回值**，紧接着无条件 `result.success(null)`。
+    `addNewDeck` 的契约是「失败返回 null」（`AnkiProvider.java:43`），所以 provider 的
+    `insert` 返回 null 时，Dart 侧拿到的是**成功**。`createNoteType`
+    （`AnkiChannelHandler.java:843` 修前）同样丢掉 `addNewCustomModel` 的返回值。
+    同一文件里 `addNote`（:143）与 `addFileToMedia`（:420）一直都在判空，
+    只有这两条**建结构**的路径漏了。
+  - `fushi/lib/src/anki/anki_view_model.dart:294`（修前）
+    `createLapisSetup` 建完回读清单时用
+    `firstWhere(name == 'Lapis', orElse: () => list.first)`：找不到 Lapis 就退而选清单里的
+    **第一个**牌组/笔记类型，顺手套上 Lapis 的字段映射，最后仍返回 `created`。
+- **用户可见形态**：新装 AnkiDroid、自己建了一个叫「日语」的牌组。点「一键创建 Lapis 卡组」
+  之后没有出现 Lapis，界面显示的选中牌组就是「日语」，还提示创建成功。字段映射是按
+  Lapis 的字段名排的，在「基础」笔记类型上一个都对不上 → 首字段恒空 → 真去制卡时被 Anki
+  以 `cannot create note because it is empty` 拒收。
+- **旁证（为什么守卫没拦住）**：`fushi/test/anki/anki_native_createmodel_guard_test.dart`
+  只断言 `addNewDeck` / `addNewCustomModel` 这些**字符串在不在**。bug 期间它们一直都在，
+  被丢掉的是**返回值**，所以守卫全程绿灯。native 侧没有任何 JVM / instrumentation 测试。
+- **[x] ① 已修复** — 三处根因 + 一处判据统一：
+  - native 判空：`addNewDeck` 返回 null → `CREATE_DECK_FAILED`；
+    `addNewCustomModel` 返回 null → 抛出并映射成 `CREATE_MODEL_FAILED`。
+  - native 如实回传「新建 / 本来就有」（`result.success(true/false)`），
+    Dart 侧删掉自己那份**第二份存在性判据**。两份判据本来就不一致（native 是
+    `equalsIgnoreCase` / 名字+字段数，Dart 是精确相等），分歧时「Dart 要求创建 →
+    native 静默跳过 → 报成功」是本 bug 的第二段。判据只留一处，分歧就无从产生。
+  - `createLapisSetup` 删掉 `orElse` 兜底：回读清单里看不到 Lapis 就返回
+    `AnkiErrorCode.lapisSetupMissing` 失败，绝不改选用户自己的牌组、绝不套 Lapis 字段映射。
+  - 新增 `AnkiSettings.canMineCards`（`packages/fushi_anki/lib/src/anki_models.dart`）：
+    「这套配置真能制出卡吗」的唯一判据，与制卡时的 `preflightNoteFields` 同源（Anki 的
+    `fields_check()` 只看首字段）。连接 Anki 之后与新手引导离开 Anki 步之前各判一次，
+    判不过弹同一个「创建并选用 Lapis」弹窗（`promptCreateLapisIfCannotMine`）。
+  - 按钮文案「创建 Lapis 卡组」→「创建并选用 Lapis」。
+- **[x] ② 已加自动化测试** —
+  - `fushi/test/anki/anki_settings_can_mine_cards_test.dart`（新增，11 例）：`canMineCards`
+    的判据，含「Lapis 字段映射套在别人的笔记类型上 → 不能制卡」这条用户实际形态，
+    以及反面「用户自己的笔记类型只要首字段接了模板就算合格」（防止把非 Lapis 用户也弹窗）。
+  - `fushi/test/anki/anki_view_model_lapis_test.dart`：新增「建完在清单里看不到 Lapis 时
+    失败，绝不改选用户自己的牌组」——直接钉死用户报的那一幕；以及「只补建了牌组时报
+    created 而非 alreadyExisted」（`createDeck` 返回值此前也被丢掉）。
+  - `fushi/test/anki/anki_native_createmodel_guard_test.dart`：把守卫从「字符串在不在」
+    升级成「**返回值被用上了**」——断言 native 判了 `== null` 并走 error 分支、
+    如实回传 true/false，且 Dart 侧不再自带第二份存在性判据。同时把原有那条按
+    `invokeMethod('createNoteType'` **连写**钉死的断言放宽成对换行不敏感（它钉的是写法
+    不是不变式，参数一多换行就红）。
+- **验证**（均按退出码判绿）：
+  - `flutter analyze`（fushi）→ No issues found，exit=0。
+  - `dart analyze`（packages/fushi_anki，`flutter analyze` 不覆盖 path 依赖包）→ exit=0。
+  - `flutter test test/anki --no-pub` → 381 例全绿，exit=0。
+  - `flutter test`（packages/fushi_anki，须 cd 到包目录）→ 544 例全绿，exit=0。
+  - 相邻域 `test/i18n test/onboarding test/settings` 571 例，唯一一条红是
+    `lookup_audio_volume_granularity_test.dart` 的 `loading` 型装载失败；单跑 5 例全绿
+    （exit=0）→ 并发伪红，与本次改动无关。
+  - **踩坑记一笔**：给 `flutter test` 注入 `HTTPS_PROXY`/`HTTP_PROXY` 会让
+    `packages/fushi_anki/test/ankiconnect_service_test.dart` 的
+    「default transport tags a failed connection before HTTP delivery」假红——那条走
+    真实 socket 判连接失败的分类。去掉代理环境变量即绿。判红前先看有没有给测试挂代理。
+  - Android Java 改动**不经任何 Dart 测试编译**（native 侧零 JVM 测试），另跑
+    `flutter build apk --debug` 真编一次 `AnkiChannelHandler.java`。
+- **备注**：native 侧仍无 JVM 测试，`addNewDeck` 返回 null 的**具体触发条件**（主包路径的
+  `AddContentApi` 是编译好的 AAR，钉在 `2.17alpha14`，本仓无源码）未能进一步定位；本次修的是
+  「失败不再被吞成成功」这个不变式，用户现在会拿到明确的失败提示而不是一个静默配坏的目标。
+  真机复测尚未进行。

--- a/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/AnkiChannelHandler.java
@@ -293,9 +293,13 @@ public class AnkiChannelHandler {
                                 "noteTypeName and noteTypeFields are required", null);
                         } else if (requirePermission(result)) {
                             try {
-                                createNoteType(noteTypeName, noteTypeFields,
-                                    cardName, front, back, css);
-                                result.success(null);
+                                // BUG-2380: true = created now, false = already
+                                // there. Dart needs the difference for its
+                                // "created" vs "already existed" message and no
+                                // longer runs a second, disagreeing existence
+                                // check of its own.
+                                result.success(createNoteType(noteTypeName,
+                                    noteTypeFields, cardName, front, back, css));
                             } catch (Exception e) {
                                 result.error("CREATE_MODEL_FAILED",
                                     e.getMessage(), null);
@@ -356,10 +360,34 @@ public class AnkiChannelHandler {
                                 "deckName is required", null);
                         } else if (requirePermission(result)) {
                             try {
-                                if (ankiDroid.findDeckIdByName(deckName) == null) {
-                                    api.addNewDeck(deckName);
+                                // BUG-2380: addNewDeck's return value is the
+                                // *only* success signal the provider gives us
+                                // (null = the insert failed, see
+                                // AnkiProvider#addNewDeck). It used to be
+                                // dropped on the floor followed by an
+                                // unconditional success(null), so a failed
+                                // creation reached Dart as a success and
+                                // "create and use Lapis" ended up selecting the
+                                // user's own first deck instead. addNote and
+                                // addFileToMedia in this same file have always
+                                // null-checked; only the two create-structure
+                                // paths were missing it.
+                                //
+                                // The name lookup here is also the single
+                                // idempotency check now (Dart's own one is
+                                // gone): this one is case-insensitive, Dart's
+                                // was exact, and when they disagreed Dart asked
+                                // for a creation that this branch silently
+                                // skipped while still reporting success.
+                                if (ankiDroid.findDeckIdByName(deckName) != null) {
+                                    result.success(false);
+                                } else if (api.addNewDeck(deckName) == null) {
+                                    result.error("CREATE_DECK_FAILED",
+                                        "AnkiDroid refused to create the deck: "
+                                            + deckName, null);
+                                } else {
+                                    result.success(true);
                                 }
-                                result.success(null);
                             } catch (Exception e) {
                                 result.error("CREATE_DECK_FAILED",
                                     e.getMessage(), null);
@@ -835,13 +863,33 @@ public class AnkiChannelHandler {
         return true;
     }
 
-    private void createNoteType(String name, ArrayList<String> fields,
-                                String cardName, String front, String back,
-                                String css) {
+    /**
+     * BUG-2380: returns true when this call actually created the note type,
+     * false when an equivalent one already existed.
+     *
+     * It used to return void and drop {@code addNewCustomModel}'s result. That
+     * result is the *only* success signal the provider gives us (it returns
+     * null on failure, see {@link AnkiProvider#addNewCustomModel}), so dropping
+     * it meant a failed creation reached Dart as a success — and "create and
+     * use Lapis" then picked whatever note type happened to be first in the
+     * user's collection. Throw instead, so the channel maps it to
+     * CREATE_MODEL_FAILED like any other failure on this path.
+     *
+     * The existence check also *is* the idempotency check now: Dart no longer
+     * runs its own (they disagreed — this one matches on name + field count,
+     * Dart compared names for exact equality, so a collection where the two
+     * disagreed made Dart ask for a creation that this method silently skipped
+     * while reporting success).
+     */
+    private boolean createNoteType(String name, ArrayList<String> fields,
+                                   String cardName, String front, String back,
+                                   String css) {
         final AnkiProvider api = AnkiProviders.forContext(context);
         // Idempotent: a model with this name + field count already exists.
-        if (ankiDroid.findModelIdByName(name, fields.size()) != null) return;
-        api.addNewCustomModel(
+        if (ankiDroid.findModelIdByName(name, fields.size()) != null) {
+            return false;
+        }
+        final Long modelId = api.addNewCustomModel(
             name,
             fields.toArray(new String[0]),
             new String[] { cardName },
@@ -851,6 +899,11 @@ public class AnkiChannelHandler {
             null,
             null
         );
+        if (modelId == null) {
+            throw new IllegalStateException(
+                "AnkiDroid refused to create the note type: " + name);
+        }
+        return true;
     }
 
     /** `content://com.ichi2.anki.flashcards/models/<mid>`。 */

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77129 (4537 per locale)
+/// Strings: 77197 (4541 per locale)
 ///
-/// Built on 2026-09-09 at 09:32 UTC
+/// Built on 2026-09-09 at 10:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -368,13 +368,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_connect_use_on_mobile => 'Use AnkiConnect instead';
   String get anki_connect_use_on_mobile_hint =>
       'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
-  String get anki_create_lapis => 'Create Lapis deck';
+  String get anki_create_lapis => 'Create and use Lapis';
   String get anki_create_lapis_exists =>
       'Lapis note type and deck already exist — selected them.';
   String anki_create_lapis_failed({required Object error}) =>
       'Could not create Lapis deck: ${error}';
   String get anki_create_lapis_hint =>
-      'Adds the Lapis note type and a Lapis deck to Anki, then selects them.';
+      'Adds the Lapis note type and a Lapis deck to Anki, then selects them as the mining target.';
   String get anki_create_lapis_success => 'Lapis note type and deck created.';
   String get anki_deck => 'Deck';
   String get anki_dedup_auto => 'Automatic processing';
@@ -6297,6 +6297,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Already a source — rescanning: ${path}';
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -16959,6 +16965,16 @@ class _StringsAr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -27848,6 +27864,16 @@ class _StringsDe extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -38791,6 +38817,16 @@ class _StringsEs extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -49768,6 +49804,16 @@ class _StringsFr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -60547,6 +60593,16 @@ class _StringsId extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -71418,6 +71474,16 @@ class _StringsIt extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -81670,6 +81736,16 @@ class _StringsJa extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -91932,6 +92008,16 @@ class _StringsKo extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -102760,6 +102846,16 @@ class _StringsNl extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -113641,6 +113737,16 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -124499,6 +124605,16 @@ class _StringsRu extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -135157,6 +135273,16 @@ class _StringsTh extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -145931,6 +146057,16 @@ class _StringsTr extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -156676,6 +156812,16 @@ class _StringsVi extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 // Path: <root>
@@ -156985,14 +157131,15 @@ class _StringsZhCn extends _StringsEn {
   String get anki_connect_use_on_mobile_hint =>
       '仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。';
   @override
-  String get anki_create_lapis => '创建 Lapis 卡组';
+  String get anki_create_lapis => '创建并选用 Lapis';
   @override
   String get anki_create_lapis_exists => 'Lapis 笔记类型和卡组已存在，已选中。';
   @override
   String anki_create_lapis_failed({required Object error}) =>
       '无法创建 Lapis 卡组：${error}';
   @override
-  String get anki_create_lapis_hint => '向 Anki 添加 Lapis 笔记类型和 Lapis 卡组并自动选中。';
+  String get anki_create_lapis_hint =>
+      '向 Anki 添加 Lapis 笔记类型和 Lapis 卡组，并选为制卡目标。';
   @override
   String get anki_create_lapis_success => '已创建 Lapis 笔记类型和卡组。';
   @override
@@ -166544,6 +166691,16 @@ class _StringsZhCn extends _StringsEn {
       '该位置已是来源，正在重新扫描：${path}';
   @override
   String get audiobook_transcribe_model_discarded => '模型文件读不出来，已自动清除，请重新下载。';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki 报告 Lapis 牌组和笔记类型已创建，但回读时仍然找不到它们。请打开 Anki 确认它没有卡住，然后重试。';
+  @override
+  String get anki_lapis_suggest_title => '现在还制不出卡';
+  @override
+  String get anki_lapis_suggest_body =>
+      '当前选中的牌组和笔记类型做不出 Anki 会接收的卡片。可以让 Hibiki 添加 Lapis 笔记类型和卡组，并直接选用它们。';
+  @override
+  String get anki_lapis_suggest_dismiss => '保持当前设置';
 }
 
 // Path: <root>
@@ -166854,14 +167011,15 @@ class _StringsZhHk extends _StringsEn {
   String get anki_connect_use_on_mobile_hint =>
       '僅在可信網路中使用。AnkiConnect 使用明文 HTTP；請配置匹配的 API key，切換後再重新整理牌組與筆記類型。';
   @override
-  String get anki_create_lapis => '建立 Lapis 卡組';
+  String get anki_create_lapis => '建立並選用 Lapis';
   @override
   String get anki_create_lapis_exists => 'Lapis 筆記類型與卡組已存在，已為你選取。';
   @override
   String anki_create_lapis_failed({required Object error}) =>
       '無法建立 Lapis 卡組：${error}';
   @override
-  String get anki_create_lapis_hint => '向 Anki 加入 Lapis 筆記類型與 Lapis 卡組並自動選取。';
+  String get anki_create_lapis_hint =>
+      '向 Anki 加入 Lapis 筆記類型和 Lapis 卡組，並選為製卡目標。';
   @override
   String get anki_create_lapis_success => '已建立 Lapis 筆記類型與卡組。';
   @override
@@ -176482,6 +176640,16 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get audiobook_transcribe_model_discarded =>
       'The model file could not be read and was removed. Download it again.';
+  @override
+  String get anki_create_lapis_not_found =>
+      'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+  @override
+  String get anki_lapis_suggest_title => 'Anki can\'t make cards yet';
+  @override
+  String get anki_lapis_suggest_body =>
+      'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+  @override
+  String get anki_lapis_suggest_dismiss => 'Keep current setup';
 }
 
 /// Flat map(s) containing all translations.
@@ -176747,14 +176915,14 @@ extension on _StringsEn {
       case 'anki_connect_use_on_mobile_hint':
         return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
       case 'anki_create_lapis':
-        return 'Create Lapis deck';
+        return 'Create and use Lapis';
       case 'anki_create_lapis_exists':
         return 'Lapis note type and deck already exist — selected them.';
       case 'anki_create_lapis_failed':
         return ({required Object error}) =>
             'Could not create Lapis deck: ${error}';
       case 'anki_create_lapis_hint':
-        return 'Adds the Lapis note type and a Lapis deck to Anki, then selects them.';
+        return 'Adds the Lapis note type and a Lapis deck to Anki, then selects them as the mining target.';
       case 'anki_create_lapis_success':
         return 'Lapis note type and deck created.';
       case 'anki_deck':
@@ -185817,6 +185985,14 @@ extension on _StringsEn {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -195147,6 +195323,14 @@ extension on _StringsAr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -204522,6 +204706,14 @@ extension on _StringsDe {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -213888,6 +214080,14 @@ extension on _StringsEs {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -223263,6 +223463,14 @@ extension on _StringsFr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -232609,6 +232817,14 @@ extension on _StringsId {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -241977,6 +242193,14 @@ extension on _StringsIt {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -251272,6 +251496,14 @@ extension on _StringsJa {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -260571,6 +260803,14 @@ extension on _StringsKo {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -269932,6 +270172,14 @@ extension on _StringsNl {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -279288,6 +279536,14 @@ extension on _StringsPtBr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -288651,6 +288907,14 @@ extension on _StringsRu {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -297986,6 +298250,14 @@ extension on _StringsTh {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -307336,6 +307608,14 @@ extension on _StringsTr {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -316680,6 +316960,14 @@ extension on _StringsVi {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }
@@ -316941,13 +317229,13 @@ extension on _StringsZhCn {
       case 'anki_connect_use_on_mobile_hint':
         return '仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。';
       case 'anki_create_lapis':
-        return '创建 Lapis 卡组';
+        return '创建并选用 Lapis';
       case 'anki_create_lapis_exists':
         return 'Lapis 笔记类型和卡组已存在，已选中。';
       case 'anki_create_lapis_failed':
         return ({required Object error}) => '无法创建 Lapis 卡组：${error}';
       case 'anki_create_lapis_hint':
-        return '向 Anki 添加 Lapis 笔记类型和 Lapis 卡组并自动选中。';
+        return '向 Anki 添加 Lapis 笔记类型和 Lapis 卡组，并选为制卡目标。';
       case 'anki_create_lapis_success':
         return '已创建 Lapis 笔记类型和卡组。';
       case 'anki_deck':
@@ -325942,6 +326230,14 @@ extension on _StringsZhCn {
         return ({required Object path}) => '该位置已是来源，正在重新扫描：${path}';
       case 'audiobook_transcribe_model_discarded':
         return '模型文件读不出来，已自动清除，请重新下载。';
+      case 'anki_create_lapis_not_found':
+        return 'Anki 报告 Lapis 牌组和笔记类型已创建，但回读时仍然找不到它们。请打开 Anki 确认它没有卡住，然后重试。';
+      case 'anki_lapis_suggest_title':
+        return '现在还制不出卡';
+      case 'anki_lapis_suggest_body':
+        return '当前选中的牌组和笔记类型做不出 Anki 会接收的卡片。可以让 Hibiki 添加 Lapis 笔记类型和卡组，并直接选用它们。';
+      case 'anki_lapis_suggest_dismiss':
+        return '保持当前设置';
       default:
         return null;
     }
@@ -326203,13 +326499,13 @@ extension on _StringsZhHk {
       case 'anki_connect_use_on_mobile_hint':
         return '僅在可信網路中使用。AnkiConnect 使用明文 HTTP；請配置匹配的 API key，切換後再重新整理牌組與筆記類型。';
       case 'anki_create_lapis':
-        return '建立 Lapis 卡組';
+        return '建立並選用 Lapis';
       case 'anki_create_lapis_exists':
         return 'Lapis 筆記類型與卡組已存在，已為你選取。';
       case 'anki_create_lapis_failed':
         return ({required Object error}) => '無法建立 Lapis 卡組：${error}';
       case 'anki_create_lapis_hint':
-        return '向 Anki 加入 Lapis 筆記類型與 Lapis 卡組並自動選取。';
+        return '向 Anki 加入 Lapis 筆記類型和 Lapis 卡組，並選為製卡目標。';
       case 'anki_create_lapis_success':
         return '已建立 Lapis 筆記類型與卡組。';
       case 'anki_deck':
@@ -335215,6 +335511,14 @@ extension on _StringsZhHk {
             'Already a source — rescanning: ${path}';
       case 'audiobook_transcribe_model_discarded':
         return 'The model file could not be read and was removed. Download it again.';
+      case 'anki_create_lapis_not_found':
+        return 'Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.';
+      case 'anki_lapis_suggest_title':
+        return 'Anki can\'t make cards yet';
+      case 'anki_lapis_suggest_body':
+        return 'The selected deck and note type can\'t produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.';
+      case 'anki_lapis_suggest_dismiss':
+        return 'Keep current setup';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -122,10 +122,10 @@
   "anki_connect_port_auto_fix_none": "No free port found on this machine.",
   "anki_connect_use_on_mobile": "Use AnkiConnect instead",
   "anki_connect_use_on_mobile_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
-  "anki_create_lapis": "Create Lapis deck",
+  "anki_create_lapis": "Create and use Lapis",
   "anki_create_lapis_exists": "Lapis note type and deck already exist — selected them.",
   "anki_create_lapis_failed": "Could not create Lapis deck: $error",
-  "anki_create_lapis_hint": "Adds the Lapis note type and a Lapis deck to Anki, then selects them.",
+  "anki_create_lapis_hint": "Adds the Lapis note type and a Lapis deck to Anki, then selects them as the mining target.",
   "anki_create_lapis_success": "Lapis note type and deck created.",
   "anki_deck": "Deck",
   "anki_dedup_auto": "Automatic processing",
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Show reading timer",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "إظهار مؤقت القراءة",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Lesetimer anzeigen",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostrar temporizador de lectura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Afficher le minuteur de lecture",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Tampilkan pengatur waktu baca",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostra timer di lettura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "読書タイマーを表示",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "독서 타이머 표시",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Leestimer tonen",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Mostrar cronômetro de leitura",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Показывать таймер чтения",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "แสดงตัวจับเวลาการอ่าน",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Okuma zamanlayıcısını göster",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "Hiển thị bộ đếm thời gian đọc",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -122,10 +122,10 @@
   "anki_connect_port_auto_fix_none": "本机没有找到空闲端口。",
   "anki_connect_use_on_mobile": "改用 AnkiConnect",
   "anki_connect_use_on_mobile_hint": "仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。",
-  "anki_create_lapis": "创建 Lapis 卡组",
+  "anki_create_lapis": "创建并选用 Lapis",
   "anki_create_lapis_exists": "Lapis 笔记类型和卡组已存在，已选中。",
   "anki_create_lapis_failed": "无法创建 Lapis 卡组：$error",
-  "anki_create_lapis_hint": "向 Anki 添加 Lapis 笔记类型和 Lapis 卡组并自动选中。",
+  "anki_create_lapis_hint": "向 Anki 添加 Lapis 笔记类型和 Lapis 卡组，并选为制卡目标。",
   "anki_create_lapis_success": "已创建 Lapis 笔记类型和卡组。",
   "anki_deck": "牌组",
   "anki_dedup_auto": "自动处理",
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "关闭（任务继续在后台运行）",
   "reader_timer_show": "显示阅读计时器",
   "media_source_root_already_added": "该位置已是来源，正在重新扫描：$path",
-  "audiobook_transcribe_model_discarded": "模型文件读不出来，已自动清除，请重新下载。"
+  "audiobook_transcribe_model_discarded": "模型文件读不出来，已自动清除，请重新下载。",
+  "anki_create_lapis_not_found": "Anki 报告 Lapis 牌组和笔记类型已创建，但回读时仍然找不到它们。请打开 Anki 确认它没有卡住，然后重试。",
+  "anki_lapis_suggest_title": "现在还制不出卡",
+  "anki_lapis_suggest_body": "当前选中的牌组和笔记类型做不出 Anki 会接收的卡片。可以让 Hibiki 添加 Lapis 笔记类型和卡组，并直接选用它们。",
+  "anki_lapis_suggest_dismiss": "保持当前设置"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -122,10 +122,10 @@
   "anki_connect_port_auto_fix_none": "本機找不到空閒的連接埠。",
   "anki_connect_use_on_mobile": "Use AnkiConnect on Android",
   "anki_connect_use_on_mobile_hint": "僅在可信網路中使用。AnkiConnect 使用明文 HTTP；請配置匹配的 API key，切換後再重新整理牌組與筆記類型。",
-  "anki_create_lapis": "建立 Lapis 卡組",
+  "anki_create_lapis": "建立並選用 Lapis",
   "anki_create_lapis_exists": "Lapis 筆記類型與卡組已存在，已為你選取。",
   "anki_create_lapis_failed": "無法建立 Lapis 卡組：$error",
-  "anki_create_lapis_hint": "向 Anki 加入 Lapis 筆記類型與 Lapis 卡組並自動選取。",
+  "anki_create_lapis_hint": "向 Anki 加入 Lapis 筆記類型和 Lapis 卡組，並選為製卡目標。",
   "anki_create_lapis_success": "已建立 Lapis 筆記類型與卡組。",
   "anki_deck": "牌組",
   "anki_dedup_auto": "自動處理",
@@ -4535,5 +4535,9 @@
   "dialog_background_close": "Close (task keeps running)",
   "reader_timer_show": "顯示閱讀計時器",
   "media_source_root_already_added": "Already a source — rescanning: $path",
-  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again."
+  "audiobook_transcribe_model_discarded": "The model file could not be read and was removed. Download it again.",
+  "anki_create_lapis_not_found": "Anki said the Lapis deck and note type were created, but they are still missing when Hibiki reads the collection back. Open Anki, make sure it is not busy, and try again.",
+  "anki_lapis_suggest_title": "Anki can't make cards yet",
+  "anki_lapis_suggest_body": "The selected deck and note type can't produce a card Anki will accept. Hibiki can add its Lapis note type and deck and select them for you.",
+  "anki_lapis_suggest_dismiss": "Keep current setup"
 }

--- a/fushi/lib/src/anki/anki_config_controls.dart
+++ b/fushi/lib/src/anki/anki_config_controls.dart
@@ -142,32 +142,7 @@ class _AnkiCreateLapisRowState extends State<AnkiCreateLapisRow> {
       _setBusy(false);
     }
     if (!mounted) return;
-    final String message;
-    switch (result.outcome) {
-      case LapisSetupOutcome.created:
-        message = t.anki_create_lapis_success;
-      case LapisSetupOutcome.alreadyExisted:
-        message = t.anki_create_lapis_exists;
-      case LapisSetupOutcome.failed:
-        message = t.anki_create_lapis_failed(error: result.message ?? '');
-    }
-    // BUG-2098：权限被永久拒绝时系统不再弹授权框，光给一句提示等于把用户堵死；
-    // 唯一出路是应用设置页里的权限项，所以直接把它做成 snackbar 上的一个按钮。
-    final bool needsSettings =
-        result.code == AnkiErrorCode.permissionPermanentlyDenied;
-    messenger.showSnackBar(SnackBar(
-      content: Text(message),
-      duration: needsSettings
-          ? const Duration(seconds: 10)
-          : const Duration(seconds: 4),
-      action: needsSettings
-          ? SnackBarAction(
-              label: t.anki_action_open_settings,
-              onPressed: () =>
-                  unawaited(AnkiRepository.openPermissionSettings()),
-            )
-          : null,
-    ));
+    showLapisSetupResult(messenger, result);
   }
 
   @override
@@ -187,4 +162,91 @@ class _AnkiCreateLapisRowState extends State<AnkiCreateLapisRow> {
       onTap: widget.isFetching || _busy ? null : () => unawaited(_run()),
     );
   }
+}
+
+/// 「创建并选用 Lapis」的结果 snackbar —— **单一实现**。
+///
+/// 设置页 / 引导页的那一行按钮，和 [promptCreateLapisIfCannotMine] 弹窗里的确认，
+/// 走的是同一个 [AnkiViewModel.createLapisSetup]，结果的呈现也必须是同一份：
+/// 复制一份就等于日后 outcome 增删时要改两处。
+void showLapisSetupResult(
+  ScaffoldMessengerState messenger,
+  LapisSetupResult result,
+) {
+  final String message;
+  switch (result.outcome) {
+    case LapisSetupOutcome.created:
+      message = t.anki_create_lapis_success;
+    case LapisSetupOutcome.alreadyExisted:
+      message = t.anki_create_lapis_exists;
+    case LapisSetupOutcome.failed:
+      message = t.anki_create_lapis_failed(error: result.message ?? '');
+  }
+  // BUG-2098：权限被永久拒绝时系统不再弹授权框，光给一句提示等于把用户堵死；
+  // 唯一出路是应用设置页里的权限项，所以直接把它做成 snackbar 上的一个按钮。
+  final bool needsSettings =
+      result.code == AnkiErrorCode.permissionPermanentlyDenied;
+  messenger.showSnackBar(SnackBar(
+    content: Text(message),
+    duration: needsSettings
+        ? const Duration(seconds: 10)
+        : const Duration(seconds: 4),
+    action: needsSettings
+        ? SnackBarAction(
+            label: t.anki_action_open_settings,
+            onPressed: () => unawaited(AnkiRepository.openPermissionSettings()),
+          )
+        : null,
+  ));
+}
+
+/// BUG-2380：当前 Anki 配置**制不出卡**时，劝用户建并选用 Lapis 的弹窗——
+/// 同样是**单一实现**，新手引导点「下一步」与设置页/引导页连接 Anki 之后各调一次。
+///
+/// 判据是 [AnkiSettings.canMineCards]（首字段有没有接模板、选中的牌组还在不在），
+/// **不是**「有没有 Lapis」：用户自己配好的笔记类型照样能制卡，拿 Lapis 当唯一合格
+/// 线会把这些人也弹一遍窗。用户报的原始故障正是反面——配置其实是坏的（牌组被静默
+/// 换成了用户自己的『日语』），却一路无声，直到制卡时才炸。
+///
+/// 清单为空时**不弹**：那是「还没连上 Anki / 这次没拉到东西」，不是配置有问题，
+/// 此时劝人建牌组只是噪音。
+///
+/// 返回 true = 用户选择了创建且真的建成了（调用方据此决定要不要继续往下走）。
+Future<bool> promptCreateLapisIfCannotMine({
+  required BuildContext context,
+  required AnkiViewModel viewModel,
+}) async {
+  final AnkiSettings settings = viewModel.settings;
+  if (settings.availableDecks.isEmpty || settings.availableNoteTypes.isEmpty) {
+    return false;
+  }
+  if (settings.canMineCards) return false;
+
+  final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+  final bool confirmed = await showAppDialog<bool>(
+        context: context,
+        builder: (BuildContext dialogContext) => AlertDialog.adaptive(
+          title: Text(t.anki_lapis_suggest_title),
+          content: Text(t.anki_lapis_suggest_body),
+          actions: <Widget>[
+            adaptiveDialogAction(
+              context: dialogContext,
+              onPressed: () => Navigator.pop(dialogContext, false),
+              child: Text(t.anki_lapis_suggest_dismiss),
+            ),
+            adaptiveDialogAction(
+              context: dialogContext,
+              isDefaultAction: true,
+              onPressed: () => Navigator.pop(dialogContext, true),
+              child: Text(t.anki_create_lapis),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+  if (!confirmed) return false;
+
+  final LapisSetupResult result = await viewModel.createLapisSetup();
+  showLapisSetupResult(messenger, result);
+  return result.outcome != LapisSetupOutcome.failed;
 }

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -272,8 +273,13 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   Future<LapisSetupResult> createLapisSetup() async {
     state = state.copyWith(isFetching: true, clearError: true);
     try {
-      final created = await _repository.createNoteType(LapisNoteType.template);
-      await _repository.createDeck(LapisNoteType.deckName);
+      // BUG-2380：牌组的返回值此前被丢掉，于是「笔记类型早就有、这次只补了牌组」
+      // 会报成「已存在」。两者任一是新建的就算这次创建过。
+      final bool noteTypeCreated =
+          await _repository.createNoteType(LapisNoteType.template);
+      final bool deckCreated =
+          await _repository.createDeck(LapisNoteType.deckName);
+      final bool created = noteTypeCreated || deckCreated;
 
       final fetch = await _repository.fetchConfiguration();
       if (fetch is AnkiFetchError) {
@@ -291,12 +297,27 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
       }
 
       final settings = await _repository.loadSettings();
-      final noteType = settings.availableNoteTypes.firstWhere(
-          (t) => t.name == LapisNoteType.modelName,
-          orElse: () => settings.availableNoteTypes.first);
-      final deck = settings.availableDecks.firstWhere(
-          (d) => d.name == LapisNoteType.deckName,
-          orElse: () => settings.availableDecks.first);
+      // BUG-2380：建完之后必须在后端**回读的清单里真的看见** Lapis 才算数。
+      //
+      // 旧实现这两行是 `firstWhere(..., orElse: () => list.first)`。后端把创建静默
+      // 吞掉时（AnkiDroid 的 `addNewDeck` 失败返回 null、native 侧照样报成功，是
+      // 已知形态），兜底会把用户自己的**第一个**牌组/笔记类型当成 Lapis 选中，
+      // 顺手套上 Lapis 的字段映射，最后还返回 `created` ——「创建成功」的 toast +
+      // 选中的却是用户自己的『日语』牌组，字段映射还全是按 Lapis 排的。
+      // 找不到就必须失败，绝不能拿别的牌组顶替。
+      final noteType = settings.availableNoteTypes
+          .firstWhereOrNull((t) => t.name == LapisNoteType.modelName);
+      final deck = settings.availableDecks
+          .firstWhereOrNull((d) => d.name == LapisNoteType.deckName);
+      if (noteType == null || deck == null) {
+        final String message = t.anki_create_lapis_not_found;
+        state = state.copyWith(isFetching: false, errorMessage: message);
+        return LapisSetupResult(
+          LapisSetupOutcome.failed,
+          message,
+          AnkiErrorCode.lapisSetupMissing,
+        );
+      }
 
       final updated = await _repository.updateSettings((s) => s.copyWith(
             selectedDeckId: deck.id,

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -748,8 +749,17 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       // 任一在途动作（刷新或 Lapis 创建）期间都不可重入。
       onTap: uiState.isFetching || _creatingLapis
           ? null
-          : () => vm.fetchConfiguration(),
+          : () => unawaited(_refreshAndCheckMining(vm)),
     );
+  }
+
+  /// BUG-2380：刷新（= 连接 Anki）之后当场判一次「这套配置真能制出卡吗」，判不过
+  /// 就地劝建并选用 Lapis —— 与新手引导「测试连接」是同一个判据、同一个弹窗
+  /// （[promptCreateLapisIfCannotMine]），两处不许各写一套。
+  Future<void> _refreshAndCheckMining(AnkiViewModel vm) async {
+    await vm.fetchConfiguration();
+    if (!mounted) return;
+    await promptCreateLapisIfCannotMine(context: context, viewModel: vm);
   }
 
   /// AnkiConnect 的 API key 编辑入口。

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -251,7 +251,23 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
     }
   }
 
-  void _goNext() {
+  void _goNext() => unawaited(_goNextAsync());
+
+  /// BUG-2380：离开 Anki 那一步之前先判一次「这套配置真能制出卡吗」，判不过就地
+  /// 劝建并选用 Lapis。放在推进**之前**而不是之后——用户按下一步的那一刻还看得见
+  /// Anki 这一页的上下文，翻页之后再弹就成了没头没尾的打断。
+  ///
+  /// 弹窗不拦路：用户选「保持当前设置」照样进下一步（引导本来就可跳过，这里不该
+  /// 变成硬门）。但建成了的话 `_steps` 会因为 Anki 变 ready 而多出一步，所以 await
+  /// 之后必须重新取一次序列，不能沿用进函数时那份。
+  Future<void> _goNextAsync() async {
+    if (_steps[_stepIndex] == OnboardingStepId.anki) {
+      await promptCreateLapisIfCannotMine(
+        context: context,
+        viewModel: ref.read(ankiViewModelProvider.notifier),
+      );
+      if (!mounted) return;
+    }
     final List<OnboardingStepId> steps = _steps;
     if (steps[_stepIndex] == OnboardingStepId.features) {
       // 不阻塞翻页（写 11 个 pref 要走 DB），但把 future 留给 [_complete] 等。
@@ -479,6 +495,13 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
           anki.availableDecks.isNotEmpty &&
           anki.availableNoteTypes.isNotEmpty;
     });
+    if (!_ankiConnectionVerified || !context.mounted) return;
+    // BUG-2380：连上了就当场判一次「这套配置真能制出卡吗」。判不过就地给出唯一
+    // 出路（创建并选用 Lapis），而不是让用户一路走到第一次制卡才发现字段全空。
+    await promptCreateLapisIfCannotMine(
+      context: context,
+      viewModel: ref.read(ankiViewModelProvider.notifier),
+    );
   }
 
   /// 当前 Anki 后端的展示名（与 platform_services 的编译期选择一致：桌面

--- a/fushi/test/anki/anki_native_createmodel_guard_test.dart
+++ b/fushi/test/anki/anki_native_createmodel_guard_test.dart
@@ -25,8 +25,12 @@ void main() {
     });
 
     test('Dart repo invokes the schema-driven channel methods', () {
-      expect(repo, contains("invokeMethod('createNoteType'"));
-      expect(repo, contains("invokeMethod('createDeck'"));
+      // 不要求 `invokeMethod('createNoteType'` 连写：那钉的是**写法**不是不变式，
+      // 参数一多换个行就红（BUG-2380 拆多行时正是如此）。要钉的是「这两个 channel
+      // method 名确实被 invokeMethod 调用了」。
+      expect(repo, contains('invokeMethod('));
+      expect(repo, contains("'createNoteType'"));
+      expect(repo, contains("'createDeck'"));
       expect(repo, contains('noteTypeFields'));
     });
   });
@@ -46,6 +50,100 @@ void main() {
       expect(page, contains('AnkiCreateLapisRow('));
       expect(controls, contains('createLapisSetup()'));
       expect(controls, contains('t.anki_create_lapis'));
+    });
+  });
+
+  // BUG-2380：这一组是**本文件原有守卫漏掉的那一半**。上面那条只断言
+  // `addNewDeck` / `addNewCustomModel` 这些字符串在不在，而 bug 期间它们一直都在
+  // ——被丢掉的是它们的**返回值**（provider 建失败时返回 null）。字符串存在性守卫
+  // 对此全程绿灯，用户拿到的却是「创建成功」+ 选中了自己的牌组。
+  //
+  // 这里改钉「返回值被用上了」这个不变式。native 没有任何 JVM 测试，源码扫描是
+  // 目前最强的可落地层。
+  group('BUG-2380 native create paths must not swallow a failed creation', () {
+    test('createDeck 判 addNewDeck 的 null 并报 CREATE_DECK_FAILED', () {
+      expect(java, contains('api.addNewDeck(deckName) == null'),
+          reason: 'addNewDeck 返回 null = 建组失败，必须判空，'
+              '不能像旧实现那样裸调用后无条件 success');
+      expect(java, contains('result.error("CREATE_DECK_FAILED"'));
+    });
+
+    test('createNoteType 判 addNewCustomModel 的 null', () {
+      expect(java, contains('if (modelId == null)'),
+          reason: 'addNewCustomModel 返回 null = 建笔记类型失败，必须判空');
+      expect(java, contains('result.error("CREATE_MODEL_FAILED"'));
+    });
+
+    test('两条创建路径都把「新建 / 本来就有」如实回给 Dart', () {
+      // 旧实现一律 success(null)，Dart 只能自己再查一遍清单去猜——而它那份判据
+      // 与 native 的不一致（native 大小写不敏感 / 按名字+字段数，Dart 精确相等）。
+      expect(java, contains('result.success(false)'));
+      expect(java, contains('result.success(true)'));
+      expect(java, contains('result.success(createNoteType('));
+    });
+
+    test('Dart 侧不再自带第二份存在性判据', () {
+      // 判据只留 native 一处；Dart 再查一遍就会与 native 分歧，分歧时
+      // 「Dart 要求创建 → native 静默跳过 → 报成功」是本 bug 的第二段根因。
+      final int createDeckStart = repo.indexOf('Future<bool> createDeck(');
+      expect(createDeckStart, greaterThan(-1));
+      final String createDeckBody =
+          repo.substring(createDeckStart, createDeckStart + 500);
+      expect(createDeckBody.contains("invokeMethod('getDecks')"), isFalse,
+          reason: 'createDeck 不该自己再查一遍牌组清单');
+
+      final int createNoteTypeStart =
+          repo.indexOf('Future<bool> createNoteType(');
+      expect(createNoteTypeStart, greaterThan(-1));
+      final String createNoteTypeBody =
+          repo.substring(createNoteTypeStart, createNoteTypeStart + 700);
+      expect(createNoteTypeBody.contains("invokeMethod('getModelList')"),
+          isFalse,
+          reason: 'createNoteType 不该自己再查一遍笔记类型清单');
+    });
+  });
+
+  // BUG-2380：「创建并选用 Lapis」在回读清单里看不到 Lapis 时必须失败，
+  // 绝不退而选清单里的第一个牌组/笔记类型。
+  group('BUG-2380 createLapisSetup has no silent fallback', () {
+    final vm = File('lib/src/anki/anki_view_model.dart').readAsStringSync();
+
+    test('不再用 orElse 退到清单第一个', () {
+      final int start = vm.indexOf('Future<LapisSetupResult> createLapisSetup');
+      expect(start, greaterThan(-1));
+      final int end = vm.indexOf('_lapisSetupFailure(Object e)', start);
+      final String body = vm.substring(start, end > start ? end : vm.length);
+      expect(body.contains('availableNoteTypes.first'), isFalse,
+          reason: '找不到 Lapis 就选清单第一个 = 把用户自己的牌组当成 Lapis');
+      expect(body.contains('availableDecks.first'), isFalse);
+      expect(body, contains('AnkiErrorCode.lapisSetupMissing'));
+    });
+  });
+
+  // BUG-2380：连接 Anki 之后与新手引导「下一步」都要判一次「这套配置真能制出卡吗」，
+  // 判不过就走同一个弹窗。两处不许各写一套判据。
+  group('BUG-2380 mining-readiness check is wired at both entry points', () {
+    final controls =
+        File('lib/src/anki/anki_config_controls.dart').readAsStringSync();
+    final page = File('lib/src/pages/implementations/anki_settings_page.dart')
+        .readAsStringSync();
+    final wizard =
+        File('lib/src/pages/implementations/onboarding_wizard_page.dart')
+            .readAsStringSync();
+
+    test('弹窗只有一处实现，判据是 canMineCards', () {
+      expect(controls, contains('promptCreateLapisIfCannotMine'));
+      expect(controls, contains('settings.canMineCards'));
+    });
+
+    test('设置页刷新之后调它', () {
+      expect(page, contains('promptCreateLapisIfCannotMine('));
+    });
+
+    test('新手引导的下一步与测试连接都调它', () {
+      expect('promptCreateLapisIfCannotMine('.allMatches(wizard).length, 2,
+          reason: '一处在 _goNextAsync（离开 Anki 步之前），'
+              '一处在 _testAnkiConnection（连上之后）');
     });
   });
 }

--- a/fushi/test/anki/anki_settings_can_mine_cards_test.dart
+++ b/fushi/test/anki/anki_settings_can_mine_cards_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+/// BUG-2380：`AnkiSettings.canMineCards` 是「这套配置真能制出卡吗」的**唯一判据**，
+/// 新手引导的下一步与设置页/引导页的连接后自检共用它。
+///
+/// 判据必须与制卡时 `BaseAnkiRepository.preflightNoteFields` 同源：Anki 的
+/// `fields_check()` 只看笔记类型的第一个字段，它空了就拒收整张卡。
+///
+/// 反面同样重要：不能拿「是不是 Lapis」当合格线，否则自己配好笔记类型的用户会被
+/// 反复劝去建 Lapis。
+void main() {
+  const AnkiNoteType lapis = AnkiNoteType(
+    id: 7,
+    name: 'Lapis',
+    fields: ['Expression', 'MainDefinition', 'Sentence'],
+  );
+  const AnkiNoteType basic = AnkiNoteType(
+    id: 8,
+    name: '基础',
+    fields: ['正面', '背面'],
+  );
+  const AnkiDeck lapisDeck = AnkiDeck(id: 1, name: 'Lapis');
+  const AnkiDeck userDeck = AnkiDeck(id: 2, name: '日语');
+
+  AnkiSettings settings({
+    int? deckId = 1,
+    String? deckName = 'Lapis',
+    int? noteTypeId = 7,
+    String? noteTypeName = 'Lapis',
+    List<AnkiDeck> decks = const [lapisDeck, userDeck],
+    List<AnkiNoteType> noteTypes = const [lapis, basic],
+    Map<String, String> mappings = const {'Expression': '{expression}'},
+  }) =>
+      AnkiSettings(
+        selectedDeckId: deckId,
+        selectedDeckName: deckName,
+        selectedNoteTypeId: noteTypeId,
+        selectedNoteTypeName: noteTypeName,
+        availableDecks: decks,
+        availableNoteTypes: noteTypes,
+        fieldMappings: mappings,
+      );
+
+  test('首字段接了模板 → 能制卡', () {
+    expect(settings().canMineCards, isTrue);
+  });
+
+  test('没配过（两个 id 都空）→ 不能制卡', () {
+    expect(
+      settings(
+        deckId: null,
+        deckName: null,
+        noteTypeId: null,
+        noteTypeName: null,
+      ).canMineCards,
+      isFalse,
+    );
+  });
+
+  test('首字段没被映射 → 不能制卡（Anki 会以「卡片为空」拒收）', () {
+    // 映射存在，但落在**非首**字段上；Anki 的 fields_check 只看首字段。
+    expect(
+      settings(mappings: const {'Sentence': '{sentence}'}).canMineCards,
+      isFalse,
+    );
+  });
+
+  test('首字段映射是空白串 → 不能制卡', () {
+    expect(
+      settings(mappings: const {'Expression': '   '}).canMineCards,
+      isFalse,
+    );
+  });
+
+  test('字段映射整个为空 → 不能制卡', () {
+    expect(settings(mappings: const {}).canMineCards, isFalse);
+  });
+
+  test('选中的牌组已经不在 Anki 里（用户在 Anki 端删了它）→ 不能制卡', () {
+    expect(settings(decks: const [userDeck]).canMineCards, isFalse);
+  });
+
+  test('牌组清单为空（这次没拉到 / 没连上）→ 无从判断，不拦', () {
+    expect(settings(decks: const []).canMineCards, isTrue);
+  });
+
+  // 关键的反面：不是 Lapis 也照样合格。拿 Lapis 当唯一合格线，会把自己配好
+  // 笔记类型的用户也弹一遍窗。
+  test('用户自己的笔记类型，只要首字段接了模板就算合格', () {
+    expect(
+      settings(
+        deckId: 2,
+        deckName: '日语',
+        noteTypeId: 8,
+        noteTypeName: '基础',
+        mappings: const {'正面': '{expression}'},
+      ).canMineCards,
+      isTrue,
+    );
+  });
+
+  // 用户报的原始故障形态：牌组被静默换成自己的「日语」、笔记类型是「基础」，
+  // 而字段映射还是按 Lapis 的字段名排的 —— 一个都对不上，首字段恒空。
+  test('BUG-2380 Lapis 字段映射套在别人的笔记类型上 → 不能制卡', () {
+    expect(
+      settings(
+        deckId: 2,
+        deckName: '日语',
+        noteTypeId: 8,
+        noteTypeName: '基础',
+        mappings: const {
+          'Expression': '{expression}',
+          'MainDefinition': '{meaning}',
+        },
+      ).canMineCards,
+      isFalse,
+    );
+  });
+
+  test('后端没报出字段表 → 无从预检，不拦（与 preflightNoteFields 同一放行）', () {
+    expect(
+      settings(
+        noteTypeId: 9,
+        noteTypeName: '无字段',
+        noteTypes: const [AnkiNoteType(id: 9, name: '无字段', fields: [])],
+        mappings: const {},
+      ).canMineCards,
+      isTrue,
+    );
+  });
+}

--- a/fushi/test/anki/anki_view_model_lapis_test.dart
+++ b/fushi/test/anki/anki_view_model_lapis_test.dart
@@ -9,9 +9,18 @@ import 'package:fushi/src/anki/anki_view_model.dart';
 /// In-memory fake；覆写 loadSettings/saveSettings 避开 SharedPreferences，
 /// 复用 base 的 updateSettings。
 class _FakeRepo extends BaseAnkiRepository {
-  _FakeRepo({this.failFetch = false, this.throwOnCreateNoteType});
+  _FakeRepo({
+    this.failFetch = false,
+    this.throwOnCreateNoteType,
+    this.lapisInvisibleAfterCreate = false,
+  });
   AnkiSettings _settings = const AnkiSettings();
   final bool failFetch;
+
+  /// BUG-2380：后端把创建**静默吞掉**——`createDeck` / `createNoteType` 报成功，
+  /// 但回读的清单里根本没有 Lapis，只有用户自己的牌组。这正是 AnkiDroid 的
+  /// `addNewDeck` 返回 null 而 native 侧照样 `result.success` 时的形态。
+  final bool lapisInvisibleAfterCreate;
 
   /// 非 null 时 `createNoteType` 抛出它——模拟一键配置撞上传输层故障。
   final Object? throwOnCreateNoteType;
@@ -46,10 +55,12 @@ class _FakeRepo extends BaseAnkiRepository {
   @override
   Future<AnkiFetchResult> fetchConfiguration() async {
     if (failFetch) return const AnkiFetchResult.error('boom');
-    final decks = [const AnkiDeck(id: 1, name: 'Lapis')];
-    final noteTypes = [
-      AnkiNoteType(id: 7, name: 'Lapis', fields: LapisNoteType.fields),
-    ];
+    final decks = lapisInvisibleAfterCreate
+        ? const [AnkiDeck(id: 1, name: '日语')]
+        : const [AnkiDeck(id: 1, name: 'Lapis')];
+    final noteTypes = lapisInvisibleAfterCreate
+        ? const [AnkiNoteType(id: 7, name: '基础', fields: ['正面', '背面'])]
+        : [AnkiNoteType(id: 7, name: 'Lapis', fields: LapisNoteType.fields)];
     _settings = _settings.copyWith(
       availableDecks: decks,
       availableNoteTypes: noteTypes,
@@ -144,5 +155,50 @@ void main() {
     expect(result.outcome, LapisSetupOutcome.failed);
     expect(vm.state.errorMessage, isNot(t.anki_error_connection_timeout));
     expect(vm.state.errorMessage, contains('boom'));
+  });
+
+  // BUG-2380（用户实测报告）：手机端新装 AnkiDroid、自己建了个叫「日语」的牌组，
+  // 点「创建并选用 Lapis」之后，界面显示的选中牌组是「日语」而不是 Lapis。
+  //
+  // 根因两段：native 的 `createDeck` 丢掉了 `addNewDeck` 的返回值（失败返回 null）
+  // 并无条件报成功；Dart 这一侧拿到「成功」后用
+  // `firstWhere(name == 'Lapis', orElse: () => list.first)` 找不到就退而选清单里的
+  // **第一个**牌组/笔记类型，还顺手套上 Lapis 的字段映射、返回 created。
+  // 「一键把三样对齐」于是变成「静默把用户自己的牌组配成一个字段全对不上的目标」。
+  test('BUG-2380 建完在清单里看不到 Lapis 时失败，绝不改选用户自己的牌组', () async {
+    final repo = _FakeRepo(lapisInvisibleAfterCreate: true);
+    final vm = AnkiViewModel(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    final result = await vm.createLapisSetup();
+
+    expect(result.outcome, LapisSetupOutcome.failed);
+    expect(result.code, AnkiErrorCode.lapisSetupMissing);
+
+    final s = vm.state.settings;
+    // 关键断言：不许**谎称**选中了 Lapis。选中的仍是 fetchConfiguration 自动挑的
+    // 那个用户牌组（那是它一贯的行为，与本 bug 无关），但 createLapisSetup 这一步
+    // 不再往上面盖一层「这就是 Lapis」。
+    expect(s.selectedDeckName, isNot('Lapis'));
+    expect(s.selectedNoteTypeName, isNot('Lapis'));
+    // 更关键：Lapis 的字段映射绝不许套到别人的笔记类型上——那正是让制卡时
+    // 「字段一个都对不上 / 首字段为空」的来源。
+    expect(s.fieldMappings, isEmpty);
+    expect(vm.state.isFetching, isFalse);
+    expect(vm.state.errorMessage, t.anki_create_lapis_not_found);
+    // 这套配置制不出卡，正是弹窗（promptCreateLapisIfCannotMine）该被触发的形态。
+    expect(s.canMineCards, isFalse);
+  });
+
+  // 牌组是这次补建的、笔记类型早就在 —— 也算「这次创建过」。此前 `createDeck` 的
+  // 返回值被丢掉，只看 `createNoteType`，于是这种情形报成「已存在」。
+  test('BUG-2380 只补建了牌组时报 created 而非 alreadyExisted', () async {
+    final repo = _FakeRepo()..noteTypeExists = true;
+    final vm = AnkiViewModel(repo);
+    await Future<void>.delayed(Duration.zero);
+
+    final result = await vm.createLapisSetup();
+
+    expect(result.outcome, LapisSetupOutcome.created);
   });
 }

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -399,6 +399,36 @@ class AnkiSettings {
 
   bool get isConfigured => selectedDeckId != null && selectedNoteTypeId != null;
 
+  /// BUG-2380：不需要真卡内容就能下的结论——当前选中的牌组 + 笔记类型 + 字段映射，
+  /// 能不能产出一张 Anki 不会当场拒收的卡。UI 用它决定要不要劝用户去建 Lapis。
+  ///
+  /// [isConfigured] 只看两个 id 非空，答不了这个问题：id 指向的牌组可能已经被用户
+  /// 在 Anki 端删掉，笔记类型的首字段也可能压根没接任何模板——两种情况下卡都制不
+  /// 出来，但 [isConfigured] 一律为真。
+  ///
+  /// 首字段判据与制卡时的 `BaseAnkiRepository.preflightNoteFields` **同源**：Anki
+  /// 的 `fields_check()` 只看笔记类型的**第一个字段**，它空了就拒收整张卡（服务端
+  /// 原文 `cannot create note because it is empty`）。后端没报出字段表（`fields`
+  /// 为空）时无从预检，和 `preflightNoteFields` 一样放行。
+  ///
+  /// 有意**不**要求「必须是 Lapis」：用户自己配好的笔记类型照样能制卡，拿 Lapis 当
+  /// 唯一合格线会把这些人也弹一遍窗。
+  bool get canMineCards {
+    if (!isConfigured) return false;
+    // 选中的牌组还在不在 Anki 里。清单为空 = 这次没拉到清单（离线/没连过），
+    // 无从判断，不拦。
+    if (availableDecks.isNotEmpty &&
+        availableDecks.every((AnkiDeck d) =>
+            d.id != selectedDeckId && d.name != selectedDeckName)) {
+      return false;
+    }
+    final AnkiNoteType? noteType = selectedNoteType;
+    if (noteType == null) return false;
+    if (noteType.fields.isEmpty) return true;
+    final String? template = fieldMappings[noteType.fields.first];
+    return template != null && template.trim().isNotEmpty;
+  }
+
   AnkiNoteType? get selectedNoteType =>
       availableNoteTypes.firstWhereOrNull((t) => t.id == selectedNoteTypeId) ??
       (selectedNoteTypeName != null
@@ -1447,6 +1477,15 @@ class AnkiErrorCode {
   /// Anki 的 `fields_check()` 只看首字段，空就拒收整张卡（服务端原文同样是
   /// `cannot create note because it is empty`）。本地预检把它变成一句能照着做的话。
   static const String firstFieldEmpty = 'ANKI_FIRST_FIELD_EMPTY';
+
+  /// BUG-2380：「创建并选用 Lapis」建完之后，Lapis 牌组 / 笔记类型仍然不在后端
+  /// 回读的清单里 —— 也就是后端把创建**静默吞掉**了（AnkiDroid 的 `addNewDeck`
+  /// 失败返回 null 而 native 侧照样 `result.success`，是已知形态）。
+  ///
+  /// 必须单列成一个失败码，不能像旧实现那样「找不到 Lapis 就退而选清单里的第一个
+  /// 牌组/笔记类型」：那会把用户自己的牌组当成 Lapis 选中、套上 Lapis 的字段映射，
+  /// 还照样报「创建成功」。用户看到的就是「点了创建，选中的却是我自己的牌组」。
+  static const String lapisSetupMissing = 'ANKI_LAPIS_SETUP_MISSING';
 }
 
 sealed class AnkiFetchResult {

--- a/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
@@ -659,22 +659,27 @@ class AnkiRepository extends BaseAnkiRepository {
     }
   }
 
+  /// BUG-2380：存在性判断**只在 native 一处**（`AnkiChannelHandler.createNoteType`
+  /// 按「名字 + 字段数」查），返回值 true = 这次真建了、false = 本来就有。
+  ///
+  /// 此前这里还有一份自己的判据（`getModelList` 里按名字精确相等），与 native 那份
+  /// 不一致：两边判断分歧时，Dart 认为「不存在，去建」，native 认为「已存在，跳过」，
+  /// 然后报成功——建没建成没人知道。判据只留一份，分歧就无从产生。
   @override
   Future<bool> createNoteType(AnkiNoteTypeTemplate template) async {
     await _ensurePermission();
-    final models = await _channel.invokeMethod('getModelList') as Map?;
-    final exists =
-        models?.values.any((v) => v?.toString() == template.name) ?? false;
-    if (exists) return false;
-    await _channel.invokeMethod('createNoteType', <String, dynamic>{
+    final bool? created =
+        await _channel.invokeMethod('createNoteType', <String, dynamic>{
       'noteTypeName': template.name,
       'noteTypeFields': template.fields,
       'cardName': template.cardName,
       'front': template.front,
       'back': template.back,
       'css': template.css,
-    });
-    return true;
+    }) as bool?;
+    // null 只可能来自契约漂移（native 该回 bool）。当成「建了」，最坏只是 toast
+    // 说成新建而非已存在；真正的成败由 native 抛 CREATE_MODEL_FAILED 表达。
+    return created ?? true;
   }
 
   // ── note type 模板读写（Lapis 客制化/备份/自动迁移）────────────────────
@@ -755,16 +760,18 @@ class AnkiRepository extends BaseAnkiRepository {
     return ok ?? false;
   }
 
+  /// BUG-2380：与 [createNoteType] 同理——存在性判断只留 native 一处（那边是大小写
+  /// 不敏感比较，这里此前是精确相等，两者分歧时 Dart 请求创建、native 静默跳过并报
+  /// 成功）。返回值 true = 这次真建了、false = 本来就有；建失败由 native 抛
+  /// `CREATE_DECK_FAILED`，不再被吞成成功。
   @override
   Future<bool> createDeck(String name) async {
     await _ensurePermission();
-    final decks = await _channel.invokeMethod('getDecks') as Map?;
-    final exists = decks?.values.any((v) => v?.toString() == name) ?? false;
-    if (exists) return false;
-    await _channel.invokeMethod('createDeck', <String, dynamic>{
+    final bool? created =
+        await _channel.invokeMethod('createDeck', <String, dynamic>{
       'deckName': name,
-    });
-    return true;
+    }) as bool?;
+    return created ?? true;
   }
 
   Future<String?> _addCoverImage(String path) async {


### PR DESCRIPTION
用户报告（手机 AnkiDroid，QQ 群）：新装 Anki、自己建了个叫「日语」的牌组，点「一键创建 Lapis 卡组」之后**没有出现 Lapis，界面显示的选中牌组就是「日语」，还提示创建成功**。

## 根因 — 两段，都是「创建失败被吞成成功」

**① `AnkiChannelHandler.java:360`（修前）** 裸调 `api.addNewDeck(deckName)` 后**丢掉返回值**，紧接着无条件 `result.success(null)`。而 `addNewDeck` 的契约是**失败返回 null**（`AnkiProvider.java:43`）。`createNoteType`（:843 修前）同样丢掉 `addNewCustomModel` 的返回值。同一文件里 `addNote`（:143）与 `addFileToMedia`（:420）一直都在判空，**只有这两条建结构的路径漏了**。

**② `anki_view_model.dart:294`（修前）** 拿到「成功」后回读清单找 Lapis：

```dart
firstWhere((t) => t.name == 'Lapis', orElse: () => list.first)
```

找不到就**退而选清单里的第一个**牌组/笔记类型，顺手套上 Lapis 的字段映射，最后仍返回 `created`。用户只有一个牌组时，那个「第一个」就是他自己的。字段映射按 Lapis 的字段名排，在「基础」笔记类型上一个都对不上 → 首字段恒空 → 真去制卡被 Anki 以 `cannot create note because it is empty` 拒收。

## 为什么守卫没拦住

`anki_native_createmodel_guard_test.dart` 只断言 `addNewDeck` / `addNewCustomModel` 这些**字符串在不在**。bug 期间它们一直都在——被丢掉的是**返回值**，所以守卫全程绿灯。native 侧没有任何 JVM / instrumentation 测试。

## 修复

- **native 判空**：`addNewDeck` 返回 null → `CREATE_DECK_FAILED`；`addNewCustomModel` 返回 null → 抛出并映射成 `CREATE_MODEL_FAILED`。
- **判据只留一处**：native 如实回传「新建 / 本来就有」（`result.success(true/false)`），Dart 侧删掉自己那份第二份存在性判据。两份判据本来就不一致（native 是 `equalsIgnoreCase` / 名字+字段数，Dart 是精确相等），分歧时「Dart 要求创建 → native 静默跳过 → 报成功」是本 bug 的第二段。
- **`createLapisSetup` 删掉 `orElse` 兜底**：回读清单里看不到 Lapis 就返回 `AnkiErrorCode.lapisSetupMissing` 失败，绝不改选用户自己的牌组、绝不套 Lapis 字段映射。
- **新增 `AnkiSettings.canMineCards`**：「这套配置真能制出卡吗」的唯一判据，与制卡时的 `preflightNoteFields` **同源**（Anki 的 `fields_check()` 只看首字段），另外还判选中的牌组是否仍在 Anki 里（用户在 Anki 端删掉时 `isConfigured` 照样为真）。**连接 Anki 之后**与**新手引导离开 Anki 步之前**各判一次，判不过弹同一个 `promptCreateLapisIfCannotMine` 弹窗。
  - 判据有意**不是**「有没有 Lapis」：用户自己配好的笔记类型照样能制卡，拿 Lapis 当唯一合格线会把这些人也反复弹窗。
  - 弹窗**不拦路**：新手引导本来就可跳过，选「保持当前设置」照样进下一步。
- 按钮文案「创建 Lapis 卡组」→「**创建并选用 Lapis**」（en / zh-CN / zh-HK；其余 14 语言的既有翻译保留，属翻译欠账不是错译）。

## 测试

- **新增** `fushi/test/anki/anki_settings_can_mine_cards_test.dart`（11 例）：`canMineCards` 判据，含「Lapis 字段映射套在别人的笔记类型上 → 不能制卡」这条用户实际形态，以及反面「用户自己的笔记类型只要首字段接了模板就算合格」（防止把非 Lapis 用户也弹窗）。
- `anki_view_model_lapis_test.dart`：新增「建完在清单里看不到 Lapis 时失败，绝不改选用户自己的牌组」——直接钉死用户报的那一幕；以及「只补建了牌组时报 created 而非 alreadyExisted」（`createDeck` 的返回值此前也被丢掉）。
- `anki_native_createmodel_guard_test.dart`：把守卫从「字符串在不在」升级成「**返回值被用上了**」。同时把原有那条按 `invokeMethod('createNoteType'` **连写**钉死的断言放宽成对换行不敏感——它钉的是写法不是不变式，参数一多换行就红。

## 验证（均按退出码判绿）

| 检查 | 结果 |
|---|---|
| `flutter analyze`（fushi） | No issues found，exit=0 |
| `dart analyze`（packages/fushi_anki，`flutter analyze` 不覆盖 path 依赖包） | exit=0 |
| `flutter test test/anki --no-pub` | 381 例全绿，exit=0 |
| `flutter test`（packages/fushi_anki，cd 到包目录） | 544 例全绿，exit=0 |
| `flutter build apk --debug` | Built app-debug.apk，exit=0 |

相邻域 `test/i18n test/onboarding test/settings` 571 例，唯一一条红是 `lookup_audio_volume_granularity_test.dart` 的 `loading` 型装载失败；单跑 5 例全绿（exit=0）→ 并发伪红，与本次改动无关。

Android Java 改动**不经任何 Dart 测试编译**（native 侧零 JVM 测试，唯一「覆盖」是源码扫描守卫），所以另跑了 APK 构建真编一次。

## 已知缺口

- **真机复测尚未进行。**
- `addNewDeck` 返回 null 的**具体触发条件**未能进一步定位：主包路径的 `AddContentApi` 是编译好的 AAR（钉在 `2.17alpha14`，`fushi/android/app/build.gradle:268`），本仓无源码。本次修的是「失败不再被吞成成功」这个不变式——用户现在会拿到明确的失败提示，而不是一个静默配坏的制卡目标。

https://claude.ai/code/session_01GspBSZibQGU3UE4yv5Tvwz
