### PR TITLE
fix(reader): 顶部工具栏不再压住正文首行（BUG-2382）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2190 条。点号进各自文件。
+> 共 2191 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2382](bugs/BUG-2382-reader-floating-header-covers-first-line.md) | ✅ | ✅ | 悬浮顶部工具栏压住正文首行（小窗/分屏下暴露） |
 | [BUG-2375](bugs/BUG-2375-asr-unusable-model.md) | ✅ | ✅ | ASR 模型文件损坏后永久卡死：Protobuf parsing failed 且无自愈路径 |
 | [BUG-2374](bugs/BUG-2374-collection-cover-and-rescrape-entries-lost.md) | ✅ | ✅ | 合集丢失设置封面与重新刮削入口 |
 | [BUG-2373](bugs/BUG-2373-android-stylus-idle-loses-hover-pressure-buttons.md) | 🚧 | 🚧 | 安卓平板触控笔闲置1-2分钟后悬停/压力/侧键全失效 |

--- a/docs/bugs/BUG-2382-reader-floating-header-covers-first-line.md
+++ b/docs/bugs/BUG-2382-reader-floating-header-covers-first-line.md
@@ -1,0 +1,74 @@
+## BUG-2382 · 悬浮顶部工具栏压住正文首行（小窗/分屏下暴露）
+- **报告**：2026-09-09（用户：截图，手机小窗/分屏下的阅读界面；后续澄清「是顶部工具栏，
+  上面还有文字，上面应该是空的」）
+- **真实性**：✅ 真 bug，根因 `fushi/lib/src/reader/reader_desktop_chrome.dart:56-64`
+  （修复前）+ `fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart:2224-2225`
+
+  顶部工具栏 `ReaderDesktopHeader`（固定高 `kReaderDesktopHeaderHeight` = 48，
+  `reader_desktop_chrome.dart:27`）在**悬浮态**下画成
+  `Positioned(top: _stableTopInset)` 的**不透明**叠层（背景 `_themeBackgroundColor()`，
+  `chrome.part.dart:2243`）；而正文 WebView 是 `Positioned.fill`，内容盒顶部
+  = `marginTop` + `--chrome-top-inset`（`reader_content_styles.dart:947`）。
+
+  悬浮态下 `readerDesktopHeaderReserve(... floating: true)` **恒返回 0**，于是
+  `_readerTopOffset = _stableTopInset + 0 + 0`（`reader_fushi_page.dart:2087-2088`），
+  `--chrome-top-inset == _stableTopInset`。**工具栏与正文内容盒起点相同**，
+  那 48px 整条压在正文首行上。`floating` 取自 `_bottomBarFloating`
+  = `tapEmptyToHideChrome`，**默认 true**（`reader_fushi_source.dart:1427`），
+  即默认配置就命中。
+
+  **与分屏/小窗无关**（这一点靠实测推翻了最初的假设）。修复前实测：
+
+  | 平台 | vpTop | cssInset | firstTop | OVERLAP | ABOVE_BAR | insetMismatch |
+  |---|---|---|---|---|---|---|
+  | Android API34 全屏 | 49.45 | 49.45 | 49.45 | **48.01** | 0.01 | 0.00 |
+  | Windows 桌面 | 0 | 0 | 0 | **48.0** | — | 0 |
+
+  两端都是满 48px 重叠。小窗只是让它更刺眼——可读行数本就少，被吃掉一行占比大得多。
+  另注：`insetMismatch = 0`，说明 Flutter 侧与 WebView 侧的 inset **是同步的**，
+  「推送被丢弃导致 CSS 停在旧值」这条曾被怀疑的路径**未被证实**（`_applyChromeInsets`
+  确实会在内容未就绪时早返回丢弃，但 BUG-467 加的 `_reapplyChromeInsetsAfterFirstLoad`
+  在每条就绪路径上都补下发，实测收敛）。
+
+- **[x] ① 已修复** — 删掉 `readerDesktopHeaderReserve` 里的 `floating → 0` 特例
+  （连同 `floating` 参数一起删，消除该分支而非增加条件）：占位即预留工具栏高。
+  该特例是顶栏引入时（`afdf667e6e`，2026-09-06）照抄底栏/顶部进度悬浮模型的结果，
+  commit message 只写机制、从未论证顶栏为何适用；而顶栏与那两者的关键差异是
+  **48px 且不透明**（顶部进度只有 18px 且是半透明毛玻璃，见 BUG-547/BUG-843；
+  底栏同样不透明但压的是页尾留白）。
+
+  **「悬浮显隐不重锚」的设计律未被破坏**（`reader_chrome_floating.dart:9-13`）：
+  悬浮态的显隐走 `_handleFloatingChromeReveal`，**从不翻转 `_showChrome`**，故
+  `barOccupiesLayout` 在悬浮态恒定 ⇒ 预留值恒定 ⇒ 唤出/收起不改 inset、不 reflow、
+  不重锚。被去掉的只有「正文可以被盖」这一条——那从来不是悬浮态的收益，是它的代价。
+
+  **代价（需知悉）**：悬浮态下正文顶部恒定让出 48px。这是"不被遮挡"的必要代价：
+  若要既满屏又不遮挡，只能改成「唤出时用 CSS transform 整体下移、收起还原」
+  （不 reflow、不重锚，锚点走 `getBoundingClientRect` 会自动跟随），成本更高，未采用。
+
+  修复后实测（Android API34）：cssInset 49.45→97.45，正文首行落在工具栏下沿
+  （firstTopLogical 97.44 vs header.bottom 97.45），`OVERLAP=0.01`、
+  `ABOVE_BAR=-47.99`（负值 = 工具栏那条带是空白的）。
+
+- **[x] ② 已加自动化测试** —
+  - `fushi/integration_test/reader_header_overlap_bug2381_itest.dart`（新增）：真 app +
+    真 WebView，量工具栏下沿与正文首行上沿的重叠逻辑 px，并断言工具栏**上方**不露出
+    正文。DOM→逻辑坐标缩放比由 `webViewRect.height / documentElement.clientHeight`
+    **实测**得出（不假设 1:1）。多次采样还钉住「显隐不改 `--chrome-top-inset`」。
+    三端可跑（Android 模拟器 / Windows 离屏 runner / Mac）。
+  - `fushi/test/reader/reader_desktop_chrome_test.dart`：改为钉「占位即预留」+ 新增
+    「同一 barOccupiesLayout 下返回值恒定（显隐不改预留高）」。
+  - `fushi/integration_test/reader_chrome_floating_itest.dart` goal2：原断言
+    「悬浮 ⇒ `--chrome-top-inset == 0`」会把顶栏预留与进度条预留混成一个数，改为钉
+    **差值**——把顶部进度切悬浮应当且仅应当回收进度条那 18px。
+
+- **备注**：
+  - **不是 BUG-843 的重复**。BUG-843 修的是顶部进度 **pill**（18px、毛玻璃半透明），
+    并明文写「悬浮态 pill 浮在正文上自动收起**属设计内**」。那条「设计内」的前提是
+    *小且半透明*；换成 48px **不透明**工具栏后前提不再成立。
+  - 用户报告里的「工具栏上方还有文字」在**全屏实测中未复现**（`ABOVE_BAR=0.01`）。
+    受限于本机模拟器（API36 AVD 的 surfaceflinger 在 `RegionSampling` 反复 SIGABRT；
+    `am task resize` 只能把任务推进沉浸式全屏、拿不到真 freeform 小窗），**真小窗
+    形态未能取证**。修复后 `ABOVE_BAR` 变为 -47.99，即便小窗下仍有残余不同步，
+    可见症状也会被这 48px 让位吸收掉。若用户复测仍见上方露字，需在真机小窗补测
+    `viewPadding.top` 与 `--chrome-top-inset` 的差值。

--- a/fushi/integration_test/reader_chrome_floating_itest.dart
+++ b/fushi/integration_test/reader_chrome_floating_itest.dart
@@ -14,6 +14,8 @@ import 'package:fushi/media.dart';
 import 'package:fushi/src/epub/epub_importer.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/reader_fushi_page.dart';
+import 'package:fushi/src/reader/reader_desktop_chrome.dart'
+    show kReaderDesktopHeaderHeight;
 
 import 'helpers/focus_driver.dart';
 import 'helpers/generate_test_epub.dart' show EpubGenerator;
@@ -28,12 +30,14 @@ import 'test_helpers.dart';
 /// real CSS variables injected into the WebView (--chrome-top-inset /
 /// --chrome-bottom-inset) plus the body first-line getBoundingClientRect().top:
 ///
-///  1. Reclaim blank: show_top_progress_bar ON->OFF reclaims the 18px reserve
-///     (--chrome-top-inset -> 0, first line top -> ~0). reader_chrome_floating
-///     topProgressReserve:48 returns 0 when progress disabled.
+///  1. Reclaim blank: show_top_progress_bar ON->OFF reclaims the 18px reserve.
+///     reader_chrome_floating topProgressReserve returns 0 when progress is
+///     disabled. 注意 BUG-2382 起 --chrome-top-inset 恒含 48px 顶部工具栏预留，
+///     故本 goal 断言的是「回收 18px 后只剩顶栏那份」，不是归 0。
 ///  2. Floating does not take text space (975 core ask): top progress floating
-///     false->true keeps --chrome-top-inset at 0 (floating reserve is 0); first
-///     line top stays ~0 (strip overlays body, not pushed down).
+///     false->true 回收进度条那 18px。同样因 BUG-2382，断言的是**差值**恰为
+///     18px，而不是 --chrome-top-inset 归 0（那会把顶栏预留和进度条预留混成
+///     一个数，且顶栏预留归 0 正是 BUG-2382 的病）。
 ///  3. Bottom tap-reveal no-layout-shift: tap_empty_hide_chrome false->true
 ///     drops --chrome-bottom-inset from (bar height ~56px) to system inset only;
 ///     onTapEmpty reveal keeps --chrome-bottom-inset unchanged.
@@ -100,17 +104,11 @@ void main() {
 
         await _openBooksTab(tester, driver);
         final String bookKey = await _seedTestBook(tester);
-        await _openBooksTab(tester, driver);
 
-        final String seededKey =
-            'book_entry_${ReaderFushiSource.mediaIdentifierFor(bookKey)}';
-        final Finder seededEntry = find.byKey(ValueKey<String>(seededKey));
-        for (int i = 0; i < 40 && seededEntry.evaluate().isEmpty; i++) {
-          await tester.pump(const Duration(milliseconds: 500));
-        }
-        expect(seededEntry, findsOneWidget,
-            reason: 'freshly seeded paginated book must appear on the shelf');
-
+        // 不经书架卡片：[_activateBook] 直接驱动 AppModel.openMedia（与卡片 onTap
+        // 同一调用），书架列表是否已刷出与本测试要量的 chrome inset 几何无关。原先
+        // 这里等书架卡片入树，是本测试唯一的不确定点——刷不出来就整条挂在前置上、
+        // 下面的 DOM 断言一条都跑不到（实测撞到过）。
         await _activateBook(tester, bookKey);
         await tester.pump(const Duration(seconds: 3));
 
@@ -192,26 +190,34 @@ void main() {
 
         const double kTopReservePx = 18.0; // _infoFontSize(12) * 1.5
         const double kEps = 1.5;
+        // BUG-2382 起 --chrome-top-inset 恒含顶部工具栏预留（顶栏不透明，正文不得
+        // 排到它下面）。本测试原先把 top-inset 当成「只由进度条构成」，谓词
+        // `v >= 18` 会被这 48px 直接满足、settle 立刻返回，后续读数在尚未 settle
+        // 时就被采走（实测底栏 inset 读到 28 而非 ~56）。故所有绝对值预期都加上它。
+        const double kHeaderPx = kReaderDesktopHeaderHeight;
 
         // ───────────────────────────────────────────────────────────────
         // Baseline: top squeeze ON -> top-inset has 18px reserve; bottom squeeze
         // -> bottom-inset has bar height (~56px). The 975 "old behavior" control.
         // ───────────────────────────────────────────────────────────────
+        // 只等顶栏那份落地。进度条预留经 `_showTopProgress` 门控、需要
+        // `_progressTotalChars > 0`（BUG-470），本机实测在基线采样窗口内并不总能
+        // 落地；把它写进等待条件会让 settle 空转到超时。进度条那 18px 由 goal1 /
+        // goal2 的**差值**断言负责，那里才是它真正被测量的地方。
         final double baseTopInset = await settleCssVar(
           readChromeTopInset,
-          (v) => v >= kTopReservePx - 1.0,
+          (v) => v >= kHeaderPx - 1.0,
         );
         final double baseBottomInset = await readChromeBottomInset();
         final double baseFirstTop = await firstLineTop();
         debugPrint('[CHROME975] BASELINE topInset=$baseTopInset '
             'bottomInset=$baseBottomInset firstTop=$baseFirstTop');
 
-        expect(baseTopInset, greaterThanOrEqualTo(kTopReservePx - 1.0),
-            reason: 'baseline: top squeeze ON, --chrome-top-inset has 18px. '
-                'got=$baseTopInset');
-        expect(baseFirstTop, greaterThanOrEqualTo(kTopReservePx - 1.0),
-            reason:
-                'baseline: first line top clears the strip. got=$baseFirstTop');
+        expect(baseTopInset, greaterThanOrEqualTo(kHeaderPx - 1.0),
+            reason: 'baseline: --chrome-top-inset 至少含顶栏预留 ${kHeaderPx}px'
+                '（BUG-2382：顶栏不透明，正文不得排到它下面）。got=$baseTopInset');
+        expect(baseFirstTop, greaterThanOrEqualTo(kHeaderPx - 1.0),
+            reason: 'baseline: 正文首行须落在顶栏下沿之下。got=$baseFirstTop');
         // System bottom inset is usually 0 on desktop; assert "clearly > 0" with
         // a wide tolerance rather than coupling to the exact scaled height.
         expect(baseBottomInset, greaterThan(30.0),
@@ -230,18 +236,18 @@ void main() {
 
         final double offTopInset = await settleCssVar(
           readChromeTopInset,
-          (v) => v <= 1.0,
+          (v) => v <= kHeaderPx + 1.0,
         );
         final double offFirstTop = await firstLineTop();
         debugPrint('[CHROME975] PROGRESS-OFF topInset=$offTopInset '
             'firstTop=$offFirstTop');
 
-        expect(offTopInset, lessThanOrEqualTo(1.0),
-            reason: 'goal1: progress OFF -> --chrome-top-inset reclaimed to 0. '
-                'got=$offTopInset');
-        expect(offFirstTop, lessThanOrEqualTo(kTopReservePx - 1.0),
-            reason: 'goal1: progress OFF -> first line moves into former strip '
-                'area (< 18px). got=$offFirstTop');
+        expect(offTopInset, lessThanOrEqualTo(kHeaderPx + 1.0),
+            reason: 'goal1: 关进度回收那 ${kTopReservePx}px，只剩顶栏预留 '
+                '${kHeaderPx}px。got=$offTopInset');
+        expect(offFirstTop, lessThanOrEqualTo(kHeaderPx + kTopReservePx - 1.0),
+            reason: 'goal1: 关进度后正文首行上移进原进度条带。'
+                'got=$offFirstTop');
 
         // ───────────────────────────────────────────────────────────────
         // Goal 2: floating does not take text space. Restore progress ON (now
@@ -254,11 +260,12 @@ void main() {
         ReaderFushiSource.onChromeReanchorLive?.call();
         final double reTopInset = await settleCssVar(
           readChromeTopInset,
-          (v) => v >= kTopReservePx - 1.0,
+          (v) => v >= kHeaderPx - 1.0,
         );
-        expect(reTopInset, greaterThanOrEqualTo(kTopReservePx - 1.0),
-            reason: 'precondition: restoring progress ON re-adds 18px. '
-                'got=$reTopInset');
+        expect(reTopInset, greaterThanOrEqualTo(kHeaderPx - 1.0),
+            reason: 'precondition: 顶栏预留仍在。got=$reTopInset');
+        // 挤压态下的正文首行位置，作为下面「切悬浮应上移 18px」的基线。
+        final double reFirstTop = await firstLineTop();
 
         ReaderFushiSource.instance.toggleTopProgressFloating(); // to floating
         await _pumpForPref(tester);
@@ -266,20 +273,30 @@ void main() {
             reason: 'top floating pref must land true');
         ReaderFushiSource.onChromeReanchorLive?.call();
 
+        // BUG-2382 起 `--chrome-top-inset` 恒含 48px 顶部工具栏预留（顶栏是不透明
+        // 面，正文不得排到它下面），故本 goal 不再断言它归 0——那会把「顶栏预留」
+        // 和「进度条预留」两件事混成一个数。真正要钉的不变式是**差值**：把顶部进度
+        // 切成悬浮，应当且仅应当回收进度条那 18px。
         final double floatTopInset = await settleCssVar(
           readChromeTopInset,
-          (v) => v <= 1.0,
+          (v) => v <= reTopInset - (kTopReservePx - 1.0),
         );
         final double floatFirstTop = await firstLineTop();
+        final double reclaimed = reTopInset - floatTopInset;
         debugPrint('[CHROME975] TOP-FLOATING topInset=$floatTopInset '
-            'firstTop=$floatFirstTop');
+            'firstTop=$floatFirstTop reclaimed=$reclaimed');
 
-        expect(floatTopInset, lessThanOrEqualTo(1.0),
-            reason: 'goal2: top floating -> --chrome-top-inset is 0 (floating '
-                'reserve 0, strip overlays body). got=$floatTopInset');
-        expect(floatFirstTop, lessThanOrEqualTo(kTopReservePx - 1.0),
-            reason: 'goal2: floating -> first line not pushed down (< 18px), '
-                'i.e. does not take text space. got=$floatFirstTop');
+        expect(reclaimed, greaterThanOrEqualTo(kTopReservePx - 1.0),
+            reason: 'goal2: 顶部进度切悬浮应回收进度条预留（约 ${kTopReservePx}px）。'
+                'squeeze=$reTopInset floating=$floatTopInset '
+                'reclaimed=$reclaimed');
+        expect(reclaimed, lessThanOrEqualTo(kTopReservePx + kEps),
+            reason: 'goal2: 只应回收进度条那一份，不得连顶栏的 48px 一起回收'
+                '（正文会被工具栏压住，BUG-2382）。reclaimed=$reclaimed');
+        expect(floatFirstTop,
+            lessThanOrEqualTo(reFirstTop - (kTopReservePx - 1.0)),
+            reason: 'goal2: 悬浮后正文首行应上移约 ${kTopReservePx}px（进度条不再占位）。'
+                'squeezeFirstTop=$reFirstTop floatingFirstTop=$floatFirstTop');
 
         await takeScreenshot(binding, 'todo975_top_floating_no_layout_shift');
 

--- a/fushi/integration_test/reader_header_overlap_bug2382_itest.dart
+++ b/fushi/integration_test/reader_header_overlap_bug2382_itest.dart
@@ -1,0 +1,401 @@
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'support/test_app_launcher.dart';
+import 'package:fushi/main.dart' as app;
+import 'package:fushi/media.dart';
+import 'package:fushi/src/epub/epub_importer.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart';
+import 'package:fushi/src/reader/reader_desktop_chrome.dart'
+    show kReaderDesktopHeaderHeight;
+
+import 'helpers/focus_driver.dart';
+import 'helpers/generate_test_epub.dart' show EpubGenerator;
+import 'test_helpers.dart';
+
+/// BUG-2382 回归 —— 顶部工具栏压住正文首行（real-DOM + 真渲染树几何验证）。
+///
+/// 根因：顶部工具栏是 `Positioned(top: _stableTopInset)` 的**不透明**叠层、固定高
+/// [kReaderDesktopHeaderHeight]=48；而正文内容盒起点
+/// = `marginTop`(默认 0vh) + `--chrome-top-inset`。悬浮态下
+/// `readerDesktopHeaderReserve` 曾恒返回 0（照抄底栏 / 顶部进度的悬浮模型），
+/// 于是 `--chrome-top-inset == _stableTopInset` —— **与工具栏起点相同**，那 48px
+/// 整条压在正文首行上。
+///
+/// 用户报告场景是手机小窗/分屏，但**与分屏无关**：修复前实测重叠在
+/// Android API34 全屏（`OVERLAP=48.01`，vpTop=49.45 / cssInset=49.45）与
+/// Windows 桌面（`OVERLAP=48.0`，两者皆 0）**都是满 48px**。小窗只是让它更刺眼
+/// ——可读行数本就少，被吃掉一行占比大得多。
+///
+/// 修复：删掉 `floating → 0` 特例，占位即预留工具栏高。因为悬浮态的显隐走
+/// `_handleFloatingChromeReveal`、**从不翻转 `_showChrome`**，预留值仍恒定 ⇒
+/// 「悬浮显隐不重锚」的设计律不受影响（本测试的多次采样即钉这一条）。
+///
+/// 本测试在默认（悬浮）配置下唤出工具栏，量三件事：
+///  1. `--chrome-top-inset`（注入 WebView 的正文顶部让位）；
+///  2. 正文首个可见文本元素的 client rect（DOM 坐标）；
+///  3. 工具栏与 WebView 的 Flutter 渲染树 rect（逻辑坐标）。
+///
+/// DOM→逻辑坐标的换算比**实测**（WebView widget 高 / documentElement.clientHeight），
+/// 不假设 1:1 —— 阅读器 WebView 有自己的缩放，硬套会得到「可信但错」的读数。
+///
+/// 修复后实测（Android API34）：cssInset 49.45→97.45、正文首行正好落在工具栏下沿
+/// （firstTopLogical 97.44 vs header.bottom 97.45），`OVERLAP=0.01`、
+/// `ABOVE_BAR=-47.99`（负值 = 工具栏那条带是空白）。
+///
+/// Run（Windows 离屏 harness）：
+///   powershell -ExecutionPolicy Bypass -File tool/run_windows_itest.ps1
+///       -Target integration_test/reader_header_overlap_bug2382_itest.dart
+/// Run（Android 模拟器）：
+///   flutter test integration_test/reader_header_overlap_bug2382_itest.dart \
+///       -d emulator-5554 --no-pub
+void main() {
+  final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('BUG-2382: 顶部工具栏既不压住正文首行，其上方也不露出正文',
+      timeout: const Timeout(Duration(minutes: 6)),
+      (WidgetTester tester) async {
+    final List<FlutterErrorDetails> errors = [];
+    final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      errors.add(details);
+      debugPrint('[HDROVL] FlutterError: ${details.exceptionAsString()}');
+    };
+
+    try {
+      await launchFushiTestApp();
+      expect(await waitForHome(tester), isTrue, reason: 'Home within 90s');
+      await tester.pump(const Duration(seconds: 2));
+
+      // 默认配置就是本 bug 的触发条件：底栏/顶栏悬浮 + marginTop 默认 0vh。
+      // 显式断言默认没被改，否则读数说明不了问题。
+      expect(ReaderFushiSource.instance.tapEmptyToHideChrome, isTrue,
+          reason: '本探针要的是悬浮态（默认）。tap_empty_hide_chrome 默认必须为 true。');
+
+      await enableFocusNavigation(tester);
+      final FocusDriver driver = FocusDriver(tester);
+
+      await _openBooksTab(tester, driver);
+      final String bookKey = await _seedTestBook(tester);
+
+      // 不经书架卡片：_activateBook 直接驱动 AppModel.openMedia（与卡片 onTap 同一
+      // 调用），书架列表是否已刷出与本探针要量的几何无关。
+      await _activateBook(tester, bookKey);
+      await tester.pump(const Duration(seconds: 3));
+
+      for (int i = 0;
+          i < 40 && find.byType(ReaderFushiPage).evaluate().isEmpty;
+          i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      expect(find.byType(ReaderFushiPage), findsOneWidget,
+          reason: 'ReaderFushiPage must mount after openMedia');
+
+      const Key webViewKey = ValueKey<String>('fushi_webview');
+      bool webViewPresent = false;
+      for (int i = 0; i < 180; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(webViewKey).evaluate().isNotEmpty) {
+          webViewPresent = true;
+          break;
+        }
+        if (i % 20 == 0) debugPrint('[HDROVL] waiting for WebView i=$i');
+      }
+      expect(webViewPresent, isTrue, reason: 'WebView present');
+
+      const Key contentReadyKey = ValueKey<String>('fushi_content_ready');
+      bool contentReady = false;
+      for (int i = 0; i < 120; i++) {
+        await tester.pump(const Duration(milliseconds: 500));
+        if (find.byKey(contentReadyKey).evaluate().isNotEmpty) {
+          contentReady = true;
+          break;
+        }
+      }
+      expect(contentReady, isTrue, reason: 'Reader content ready within 60s');
+
+      final eval = ReaderFushiPage.debugEvaluateJavascript;
+      expect(eval, isNotNull, reason: 'Reader debug JS hook must be set');
+
+      Future<double> readNumber(String expr) async {
+        final Object? raw = await eval!('(function(){return $expr;})()');
+        return double.tryParse(raw.toString()) ?? double.nan;
+      }
+
+      Future<Map<String, dynamic>> readFirstTextLine() async {
+        final Object? raw = await eval!(jsFirstTextLineProbe);
+        final dynamic decoded = jsonDecode(raw.toString());
+        return decoded == null
+            ? <String, dynamic>{}
+            : (decoded as Map<String, dynamic>);
+      }
+
+      // 唤出悬浮 chrome：走真 JS 桥的 onTapEmpty（与用户点空白同一入口）。
+      await eval!(
+        'setTimeout(function(){window.flutter_inappwebview.callHandler('
+        "'onTapEmpty');},0)",
+      );
+
+      const Key headerKey = ValueKey<String>('fushi_desktop_header');
+      bool headerVisible = false;
+      for (int i = 0; i < 40; i++) {
+        await tester.pump(const Duration(milliseconds: 200));
+        if (find.byKey(headerKey).evaluate().isNotEmpty) {
+          headerVisible = true;
+          break;
+        }
+      }
+      expect(headerVisible, isTrue,
+          reason: 'onTapEmpty 必须唤出悬浮顶部工具栏（fushi_desktop_header）');
+
+      // ── 测量 ─────────────────────────────────────────────────────────
+      // 一次采样：读 Flutter 渲染树几何 + WebView DOM 几何，换算到同一坐标系。
+      // DOM→逻辑坐标比实测（webView 高 / clientHeight），不假设 1:1。
+      // 悬浮 chrome 3s 自动收起，每次采样前重新唤出并等它入树。
+      Future<bool> revealHeader() async {
+        for (int attempt = 0; attempt < 3; attempt++) {
+          await eval(
+            'setTimeout(function(){window.flutter_inappwebview.callHandler('
+            "'onTapEmpty');},0)",
+          );
+          for (int i = 0; i < 10; i++) {
+            await tester.pump(const Duration(milliseconds: 100));
+            if (find.byKey(headerKey).evaluate().isNotEmpty) return true;
+          }
+        }
+        return false;
+      }
+
+      Future<_Sample?> sample(String tag) async {
+        if (!await revealHeader()) {
+          debugPrint('[HDROVL] $tag: 工具栏唤不出，跳过本次采样');
+          return null;
+        }
+        final Rect headerRect = tester.getRect(find.byKey(headerKey));
+        final Rect webViewRect = tester.getRect(find.byKey(webViewKey));
+        final EdgeInsets viewPadding =
+            MediaQuery.viewPaddingOf(tester.element(find.byKey(webViewKey)));
+        final double chromeTopInset = await readNumber(
+          r'parseFloat(getComputedStyle(document.documentElement)'
+          r".getPropertyValue('--chrome-top-inset'))||0",
+        );
+        final double clientHeight =
+            await readNumber('document.documentElement.clientHeight');
+        final Map<String, dynamic> firstLine = await readFirstTextLine();
+        final double firstTopCss = (firstLine['top'] as num?)?.toDouble() ?? -1;
+        final double scale =
+            clientHeight > 0 ? webViewRect.height / clientHeight : double.nan;
+        final double firstTopLogical = webViewRect.top + firstTopCss * scale;
+        final _Sample s = _Sample(
+          tag: tag,
+          windowSize: tester.view.physicalSize / tester.view.devicePixelRatio,
+          viewPaddingTop: viewPadding.top,
+          headerRect: headerRect,
+          webViewRect: webViewRect,
+          chromeTopInset: chromeTopInset,
+          firstTopCss: firstTopCss,
+          firstTopLogical: firstTopLogical,
+          firstText: '${firstLine['text']}',
+        );
+        debugPrint('[HDROVL] $s');
+        return s;
+      }
+
+      final _Sample? baseline = await sample('BASELINE');
+      expect(baseline, isNotNull, reason: '基线采样必须成功（工具栏可唤出、正文可定位）');
+      expect(baseline!.firstTopCss, greaterThanOrEqualTo(0),
+          reason: '必须在 WebView 里定位到正文首个可见文本元素');
+
+      // 再采几次确认读数稳定（悬浮 chrome 3s 自动收起 → 每次采样前重新唤出，
+      // 顺带验证「显隐不改预留高」：多次采样的 header/inset 必须一致）。
+      const int kPolls = 3;
+      _Sample last = baseline;
+      for (int i = 0; i < kPolls; i++) {
+        for (int f = 0; f < 12; f++) {
+          await tester.pump(const Duration(milliseconds: 250));
+        }
+        final _Sample? s = await sample('POLL#$i');
+        if (s != null) {
+          expect(s.chromeTopInset, closeTo(baseline.chromeTopInset, 1.0),
+              reason: '悬浮 chrome 的显隐不得改变 --chrome-top-inset（不重锚设计律）。'
+                  'baseline=${baseline.chromeTopInset} now=${s.chromeTopInset}');
+          last = s;
+        }
+      }
+
+      await takeScreenshot(binding, 'header_overlap_probe');
+
+      debugPrint('[HDROVL] === FINAL ===');
+      debugPrint('[HDROVL] $last');
+
+      // 不变式 1：工具栏上方那条带必须是空白让位区，不得露出正文。
+      expect(last.aboveBar, lessThanOrEqualTo(1.0),
+          reason: '工具栏上沿(${last.headerRect.top}) 之上露出了正文'
+              '（首行上沿 ${last.firstTopLogical}），露出 ${last.aboveBar} 逻辑 px。'
+              '那条带本该是空白让位区。$last');
+
+      // 不变式 2：工具栏下沿必须不越过正文首行上沿。
+      expect(last.overlap, lessThanOrEqualTo(1.0),
+          reason: '悬浮顶部工具栏下沿(${last.headerRect.bottom}) 压过正文首行上沿'
+              '(${last.firstTopLogical})，重叠 ${last.overlap} 逻辑 px。$last');
+
+      final NavigatorState nav =
+          Navigator.of(tester.element(find.byType(Scaffold).first));
+      nav.pop();
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+
+      assertStrictErrors(errors);
+      debugPrint('[HDROVL] === BUG-2382 HEADER OVERLAP TEST PASSED ===');
+    } finally {
+      FlutterError.onError = oldHandler;
+    }
+  });
+}
+
+/// 一次几何采样。所有量都换算到 Flutter 逻辑坐标系，便于直接相减。
+class _Sample {
+  const _Sample({
+    required this.tag,
+    required this.windowSize,
+    required this.viewPaddingTop,
+    required this.headerRect,
+    required this.webViewRect,
+    required this.chromeTopInset,
+    required this.firstTopCss,
+    required this.firstTopLogical,
+    required this.firstText,
+  });
+
+  final String tag;
+  final Size windowSize;
+  final double viewPaddingTop;
+  final Rect headerRect;
+  final Rect webViewRect;
+  final double chromeTopInset;
+  final double firstTopCss;
+  final double firstTopLogical;
+  final String firstText;
+
+  /// >0 = 工具栏**上方**露出正文（那条带本该空白）——用户报的症状。
+  double get aboveBar => headerRect.top - firstTopLogical;
+
+  /// >0 = 工具栏**压住**正文首行。
+  double get overlap => headerRect.bottom - firstTopLogical;
+
+  /// 非 0 = Flutter 按一个 inset 画栏、WebView 按另一个 inset 排字。
+  double get insetMismatch => viewPaddingTop - chromeTopInset;
+
+  @override
+  String toString() => '$tag win=${windowSize.width.toStringAsFixed(1)}x'
+      '${windowSize.height.toStringAsFixed(1)} '
+      'vpTop=${viewPaddingTop.toStringAsFixed(2)} '
+      'header=[${headerRect.top.toStringAsFixed(2)},'
+      '${headerRect.bottom.toStringAsFixed(2)}] '
+      'webViewTop=${webViewRect.top.toStringAsFixed(2)} '
+      'cssInset=${chromeTopInset.toStringAsFixed(2)} '
+      'firstTopCss=${firstTopCss.toStringAsFixed(2)} '
+      'firstTopLogical=${firstTopLogical.toStringAsFixed(2)} '
+      'ABOVE_BAR=${aboveBar.toStringAsFixed(2)} '
+      'OVERLAP=${overlap.toStringAsFixed(2)} '
+      'insetMismatch=${insetMismatch.toStringAsFixed(2)} '
+      'text="$firstText"';
+}
+
+/// 在 WebView 里定位正文首个可见文本块并回传其 client rect（JSON）。
+const String jsFirstTextLineProbe = r'''
+(function(){
+  function visible(el){
+    var r = el.getBoundingClientRect();
+    if (r.width <= 0 || r.height <= 0) return false;
+    var cs = getComputedStyle(el);
+    if (cs.display === 'none' || cs.visibility === 'hidden') return false;
+    return (el.textContent || '').trim().length > 0;
+  }
+  var nodes = document.querySelectorAll('p,div,span,li,blockquote,h1,h2,h3');
+  for (var i = 0; i < nodes.length; i++) {
+    var el = nodes[i];
+    var hasChildBlock = false;
+    for (var j = 0; j < el.children.length; j++) {
+      if (visible(el.children[j])) { hasChildBlock = true; break; }
+    }
+    if (hasChildBlock) continue;
+    if (!visible(el)) continue;
+    var r = el.getBoundingClientRect();
+    return JSON.stringify({
+      top: r.top,
+      bottom: r.bottom,
+      tag: el.tagName,
+      text: (el.textContent || '').trim().substr(0, 12)
+    });
+  }
+  return JSON.stringify(null);
+})()
+''';
+
+Future<void> _openBooksTab(WidgetTester tester, FocusDriver driver) async {
+  final List<Finder> navTargets = findPrimaryNavigationTargets();
+  if (navTargets.isEmpty) return;
+  final bool focused = await driver.focusWidget(navTargets.first);
+  expect(focused, isTrue, reason: 'Books tab must be reachable by focus');
+  await driver.activate();
+  await tester.pump(const Duration(milliseconds: 500));
+}
+
+Future<String> _seedTestBook(WidgetTester tester) async {
+  final ProviderContainer container = ProviderScope.containerOf(
+    tester.element(find.byType(MaterialApp).first),
+  );
+  final AppModel appModel = container.read(appProvider);
+  for (int i = 0; i < 120 && !appModel.isInitialised; i++) {
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  expect(appModel.isInitialised, isTrue,
+      reason: 'AppModel must be initialised before importing a book');
+
+  final Uint8List bytes = EpubGenerator().generate();
+  final String bookKey = await EpubImporter.import(
+    db: appModel.database,
+    bytes: bytes,
+    fileName: 'test_header_overlap.epub',
+  );
+  debugPrint('[HDROVL] Imported test EPUB as book key=$bookKey');
+
+  container.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+  await tester.pumpAndSettle();
+  return bookKey;
+}
+
+Future<void> _activateBook(WidgetTester tester, String bookKey) async {
+  final BuildContext appContext =
+      tester.element(find.byType(MaterialApp).first);
+  final ProviderContainer container = ProviderScope.containerOf(appContext);
+  final AppModel appModel = container.read(appProvider);
+
+  final ConsumerStatefulElement appElement = tester
+      .element(find.byType(app.FushiReaderApp)) as ConsumerStatefulElement;
+  final WidgetRef ref = appElement;
+
+  final MediaItem? item =
+      await ReaderFushiSource.instance.mediaItemForBookKey(bookKey);
+  expect(item, isNotNull,
+      reason: 'Seeded book must resolve to a MediaItem (key=$bookKey)');
+
+  unawaited(appModel.openMedia(
+    ref: ref,
+    mediaSource: ReaderFushiSource.instance,
+    item: item!,
+  ));
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+}

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -1991,12 +1991,11 @@ class _ReaderFushiPageState extends BaseSourcePageState<ReaderFushiPage>
   /// 冻住的旧数。
   bool get _desktopChromeEnabled => true;
 
-  /// 顶部工具栏的顶部预留高：悬浮态（默认）恒 0；挤压态且底栏占位时占工具栏高
-  /// （与 [_bottomChromeReserve] 同一台状态机的上端），并入 [_readerTopOffset]。
+  /// 顶部工具栏的顶部预留高：占位时恒占工具栏高（悬浮/挤压同值，BUG-2382——
+  /// 顶栏是不透明面，正文不得排到它下面），并入 [_readerTopOffset]。
   double get _desktopHeaderReserve => readerDesktopHeaderReserve(
     enabled: _desktopChromeEnabled,
     barOccupiesLayout: _hasEverLoaded && _showChrome,
-    floating: _bottomBarFloating,
     headerHeight: kReaderDesktopHeaderHeight,
   );
 

--- a/fushi/lib/src/reader/reader_desktop_chrome.dart
+++ b/fushi/lib/src/reader/reader_desktop_chrome.dart
@@ -48,18 +48,30 @@ bool readerAudiobookUsesDialog({required bool desktop, required Size window}) =>
 
 /// 顶部工具栏的顶部预留高。
 ///
-///  * 未启用 → 0；
-///  * 悬浮态（默认：点空白唤出、自动收起）→ 0，工具栏盖在正文之上；
-///  * 挤压态且底栏占位（`_hasEverLoaded && _showChrome`）→ [headerHeight]。
+///  * 未启用 / 未占位（`_hasEverLoaded && _showChrome`）→ 0；
+///  * 否则 → [headerHeight]，**不分悬浮/挤压**。
+///
+/// BUG-2382：这里曾有一条 `floating → 0` 的特例（照抄底栏与顶部进度的悬浮模型）。
+/// 它对那两者成立、对顶栏不成立，因为顶栏是 **48px 的不透明面**（底栏同样不透明但
+/// 画在底部、压住的是页尾留白；顶部进度只有 18px 且是半透明毛玻璃）。顶栏画在
+/// `Positioned(top: _stableTopInset)`、高 [kReaderDesktopHeaderHeight]，而正文内容盒
+/// 顶部 = `marginTop`(默认 0vh) + `--chrome-top-inset`(悬浮态恒等于 `_stableTopInset`)
+/// —— 二者起点相同，唤出时整条 48px 压在正文首行上。实测（Android API34 全屏 +
+/// Windows 桌面）重叠恒为 48.0 逻辑 px。
+///
+/// 为什么去掉特例不会破坏「悬浮显隐不重锚」（`reader_chrome_floating.dart` 文件头
+/// 的设计律）：悬浮态的显隐走 `_handleFloatingChromeReveal`，**从不翻转
+/// `_showChrome`**，故 `barOccupiesLayout` 在悬浮态恒定 ⇒ 本函数的返回值恒定 ⇒
+/// 唤出/收起不改预留高、不 reflow、不重锚。被去掉的只是「正文可以被盖」这一条，
+/// 而那从来不是悬浮态的收益，是它的代价。
 ///
 /// 与 `bottomChromeReserve` 同构：工具栏和底栏是同一台显隐状态机的上下两端。
 double readerDesktopHeaderReserve({
   required bool enabled,
   required bool barOccupiesLayout,
-  required bool floating,
   required double headerHeight,
 }) {
-  if (!enabled || !barOccupiesLayout || floating) return 0;
+  if (!enabled || !barOccupiesLayout) return 0;
   return headerHeight;
 }
 

--- a/fushi/test/reader/reader_desktop_chrome_test.dart
+++ b/fushi/test/reader/reader_desktop_chrome_test.dart
@@ -113,21 +113,14 @@ void main() {
   });
 
   group('readerDesktopHeaderReserve', () {
-    test('悬浮态恒 0；挤压态且底栏占位时占工具栏高', () {
+    // BUG-2382：悬浮态曾恒返回 0（照抄底栏/顶部进度的悬浮模型），导致 48px 不透明
+    // 顶栏整条压在正文首行上——Android API34 全屏与 Windows 桌面实测重叠均为 48.0
+    // 逻辑 px。顶栏不适用那个模型，故特例（连同 `floating` 参数）已删除：占位即预留。
+    test('占位即预留工具栏高（不分悬浮/挤压）；未占位 / 未启用为 0', () {
       expect(
         readerDesktopHeaderReserve(
           enabled: true,
           barOccupiesLayout: true,
-          floating: true,
-          headerHeight: kReaderDesktopHeaderHeight,
-        ),
-        0,
-      );
-      expect(
-        readerDesktopHeaderReserve(
-          enabled: true,
-          barOccupiesLayout: true,
-          floating: false,
           headerHeight: kReaderDesktopHeaderHeight,
         ),
         kReaderDesktopHeaderHeight,
@@ -136,7 +129,6 @@ void main() {
         readerDesktopHeaderReserve(
           enabled: true,
           barOccupiesLayout: false,
-          floating: false,
           headerHeight: kReaderDesktopHeaderHeight,
         ),
         0,
@@ -145,11 +137,27 @@ void main() {
         readerDesktopHeaderReserve(
           enabled: false,
           barOccupiesLayout: true,
-          floating: false,
           headerHeight: kReaderDesktopHeaderHeight,
         ),
         0,
       );
+    });
+
+    // 「悬浮显隐不重锚」（reader_chrome_floating.dart 文件头设计律）仍然成立的理由：
+    // 悬浮态的显隐走 _handleFloatingChromeReveal，从不翻转 _showChrome，故
+    // barOccupiesLayout 恒定 ⇒ 本函数返回值恒定 ⇒ 唤出/收起不改预留高。
+    test('同一 barOccupiesLayout 下返回值恒定——显隐不改预留高', () {
+      final double revealed = readerDesktopHeaderReserve(
+        enabled: true,
+        barOccupiesLayout: true,
+        headerHeight: kReaderDesktopHeaderHeight,
+      );
+      final double hidden = readerDesktopHeaderReserve(
+        enabled: true,
+        barOccupiesLayout: true,
+        headerHeight: kReaderDesktopHeaderHeight,
+      );
+      expect(revealed, hidden);
     });
   });
 


### PR DESCRIPTION
## 现象

用户在手机小窗/分屏下截图：阅读界面顶部工具栏上下都是正文，中间被吃掉一行。

## 根因

顶栏是 `Positioned(top: _stableTopInset)` 的**不透明**叠层、固定高 48（`kReaderDesktopHeaderHeight`），而正文内容盒顶部 = `marginTop`(默认 0vh) + `--chrome-top-inset`。悬浮态下 `readerDesktopHeaderReserve` **恒返回 0**（照抄底栏 / 顶部进度的悬浮模型），于是 `--chrome-top-inset == _stableTopInset` —— **与顶栏起点相同**，那 48px 整条压在正文首行上。默认配置（`tap_empty_hide_chrome=true`）即命中。

该特例是顶栏引入时（`afdf667e6e`）照抄来的，commit message 只写机制、从未论证顶栏为何适用。顶栏与那两者的关键差异是 **48px 且不透明**（顶部进度只有 18px 且半透明毛玻璃，见 BUG-547/BUG-843；底栏同样不透明但压的是页尾留白）。

**与小窗/分屏无关**——实测两端都是满 48px 重叠：

| 平台 | vpTop | cssInset | firstTop | OVERLAP |
|---|---|---|---|---|
| Android API34 全屏 | 49.45 | 49.45 | 49.45 | **48.01** |
| Windows 桌面 | 0 | 0 | 0 | **48.0** |

小窗只是让它更刺眼——可读行数本就少，被吃掉一行占比大得多。

## 修复

删掉 `floating → 0` 特例（连同 `floating` 参数一起删，**消除分支**而非增加条件）：占位即预留工具栏高。

**「悬浮显隐不重锚」的设计律未被破坏**：悬浮态显隐走 `_handleFloatingChromeReveal`、**从不翻转 `_showChrome`**，故 `barOccupiesLayout` 恒定 ⇒ 预留值恒定 ⇒ 唤出/收起不改 inset、不 reflow、不重锚。被去掉的只有「正文可以被盖」——那从来不是悬浮态的收益，是它的代价。

**代价**：悬浮态下正文顶部恒定让出 48px。若想既满屏又不遮挡，只能改成「唤出时 CSS transform 整体下移、收起还原」，成本更高，未采用。

## 验证（实测）

修复后 Android API34：`cssInset 49.45→97.45`，正文首行落在顶栏下沿（`97.44` vs `header.bottom 97.45`），`OVERLAP 48.01→0.01`，`ABOVE_BAR=-47.99`（顶栏那条带空白）。Windows 桌面同样 `48.0→0.00`。两端 `All tests passed`。

- `flutter analyze lib test integration_test` → `No issues found`
- 定向单测 130 条全绿
- 51 条目录枚举型守卫整批 → `368 tests ran, all tests passed`

## 测试改动

- 新增 `reader_header_overlap_bug2382_itest.dart`：真 app + 真 WebView 几何，DOM→逻辑坐标缩放比**实测**得出（不假设 1:1）；多次采样并钉住「显隐不改 `--chrome-top-inset`」。
- `reader_desktop_chrome_test.dart`：改为钉「占位即预留」+「显隐不改预留高」。
- `reader_chrome_floating_itest.dart`：原 goal2 断言「悬浮 ⇒ `top-inset == 0`」会把顶栏预留与进度条预留混成一个数，改为钉**差值**；基线谓词改为只依赖顶栏预留；去掉书架卡片前置。

## 已知问题（与本 PR 无关，对照实验已确认）

`reader_chrome_floating_itest.dart` 在本机 develop 上**本来就是红的**：去掉书架前置后，未修改的 develop 代码跑出 `topInset=48.0 bottomInset=28.0`，红在一条我从未碰过的原始断言 `expect(baseBottomInset, greaterThan(30.0))`。底栏预留（~56）与顶部进度预留（18）都没落地，是独立的既有问题，需另行排查。

另：该测试原基线断言 `topInset >= 17` 是**靠巧合通过**的——挤压态顶栏本就占 48，`48 >= 17` 恒真，进度条那 18px 其实从未被真正验证。

## 未取证部分

用户报的「工具栏**上方**露出正文」在全屏实测中未复现（`ABOVE_BAR=0.01`，`insetMismatch=0.00`）。受限于本机模拟器（API36 AVD 的 surfaceflinger 在 `RegionSampling` 反复 SIGABRT；`am task resize` 只能推进沉浸式全屏、拿不到真 freeform 小窗），**真小窗形态未能取证**。修复后 `ABOVE_BAR` 变为 -47.99，即便小窗下仍有残余不同步，可见症状也会被这 48px 让位吸收。若复测仍见上方露字，需在真机小窗补测 `viewPadding.top` 与 `--chrome-top-inset` 的差值。
