### PR TITLE
fix(anki): 同步有声书扩展上下文的字幕原句字段

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2181 条。点号进各自文件。
+> 共 2182 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2386](bugs/BUG-2386-reader-context-cue-sentence.md) | ✅ | ✅ | 有声书扩展例句后字幕原句字段仍只收录当前句 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |

--- a/docs/bugs/BUG-2386-reader-context-cue-sentence.md
+++ b/docs/bugs/BUG-2386-reader-context-cue-sentence.md
@@ -1,0 +1,6 @@
+## BUG-2386 · 有声书扩展例句后字幕原句字段仍只收录当前句
+- **报告**：2026-09-09（用户转述定力：添加上一句后卡片仅有当前句，音频却包含上一句）
+- **真实性**：✅ 真 bug（条件性代码路径已确认）。`fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart:27` 合并例句，`:50` 原先只快照当前 cue，`:180` 附近将其传给 Anki；映射为 `{cue-sentence}` 时，`packages/fushi_anki/lib/src/anki_models.dart:976` 优先渲染该单句，音频却来自扩展草稿。默认 Lapis 使用 `{sentence}`，尚未取得报告者实际映射，不能断言已复现其设备问题。
+- **[x] ① 已修复** — `e6786db37a`：有上下文草稿时，cue 文本快照使用已合并例句；无草稿时保留原 cue 全文。快照仍在音频导出的首个 await 前完成，新建与覆盖共用此路径。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/sentence_draft_wiring_guard_test.dart` 新增扩展 cue 文本与异步快照接线守卫；与视频接线、草稿文本/音频合并、reader race/audio 守卫共 55 项通过。`flutter analyze --no-pub` 全量通过。
+- **备注**：未完成用户设备上的真实制卡复测，未运行全量测试及平台构建。测试辅助工具首轮 PDFium 下载超时，配置本机代理后恢复；formatter 改动无关区域导致的两项接线守卫失败已通过收回无关格式变更解决，最终 55 项退出码 0。视频已合并两种文本；本次只修有声书/阅读器确定的字段不一致，不修改 Galgame。

--- a/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
@@ -47,8 +47,10 @@ extension _ReaderMining on _ReaderFushiPageState {
     // _cachedSentenceOffset）会把这些成员改成第二个词的值，导致第一张卡的 cue 句 / 加粗
     // 偏移与第二个词错配（或第二次中途清空时丢失）。await 之后一律只读这些局部值，消除
     // 「await 后读可变成员」整类时序漏洞。
-    final String snapshotCueSentence =
-        appModel.currentMediaSource?.currentCueSentence.text ?? '';
+    // 扩展上下文后两个句子字段必须对应同一段音频；未扩展时保留原 cue 全文。
+    final String snapshotCueSentence = _miningDraft.isEmpty
+        ? appModel.currentMediaSource?.currentCueSentence.text ?? ''
+        : sentence;
     final int? snapshotSentenceOffset = _cachedSentenceOffset;
 
     String? sentenceAudioPath;

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1274
+version: 2.3.0+1275
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/pages/sentence_draft_wiring_guard_test.dart
+++ b/fushi/test/pages/sentence_draft_wiring_guard_test.dart
@@ -110,6 +110,46 @@ void main() {
     expect(src, contains('_miningDraft.composeAudioRange(currentRange)'));
   });
 
+  test('reader snapshots merged cue text before awaiting media export', () {
+    final String mining = readSource(
+      'lib/src/pages/implementations/reader_fushi/mining.part.dart',
+    );
+    final String body = maskComments(
+      methodBody(mining, '_prepareMiningContext() async {'),
+    );
+    final RegExpMatch? firstAwait = RegExp(
+      r'\bawait\b',
+    ).firstMatch(maskCommentsAndStrings(body));
+    expect(firstAwait, isNotNull);
+    final int firstAwaitAt = firstAwait!.start;
+    final String snapshotBody = body.substring(0, firstAwaitAt);
+    expect(
+      snapshotBody,
+      contains(
+        'final String sentence = _miningDraft.composeText(currentSentence);',
+      ),
+    );
+    expect(
+      RegExp(
+        r'final\s+String\s+snapshotCueSentence\s*=\s*'
+        r'_miningDraft\.isEmpty\s*\?\s*'
+        r"appModel\.currentMediaSource\?\.currentCueSentence\.text\s*\?\?\s*''"
+        r'\s*:\s*sentence\s*;',
+      ).hasMatch(snapshotBody),
+      isTrue,
+      reason:
+          '选取上下文后 cue-sentence 必须与合并文本一致；单句仍保留原 cue 文本，'
+          '并在音频导出的首次 await 前快照，避免换词或清草稿改变本次制卡内容。',
+    );
+    expect(
+      body.substring(firstAwaitAt),
+      contains(
+        'cueSentence: snapshotCueSentence.isNotEmpty ? snapshotCueSentence : null',
+      ),
+      reason: '最终 Anki 上下文必须消费先前快照，不能重新读取当前 cue 或草稿。',
+    );
+  });
+
   test('reader clears the draft on a new lookup, after mine, and on dismiss',
       () {
     final String src = readReaderPageSource();


### PR DESCRIPTION
有声书制卡选择上一句/下一句后，音频与 `{sentence}` 已合并，但 `{cue-sentence}` 仍取原当前 cue，导致使用该字段映射的卡片缺少扩展文本。

本次让有草稿时的 cue 文本使用已合并例句，并在音频导出前快照；无草稿仍保留原 cue 全文。新建与覆盖共用该修复。记录 BUG-2386，build 递增到 2.3.0+1275。

验证：
- 55 项定向测试通过：句子上下文接线、视频接线、草稿文本/音频合并、reader 并发快照与音频守卫。
- flutter analyze --no-pub 全量通过；git diff --cached --check 通过。
- 未运行全量测试、平台构建和用户设备上的实际 Anki 制卡；默认 Lapis 使用 {sentence}，报告者的实际字段映射尚未核实。