### PR TITLE
feat(mining): 小说制卡补「制卡所在字符数」标签 chars_12345

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77588 (4564 per locale)
+/// Strings: 77622 (4566 per locale)
 ///
-/// Built on 2026-09-09 at 11:49 UTC
+/// Built on 2026-09-09 at 14:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6332,6 +6332,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get reader_vn_click_advance => 'Blank tap advances';
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -17056,6 +17060,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -28007,6 +28017,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -39012,6 +39028,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -50051,6 +50073,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -60892,6 +60920,12 @@ class _StringsId extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -71825,6 +71859,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -82139,6 +82179,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags => 'タグにカード作成位置を自動追加';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'カード作成時に本の何文字目まで読んだかを chars_12345 タグで記録します。';
 }
 
 // Path: <root>
@@ -92463,6 +92508,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -103353,6 +103404,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -114296,6 +114353,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -125216,6 +125279,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -135936,6 +136005,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -146772,6 +146847,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -157579,6 +157660,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags =>
+      'Auto-add mining position to tags';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      'Tags each card with chars_12345 — how many characters into the book it was mined.';
 }
 
 // Path: <root>
@@ -167504,6 +167591,11 @@ class _StringsZhCn extends _StringsEn {
   String get reader_vn_click_advance => '点击空白处推进';
   @override
   String get reader_vn_merge_spoken_sentence => '有声句保持在同一屏';
+  @override
+  String get auto_add_char_position_to_tags => '自动添加制卡位置到标签';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      '给卡片加上 chars_12345 标签，记录制卡时读到全书第几个字。';
 }
 
 // Path: <root>
@@ -177502,6 +177594,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get reader_vn_merge_spoken_sentence =>
       'Keep spoken sentence on one screen';
+  @override
+  String get auto_add_char_position_to_tags => '自動將製卡位置加入標籤';
+  @override
+  String get auto_add_char_position_to_tags_hint =>
+      '為卡片加上 chars_12345 標籤，記錄製卡時讀到全書第幾個字。';
 }
 
 /// Flat map(s) containing all translations.
@@ -186891,6 +186988,10 @@ extension on _StringsEn {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -196275,6 +196376,10 @@ extension on _StringsAr {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -205704,6 +205809,10 @@ extension on _StringsDe {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -215124,6 +215233,10 @@ extension on _StringsEs {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -224553,6 +224666,10 @@ extension on _StringsFr {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -233953,6 +234070,10 @@ extension on _StringsId {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -243375,6 +243496,10 @@ extension on _StringsIt {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -252724,6 +252849,10 @@ extension on _StringsJa {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'タグにカード作成位置を自動追加';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'カード作成時に本の何文字目まで読んだかを chars_12345 タグで記録します。';
       default:
         return null;
     }
@@ -262077,6 +262206,10 @@ extension on _StringsKo {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -271492,6 +271625,10 @@ extension on _StringsNl {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -280902,6 +281039,10 @@ extension on _StringsPtBr {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -290319,6 +290460,10 @@ extension on _StringsRu {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -299708,6 +299853,10 @@ extension on _StringsTh {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -309112,6 +309261,10 @@ extension on _StringsTr {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -318510,6 +318663,10 @@ extension on _StringsVi {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return 'Auto-add mining position to tags';
+      case 'auto_add_char_position_to_tags_hint':
+        return 'Tags each card with chars_12345 — how many characters into the book it was mined.';
       default:
         return null;
     }
@@ -327826,6 +327983,10 @@ extension on _StringsZhCn {
         return '点击空白处推进';
       case 'reader_vn_merge_spoken_sentence':
         return '有声句保持在同一屏';
+      case 'auto_add_char_position_to_tags':
+        return '自动添加制卡位置到标签';
+      case 'auto_add_char_position_to_tags_hint':
+        return '给卡片加上 chars_12345 标签，记录制卡时读到全书第几个字。';
       default:
         return null;
     }
@@ -337153,6 +337314,10 @@ extension on _StringsZhHk {
         return 'Blank tap advances';
       case 'reader_vn_merge_spoken_sentence':
         return 'Keep spoken sentence on one screen';
+      case 'auto_add_char_position_to_tags':
+        return '自動將製卡位置加入標籤';
+      case 'auto_add_char_position_to_tags_hint':
+        return '為卡片加上 chars_12345 標籤，記錄製卡時讀到全書第幾個字。';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "タグにカード作成位置を自動追加",
+  "auto_add_char_position_to_tags_hint": "カード作成時に本の何文字目まで読んだかを chars_12345 タグで記録します。"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "Auto-add mining position to tags",
+  "auto_add_char_position_to_tags_hint": "Tags each card with chars_12345 — how many characters into the book it was mined."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "每屏句数",
   "reader_vn_preserve_dialogue": "保持对话完整",
   "reader_vn_click_advance": "点击空白处推进",
-  "reader_vn_merge_spoken_sentence": "有声句保持在同一屏"
+  "reader_vn_merge_spoken_sentence": "有声句保持在同一屏",
+  "auto_add_char_position_to_tags": "自动添加制卡位置到标签",
+  "auto_add_char_position_to_tags_hint": "给卡片加上 chars_12345 标签，记录制卡时读到全书第几个字。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4562,5 +4562,7 @@
   "reader_vn_sentences_per_screen": "Sentences per screen",
   "reader_vn_preserve_dialogue": "Keep dialogue together",
   "reader_vn_click_advance": "Blank tap advances",
-  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen"
+  "reader_vn_merge_spoken_sentence": "Keep spoken sentence on one screen",
+  "auto_add_char_position_to_tags": "自動將製卡位置加入標籤",
+  "auto_add_char_position_to_tags_hint": "為卡片加上 chars_12345 標籤，記錄製卡時讀到全書第幾個字。"
 }

--- a/fushi/lib/src/anki/ankimobile_repository.dart
+++ b/fushi/lib/src/anki/ankimobile_repository.dart
@@ -387,6 +387,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
         includeCategory: settings.tagIncludeCategory,
         titleTag: context.bookTitleTag,
         collectionTag: context.collectionTag,
+        charPositionTag: context.charPositionTag,
       );
       final success = Uri.parse(fushiAnkiSuccessCallback).replace(
         queryParameters: <String, String>{

--- a/fushi/lib/src/anki/remote_mining_anki_repository.dart
+++ b/fushi/lib/src/anki/remote_mining_anki_repository.dart
@@ -183,6 +183,7 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
       sentenceOffset: context.sentenceOffset,
       source: context.source?.name,
       bookTitleTag: context.bookTitleTag,
+      charPositionTag: context.charPositionTag,
       clipStartMs: context.clipStartMs,
       clipEndMs: context.clipEndMs,
       coverBytes: coverBytes,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6696,6 +6696,10 @@ class AppModel with ChangeNotifier {
   bool get autoAddBookNameToTags => prefsRepo.autoAddBookNameToTags;
   void toggleAutoAddBookNameToTags() => prefsRepo.toggleAutoAddBookNameToTags();
 
+  bool get autoAddCharPositionToTags => prefsRepo.autoAddCharPositionToTags;
+  void toggleAutoAddCharPositionToTags() =>
+      prefsRepo.toggleAutoAddCharPositionToTags();
+
   // TODO-1650 制卡图片/GIF 清晰度档 + 音频质量档（透传 prefsRepo）。默认档 = 旧压缩档
   // （现状零破坏）。制卡消费点用 [MiningMediaCompression.resolve] 据这两个档组装媒体档。
   int get miningImageQuality => prefsRepo.miningImageQuality;
@@ -7940,6 +7944,7 @@ class _AppModelRemoteLookupService
         sentenceOffset: payload.sentenceOffset,
         source: _forwardedSourceFromName(payload.source),
         bookTitleTag: payload.bookTitleTag,
+        charPositionTag: payload.charPositionTag,
         // 转发 payload 本来就带片段时间窗（Netflix / YouTube 扩展制卡按视频
         // 时间轴填）。原样透传，有效性由 formatClipTimestamp 单点判定——非视频
         // 转发两端为 null，渲染成空串。

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -31,6 +31,9 @@ const Set<String> kKnownPreferenceKeys = <String>{
   // media/audiobook/audiobook_material_library.dart。
   'audiobook_material_dirs',
   'auto_add_book_name_to_tags',
+  // bool：小说阅读器制卡时给卡片追加「制卡所在字符数」标签（`chars_12345`，
+  // countStudyChars 口径的全书绝对位置）。默认开。
+  'auto_add_char_position_to_tags',
   'auto_search',
   'auto_search_debounce_delay',
   'auto_update_dictionaries',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -1605,6 +1605,17 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 小说阅读器制卡时是否给卡片追加「制卡所在字符数」标签（`chars_12345`，全书绝对
+  /// 学习字数位置，countStudyChars 口径）。默认开：这是用户点名要的标注，且只多一个
+  /// tag、不动任何既有字段。
+  bool get autoAddCharPositionToTags =>
+      getPref('auto_add_char_position_to_tags', defaultValue: true) as bool;
+
+  void toggleAutoAddCharPositionToTags() async {
+    await setPref('auto_add_char_position_to_tags', !autoAddCharPositionToTags);
+    notifyListeners();
+  }
+
   // TODO-1650 制卡图片/GIF 清晰度档（0..3，见 [MiningMediaCompression.imageTiers]）。
   // 替代旧的单一「压缩」开关。未显式设过时从旧 `compress_mining_media` 布尔迁移：
   // 开(默认)→标准档 1（= TODO-646 现状，零行为破坏）；关→高清档 2。读写都夹到 0..3，

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -456,6 +456,19 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 setState(() {});
               },
             ),
+            // 制卡所在字符数标签（`chars_12345`）：只有小说阅读器会注入（其它来源没有
+            // 「全书第几个字」这个坐标），但开关与其余标签开关同区——用户找「卡片带哪些
+            // 标签」只会来这里找。
+            AdaptiveSettingsSwitchRow(
+              title: t.auto_add_char_position_to_tags,
+              subtitle: t.auto_add_char_position_to_tags_hint,
+              icon: Icons.my_location_outlined,
+              value: appModel.autoAddCharPositionToTags,
+              onChanged: (bool value) {
+                appModel.toggleAutoAddCharPositionToTags();
+                setState(() {});
+              },
+            ),
           ],
         ),
         // TODO-1650 制卡媒体清晰度：媒体清晰度与「卡片带哪些标签」语义无关，单独占

--- a/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/mining.part.dart
@@ -52,6 +52,9 @@ extension _ReaderMining on _ReaderFushiPageState {
         ? appModel.currentMediaSource?.currentCueSentence.text ?? ''
         : sentence;
     final int? snapshotSentenceOffset = _cachedSentenceOffset;
+    // 同一条快照纪律：制卡位置读的是 _cachedSentenceRange / _lastProgressCharOffset，
+    // 两个都会被 await 悬挂期间的第二次查词（或一次翻页）改写，必须在这里定格。
+    final int? snapshotCharPosition = _miningCharPosition();
 
     String? sentenceAudioPath;
     Directory? sentenceAudioTempDir;
@@ -196,9 +199,47 @@ extension _ReaderMining on _ReaderFushiPageState {
           ? BaseAnkiRepository.sanitizeTitleTag(displayDocumentTitle)
           : null,
       collectionTag: collectionTag,
+      // 「制卡所在字符数」标签（`chars_12345`）：这张卡是在全书第几个学习字处制的。
+      // 与书名/合集名标签同构——真值源（章内锚 + 每章累计前缀）在本页 state 里，
+      // hibiki_anki 拿不到，故在这里算好字面量注入。开关关闭或锚点取不到时为 null。
+      charPositionTag: appModel.autoAddCharPositionToTags
+          ? BaseAnkiRepository.formatCharPositionTag(snapshotCharPosition)
+          : null,
     );
 
     return (context: miningContext, cleanup: cleanupSentenceAudioTempDir);
+  }
+
+  /// 制卡所在的**全书绝对学习字数位置**（`countStudyChars` 口径，与状态行「已读字数」
+  /// 和 `study_segments.chars` 同一根数轴，所以卡片上的数字和用户看到的进度对得上）；
+  /// 取不到锚点时返回 `null`。
+  ///
+  /// 两级锚，第一级与 [_recordMinedSentence] 落库的制卡历史**同源**（同一个 section +
+  /// 同一个句内偏移），所以卡片上的数字和「制卡历史」里那条能跳到同一处：
+  /// ① 句锚（[_cachedSentenceRange]，无句级 span 时退到 [_cachedSelectionRange]）——
+  ///    制卡的那句话在本章的偏移，精确到句；
+  /// ② 视口锚（[_lastProgressCharOffset]，当前页首字符）——纯图片页 / caret 探测失败
+  ///    时句锚为空，退到「读到这一页」的粒度。
+  ///
+  /// 两级都不可用（JS 拿不到 caret、章字数还没算完、章号越界）→ [absoluteCharOffsetOf]
+  /// 返回 -1 → 这里返回 `null`，[BaseAnkiRepository.buildNoteTags] 不追加标签。
+  /// **绝不退化成 0**：那会把一整批卡片假标成「书首第 0 字」，比没有标签更坏——用户按
+  /// 标签排序时看不出这些数字是编的。
+  int? _miningCharPosition() {
+    final ({int offset, int length})? sentenceRange = _cachedSentenceRange ??
+        (_cachedSelectionRange != null
+            ? (
+                offset: _cachedSelectionRange!.offset,
+                length: _cachedSelectionRange!.length
+              )
+            : null);
+    final int absolute = absoluteCharOffsetOf(
+      chapterCumulativeChars: _chapterCumulativeChars,
+      chapterCharCounts: _chapterCharCounts,
+      chapter: _favoriteSectionIndex,
+      charOffset: sentenceRange?.offset ?? _lastProgressCharOffset,
+    );
+    return absolute < 0 ? null : absolute;
   }
 
   /// 反查当前书/有声书所属合集名（供制卡「合集名标签」用）。折叠归属跟随

--- a/fushi/lib/src/settings/settings_schema_card_creation.dart
+++ b/fushi/lib/src/settings/settings_schema_card_creation.dart
@@ -111,6 +111,11 @@ SettingsDestination buildCardCreationDestination() {
         subtitle: t.anki_tag_default_section,
       ),
       SettingsBodySearchEntry(
+        id: 'card_creation.anki.tag_char_position',
+        title: t.auto_add_char_position_to_tags,
+        subtitle: t.auto_add_char_position_to_tags_hint,
+      ),
+      SettingsBodySearchEntry(
         id: 'card_creation.anki.mining_image_quality',
         title: t.mining_image_quality,
         subtitle: t.mining_image_quality_hint,

--- a/fushi/lib/src/sync/forwarded_mine_payload.dart
+++ b/fushi/lib/src/sync/forwarded_mine_payload.dart
@@ -27,6 +27,7 @@ class ForwardedMinePayload {
     this.sentenceOffset,
     this.source,
     this.bookTitleTag,
+    this.charPositionTag,
     this.clipStartMs,
     this.clipEndMs,
     this.coverBytes,
@@ -48,6 +49,11 @@ class ForwardedMinePayload {
   /// `AnkiMiningSource.name`（`'book'` / `'video'` / `'game'`）；null = 不追加分类标签。
   final String? source;
   final String? bookTitleTag;
+
+  /// `AnkiMiningContext.charPositionTag`：制卡所在字符数标签（`chars_12345`）。可空 =
+  /// 非小说来源、开关关闭、锚点取不到，或对端是尚未带这个键的旧版本——服务端解析成
+  /// null，`buildNoteTags` 不追加，卡照建。
+  final String? charPositionTag;
 
   /// `AnkiMiningContext.clipStartMs|clipEndMs`：本卡截取的媒体片段起止（毫秒偏移），
   /// 服务端渲染 `{clip-timestamp}` 用。可空 = 无时间轴来源（书 / galgame），或对端是
@@ -73,6 +79,7 @@ class ForwardedMinePayload {
         if (sentenceOffset != null) 'sentenceOffset': sentenceOffset,
         if (source != null) 'source': source,
         if (bookTitleTag != null) 'bookTitleTag': bookTitleTag,
+        if (charPositionTag != null) 'charPositionTag': charPositionTag,
         if (clipStartMs != null) 'clipStartMs': clipStartMs,
         if (clipEndMs != null) 'clipEndMs': clipEndMs,
         if (coverBytes != null) 'coverBase64': base64Encode(coverBytes!),
@@ -113,6 +120,7 @@ class ForwardedMinePayload {
       sentenceOffset: (json['sentenceOffset'] as num?)?.toInt(),
       source: json['source'] as String?,
       bookTitleTag: json['bookTitleTag'] as String?,
+      charPositionTag: json['charPositionTag'] as String?,
       clipStartMs: (json['clipStartMs'] as num?)?.toInt(),
       clipEndMs: (json['clipEndMs'] as num?)?.toInt(),
       coverBytes: tryDecodeBase64(json['coverBase64']),

--- a/fushi/test/anki/remote_mining_anki_repository_test.dart
+++ b/fushi/test/anki/remote_mining_anki_repository_test.dart
@@ -189,6 +189,40 @@ void main() {
       expect(cap.dictionaryMedia.single.bytes, <int>[9, 9]);
     });
 
+    // 「制卡所在字符数」标签（`chars_12345`）：小说阅读器算好字面量放进
+    // AnkiMiningContext，远端制卡时必须原样搬进转发 payload——否则卡落在主机上
+    // 就只有本机才有这条标签，同一本书两台设备制的卡对不上。
+    // 撤掉 remote_mining_anki_repository.dart 里
+    // `charPositionTag: context.charPositionTag` 这一行 → 第一条断言红。
+    test('制卡位置标签从 context 搬进转发 payload', () async {
+      final _FakeSender sender =
+          _FakeSender(<String, dynamic>{'result': 'success'});
+      final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+        local: _FakeLocal(),
+        client: sender,
+        fileByteLoader: (String p) async => null,
+        dictMediaLoader: (String d, String p) => null,
+      );
+
+      await repo.mineEntry(
+        rawPayloadJson: jsonEncode(<String, dynamic>{'expression': '猫'}),
+        context: const AnkiMiningContext(
+          sentence: '猫がいる',
+          source: AnkiMiningSource.book,
+          charPositionTag: 'chars_12345',
+        ),
+      );
+      expect(sender.captured!.charPositionTag, 'chars_12345');
+
+      // 开关关闭 / 非小说来源 / 锚点取不到 → context 侧就是 null，转发也保持 null
+      // （主机端 buildNoteTags 不追加，绝不补一个 chars_0）。
+      await repo.mineEntry(
+        rawPayloadJson: jsonEncode(<String, dynamic>{'expression': '犬'}),
+        context: const AnkiMiningContext(sentence: '犬がいる'),
+      );
+      expect(sender.captured!.charPositionTag, isNull);
+    });
+
     test('http 单词音频不搬字节（留给服务端下载）', () async {
       final _FakeSender sender =
           _FakeSender(<String, dynamic>{'result': 'success'});

--- a/fushi/test/pages/reader_mining_char_position_tag_guard_test.dart
+++ b/fushi/test/pages/reader_mining_char_position_tag_guard_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+import 'reader_fushi_page_source_corpus.dart';
+
+/// 源码守卫：小说阅读器制卡时注入的「制卡所在字符数」标签（`chars_12345`）。
+///
+/// 为什么只能守源码：注入点 `_prepareMiningContext` / `_miningCharPosition()` 是
+/// `reader_fushi/mining.part.dart` 里 `extension _ReaderMining on
+/// _ReaderFushiPageState` 的**私有**成员，读的又是页面 state 上的锚点字段
+/// （`_cachedSentenceRange` / `_lastProgressCharOffset` / `_chapterCumulativeChars`）。
+/// 这个页面 headless 起不来（WebView + 真 EPUB + 真 Anki），行为层拿不到这条线，
+/// 只能在结构上把三条不变式钉死。
+///
+/// 标签字面量的生成规则（null/负数 → null、`chars_` 前缀）与 `buildNoteTags` 的追加
+/// 与去重由 `packages/fushi_anki` 侧的行为测试咬住；本守卫只管**阅读器这一端有没有
+/// 按开关注入、按什么口径算位置**。
+///
+/// 读的是「主壳 + 全部 `reader_fushi/*.part.dart`」合并语料（见
+/// `reader_fushi_page_source_corpus.dart`）：方法在 part 之间搬家不会让守卫失效，
+/// 新增 part 也自动进扫描面。
+void main() {
+  group('reader 制卡注入 chars_ 位置标签', () {
+    test('AnkiMiningContext 的构造带 charPositionTag，且经开关门控', () {
+      final String src = readReaderPageSource();
+
+      // ① 注入点确实在 AnkiMiningContext 的构造里（不是别的调用的同名参数）。
+      //    撤掉 mining.part.dart 里 `charPositionTag: ...` 那几行 → enclosingCallOf
+      //    找不到锚点直接 fail。
+      final EnclosingCall call = enclosingCallOf(src, 'charPositionTag:');
+      expect(
+        call.name,
+        'AnkiMiningContext',
+        reason:
+            '「制卡所在字符数」标签必须注入进 AnkiMiningContext 的构造，'
+            '否则两个 backend 的 buildNoteTags 都拿不到它',
+      );
+
+      final List<String> values = namedArgumentValues(src, 'charPositionTag');
+      expect(
+        values,
+        hasLength(1),
+        reason:
+            '阅读器语料里只该有一处注入点（_prepareMiningContext）；'
+            '多出一处说明有第二条口径不同的注入链路',
+      );
+      final String value = values.single;
+
+      // ② 开关门控：撤掉 `appModel.autoAddCharPositionToTags ? ... : null` 这个三元，
+      //    偏好开关就成了摆设（关掉照样打标签）→ 本条红。
+      expect(
+        value,
+        contains('appModel.autoAddCharPositionToTags'),
+        reason:
+            '注入必须被「自动添加制卡位置到标签」偏好门控；'
+            '开关关掉时这个值必须是 null',
+      );
+
+      // ③ 字面量由 fushi_anki 的单一格式化口径产出，阅读器不自己拼 'chars_$x'——
+      //    否则前缀/分隔符会和 buildNoteTags 侧漂开。
+      expect(
+        containsIdentifierCall(
+          value,
+          'BaseAnkiRepository.formatCharPositionTag',
+        ),
+        isTrue,
+        reason:
+            '标签字面量必须走 BaseAnkiRepository.formatCharPositionTag，'
+            '不得在阅读器里另拼一份 chars_ 前缀',
+      );
+    });
+
+    test('位置取的是 await 前的快照，不是构造时的当前值', () {
+      final String src = readReaderPageSource();
+
+      // 制卡链路在 `AnkiMiningContext(...)` 之前有一串 await（截图 / 句子音频 /
+      // 合集反查）。悬挂期间用户可以再查一个词、甚至翻一页，把 _cachedSentenceRange
+      // 与 _lastProgressCharOffset 改写。同 snapshotSentenceOffset 的既有纪律：
+      // 位置必须在第一个 await 前定格。
+      final String? snapshot = initializerExpression(
+        src,
+        'snapshotCharPosition',
+      );
+      expect(
+        snapshot,
+        isNotNull,
+        reason: '_prepareMiningContext 必须在第一个 await 前把制卡位置快照下来',
+      );
+      expect(
+        containsIdentifierCall(snapshot!, '_miningCharPosition'),
+        isTrue,
+        reason: '快照的来源必须是 _miningCharPosition()',
+      );
+
+      // 把构造里的 `snapshotCharPosition` 换回 `_miningCharPosition()`（await 后重算）
+      // → 本条红。
+      final String value = namedArgumentValues(src, 'charPositionTag').single;
+      expect(
+        containsIdentifier(value, 'snapshotCharPosition'),
+        isTrue,
+        reason: '构造里必须用快照变量',
+      );
+      expect(
+        containsIdentifierCall(value, '_miningCharPosition'),
+        isFalse,
+        reason: 'await 之后重新取一次锚点就等于没做快照',
+      );
+    });
+
+    test('_miningCharPosition 走 absoluteCharOffsetOf 换算，不另算一套口径', () {
+      final String body = methodBody(
+        readReaderPageSource(),
+        'int? _miningCharPosition()',
+      );
+
+      // countStudyChars 口径的「章首累计 + 章内偏移」只有这一个实现（见
+      // reader_fushi_page.dart 的 absoluteCharOffsetOf，与阅读进度条分子、
+      // study_segments.chars 同一根数轴）。撤掉这一行改成手写
+      // `_chapterCumulativeChars[i] + offset` → 本条红，也就挡住了「卡上的数字和
+      // 状态行的已读字数对不上」这类静默漂移。
+      expect(
+        containsCodeLine(body, 'absoluteCharOffsetOf('),
+        isTrue,
+        reason: '制卡位置必须与阅读账本共用 absoluteCharOffsetOf 换算',
+      );
+
+      // 两级锚都在：句锚（与制卡历史同源）+ 视口锚兜底。
+      expect(
+        containsIdentifier(body, '_cachedSentenceRange'),
+        isTrue,
+        reason: '一级锚是制卡那句话在本章的偏移',
+      );
+      expect(
+        containsIdentifier(body, '_cachedSelectionRange'),
+        isTrue,
+        reason: '无句级 span 时退到选区偏移',
+      );
+      expect(
+        containsIdentifier(body, '_lastProgressCharOffset'),
+        isTrue,
+        reason: '句锚取不到时退到视口锚（当前页首字符），而不是退到章首',
+      );
+    });
+
+    test('取不到锚点返回 null，绝不退化成 0（不打 chars_0 冒充书首）', () {
+      final String src = readReaderPageSource();
+      final String body = methodBody(src, 'int? _miningCharPosition()');
+      final String code = maskComments(body);
+
+      // absoluteCharOffsetOf 的「取不到」哨兵是 -1（章号越界 / 章字数未算完 /
+      // JS 拿不到 caret）。它必须映射成 null 让 buildNoteTags 不追加标签。
+      // 换成 `absolute < 0 ? 0 : absolute` → 一整批卡被假标成「全书第 0 字」，
+      // 用户按标签排序时看不出这些数字是编的。
+      final String compact = compactCode(body);
+      expect(
+        compact.contains('<0?null') || compact.contains('<0)returnnull'),
+        isTrue,
+        reason: '负数哨兵必须落到 null（三元或 if-return 都行），不得落到 0',
+      );
+
+      // 方法体里不许出现任何「兜底成 0」的形态。两条都要禁，缺一条就漏：
+      // - `?? 0` 会吃掉 `sentenceRange?.offset ?? _lastProgressCharOffset`
+      //   那一级视口锚兜底，句锚取不到时直接变成「章首」；
+      // - 三元退化 `absolute < 0 ? 0 : absolute` 把 0 写在 `?` 分支上——
+      //   只盯 `: 0` 的正则漏得掉（实测：变异探针当场抓到），故两个分支都禁。
+      expect(
+        RegExp(r'\?\?\s*0(?![0-9.])').hasMatch(code),
+        isFalse,
+        reason: '不得用 `?? 0` 兜底：0 是合法的书首位置，不是「取不到」',
+      );
+      expect(
+        RegExp(r'[?:]\s*0(?![0-9.])').hasMatch(code),
+        isFalse,
+        reason: '不得用三元把取不到的锚点退化成 0（`? 0` 与 `: 0` 两个分支都算）',
+      );
+
+      // 返回类型必须可空——写成 `int _miningCharPosition()` 就没有「不打标签」这个
+      // 状态可表达了。methodBody 的签名检索本身已经钉住这一点（改成非空即 fail），
+      // 这里再显式记一条，说明为什么签名不能改。
+      expect(
+        src,
+        contains('int? _miningCharPosition()'),
+        reason: '返回类型必须可空：null = 锚点取不到 = 不打标签',
+      );
+    });
+  });
+}

--- a/fushi/test/settings/settings_flatten_anki_profile_test.dart
+++ b/fushi/test/settings/settings_flatten_anki_profile_test.dart
@@ -181,15 +181,15 @@ void main() {
     expect(find.byType(AdaptiveSettingsNavigationRow), findsNothing,
         reason: '平铺后不应再出现指向 Anki 子页的跳转行');
 
-    // ③ TODO-135 方案A：默认标签区三个开关（hibiki / 来源分类 / 自动添加书名）都
-    //    并入一个无条件显示的区块。未配置 Anki 时它们也都露出——故恰有三个 SwitchRow。
+    // ③ TODO-135 方案A：默认标签区的开关（hibiki / 来源分类 / 自动添加书名 /
+    //    自动添加制卡位置）都并入一个无条件显示的区块。未配置 Anki 时它们也都露出。
     //    TODO-1650 把旧「压缩制卡媒体」开关换成「图片/GIF 清晰度 + 音频质量」两滑块，
     //    紧随其后的独立无标题区（同样无条件显示）。
-    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(5),
-        reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名），未配置 Anki '
-            '时都应显示（旧「压缩」开关已换成两滑块，不再是 SwitchRow；「制卡到已配对'
-            '设备」已移到 Hibiki 互联分类）。外加媒体去重区的两个自动开关'
-            '（自动处理 + 自动直接删除），共 5 个。');
+    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(6),
+        reason: 'TODO-135 方案A 四开关（hibiki / 来源分类 / 自动添加书名 / 自动添加制卡'
+            '位置），未配置 Anki 时都应显示（旧「压缩」开关已换成两滑块，不再是 '
+            'SwitchRow；「制卡到已配对设备」已移到 Hibiki 互联分类）。外加媒体去重区的'
+            '两个自动开关（自动处理 + 自动直接删除），共 6 个。');
     expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2),
         reason: 'TODO-1650「图片/GIF 清晰度」+「音频质量」两滑块应无条件显示');
     // 媒体去重的两个自动开关：**默认都关**（方案 A 的核心），且「自动直接删除」

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -360,6 +360,16 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'cardCreation/Auto-add book title to tags':
       'test/settings/settings_flatten_anki_profile_test.dart + live consume in '
           'reader_fushi/mining.part.dart & video_fushi/lookup_mining.part.dart (bookTitleTag)',
+  // 「制卡所在字符数」标签（`chars_12345`）。与上面那条同构：写 prefsRepo
+  // （changed=true），真正的消费点在制卡路径 reader_fushi/mining.part.dart 的
+  // charPositionTag（读 appModel.autoAddCharPositionToTags），harness 里没有阅读器、
+  // 也没有 Anki，探不到「卡上真带了这个 tag」。两端各有专项测试咬住：注入点由源码
+  // 守卫钉死（开关门控 + 走 absoluteCharOffsetOf + 负数哨兵不退化成 0），tag 装配由
+  // hibiki_anki 的 buildNoteTags 用例钉死（追加位置 / 去重 / 清洗 / withMediaRefs）。
+  'cardCreation/Auto-add mining position to tags':
+      'test/pages/reader_mining_char_position_tag_guard_test.dart + '
+          'packages/fushi_anki/test/mining_tag_and_parallel_test.dart '
+          '(charPositionTag group)',
   // TODO-1650: 制卡图片/GIF 清晰度 + 音频质量两滑块（替代旧「压缩」开关）。写
   // AppModel.miningImageQuality / miningAudioQuality（prefsRepo），焦点遍历能切到
   // 并写穿 DB（changed=true），但消费点在 ffmpeg/截图编码参数（非 reader CSS / 主题

--- a/fushi/test/sync/forwarded_mine_payload_test.dart
+++ b/fushi/test/sync/forwarded_mine_payload_test.dart
@@ -153,5 +153,38 @@ void main() {
       expect(j.containsKey('source'), isFalse);
       expect(j.containsKey('cueSentence'), isFalse);
     });
+
+    // 「制卡所在字符数」标签（`chars_12345`）：小说阅读器算好字面量，经互联转发到
+    // 主机端由 buildNoteTags 追加。撤掉 forwarded_mine_payload.dart 里
+    // `if (charPositionTag != null) 'charPositionTag': charPositionTag`
+    // 或 fromJson 的 `charPositionTag: json['charPositionTag'] as String?`
+    // 任一行，这三条里就有红的。
+    test('制卡位置标签：round-trip 原样往返', () {
+      const ForwardedMinePayload p = ForwardedMinePayload(
+        rawPayloadJson: '{"expression":"猫"}',
+        sentence: '猫がいる',
+        charPositionTag: 'chars_12345',
+      );
+      final ForwardedMinePayload r = ForwardedMinePayload.fromJson(
+          jsonDecode(jsonEncode(p.toJson())) as Map<String, dynamic>);
+      expect(r.charPositionTag, 'chars_12345');
+    });
+
+    test('制卡位置标签：旧对端不发这个键 → 解析成 null，卡照建', () {
+      // 主机端 buildNoteTags 收到 null 就不追加这条 tag——绝不能因为对端版本旧
+      // 就把整条远端制卡请求抛掉（对齐 clipStartMs/clipEndMs 的同一条纪律）。
+      final ForwardedMinePayload r =
+          ForwardedMinePayload.fromJson(<String, dynamic>{
+        'rawPayloadJson': '{"expression":"猫"}',
+        'sentence': 'x',
+      });
+      expect(r.charPositionTag, isNull);
+    });
+
+    test('制卡位置标签：null 时不写进 wire（旧服务端不会收到多余键）', () {
+      const ForwardedMinePayload p =
+          ForwardedMinePayload(rawPayloadJson: '{}', sentence: '');
+      expect(p.toJson().containsKey('charPositionTag'), isFalse);
+    });
   });
 }

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -744,6 +744,7 @@ class AnkiMiningContext {
     this.source,
     this.bookTitleTag,
     this.collectionTag,
+    this.charPositionTag,
     this.clipStartMs,
     this.clipEndMs,
   });
@@ -775,6 +776,17 @@ class AnkiMiningContext {
   /// 二者字面量不同则各成一个 tag（Anki 里可按系列聚合、也可按单集/单本区分）；相同时由
   /// [buildNoteTags] 去重合并。见视频 `lookup_mining` / reader `mining` 注入点。
   final String? collectionTag;
+
+  /// 「制卡位置标签」开关开启时，调用方（小说阅读器）算好的**制卡所在字符数标签**
+  /// （`chars_12345`，见 [BaseAnkiRepository.formatCharPositionTag]）：这张卡是在全书
+  /// 第几个学习字（`countStudyChars` 口径）处制的。开关关闭、非小说来源、或锚点取不到
+  /// （章字数未算完 / JS 拿不到 caret）时为 `null`，[BaseAnkiRepository.buildNoteTags]
+  /// 不追加——宁可不打标签，也不打一个 `chars_0` 冒充书首。
+  ///
+  /// 与 [bookTitleTag] / [collectionTag] 同构：真值源（`countStudyChars` 口径的章内锚 +
+  /// 每章累计前缀）都在主 app 的阅读器 state 里，hibiki_anki 是独立包拿不到，故由调用方
+  /// 算好字面量后注入，本包只负责按既有去重规则追加。
+  final String? charPositionTag;
 
   /// 本张卡截取的媒体片段起止（毫秒，媒体时间轴上的**偏移**，非 wall-clock 时刻，
   /// 故按术语表用 `Ms` 后缀）。渲染 `{clip-timestamp}` 用。
@@ -814,6 +826,7 @@ class AnkiMiningContext {
         source: source,
         bookTitleTag: bookTitleTag,
         collectionTag: collectionTag,
+        charPositionTag: charPositionTag,
         clipStartMs: clipStartMs,
         clipEndMs: clipEndMs,
       );

--- a/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/fushi_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -711,6 +711,9 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         titleTag: context.bookTitleTag,
         // 合集/系列名标签（同上开关）：视频=播放列表系列名、书籍=所属合集名；不属合集时 null。
         collectionTag: context.collectionTag,
+        // 制卡所在字符数标签（`chars_12345`）：小说阅读器按「自动添加制卡位置到标签」
+        // 开关注入；其它来源与开关关闭时为 null，buildNoteTags 不追加。
+        charPositionTag: context.charPositionTag,
       );
 
       // `fields` only holds entries that rendered to a non-empty value; if it is

--- a/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
+++ b/packages/fushi_anki/lib/src/ankidroid/anki_repository.dart
@@ -320,6 +320,9 @@ class AnkiRepository extends BaseAnkiRepository {
       titleTag: context.bookTitleTag,
       // 合集/系列名标签（同上开关）：视频=播放列表系列名、书籍=所属合集名；不属合集时 null。
       collectionTag: context.collectionTag,
+      // 制卡所在字符数标签（`chars_12345`）：小说阅读器按「自动添加制卡位置到标签」
+      // 开关注入；其它来源与开关关闭时为 null，buildNoteTags 不追加。
+      charPositionTag: context.charPositionTag,
     );
 
     try {

--- a/packages/fushi_anki/lib/src/base_anki_repository.dart
+++ b/packages/fushi_anki/lib/src/base_anki_repository.dart
@@ -518,6 +518,24 @@ abstract class BaseAnkiRepository {
   /// `video` 的旧卡不迁移不重写。
   static const String gameTag = 'game';
 
+  /// 「制卡所在字符数」标签的前缀（`chars_12345`）。下划线而非 `::`：Anki 里
+  /// `chars::12345` 会在标签树下堆出成千上万个一次性子节点，而扁平 `chars_12345`
+  /// 既能被 `tag:chars_*` 整体检索，也能按字面量排序看出制卡是在书的哪一段。
+  static const String charPositionTagPrefix = 'chars_';
+
+  /// 把制卡时的**全书绝对学习字数位置**格式化成单个 Anki tag（`chars_12345`）。
+  ///
+  /// 口径是 `countStudyChars`（全仓唯一计字口径，见 `stats/study_char_count.dart`），
+  /// 与阅读进度条分子、`study_segments.chars` 同一根数轴——所以卡片上的数字和用户在
+  /// 状态行看到的「已读字数」是同一个数，能直接对上。
+  ///
+  /// [absoluteChars] 为 `null` / 负数时返回 `null`：那是「锚点没取到」（章字数还没算完、
+  /// JS 拿不到 caret），不是「在第 0 字」。宁可不打标签，也不打一个 `chars_0` 冒充书首。
+  static String? formatCharPositionTag(int? absoluteChars) {
+    if (absoluteChars == null || absoluteChars < 0) return null;
+    return '$charPositionTagPrefix$absoluteChars';
+  }
+
   /// 把制卡来源类别映射成分类标签；`null`（未指定来源）时返回 `null`（不追加）。
   static String? _categoryTagForSource(AnkiMiningSource? source) {
     switch (source) {
@@ -547,6 +565,9 @@ abstract class BaseAnkiRepository {
   /// - [collectionTag]（同「自动添加书名到标签」开关）非空时追加**已清洗的合集/系列名
   ///   标签**（去重后）：视频=播放列表系列名，书籍=所属合集名。与 [titleTag] 并列，二者
   ///   字面量不同则各成一个 tag，相同时由 [seen] 去重合并。
+  /// - [charPositionTag]（「自动添加制卡位置到标签」开关）非空时追加**制卡所在字符数
+  ///   标签**（`chars_12345`，由 [formatCharPositionTag] 产出）：小说阅读器制卡时这张
+  ///   卡在全书第几个学习字处制的。只有书籍来源会注入；开关关闭或锚点取不到时为 `null`。
   /// - 两 backend（AnkiConnect / AnkiDroid）共用同一逻辑，避免一端漏加或漂移。
   @protected
   List<String> buildNoteTags(
@@ -556,6 +577,7 @@ abstract class BaseAnkiRepository {
     bool includeCategory = true,
     String? titleTag,
     String? collectionTag,
+    String? charPositionTag,
   }) {
     final seen = <String>{};
     final result = <String>[];
@@ -579,6 +601,14 @@ abstract class BaseAnkiRepository {
     final cleanCollection = sanitizeTitleTag(collectionTag);
     if (cleanCollection != null && seen.add(cleanCollection)) {
       result.add(cleanCollection);
+    }
+    // 制卡所在字符数标签（`chars_12345`）：排在最后，因为它是这批 tag 里唯一**每张卡
+    // 都不同**的——放前面会把 Anki 标签列表里稳定的那几个挤到看不见的地方。同样过
+    // [sanitizeTitleTag]：字面量本该由 [formatCharPositionTag] 产出（无空白），但互联
+    // 转发端送来的值是外部输入，带空格会被 Anki 拆成两个垃圾 tag。
+    final cleanCharPosition = sanitizeTitleTag(charPositionTag);
+    if (cleanCharPosition != null && seen.add(cleanCharPosition)) {
+      result.add(cleanCharPosition);
     }
     return result;
   }

--- a/packages/fushi_anki/test/mining_tag_and_parallel_test.dart
+++ b/packages/fushi_anki/test/mining_tag_and_parallel_test.dart
@@ -740,6 +740,133 @@ void main() {
     },
   );
 
+  group(
+    'charPositionTag appends the mining position tag (`chars_12345`), '
+    'de-duped, sanitised',
+    () {
+      Future<List<String>> tagsForConnect(
+        String configured, {
+        AnkiMiningSource? source,
+        String? bookTitleTag,
+        String? collectionTag,
+        String? charPositionTag,
+      }) async {
+        final service = _RecordingAnkiConnectService();
+        final repo = _ConfiguredAnkiConnectRepository(
+          service: service,
+          settings: _settingsWithTags(configured),
+        );
+        final outcome = await repo.mineEntry(
+          rawPayloadJson: _payload,
+          context: AnkiMiningContext(
+            sentence: '',
+            source: source,
+            bookTitleTag: bookTitleTag,
+            collectionTag: collectionTag,
+            charPositionTag: charPositionTag,
+          ),
+        );
+        expect(outcome.result, MineResult.success);
+        return service.addedTags.single;
+      }
+
+      test('formatCharPositionTag：位置 → 单个 tag 字面量', () {
+        expect(BaseAnkiRepository.formatCharPositionTag(12345), 'chars_12345');
+        // 书首第 0 字是**合法位置**（真的在开头制的卡），必须出标签——与「锚点取不到」
+        // 是两回事，后者由调用方传 null 表达。
+        expect(BaseAnkiRepository.formatCharPositionTag(0), 'chars_0');
+        expect(BaseAnkiRepository.charPositionTagPrefix, 'chars_');
+      });
+
+      test('formatCharPositionTag：null / 负数 → null（锚点取不到，不打假标签）', () {
+        // 撤掉那个判空、改成直出 `chars_$absoluteChars`，这里会拿到 `chars_-1` 转红。
+        // -1 是 absoluteCharOffsetOf 的「取不到锚点」哨兵，绝不能变成标签。
+        expect(BaseAnkiRepository.formatCharPositionTag(null), isNull);
+        expect(BaseAnkiRepository.formatCharPositionTag(-1), isNull);
+      });
+
+      test('位置标签排在所有稳定标签之后（每张卡都不同的那个放最后）', () async {
+        // 撤掉 buildNoteTags 的 charPositionTag 追加（或 reader 调用方不传）此处转红。
+        expect(
+          await tagsForConnect(
+            'jp',
+            source: AnkiMiningSource.book,
+            bookTitleTag: 'Kokoro',
+            collectionTag: 'Natsume_Souseki',
+            charPositionTag: BaseAnkiRepository.formatCharPositionTag(48210),
+          ),
+          <String>[
+            'jp',
+            'fushi',
+            'book',
+            'Kokoro',
+            'Natsume_Souseki',
+            'chars_48210',
+          ],
+        );
+      });
+
+      test('null 位置标签什么都不追加（非小说来源 / 开关关闭 / 锚点取不到）', () async {
+        expect(
+          await tagsForConnect(
+            'jp',
+            source: AnkiMiningSource.video,
+            bookTitleTag: 'Ep',
+          ),
+          <String>['jp', 'fushi', 'video', 'Ep'],
+        );
+        expect(
+          await tagsForConnect(
+            'jp',
+            source: AnkiMiningSource.book,
+            charPositionTag: '',
+          ),
+          <String>['jp', 'fushi', 'book'],
+        );
+      });
+
+      test('用户已手配同名标签时去重（不出现两个 chars_1）', () async {
+        expect(
+          await tagsForConnect(
+            'chars_1',
+            source: AnkiMiningSource.book,
+            charPositionTag: 'chars_1',
+          ),
+          <String>['chars_1', 'fushi', 'book'],
+        );
+      });
+
+      test('外部输入里的空白被清洗成单个 tag（互联转发端送来的值不可信）', () async {
+        // 转发 payload 的 charPositionTag 是对端送来的字符串，带空格会被 Anki 拆成
+        // 两个垃圾 tag；撤掉 buildNoteTags 里那次 sanitizeTitleTag 此处转红。
+        expect(
+          await tagsForConnect(
+            '',
+            source: AnkiMiningSource.book,
+            charPositionTag: 'chars 4 2',
+          ),
+          <String>['fushi', 'book', 'chars_4_2'],
+        );
+      });
+
+      test('withMediaRefs 原样带过位置标签（媒体落盘不该丢标签）', () {
+        // AnkiMiningContext 每新增一个字段就漏抄一次的老坑（见该类注释）：落卡路径
+        // 统一经 withMediaRefs 重建 context，漏抄这一行 → 带媒体的卡恒无位置标签。
+        const AnkiMiningContext context = AnkiMiningContext(
+          sentence: 'x',
+          source: AnkiMiningSource.book,
+          charPositionTag: 'chars_777',
+        );
+        expect(
+          context
+              .withMediaRefs(coverRef: null, sentenceAudioRef: null)
+              .charPositionTag,
+          'chars_777',
+        );
+      });
+    },
+  );
+
   group('media uploads run in parallel (timing proof for the 6s fix)', () {
     late Directory dir;
 


### PR DESCRIPTION
## 做了什么

小说（EPUB 阅读器 `reader_fushi`）制卡时，给 Anki 卡片补一个 **「制卡所在字符数」标签**：`chars_12345` —— 这张卡是在全书第 12345 个学习字处制的。

Anki 里可以 `tag:chars_*` 整体检索、按字面量排序看出一张卡出自书的哪一段。

## 数字的口径

`countStudyChars`（全仓唯一计字口径）的**全书绝对位置** = 章首累计字数 + 章内偏移，经既有纯函数 `absoluteCharOffsetOf` 换算 —— 与阅读进度条分子、状态行「已读字数」、`study_segments.chars` 同一根数轴，所以卡片上的数字和用户看到的进度能直接对上。

两级锚，第一级与制卡历史 `addMinedSentence` 落库的锚**同源**（同 section + 同句内偏移），因此卡上的数字和「制卡历史」那条能跳到同一处：

1. 句锚 `_cachedSentenceRange`（无句级 span 时退到 `_cachedSelectionRange`）—— 精确到制卡的那句话；
2. 视口锚 `_lastProgressCharOffset`（当前页首字符）—— 纯图片页 / caret 探测失败时退到「读到这一页」。

两级都取不到（章字数还没算完、JS 拿不到 caret、章号越界）→ **不打标签**。绝不退化成 `chars_0`：那会把一批卡片假标成书首，比没有标签更坏。

## 开关

新偏好 `auto_add_char_position_to_tags`，**默认开**，UI 在 Anki 设置页「默认标签」区（与 `fushi` / 分类 / 书名三个既有标签开关同区），并进了设置搜索 schema。i18n 走 `i18n_sync --add`（17 语言，ja / zh-HK 补了本地化译文）。

## 改动面

- `packages/fushi_anki`：`AnkiMiningContext.charPositionTag` 字段（含 `withMediaRefs` 透传）、`BaseAnkiRepository.formatCharPositionTag` 纯函数 + `charPositionTagPrefix`、`buildNoteTags` 新增可选参数（过 `sanitizeTitleTag`、参与去重、排在所有稳定标签之后）
- 三个 backend 调用点都透传：AnkiConnect / AnkiDroid / AnkiMobile
- 互联转发链路完整透传：`ForwardedMinePayload`（新键 + toJson/fromJson，旧版对端缺键 → null 不抛）→ `remote_mining_anki_repository` → `app_model` 重建 context
- reader 注入在 `_prepareMiningContext` 的**快照区**（第一个 await 之前）：`_cachedSentenceRange` / `_lastProgressCharOffset` 都会被 await 悬挂期间的第二次查词或一次翻页改写，与既有 `snapshotCueSentence` / `snapshotSentenceOffset` 同一条快照纪律

## 测试

- `packages/fushi_anki/test/mining_tag_and_parallel_test.dart` +7：格式化纯函数（含 `0` 是合法位置、`-1`/null 不出标签）、排序位置、null 不追加、去重、外部输入清洗、`withMediaRefs` 不漏抄
- `fushi/test/sync/forwarded_mine_payload_test.dart` / `fushi/test/anki/remote_mining_anki_repository_test.dart`：转发往返 + context→payload 透传
- `fushi/test/pages/reader_mining_char_position_tag_guard_test.dart`：reader 注入点的源码守卫（注入存在、经开关门控、走 `absoluteCharOffsetOf` 不另算口径、不做 `?? 0` 退化）

## 验证

- `flutter analyze`（`fushi/` + `packages/fushi_anki/`，含 test 目录）：`No issues found!`
- 定向测试：`packages/fushi_anki` 36 条、`settings_flatten_anki_profile` + 新增守卫 + 转发往返等 57 条、设置 schema 覆盖/搜索/缓存 37 条，全绿
- 「目录枚举型守卫」整批 51 条：`364 tests ran, all tests passed`（基线 362，+2 是期间合入 develop 的其它改动带来的漂移，与本 PR 无关——本 PR 不往那 51 条里加用例）

## 没做的

未真机验证「制出的卡在 Anki 里真的带上了这个 tag」——需要连 AnkiConnect 的环境。tag 装配链路由单测覆盖，reader 注入由源码守卫钉住。


https://claude.ai/code/session_015huT4vuZ8QpeQYdmTRoabw
