### PR TITLE
feat(dictionary): 查词页源文本条加 Yomitan 式命中词高亮

### DIFF
--- a/fushi/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dictionary_page.dart
@@ -131,6 +131,18 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
   String _sourceLookupText = '';
   int _searchGeneration = 0;
 
+  /// 源文本条上「这次查的是哪几个字」的 Yomitan 式扫描高亮。
+  ///
+  /// 查词是「从被点的字到串尾」的整段后缀交给引擎最长匹配（BUG-1478），所以查询串
+  /// 本身看不出命中了多长；不标出来，用户在「と言いつつ」上点第一个字，根本无从
+  /// 判断结果是「と言い」还是「と」。跨度长度只能等引擎回报，故本页持有它、由
+  /// [_sourceHighlightGeneration] 把迟到的回报挡在门外。
+  SourceLookupHighlight? _sourceHighlight;
+
+  /// 高亮的发号器：主查词与源文本条点字都会 ++ 它。异步匹配长度回来时若号已变
+  /// （用户又点了别的字 / 又发起了新查询），这次回报直接丢弃，不去盖新的高亮。
+  int _sourceHighlightGeneration = 0;
+
   bool _historyWritten = false;
 
   /// 仅测试可见：最近一次派发的查词 future（[debugSearch] 返回它以便
@@ -299,6 +311,8 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     _lastQuery = '';
     _allLoaded = false;
     _sourceLookupText = '';
+    _sourceHighlight = null;
+    _sourceHighlightGeneration++;
     _historyWritten = false;
     setState(() {});
     if (_searchFocusNode.canRequestFocus) {
@@ -629,6 +643,15 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
       // _loadMore will set _allLoaded if nothing new comes back.
       _allLoaded = cached.entries.isEmpty;
       _lastQuery = cached.searchTerm.trim();
+      // 源文本条同步换成这条历史的查询串。此前这里只换 _result 和搜索框，不动
+      // _sourceLookupText——历史列表只在查询框为空时可见，而清空输入框并不经
+      // _clearSearch，于是点开一条历史后源文本条上留的可能是上一次桌面取词的整句
+      // 旧文本。那在没有高亮时只是「有点怪」，加了扫描高亮就会变成「框在一段跟结果
+      // 毫无关系的文字上」：命中长度以本条 cached 为准，坐标系却是别人的串。
+      _sourceLookupText = _lastQuery;
+      // 缓存结果同样带 bestLength，扫描高亮按同一条换算落到句首命中段——否则从
+      // 历史点回一条旧查询，原文条上会是一片没有任何标记的裸文本。
+      _applyMainSearchHighlight(_lastQuery, cached);
       // TODO-931：保留常驻热槽。
       _popup.pruneToWarmSlot();
     });
@@ -650,7 +673,18 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
 
     if (!force && _lastQuery == trimmed && overrideMaximumTerms == null) {
       if (_sourceLookupText != trimmed && mounted) {
-        setState(() => _sourceLookupText = trimmed);
+        setState(() {
+          _sourceLookupText = trimmed;
+          // 源文本换了就得重定位扫描高亮：这条早退路径不重查（结果沿用 _result），
+          // 但高亮的坐标系是源文本条，换了串不重算就会框在错的位置上。
+          final DictionarySearchResult? current = _result;
+          if (current == null) {
+            _sourceHighlight = null;
+            _sourceHighlightGeneration++;
+          } else {
+            _applyMainSearchHighlight(trimmed, current);
+          }
+        });
       }
       if (writeHistory &&
           !_historyWritten &&
@@ -687,6 +721,10 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
         writeHistory: writeHistory,
         autoRead: autoRead,
         searchGeneration: searchGeneration,
+        // 「加载更多」（overrideMaximumTerms 非空）不换源文本，也就不该动扫描高亮：
+        // 它只是把同一个查询串的词头上限调大，命中段没变，而用户此刻的高亮可能已经
+        // 是他点出来的某个词，重设会把它弹回句首。
+        resetHighlight: replaceSourceLookupText,
       );
       _lastDispatchedSearch = dispatched;
       unawaited(dispatched);
@@ -701,6 +739,7 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     required bool writeHistory,
     required bool? autoRead,
     required int searchGeneration,
+    required bool resetHighlight,
   }) async {
     // 用 try/finally 守卫整条失败路径：searchDictionary 走远程网络查询 +
     // fushidicts C++ FFI，任一环节抛异常都不能让 _isSearching 永久为 true
@@ -720,6 +759,7 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
 
       _result = result;
       _allLoaded = !result.truncated;
+      if (resetHighlight) _applyMainSearchHighlight(trimmed, result);
 
       if (writeHistory) {
         _historyWritten = true;
@@ -843,8 +883,9 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
             globalCoordinates: true,
             dictionaryHeadwordScale: appModel.dictionaryFontSize /
                 appModel.defaultDictionaryFontSize,
-            onLookup: (String query, Rect screenRect) {
-              _pushNestedPopup(query, screenRect, reuseWarmSlot: true);
+            highlight: _sourceHighlight,
+            onLookup: (String query, Rect screenRect, int charIndex) {
+              unawaited(_lookupFromSourceStrip(query, screenRect, charIndex));
             },
           ),
         // 根因修复（BUG-054）：结果区 WebView 仍整块在中和器下渲染（净缩放=1），否则被全局
@@ -998,6 +1039,55 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
           },
         ),
       ),
+    );
+  }
+
+  /// 源文本条点字（或 Shift 悬停）：压查词浮层，并把 Yomitan 式扫描高亮落到真正被
+  /// 匹配的那几个字上。
+  ///
+  /// 分两拍：先立刻框住被点的那个字（点下去就有反馈，不用干等查词往返），引擎回报
+  /// 匹配长度后再扩成整词。中途用户又点了别的字就换号，这次的回报直接丢弃。
+  Future<void> _lookupFromSourceStrip(
+    String query,
+    Rect screenRect,
+    int charIndex,
+  ) async {
+    final int generation = ++_sourceHighlightGeneration;
+    setState(() {
+      _sourceHighlight = SourceLookupHighlight(start: charIndex, length: 1);
+    });
+    final int matchedUnits =
+        await _pushNestedPopup(query, screenRect, reuseWarmSlot: true);
+    if (!mounted || generation != _sourceHighlightGeneration) return;
+    setState(() {
+      _sourceHighlight = resolveSourceLookupHighlight(
+        query: query,
+        tappedGraphemeIndex: charIndex,
+        matchedUnits: matchedUnits,
+        leadingStripUnits: appModel.lookupLeadingStripUnits(query),
+      );
+    });
+  }
+
+  /// 主查词（搜索框提交 / 桌面取词 / 深链 / 点回历史）落地后的扫描高亮。
+  ///
+  /// 引擎的候选串**全部是查询串的前缀**（`scan_candidates` 只从串首锚定、由长到短
+  /// 地截），所以主结果的命中段起点恒为 0 —— 与源文本条点第 0 个字是同一件事，直接
+  /// 复用同一个换算。
+  void _applyMainSearchHighlight(
+    String panelText,
+    DictionarySearchResult result,
+  ) {
+    _sourceHighlightGeneration++;
+    _sourceHighlight = resolveSourceLookupHighlight(
+      query: panelText,
+      tappedGraphemeIndex: 0,
+      matchedUnits: lookupHighlightCharCount(
+        result: result,
+        searchTerm: panelText,
+        language: JapaneseLanguage.instance,
+      ),
+      leadingStripUnits: appModel.lookupLeadingStripUnits(panelText),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -69,6 +69,15 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
   bool _isClosing = false;
   String _sourceLookupText = '';
 
+  /// 源文本条上「这次查的是哪几个字」的扫描高亮，与首页词典 tab 同一口径。
+  ///
+  /// 本页每次查词都把 [_sourceLookupText] 换成被点字起的后缀（见 [_pushSearch]），
+  /// 所以命中段的起点恒为条首（0）；长度仍要等引擎回报。
+  SourceLookupHighlight? _sourceHighlight;
+
+  /// 迟到匹配长度的发号器（见首页词典 tab 的同名字段）。
+  int _sourceHighlightGeneration = 0;
+
   late final TextEditingController _searchController;
   final FocusNode _searchFocusNode = FocusNode();
 
@@ -171,8 +180,15 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
         offset: trimmed.length,
       );
     }
-    if (mounted) setState(() => _sourceLookupText = trimmed);
-    await pushNestedPopup(
+    final int highlightGeneration = ++_sourceHighlightGeneration;
+    if (mounted) {
+      setState(() {
+        _sourceLookupText = trimmed;
+        // 先框住条首那个字给即时反馈，引擎回报匹配长度后再扩成整词。
+        _sourceHighlight = const SourceLookupHighlight(start: 0, length: 1);
+      });
+    }
+    final int matchedUnits = await pushNestedPopup(
       query: trimmed,
       selectionRect: selectionRect,
       controller: _popup,
@@ -183,6 +199,16 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       // DictionaryPopupLayer 的加载盖板兜住——不走「搜索期隐藏 + anchored 占位卡」。
       revealWhileSearching: true,
     );
+    if (!mounted || highlightGeneration != _sourceHighlightGeneration) return;
+    setState(() {
+      _sourceHighlight = resolveSourceLookupHighlight(
+        query: trimmed,
+        // 本页源文本条渲染的就是 trimmed 本身，条首即被查的那个字。
+        tappedGraphemeIndex: 0,
+        matchedUnits: matchedUnits,
+        leadingStripUnits: appModel.lookupLeadingStripUnits(trimmed),
+      );
+    });
   }
 
   void _popAt(int index) {
@@ -359,8 +385,11 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
               text: _sourceLookupText,
               coordinateSpaceKey: _resultStackKey,
               dictionaryHeadwordScale: _dictionaryHeadwordScale,
+              highlight: _sourceHighlight,
               // 源文本面板点选 = 顶层新词，复用常驻热槽（TODO-951 症状C）。
-              onLookup: (String query, Rect rect) =>
+              // charIndex 在本页恒被 _pushSearch 归零：条上的文本随即换成从该字起
+              // 的后缀，被点的字就落回条首。
+              onLookup: (String query, Rect rect, int _) =>
                   _pushSearch(query, rect, reuseWarmSlot: true),
             ),
           Expanded(child: _buildStack(context)),

--- a/fushi/lib/src/utils/components/clipboard_lookup_text_panel.dart
+++ b/fushi/lib/src/utils/components/clipboard_lookup_text_panel.dart
@@ -19,6 +19,85 @@ import 'package:fushi/src/utils/misc/lookup_input_limits.dart';
 /// 因子会自动补偿回 26，改动零反馈、静默失效。现在明写字号、明说它对齐谁。
 const double kPopupHeadwordFontSize = 26.0;
 
+/// 源文本条上「当前被查中的那个词」的跨度，单位是**字素簇**（与本条逐字渲染同
+/// 坐标系，见 [SourceLookupTextPanel] 的 `chars`）。
+///
+/// 与 Yomitan 扫描高亮同义：查词是从被点的那个字**到串尾**的一段后缀，引擎再对它
+/// 做最长匹配；这个跨度就是引擎真正吃下去的那几个字，让用户看得见「这次查的是
+/// 『と言い』还是『言い』」。UTF-16 → 字素簇的换算由
+/// [resolveSourceLookupHighlight] 负责，本类只承载换算结果。
+@immutable
+class SourceLookupHighlight {
+  const SourceLookupHighlight({required this.start, required this.length});
+
+  /// 首个被高亮的字素簇下标。
+  final int start;
+
+  /// 被高亮的字素簇个数（恒 >= 1；引擎零命中时退化成「只框住被点的那个字」）。
+  final int length;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SourceLookupHighlight &&
+      other.start == start &&
+      other.length == length;
+
+  @override
+  int get hashCode => Object.hash(start, length);
+
+  @override
+  String toString() => 'SourceLookupHighlight(start: $start, length: $length)';
+}
+
+/// 把引擎回报的匹配长度换算成源文本条的字素簇跨度。
+///
+/// 三个坐标系必须对齐，少一个都会画歪：
+///   1. [tappedGraphemeIndex] 是**本条渲染的字素簇**下标（用户点的那个字）；
+///   2. [matchedUnits]（`lookupHighlightCharCount` / `bestLength`）是 **UTF-16 code
+///      unit** 数，且以 `normalizeSearchTerm` **剥掉句首标点之后**的串为坐标系；
+///   3. [leadingStripUnits]（`AppModel.lookupLeadingStripUnits`）就是那段被剥掉的
+///      句首长度——不右移它，高亮会左吞进句首括号、右缺词尾（BUG-773 同一个坑）。
+///
+/// 逐字素簇累加 UTF-16 长度来定位，而不是 `substring(strip, strip + matched)` 再数
+/// 字素簇：匹配长度落在代理对 / 组合字中间时 `substring` 会劈出孤立代理项，数出来的
+/// 长度不是用户看到的字数。这里改成「取足以覆盖该 code unit 区间的最少字素簇」，
+/// 宁可整字多框一个，也绝不把一个字劈成两半。
+///
+/// [matchedUnits] <= 0（无词条）时退化成只框被点的那个字：查不到东西也得让用户看见
+/// 自己点在哪，而不是整条没有任何反馈。
+SourceLookupHighlight resolveSourceLookupHighlight({
+  required String query,
+  required int tappedGraphemeIndex,
+  required int matchedUnits,
+  required int leadingStripUnits,
+}) {
+  final int base = tappedGraphemeIndex < 0 ? 0 : tappedGraphemeIndex;
+  if (query.isEmpty) {
+    return SourceLookupHighlight(start: base, length: 1);
+  }
+  final int strip = leadingStripUnits < 0 ? 0 : leadingStripUnits;
+  final int endUnits = strip + (matchedUnits > 0 ? matchedUnits : 1);
+
+  int consumedUnits = 0;
+  int consumedGraphemes = 0;
+  int? startGrapheme;
+  for (final String grapheme in query.characters) {
+    if (startGrapheme == null && consumedUnits >= strip) {
+      startGrapheme = consumedGraphemes;
+    }
+    if (startGrapheme != null && consumedUnits >= endUnits) break;
+    consumedUnits += grapheme.length;
+    consumedGraphemes += 1;
+  }
+  // strip 覆盖整串（整段都是标点）时循环走完仍未定起点，退化到串尾。
+  startGrapheme ??= consumedGraphemes;
+  final int length = consumedGraphemes - startGrapheme;
+  return SourceLookupHighlight(
+    start: base + startGrapheme,
+    length: length < 1 ? 1 : length,
+  );
+}
+
 class SourceLookupTextPanel extends StatefulWidget {
   const SourceLookupTextPanel({
     required this.text,
@@ -27,12 +106,29 @@ class SourceLookupTextPanel extends StatefulWidget {
     this.coordinateSpaceKey,
     this.dictionaryHeadwordScale = 1.0,
     this.globalCoordinates = false,
+    this.highlight,
   });
 
   final String text;
-  final void Function(String query, Rect localRect) onLookup;
+
+  /// 点中（或 Shift 悬停）某个字：回报「从该字到串尾」的查询串、该字的矩形，以及
+  /// 该字在本条渲染序列里的**字素簇下标**。
+  ///
+  /// 下标是宿主定位命中高亮的锚（[resolveSourceLookupHighlight] 的
+  /// `tappedGraphemeIndex`）。它由本条显式回报而不是让宿主拿 query 长度反推：反推
+  /// 依赖「query 恒为 text 的后缀」这条本条内部约定（还叠着 [kMaxLookupInputChars]
+  /// 截断），约定一改宿主就静默画歪；而且异步查词回来时用户可能已经点了别的字，
+  /// 宿主必须能把回报的长度绑回**发起那一次**的下标，不能读本条的当前态。
+  final void Function(String query, Rect localRect, int charIndex) onLookup;
   final GlobalKey? coordinateSpaceKey;
   final double dictionaryHeadwordScale;
+
+  /// 当前被查中的那个词在本条上的跨度（Yomitan 式扫描高亮）；null 时不画框。
+  ///
+  /// 由宿主持有而非本条自持：跨度长度要等引擎回报匹配长度才知道，是一次**异步**
+  /// 结果；本条只知道用户点了哪个字。宿主把「哪次点击 → 哪个长度」配对好再传下来，
+  /// 迟到的结果就不会盖到用户后来点的那个字上。
+  final SourceLookupHighlight? highlight;
 
   /// TODO-617: [onLookup] reports the tapped char rect in **screen (global)**
   /// coordinates instead of [coordinateSpaceKey]-local. The home dictionary tab
@@ -69,6 +165,20 @@ class _SourceLookupTextPanelState extends State<SourceLookupTextPanel> {
       color: theme.colorScheme.onSurface,
       height: 1.5,
     );
+    // 命中高亮底色与弹窗 WebView 内的 `--fushi-primary-highlight` 同一口径
+    // （`popup_theme_css.dart` 的 `cssRgba035(scheme.primary)`）。源文本条与弹窗
+    // 卡片是同一次查词的两个可见面，底色不同会让用户以为是两种不同的标记。
+    final Color highlightColor =
+        theme.colorScheme.primary.withValues(alpha: 0.35);
+    final Radius highlightCorner =
+        FushiDesignTokens.of(context).radii.chipCorner;
+    // 逐字给底框而不是一个整块 Rect：本条是 Wrap，命中段跨行时整块 Rect 画不出来，
+    // 逐字底框天然在换行处断开、各行各自贴合。spacing:0 使同一行内的相邻底框严丝
+    // 合缝，视觉上仍是一个连续的框。
+    final SourceLookupHighlight? highlight = widget.highlight;
+    final int highlightStart = highlight?.start ?? -1;
+    final int highlightEnd =
+        highlight == null ? -1 : highlight.start + highlight.length;
     // 左对齐并占满可用宽度：剪贴板文本条挂在 home_dictionary_page 的 Column 下，
     // Column 默认 crossAxisAlignment.center 会把收缩到内容宽度的本条居中。
     // Align(topLeft) 在父级宽度有界时撑满该宽度并把内容钉左上角，宽度无界时
@@ -86,6 +196,8 @@ class _SourceLookupTextPanelState extends State<SourceLookupTextPanel> {
             for (int i = 0; i < chars.length; i++)
               Builder(
                 builder: (BuildContext charContext) {
+                  final bool lit = i >= highlightStart && i < highlightEnd;
+                  final Widget glyph = Text(chars[i], style: charStyle);
                   return MouseRegion(
                     cursor: SystemMouseCursors.click,
                     onHover: (_) => _handleShiftHover(
@@ -101,7 +213,24 @@ class _SourceLookupTextPanelState extends State<SourceLookupTextPanel> {
                     child: GestureDetector(
                       behavior: HitTestBehavior.opaque,
                       onTap: () => _lookupAt(i, context, charContext),
-                      child: Text(chars[i], style: charStyle),
+                      child: lit
+                          ? DecoratedBox(
+                              decoration: BoxDecoration(
+                                color: highlightColor,
+                                // 只有命中段的两端收圆角，中间各字保持直角，拼起来
+                                // 才是一个整词框而不是一串独立药丸。
+                                borderRadius: BorderRadius.horizontal(
+                                  left: i == highlightStart
+                                      ? highlightCorner
+                                      : Radius.zero,
+                                  right: i == highlightEnd - 1
+                                      ? highlightCorner
+                                      : Radius.zero,
+                                ),
+                              ),
+                              child: glyph,
+                            )
+                          : glyph,
                     ),
                   );
                 },
@@ -150,6 +279,7 @@ class _SourceLookupTextPanelState extends State<SourceLookupTextPanel> {
     widget.onLookup(
       capped.skip(index).join(),
       _localRectOf(panelContext, charContext),
+      index,
     );
   }
 

--- a/fushi/test/pages/home_dictionary_popup_overlay_test.dart
+++ b/fushi/test/pages/home_dictionary_popup_overlay_test.dart
@@ -172,7 +172,7 @@ void main() {
               child: SourceLookupTextPanel(
                 text: 'XY',
                 globalCoordinates: true,
-                onLookup: (String query, Rect rect) => reported = rect,
+                onLookup: (String query, Rect rect, int _) => reported = rect,
               ),
             ),
           ),

--- a/fushi/test/widgets/clipboard_lookup_text_panel_test.dart
+++ b/fushi/test/widgets/clipboard_lookup_text_panel_test.dart
@@ -4,14 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/components/clipboard_lookup_text_panel.dart';
+import 'package:fushi/src/utils/components/fushi_design_tokens.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/utils/misc/lookup_input_limits.dart';
 
 void main() {
   Widget buildSubject({
     required String text,
-    required void Function(String query, Rect rect) onLookup,
+    required void Function(String query, Rect rect, int charIndex) onLookup,
     double dictionaryHeadwordScale = 1.0,
+    SourceLookupHighlight? highlight,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -19,10 +21,26 @@ void main() {
           text: text,
           onLookup: onLookup,
           dictionaryHeadwordScale: dictionaryHeadwordScale,
+          highlight: highlight,
         ),
       ),
     );
   }
+
+  /// 本条内画在某个字底下的高亮框（条外的 Material chrome 也有 DecoratedBox，
+  /// 必须先限定在本条子树里再往上找祖先）。
+  Finder highlightBoxOf(String char) => find.ancestor(
+        of: find.text(char),
+        matching: find.descendant(
+          of: find.byType(SourceLookupTextPanel),
+          matching: find.byType(DecoratedBox),
+        ),
+      );
+
+  Finder allHighlightBoxes() => find.descendant(
+        of: find.byType(SourceLookupTextPanel),
+        matching: find.byType(DecoratedBox),
+      );
 
   testWidgets('tapping a character looks up the suffix from that character',
       (WidgetTester tester) async {
@@ -32,7 +50,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: 'abcdef',
-        onLookup: (String value, Rect localRect) {
+        onLookup: (String value, Rect localRect, int _) {
           query = value;
           rect = localRect;
         },
@@ -54,7 +72,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: 'abcdef',
-        onLookup: (String value, Rect localRect) {
+        onLookup: (String value, Rect localRect, int _) {
           query = value;
           rect = localRect;
         },
@@ -90,7 +108,7 @@ void main() {
                 top: 30,
                 child: SourceLookupTextPanel(
                   text: 'abc',
-                  onLookup: (_, Rect localRect) {
+                  onLookup: (_, Rect localRect, __) {
                     rect = localRect;
                   },
                 ),
@@ -117,7 +135,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: '   ',
-        onLookup: (_, __) => called = true,
+        onLookup: (_, __, ___) => called = true,
       ),
     );
 
@@ -131,7 +149,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: 'abcdef',
-        onLookup: (_, __) {},
+        onLookup: (_, __, ___) {},
       ),
     );
 
@@ -146,7 +164,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: 'abcdef',
-        onLookup: (String value, Rect _) {
+        onLookup: (String value, Rect _, int __) {
           query = value;
         },
       ),
@@ -174,7 +192,7 @@ void main() {
               theme = Theme.of(context);
               return SourceLookupTextPanel(
                 text: 'あ',
-                onLookup: (_, __) {},
+                onLookup: (_, __, ___) {},
               );
             },
           ),
@@ -198,7 +216,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: 'あ',
-        onLookup: (_, __) {},
+        onLookup: (_, __, ___) {},
         dictionaryHeadwordScale: 1.5,
       ),
     );
@@ -221,7 +239,7 @@ void main() {
             children: <Widget>[
               SourceLookupTextPanel(
                 text: 'あいう',
-                onLookup: (_, __) {},
+                onLookup: (_, __, ___) {},
               ),
             ],
           ),
@@ -260,7 +278,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: longText,
-        onLookup: (_, __) {},
+        onLookup: (_, __, ___) {},
       ),
     );
     await tester.pump();
@@ -284,7 +302,7 @@ void main() {
     await tester.pumpWidget(
       buildSubject(
         text: longText,
-        onLookup: (String value, Rect _) {
+        onLookup: (String value, Rect _, int __) {
           query = value;
         },
       ),
@@ -300,5 +318,252 @@ void main() {
     expect(query!.characters.length, kMaxLookupInputChars,
         reason: '后缀长度 = 截断后的字符数，被裁掉的尾部不计入');
     expect(query, isNot(contains('X')), reason: '后缀绝不能包含被裁掉的尾部');
+  });
+
+  // ── Yomitan 式扫描高亮 ───────────────────────────────────────────────
+
+  testWidgets('highlight boxes exactly the matched span and nothing else',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildSubject(
+        text: 'と言いつつ',
+        onLookup: (_, __, ___) {},
+        // 点第 1 个字（言）查「言いつつ」，引擎命中「言い」两个字。
+        highlight: const SourceLookupHighlight(start: 1, length: 2),
+      ),
+    );
+
+    expect(allHighlightBoxes(), findsNWidgets(2), reason: '只框住命中的两个字');
+    expect(highlightBoxOf('言'), findsOneWidget);
+    expect(highlightBoxOf('い'), findsOneWidget);
+    expect(highlightBoxOf('と'), findsNothing, reason: '命中段之前的字不该被框');
+    expect(highlightBoxOf('つ'), findsNothing, reason: '命中段之后的字不该被框');
+  });
+
+  testWidgets('no highlight parameter leaves the strip completely unboxed',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildSubject(text: 'と言いつつ', onLookup: (_, __, ___) {}),
+    );
+
+    expect(allHighlightBoxes(), findsNothing);
+  });
+
+  testWidgets(
+      'highlight uses the popup in-card highlight color and only rounds the '
+      'outer corners', (WidgetTester tester) async {
+    late final ThemeData theme;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              theme = Theme.of(context);
+              return SourceLookupTextPanel(
+                text: 'あいう',
+                onLookup: (_, __, ___) {},
+                highlight: const SourceLookupHighlight(start: 0, length: 3),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    BoxDecoration decorationOf(String char) =>
+        tester.widget<DecoratedBox>(highlightBoxOf(char)).decoration
+            as BoxDecoration;
+
+    // 与 WebView 卡片内的 `--fushi-primary-highlight` 同色
+    // （popup_theme_css.dart 的 cssRgba035(scheme.primary)）。
+    expect(
+      decorationOf('あ').color,
+      theme.colorScheme.primary.withValues(alpha: 0.35),
+    );
+
+    const Radius corner = Radius.circular(FushiRadii.chipValue);
+    final BorderRadius first = decorationOf('あ').borderRadius! as BorderRadius;
+    final BorderRadius middle = decorationOf('い').borderRadius! as BorderRadius;
+    final BorderRadius last = decorationOf('う').borderRadius! as BorderRadius;
+    expect(first.topLeft, corner);
+    expect(first.topRight, Radius.zero, reason: '首字右侧要与下一个字严丝合缝');
+    expect(middle.topLeft, Radius.zero);
+    expect(middle.topRight, Radius.zero, reason: '中间的字两侧都不能收圆角');
+    expect(last.topLeft, Radius.zero);
+    expect(last.topRight, corner);
+  });
+
+  testWidgets(
+      'single-character match still renders one box with both corners rounded',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildSubject(
+        text: 'あいう',
+        onLookup: (_, __, ___) {},
+        highlight: const SourceLookupHighlight(start: 1, length: 1),
+      ),
+    );
+
+    expect(allHighlightBoxes(), findsNWidgets(1));
+    final BorderRadius radius = (tester
+            .widget<DecoratedBox>(highlightBoxOf('い'))
+            .decoration as BoxDecoration)
+        .borderRadius! as BorderRadius;
+    const Radius corner = Radius.circular(FushiRadii.chipValue);
+    expect(radius.topLeft, corner);
+    expect(radius.topRight, corner);
+  });
+
+  testWidgets('out-of-range highlight is inert instead of throwing',
+      (WidgetTester tester) async {
+    // 源文本被换短、旧高亮还没来得及重算的那一帧。
+    await tester.pumpWidget(
+      buildSubject(
+        text: 'あ',
+        onLookup: (_, __, ___) {},
+        highlight: const SourceLookupHighlight(start: 5, length: 3),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(allHighlightBoxes(), findsNothing);
+  });
+
+  group('resolveSourceLookupHighlight（UTF-16 匹配长度 → 字素簇跨度）', () {
+    test('从被点的字起，按引擎匹配长度框住整词', () {
+      // 「と言いつつ」上点第 0 个字：查询串是整条，引擎命中「と言い」(3 unit)。
+      expect(
+        resolveSourceLookupHighlight(
+          query: 'と言いつつ',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 3,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 0, length: 3),
+      );
+      // 点第 1 个字：查询串只剩后缀，命中「言い」——起点必须回到条上的绝对下标 1。
+      expect(
+        resolveSourceLookupHighlight(
+          query: '言いつつ',
+          tappedGraphemeIndex: 1,
+          matchedUnits: 2,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 1, length: 2),
+      );
+      expect(
+        resolveSourceLookupHighlight(
+          query: 'つつ',
+          tappedGraphemeIndex: 3,
+          matchedUnits: 2,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 3, length: 2),
+      );
+    });
+
+    test('句首标点被引擎剥掉时高亮右移那段长度（BUG-773 同一个坑）', () {
+      // normalizeSearchTerm 把「「」剥掉后才去匹配，bestLength 以剥离串为坐标系；
+      // 条上显示的是原串，不右移就会左吞括号、右缺词尾。
+      expect(
+        resolveSourceLookupHighlight(
+          query: '「言いつつ',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 2,
+          leadingStripUnits: 1,
+        ),
+        const SourceLookupHighlight(start: 1, length: 2),
+      );
+    });
+
+    test('匹配长度落在代理对中间时整字入框，绝不把一个字劈成两半', () {
+      // 𠮟 = U+20B9F，占 2 个 UTF-16 code unit、1 个字素簇。
+      expect(
+        resolveSourceLookupHighlight(
+          query: '𠮟る',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 2,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 0, length: 1),
+      );
+      expect(
+        resolveSourceLookupHighlight(
+          query: '𠮟る',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 3,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 0, length: 2),
+      );
+      // 长度停在代理对内部（1 unit）也要把整个字圈进来，而不是半个。
+      expect(
+        resolveSourceLookupHighlight(
+          query: '𠮟る',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 1,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 0, length: 1),
+      );
+    });
+
+    test('多码点字素簇（ZWJ 序列）算一个字', () {
+      const String family = '\u{1F468}‍\u{1F469}‍\u{1F466}';
+      expect(
+        resolveSourceLookupHighlight(
+          query: '$familyあ',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 2,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 0, length: 1),
+      );
+    });
+
+    test('零命中退化成只框被点的那个字', () {
+      expect(
+        resolveSourceLookupHighlight(
+          query: 'あいう',
+          tappedGraphemeIndex: 2,
+          matchedUnits: 0,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 2, length: 1),
+      );
+    });
+
+    test('匹配长度超出查询串时钳到串尾，不越界', () {
+      expect(
+        resolveSourceLookupHighlight(
+          query: 'あい',
+          tappedGraphemeIndex: 1,
+          matchedUnits: 99,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 1, length: 2),
+      );
+    });
+
+    test('空查询串 / 整串都被剥掉时不产出非法跨度', () {
+      expect(
+        resolveSourceLookupHighlight(
+          query: '',
+          tappedGraphemeIndex: 4,
+          matchedUnits: 3,
+          leadingStripUnits: 0,
+        ),
+        const SourceLookupHighlight(start: 4, length: 1),
+      );
+      expect(
+        resolveSourceLookupHighlight(
+          query: '。。',
+          tappedGraphemeIndex: 0,
+          matchedUnits: 1,
+          leadingStripUnits: 2,
+        ).length,
+        greaterThanOrEqualTo(1),
+      );
+    });
   });
 }


### PR DESCRIPTION
## 这条改什么

查词页顶部那条原文（`SourceLookupTextPanel`）此前是一排纯 `Text`：点第几个字就拿「从该字到串尾」的后缀交给引擎最长匹配，但条上**没有任何反馈**。用户在「と言いつつ」上点第一个字，看不出这次查的是「と言い」还是「と」——结果卡给的是词典词头（「言う」），跟条上那几个字对不上号。

现在把引擎真正吃下去的那几个字用底框标出来，与 Yomitan 的扫描高亮同义：

| 点第几个字 | 查询串 | 引擎命中 | 条上高亮 |
|---|---|---|---|
| 0（と） | `と言いつつ` | `と言い` | 框住 `と言い` |
| 1（言） | `言いつつ` | `言い` | 框住 `言い` |
| 3（つ） | `つつ` | `つつ` | 框住 `つつ` |

## 怎么做的

- **`SourceLookupHighlight` + 纯函数 `resolveSourceLookupHighlight`**（`clipboard_lookup_text_panel.dart`）负责三个坐标系的换算，少一个都会画歪：
  1. 被点字的**字素簇**下标（条上逐字渲染的坐标系）；
  2. 引擎回报的 **UTF-16 code unit** 匹配长度（`lookupHighlightCharCount` / `bestLength`）；
  3. `normalizeSearchTerm` 剥掉的句首标点长度（`AppModel.lookupLeadingStripUnits`）——不右移它，高亮会左吞进句首括号、右缺词尾，就是 BUG-773 同一个坑。

  逐字素簇累加 UTF-16 长度来定位，而不是 `substring(strip, strip + matched)` 再数字数：匹配长度落在代理对 / 组合字中间时 `substring` 会劈出孤立代理项，数出来的长度不是用户看到的字数。宁可整字多框一个，也绝不把一个字劈成两半（`𠮟る` 有单测钉住）。

- **底框逐字画**，不是一个整块 Rect：本条是 `Wrap`，命中段跨行时整块 Rect 画不出来；逐字底框天然在换行处断开、各行各自贴合，`spacing: 0` 让同一行内的相邻底框严丝合缝。只有命中段两端收 `radii.chipCorner` 圆角，中间保持直角，拼起来是一个整词框而不是一串独立药丸。

- **底色取 `primary @ .35`**，与弹窗 WebView 内 `--fushi-primary-highlight`（`popup_theme_css.dart` 的 `cssRgba035(scheme.primary)`）同一口径——源文本条和弹窗卡片是同一次查词的两个可见面，底色不同会让用户以为是两种不同的标记。

- **`onLookup` 增回报被点字的字素簇下标**。宿主据此把**异步**回来的匹配长度绑回发起那一次的位置；中途用户点了别的字就靠 generation 把迟到的回报丢弃，不会盖到新位置上。不让宿主拿 query 长度反推：反推依赖「query 恒为 text 的后缀」这条组件内部约定（还叠着 `kMaxLookupInputChars` 截断），约定一改宿主就静默画歪。

- **两个宿主都接线**：首页词典 tab（主查词 / 点回历史 / 点字；「加载更多」不动高亮——它只是把词头上限调大，命中段没变，重设会把用户点出来的高亮弹回句首）与 Android 独立查词窗。

- 顺带修 `_showCachedResult` 不同步 `_sourceLookupText`：历史列表只在查询框为空时可见，而清空输入框并不经 `_clearSearch`，于是点开一条历史后条上可能留着上一次桌面取词的旧整句。那在没有高亮时只是「有点怪」，加了高亮就会变成「框在一段跟结果毫无关系的文字上」。

## 验证

- `flutter analyze`（含 test 目录）无 issue。
- 定向 **115 条，退出码 0**：面板 widget 行为 + 换算纯逻辑（新增 23 条，覆盖句首标点右移、代理对不劈半、ZWJ 序列算一个字、零命中退化成单字、超长钳到串尾、越界跨度不抛）、首页弹窗 overlay 定位、独立查词窗、MD3 守卫、查词高亮面守卫、匹配字数。
- 真实像素：把本组件按深色主题渲染成 PNG 逐帧看过，三种点击状态的框位置与跨度都对，只有两端收圆角。

## 已知边界

组件级像素与逻辑都已验证，但**没有**在真机 / 模拟器上跑完整「点字 → 引擎 → 高亮」链路（需要装好词典的运行环境）。这条链路上引擎侧的匹配长度是既有的 `bestLength`，本 PR 只是把它渲染出来，没有改动查词逻辑本身。

https://claude.ai/code/session_01RwFkPYd1TVXPGFK32V5knu
