### PR TITLE
style(settings): 删掉外观 › 功能模块逐行重复的副标题

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77622 (4566 per locale)
+/// Strings: 77605 (4565 per locale)
 ///
-/// Built on 2026-09-09 at 14:49 UTC
+/// Built on 2026-09-09 at 16:07 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3475,8 +3475,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get module_downloads_hidden_hint =>
       'The Downloads tab is hidden in Settings → Appearance → Feature modules; turn it back on to manage subscriptions.';
   String get module_extension_label => 'Browser extension';
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   String get move_down => 'Move down';
   String get move_up => 'Move up';
   String get name => 'Name';
@@ -12056,9 +12054,6 @@ class _StringsAr extends _StringsEn {
       'تبويب التحميلات مخفي في الإعدادات → المظهر → وحدات الميزات؛ أعد تشغيله لإدارة الاشتراكات.';
   @override
   String get module_extension_label => 'إضافة المتصفح';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => 'تحريك لأسفل';
   @override
@@ -22907,9 +22902,6 @@ class _StringsDe extends _StringsEn {
       'Der Tab „Downloads“ ist unter Einstellungen → Erscheinungsbild → Funktionsmodule ausgeblendet; schalte ihn wieder ein, um Abos zu verwalten.';
   @override
   String get module_extension_label => 'Browser-Erweiterung';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => 'Nach unten';
   @override
@@ -33887,9 +33879,6 @@ class _StringsEs extends _StringsEn {
       'La pestaña Descargas está oculta en Configuración → Apariencia → Módulos de funciones; vuelve a activarla para gestionar las suscripciones.';
   @override
   String get module_extension_label => 'Extensión del navegador';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => 'Mover abajo';
   @override
@@ -44913,9 +44902,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get module_extension_label => 'Extension navigateur';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Descendre';
   @override
   String get move_up => 'Monter';
@@ -55862,9 +55848,6 @@ class _StringsId extends _StringsEn {
   @override
   String get module_extension_label => 'Ekstensi browser';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Turunkan';
   @override
   String get move_up => 'Naikkan';
@@ -66754,9 +66737,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get module_extension_label => 'Estensione browser';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Sposta giù';
   @override
   String get move_up => 'Sposta su';
@@ -77374,9 +77354,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get module_extension_label => 'ブラウザ拡張機能';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => '下に移動';
   @override
   String get move_up => '上に移動';
@@ -87696,9 +87673,6 @@ class _StringsKo extends _StringsEn {
       '‘다운로드’ 탭이 설정 → 외관 → 기능 모듈에서 숨겨져 있어요. 구독을 관리하려면 다시 켜세요.';
   @override
   String get module_extension_label => '브라우저 확장';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => '아래로 이동';
   @override
@@ -98315,9 +98289,6 @@ class _StringsNl extends _StringsEn {
       'Het tabblad Downloads is verborgen via Instellingen → Uiterlijk → Functiemodules; zet het weer aan om abonnementen te beheren.';
   @override
   String get module_extension_label => 'Browserextensie';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => 'Omlaag';
   @override
@@ -109244,9 +109215,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get module_extension_label => 'Extensão do navegador';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Mover para baixo';
   @override
   String get move_up => 'Mover para cima';
@@ -120166,9 +120134,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get module_extension_label => 'Расширение для браузера';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Вниз';
   @override
   String get move_up => 'Вверх';
@@ -130998,9 +130963,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get module_extension_label => 'ส่วนขยายเบราว์เซอร์';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'เลื่อนลง';
   @override
   String get move_up => 'เลื่อนขึ้น';
@@ -141793,9 +141755,6 @@ class _StringsTr extends _StringsEn {
       'İndirmeler sekmesi Ayarlar → Görünüm → Özellik modülleri altında gizli; abonelikleri yönetmek için yeniden açın.';
   @override
   String get module_extension_label => 'Tarayıcı eklentisi';
-  @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
   @override
   String get move_down => 'Aşağı taşı';
   @override
@@ -152627,9 +152586,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get module_extension_label => 'Tiện ích mở rộng trình duyệt';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => 'Di chuyển xuống';
   @override
   String get move_up => 'Di chuyển lên';
@@ -162969,8 +162925,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get module_extension_label => '浏览器扩展';
   @override
-  String get module_toggle_hint => '关闭后该模块的全部入口一起消失：导航栏、首页、设置分类与跨页跳转';
-  @override
   String get move_down => '下移';
   @override
   String get move_up => '上移';
@@ -172929,9 +172883,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get module_extension_label => '瀏覽器擴展';
   @override
-  String get module_toggle_hint =>
-      'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
-  @override
   String get move_down => '下移';
   @override
   String get move_up => '上移';
@@ -182598,8 +182549,6 @@ extension on _StringsEn {
         return 'The Downloads tab is hidden in Settings → Appearance → Feature modules; turn it back on to manage subscriptions.';
       case 'module_extension_label':
         return 'Browser extension';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Move down';
       case 'move_up':
@@ -191988,8 +191937,6 @@ extension on _StringsAr {
         return 'تبويب التحميلات مخفي في الإعدادات → المظهر → وحدات الميزات؛ أعد تشغيله لإدارة الاشتراكات.';
       case 'module_extension_label':
         return 'إضافة المتصفح';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'تحريك لأسفل';
       case 'move_up':
@@ -201403,8 +201350,6 @@ extension on _StringsDe {
         return 'Der Tab „Downloads“ ist unter Einstellungen → Erscheinungsbild → Funktionsmodule ausgeblendet; schalte ihn wieder ein, um Abos zu verwalten.';
       case 'module_extension_label':
         return 'Browser-Erweiterung';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Nach unten';
       case 'move_up':
@@ -210829,8 +210774,6 @@ extension on _StringsEs {
         return 'La pestaña Descargas está oculta en Configuración → Apariencia → Módulos de funciones; vuelve a activarla para gestionar las suscripciones.';
       case 'module_extension_label':
         return 'Extensión del navegador';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Mover abajo';
       case 'move_up':
@@ -220259,8 +220202,6 @@ extension on _StringsFr {
         return 'L\'onglet Téléchargements est masqué dans Paramètres → Apparence → Modules de fonctionnalités ; réactivez-le pour gérer les abonnements.';
       case 'module_extension_label':
         return 'Extension navigateur';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Descendre';
       case 'move_up':
@@ -229677,8 +229618,6 @@ extension on _StringsId {
         return 'Tab Unduhan disembunyikan di Pengaturan → Tampilan → Modul fitur; nyalakan lagi untuk mengelola langganan.';
       case 'module_extension_label':
         return 'Ekstensi browser';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Turunkan';
       case 'move_up':
@@ -239089,8 +239028,6 @@ extension on _StringsIt {
         return 'La scheda Download è nascosta in Impostazioni → Aspetto → Moduli funzionalità; riattivala per gestire le sottoscrizioni.';
       case 'module_extension_label':
         return 'Estensione browser';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Sposta giù';
       case 'move_up':
@@ -248481,8 +248418,6 @@ extension on _StringsJa {
         return '「ダウンロード」タブは 設定 → 外観 → 機能モジュール で非表示になっています。購読を管理するには再度オンにしてください。';
       case 'module_extension_label':
         return 'ブラウザ拡張機能';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return '下に移動';
       case 'move_up':
@@ -257835,8 +257770,6 @@ extension on _StringsKo {
         return '‘다운로드’ 탭이 설정 → 외관 → 기능 모듈에서 숨겨져 있어요. 구독을 관리하려면 다시 켜세요.';
       case 'module_extension_label':
         return '브라우저 확장';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return '아래로 이동';
       case 'move_up':
@@ -267224,8 +267157,6 @@ extension on _StringsNl {
         return 'Het tabblad Downloads is verborgen via Instellingen → Uiterlijk → Functiemodules; zet het weer aan om abonnementen te beheren.';
       case 'module_extension_label':
         return 'Browserextensie';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Omlaag';
       case 'move_up':
@@ -276642,8 +276573,6 @@ extension on _StringsPtBr {
         return 'A aba Downloads está oculta em Configurações → Aparência → Módulos de funcionalidades; reative-a para gerenciar as assinaturas.';
       case 'module_extension_label':
         return 'Extensão do navegador';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Mover para baixo';
       case 'move_up':
@@ -286063,8 +285992,6 @@ extension on _StringsRu {
         return 'Вкладка «Загрузки» скрыта в разделе Настройки → Внешний вид → Функциональные модули; включите её снова, чтобы управлять подписками.';
       case 'module_extension_label':
         return 'Расширение для браузера';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Вниз';
       case 'move_up':
@@ -295464,8 +295391,6 @@ extension on _StringsTh {
         return 'แท็บดาวน์โหลดถูกซ่อนไว้ใน การตั้งค่า → รูปลักษณ์ → โมดูลฟีเจอร์ ต้องเปิดกลับมาจึงจะจัดการรายการติดตามได้';
       case 'module_extension_label':
         return 'ส่วนขยายเบราว์เซอร์';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'เลื่อนลง';
       case 'move_up':
@@ -304867,8 +304792,6 @@ extension on _StringsTr {
         return 'İndirmeler sekmesi Ayarlar → Görünüm → Özellik modülleri altında gizli; abonelikleri yönetmek için yeniden açın.';
       case 'module_extension_label':
         return 'Tarayıcı eklentisi';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Aşağı taşı';
       case 'move_up':
@@ -314270,8 +314193,6 @@ extension on _StringsVi {
         return 'Tab Tải xuống đang bị ẩn trong Cài đặt → Giao diện → Mô-đun tính năng; bật lại để quản lý đăng ký.';
       case 'module_extension_label':
         return 'Tiện ích mở rộng trình duyệt';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return 'Di chuyển xuống';
       case 'move_up':
@@ -323631,8 +323552,6 @@ extension on _StringsZhCn {
         return '「下载」页已在 设置 → 外观 → 功能模块 中隐藏；重新打开它才能管理订阅。';
       case 'module_extension_label':
         return '浏览器扩展';
-      case 'module_toggle_hint':
-        return '关闭后该模块的全部入口一起消失：导航栏、首页、设置分类与跨页跳转';
       case 'move_down':
         return '下移';
       case 'move_up':
@@ -332957,8 +332876,6 @@ extension on _StringsZhHk {
         return '「下載」頁已在 設定 → 外觀 → 功能模塊 中隱藏；重新開啟才能管理訂閱。';
       case 'module_extension_label':
         return '瀏覽器擴展';
-      case 'module_toggle_hint':
-        return 'Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps';
       case 'move_down':
         return '下移';
       case 'move_up':

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "The Downloads tab is hidden in Settings → Appearance → Feature modules; turn it back on to manage subscriptions.",
   "module_extension_label": "Browser extension",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Move down",
   "move_up": "Move up",
   "name": "Name",

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "تبويب التحميلات مخفي في الإعدادات → المظهر → وحدات الميزات؛ أعد تشغيله لإدارة الاشتراكات.",
   "module_extension_label": "إضافة المتصفح",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "تحريك لأسفل",
   "move_up": "تحريك لأعلى",
   "name": "الاسم",

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "Der Tab „Downloads“ ist unter Einstellungen → Erscheinungsbild → Funktionsmodule ausgeblendet; schalte ihn wieder ein, um Abos zu verwalten.",
   "module_extension_label": "Browser-Erweiterung",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Nach unten",
   "move_up": "Nach oben",
   "name": "Name",

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "La pestaña Descargas está oculta en Configuración → Apariencia → Módulos de funciones; vuelve a activarla para gestionar las suscripciones.",
   "module_extension_label": "Extensión del navegador",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Mover abajo",
   "move_up": "Mover arriba",
   "name": "Nombre",

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "L'onglet Téléchargements est masqué dans Paramètres → Apparence → Modules de fonctionnalités ; réactivez-le pour gérer les abonnements.",
   "module_extension_label": "Extension navigateur",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Descendre",
   "move_up": "Monter",
   "name": "Nom",

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "Tab Unduhan disembunyikan di Pengaturan → Tampilan → Modul fitur; nyalakan lagi untuk mengelola langganan.",
   "module_extension_label": "Ekstensi browser",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Turunkan",
   "move_up": "Naikkan",
   "name": "Nama",

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "La scheda Download è nascosta in Impostazioni → Aspetto → Moduli funzionalità; riattivala per gestire le sottoscrizioni.",
   "module_extension_label": "Estensione browser",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Sposta giù",
   "move_up": "Sposta su",
   "name": "Nome",

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "「ダウンロード」タブは 設定 → 外観 → 機能モジュール で非表示になっています。購読を管理するには再度オンにしてください。",
   "module_extension_label": "ブラウザ拡張機能",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "下に移動",
   "move_up": "上に移動",
   "name": "名前",

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "‘다운로드’ 탭이 설정 → 외관 → 기능 모듈에서 숨겨져 있어요. 구독을 관리하려면 다시 켜세요.",
   "module_extension_label": "브라우저 확장",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "아래로 이동",
   "move_up": "위로 이동",
   "name": "이름",

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "Het tabblad Downloads is verborgen via Instellingen → Uiterlijk → Functiemodules; zet het weer aan om abonnementen te beheren.",
   "module_extension_label": "Browserextensie",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Omlaag",
   "move_up": "Omhoog",
   "name": "Naam",

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "A aba Downloads está oculta em Configurações → Aparência → Módulos de funcionalidades; reative-a para gerenciar as assinaturas.",
   "module_extension_label": "Extensão do navegador",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Mover para baixo",
   "move_up": "Mover para cima",
   "name": "Nome",

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "Вкладка «Загрузки» скрыта в разделе Настройки → Внешний вид → Функциональные модули; включите её снова, чтобы управлять подписками.",
   "module_extension_label": "Расширение для браузера",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Вниз",
   "move_up": "Вверх",
   "name": "Название",

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "แท็บดาวน์โหลดถูกซ่อนไว้ใน การตั้งค่า → รูปลักษณ์ → โมดูลฟีเจอร์ ต้องเปิดกลับมาจึงจะจัดการรายการติดตามได้",
   "module_extension_label": "ส่วนขยายเบราว์เซอร์",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "เลื่อนลง",
   "move_up": "เลื่อนขึ้น",
   "name": "ชื่อ",

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "İndirmeler sekmesi Ayarlar → Görünüm → Özellik modülleri altında gizli; abonelikleri yönetmek için yeniden açın.",
   "module_extension_label": "Tarayıcı eklentisi",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Aşağı taşı",
   "move_up": "Yukarı taşı",
   "name": "Ad",

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "Tab Tải xuống đang bị ẩn trong Cài đặt → Giao diện → Mô-đun tính năng; bật lại để quản lý đăng ký.",
   "module_extension_label": "Tiện ích mở rộng trình duyệt",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "Di chuyển xuống",
   "move_up": "Di chuyển lên",
   "name": "Tên",

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "该功能模块已在「设置 → 外观 → 功能模块」中关闭。",
   "module_downloads_hidden_hint": "「下载」页已在 设置 → 外观 → 功能模块 中隐藏；重新打开它才能管理订阅。",
   "module_extension_label": "浏览器扩展",
-  "module_toggle_hint": "关闭后该模块的全部入口一起消失：导航栏、首页、设置分类与跨页跳转",
   "move_down": "下移",
   "move_up": "上移",
   "name": "名称",

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2413,7 +2413,6 @@
   "module_disabled_hint": "This feature module is turned off in Settings > Appearance > Feature modules.",
   "module_downloads_hidden_hint": "「下載」頁已在 設定 → 外觀 → 功能模塊 中隱藏；重新開啟才能管理訂閱。",
   "module_extension_label": "瀏覽器擴展",
-  "module_toggle_hint": "Turn off to close every entry point for this module - navigation, home, settings and cross-page jumps",
   "move_down": "下移",
   "move_up": "上移",
   "name": "名稱",

--- a/fushi/lib/src/settings/settings_schema_appearance.dart
+++ b/fushi/lib/src/settings/settings_schema_appearance.dart
@@ -79,7 +79,6 @@ SettingsSwitchItem _moduleSwitch(ModuleId module) {
   return SettingsSwitchItem(
     id: _moduleItemId(module),
     title: identity.label,
-    subtitle: t.module_toggle_hint,
     icon: identity.icon,
     // 平台上不存在的模块不出开关（galgame 仅 Windows、浏览器扩展仅桌面）。判据
     // 与读取端同源（[ModuleId.availableOn]），不在这里另写一份 Platform 判断。


### PR DESCRIPTION
## 改了什么

`设置 › 外观 › 功能模块` 里 11 个模块开关**每一行**都挂着同一句副标题：

> 关闭后该模块的全部入口一起消失：导航栏、首页、设置分类与跨页跳转

同一句话重复 11 遍，把这一区从 11 行撑成 22 行、占掉一整屏，信息量却只有一条。本 PR 删掉这句逐行副标题，整区回到一行一个模块的紧凑形态。开关标题本身取自底栏 / 设置一级分类的真值（`_moduleNavIdentity`），已经足以说明关的是哪个模块；这条开关的语义也写在 `settings_schema_appearance.dart` 该分区上方的注释里，读代码的人不会丢上下文。

顺带回收唯一使用点消失后变成死键的 i18n key `module_toggle_hint`：走 `tool/i18n_sync.dart --remove` 清 17 个语言文件，再 `dart run slang` 重新生成 `strings.g.dart`，并按该文件在上游既有的 3.6 短格式格式化（tall 会重排整份生成文件，故不用）。

## 验证

- `flutter analyze`（含 test 目录）：No issues found。
- 定向 `flutter test --no-pub` 9 个套、80 条全过，退出码 0：
  `settings_module_gating` / `settings_module_labels_match_nav` / `settings_search` / `settings_schema_coverage` / `settings_redesign_static` / `settings_destination_order_guard` / `settings_schema_cache` / `settings_row_subtitle_wrap` / `models/module_registry`。
- 未跑真机截图：`subtitle == null` 是设置行的既有常态（同页的「应用图标」「反转导航栏」本来就没有副标题），渲染路径无新分支。

## 影响面

纯展示文案删除。item id（`system.module_*`）、持久化、模块门控逻辑、设置搜索索引均未动。

https://claude.ai/code/session_01HeBetDVcZvHAuAUVeSgLJq
