### PR TITLE
移动端底栏贴近底部：内容区 80→64dp，不再把手势 inset 叠成 104dp（BUG-2395）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2209 条。点号进各自文件。
+> 共 2210 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2395](bugs/BUG-2395-mobile-nav-bar-too-tall.md) | ✅ | ✅ | 移动端底部导航栏过高未贴近底部 |
 | [BUG-2393](bugs/BUG-2393-reader-audio-chapter-anchor.md) | ✅ | ✅ | 有声书恢复只定位章节却当作句子恢复成功 |
 | [BUG-2392](bugs/BUG-2392-reader-audio-resume-priority.md) | ✅ | ✅ | 阅读进度异步快照在导航后仍写入位置与统计 |
 | [BUG-2391](bugs/BUG-2391-windows-fullscreen-render-stall.md) | ✅ | ✅ | Windows视频退出全屏后画面停滞需拖动窗口恢复 |

--- a/docs/bugs/BUG-2395-mobile-nav-bar-too-tall.md
+++ b/docs/bugs/BUG-2395-mobile-nav-bar-too-tall.md
@@ -1,0 +1,49 @@
+## BUG-2395 · 移动端底部导航栏过高未贴近底部
+- **报告**：2026-09-10（用户：「移动端底部栏有点高，调正常，贴近底部」）
+- **真实性**：✅ 真 bug（视觉/布局），根因
+  `fushi/lib/src/utils/adaptive/adaptive_navigation.dart:133-148`（修前）：
+  自绘 Material 底栏是 `Material > SafeArea(top: false) > SizedBox(height: 80) > Row`，
+  这里的 **80 是内容区固定高**，外层 `SafeArea` 再把系统底部 inset **叠加**上去：
+  - MD3 标称的 navigation bar 容器就是 80dp（含底部留白），这里等于在 80 之外又加了一份
+    手势条高度 → Pixel 7 类设备（inset 24dp）实测总高 **104dp**。
+  - tile 内在高只有 52dp（指示药丸 32 + 间距 4 + labelSmall 一行 16，
+    `adaptive_navigation.dart:270-300`），在 80dp 里垂直居中 → 上下各空 14dp；
+    叠上 24dp 手势区后，**标签底边离屏幕底 38dp**，视觉上整条栏「浮」在底部上方
+    而不是贴住底部。
+  - 数字来自 widget 探针（`MediaQueryData(size: 411.4x914.3, dpr 2.625,
+    viewPadding.bottom: 24)`）：`bar.height=104`、`bar.bottom - label.bottom=38`、
+    `icon.top - bar.top=18`。
+  另注：底栏高度是裸字面量，而同文件的侧栏宽度有单一真相源常量
+  `kAdaptiveNavRailWidth`（`:304`）——本次顺带补上对称的高度常量。
+- **[x] ① 已修复** — 本提交 `fushi/lib/src/utils/adaptive/adaptive_navigation.dart`：
+  - 内容区高度 80 → `kAdaptiveNavBarContentHeight = 64`（tile 52 + 上下各
+    `kAdaptiveNavBarContentPadding = 6`），系统 inset 仍由 `SafeArea` 单独让出，
+    于是总高 = 64 + inset（inset 24 时 **88dp**，比原来矮 16dp），
+    标签底边离屏幕底 = 6 + inset = **30dp**（原 38dp），内容真正贴住手势区上沿。
+  - 固定 `SizedBox` 换成 `ConstrainedBox(minHeight:)` + 内边距 + `IntrinsicHeight`：
+    内容比 64 高时（大字号）底栏**自然长高**而不是 RenderFlex 溢出——旧实现靠 80 的
+    富余空间掩盖，压到 64 后必须显式处理。`IntrinsicHeight` 是这里的必需项而非装饰：
+    每个 tile 里有 `Center`（`adaptive_navigation.dart:_NavFocusCell`），松约束下它会
+    吃满可用高度——只把 `SizedBox` 换成 `ConstrainedBox` 会让底栏**撑满整屏**
+    （实测 914dp），旧的 tight 高度恰好掩盖了这个依赖。
+  - 同时按 stock `NavigationBar` 的做法把文字缩放 clamp 到 1.3
+    （`MediaQuery.withClampedTextScaling`），避免系统超大字号把底栏顶到半屏高。
+- **[x] ② 已加自动化测试** — `fushi/test/widgets/adaptive_nav_bar_height_test.dart`（本提交）：
+  无 inset 时 bar 高 = 64；inset 24 时 bar 高 = 88 且标签底边到 bar 底边 = 6 + 24；
+  textScale 2.0 时 bar 按内容长高、`takeException()` 为 null（不溢出）。
+  三条在修前实现上均红（旧实现分别是 80 / 104 / 38）。
+- **验证**（判绿只认退出码）：
+  - **Android 模拟器实测**（Pixel 7 规格 AVD：1080x2400 @420dpi、Android 15 手势导航，
+    debug APK `--target-platform android-x64`）：装修前 APK 走原始路径（跳过引导 → 首页）
+    截屏，改完重建再截，同位置裁剪并排对比 —— 整条栏下移约 17dp，标签与手势条之间的
+    空白肉眼可见地收紧。修前/修后截图与对比图见本机 job tmp（不入库）。
+  - widget 探针（同一 MediaQuery 参数）修前 `bar.height=104 / gap=38`，
+    修后 `88 / 30`，与设计值一致。
+  - `flutter test test/widgets/material_nav_focus_test.dart test/pages/adaptive_nav_rail_overflow_test.dart
+    test/pages/home_mobile_nav_traversal_guard_test.dart test/pages/video_experimental_markers_guard_test.dart
+    test/focus` → 99 例全绿，exit=0（底栏逐项焦点、Enter 激活、label 可 tap、rail 不溢出、
+    mobile layout 源码守卫都没被这次改动碰坏）。
+  - `flutter analyze`（fushi，含 test / integration_test）→ No issues found。
+- **备注**：底栏唯一生产调用点是 `home_page.dart:1383` 的 `_buildMobileLayout()`，
+  只在 compact（真实宽 < 600dp）布局启用，桌面侧栏（`adaptiveNavRail`）不受影响；
+  iOS/Cupertino 分支走 stock `CupertinoTabBar`，也不在改动面内。

--- a/fushi/lib/src/utils/adaptive/adaptive_navigation.dart
+++ b/fushi/lib/src/utils/adaptive/adaptive_navigation.dart
@@ -46,6 +46,23 @@ const Key fushiMaterialNavKey = ValueKey<String>('hibiki-material-nav');
 /// design system.
 const Key fushiMacosNavKey = ValueKey<String>('hibiki-macos-nav');
 
+/// Height of the mobile bottom bar's **content box**, in logical pixels —
+/// the system gesture inset is let through by [SafeArea] on top of this.
+///
+/// Single source of truth for the bar's height, mirroring
+/// [kAdaptiveNavRailWidth] on the rail side. MD3's nominal 80dp container
+/// leaves 28dp of pure padding around a 52dp destination (32 indicator + 4 gap
+/// + one labelSmall line); adding the gesture inset on top of that pushed the
+/// whole bar to 104dp on a gesture-navigation phone, so it read as floating
+/// above the bottom edge rather than sitting on it (BUG-2395). 64dp keeps the
+/// destination untouched and drops the slack, leaving only
+/// [kAdaptiveNavBarContentPadding] between the labels and the gesture area.
+const double kAdaptiveNavBarContentHeight = 64;
+
+/// Breathing room above and below the bottom bar's destinations.
+/// A 52dp destination plus twice this is [kAdaptiveNavBarContentHeight].
+const double kAdaptiveNavBarContentPadding = 6;
+
 Widget adaptiveBottomBar({
   required BuildContext context,
   required int currentIndex,
@@ -134,14 +151,35 @@ class _MaterialNavCluster extends StatelessWidget {
       return Material(
         key: fushiMaterialNavKey,
         color: colors.surfaceContainer,
-        child: SafeArea(
-          top: false,
-          child: SizedBox(
-            height: 80,
-            child: Row(
-              children: <Widget>[
-                for (final Widget tile in tiles) Expanded(child: tile),
-              ],
+        // Clamp text scaling exactly like the stock NavigationBar: at the
+        // system's largest font sizes an unclamped label would push the bar to
+        // a third of the screen.
+        child: MediaQuery.withClampedTextScaling(
+          maxScaleFactor: 1.3,
+          child: SafeArea(
+            top: false,
+            // minHeight, not a fixed height: even clamped, a scaled label can
+            // outgrow the content box, and a fixed box would overflow instead
+            // of growing (the old 80 only hid this behind spare room).
+            // IntrinsicHeight is what makes that "grow" well defined — each
+            // destination centers itself inside the row, so under a loose
+            // constraint the row would otherwise stretch to the whole screen.
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                minHeight: kAdaptiveNavBarContentHeight,
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: kAdaptiveNavBarContentPadding,
+                ),
+                child: IntrinsicHeight(
+                  child: Row(
+                    children: <Widget>[
+                      for (final Widget tile in tiles) Expanded(child: tile),
+                    ],
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/fushi/test/widgets/adaptive_nav_bar_height_test.dart
+++ b/fushi/test/widgets/adaptive_nav_bar_height_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_navigation.dart';
+
+// 移动端底栏几何守卫。自绘的 Material 底栏曾用固定 SizedBox(height: 80)，叠上
+// Android 手势条的 24dp bottom inset 后总高 104dp，标签底边离屏幕底 38dp —— 比
+// MD3 标称的 80dp 容器还高，视觉上「浮」在底部而不是贴住底部。
+//
+// 现在内容区固定 kAdaptiveNavBarContentHeight(64)，inset 只作为系统手势区留白，
+// 所以总高 = 64 + inset，内容与手势区之间只剩 kAdaptiveNavBarContentPadding(6)。
+// 大字号下高度必须自适应增长（ConstrainedBox 的是 min 而非固定高），否则 tile
+// 会 RenderFlex 溢出。
+void main() {
+  const List<AdaptiveNavItem> items = <AdaptiveNavItem>[
+    AdaptiveNavItem(icon: Icons.menu_book_outlined, label: 'Books'),
+    AdaptiveNavItem(icon: Icons.search, label: 'Dict'),
+    AdaptiveNavItem(icon: Icons.tune, label: 'Settings'),
+  ];
+
+  Future<void> pumpBar(
+    WidgetTester tester, {
+    double bottomInset = 0,
+    double textScale = 1,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(
+            size: const Size(411.4, 914.3),
+            devicePixelRatio: 2.625,
+            textScaler: TextScaler.linear(textScale),
+            padding: EdgeInsets.only(bottom: bottomInset),
+            viewPadding: EdgeInsets.only(bottom: bottomInset),
+          ),
+          child: FushiFocusRoot(
+            child: Scaffold(
+              body: const SizedBox.expand(),
+              bottomNavigationBar: Builder(
+                builder: (BuildContext context) => adaptiveBottomBar(
+                  context: context,
+                  currentIndex: 0,
+                  onTap: (_) {},
+                  items: items,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('bottom bar content is 64dp tall without system inset', (
+    WidgetTester tester,
+  ) async {
+    await pumpBar(tester);
+
+    final Rect bar = tester.getRect(find.byKey(fushiMaterialNavKey));
+    expect(bar.height, kAdaptiveNavBarContentHeight);
+  });
+
+  testWidgets('system inset only adds gesture padding below the content', (
+    WidgetTester tester,
+  ) async {
+    const double inset = 24;
+    await pumpBar(tester, bottomInset: inset);
+
+    final Rect bar = tester.getRect(find.byKey(fushiMaterialNavKey));
+    // 总高 = 内容 64 + 手势区 24 = 88；旧实现是 80 + 24 = 104。
+    expect(bar.height, kAdaptiveNavBarContentHeight + inset);
+
+    // 标签底边只隔着内容内边距 + 手势区，不再多出 14dp 的空白。
+    final Rect label = tester.getRect(find.text('Books'));
+    expect(
+      bar.bottom - label.bottom,
+      kAdaptiveNavBarContentPadding + inset,
+    );
+  });
+
+  testWidgets('bar grows instead of overflowing at large text scale', (
+    WidgetTester tester,
+  ) async {
+    await pumpBar(tester, bottomInset: 24, textScale: 2);
+
+    // 文字缩放被 clamp 到 1.3（与 stock NavigationBar 一致），高度按内容自适应
+    // 增长；任何 RenderFlex 溢出都会让 pumpAndSettle 抛异常。
+    final Rect bar = tester.getRect(find.byKey(fushiMaterialNavKey));
+    expect(bar.height, greaterThanOrEqualTo(kAdaptiveNavBarContentHeight + 24));
+    expect(bar.height, lessThan(kAdaptiveNavBarContentHeight + 24 + 20));
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
用户反馈：移动端底部导航栏「有点高」，希望调回正常高度并贴近底部。

## 根因

自绘 Material 底栏是 `Material > SafeArea(top: false) > SizedBox(height: 80) > Row`
（`fushi/lib/src/utils/adaptive/adaptive_navigation.dart`）。这里的 **80 是内容区固定高**，
外层 `SafeArea` 再把系统底部 inset **叠加**上去：

- MD3 标称的 navigation bar 容器就是 80dp（已含底部留白），这里等于在 80 之外又加了一份
  手势条高度 → Pixel 7 类设备（inset 24dp）实测总高 **104dp**。
- 而一个 destination 内在高只有 52dp（指示药丸 32 + 间距 4 + labelSmall 一行 16），
  80dp 里有 28dp 是纯空白；叠上 24dp 手势区后，**标签底边离屏幕底 38dp**，
  整条栏视觉上「浮」在底部上方而不是贴住底部。

## 改动

- 内容区高度 80 → `kAdaptiveNavBarContentHeight = 64`（52 + 上下各
  `kAdaptiveNavBarContentPadding = 6`），与侧栏的 `kAdaptiveNavRailWidth` 对称，
  作为底栏高度的单一真相源（原来是裸字面量）。系统 inset 仍由 `SafeArea` 单独让出。
  → inset 24dp 时总高 **104 → 88**，标签底边到屏幕底 **38 → 30**（6 呼吸位 + 24 手势区）。
- 固定 `SizedBox` 换成 `ConstrainedBox(minHeight:) + Padding + IntrinsicHeight`：
  压到 64dp 后大字号会顶出内容区，底栏必须自然长高而不是 RenderFlex 溢出
  （旧的 80dp 只是空间富余到看不出来）。**`IntrinsicHeight` 是必需项而非装饰**——
  每个 tile 里的 `Center` 在松约束下会吃满可用高度，只换 `ConstrainedBox` 会让底栏
  撑满整屏（实测 914dp），旧的 tight 高度恰好掩盖了这个依赖。
- 按 stock `NavigationBar` 的做法把文字缩放 clamp 到 1.3
  （`MediaQuery.withClampedTextScaling`），避免系统超大字号把底栏顶到半屏高。

底栏唯一生产调用点是 `home_page.dart` 的 `_buildMobileLayout()`（compact，真实宽 < 600dp），
桌面侧栏（`adaptiveNavRail`）与 Cupertino 分支不在改动面内。

## 验证

- **Android 模拟器实测**（Pixel 7 规格 AVD：1080x2400 @420dpi、Android 15 手势导航）：
  装修前 debug APK 走原始路径（跳过引导 → 首页）截屏，改完重建再截，同位置裁剪对比 ——
  整条栏下移约 17dp，标签与手势条之间的空白肉眼可见地收紧。
- 新增 `fushi/test/widgets/adaptive_nav_bar_height_test.dart` 三条：无 inset 时 64；
  inset 24 时 88 且标签底边到栏底 = 6 + 24；textScale 2.0 时按内容长高、不溢出。
  三条在修前实现上均红（旧值分别是 80 / 104 / 38）。
- 相邻定向测试 99 例全绿（`material_nav_focus_test`、`adaptive_nav_rail_overflow_test`、
  `home_mobile_nav_traversal_guard_test`、`video_experimental_markers_guard_test`、`test/focus`）——
  底栏逐项焦点、Enter 激活、label 可 tap、rail 不溢出、mobile layout 源码守卫都没被碰坏。
- `flutter analyze`（fushi，含 test / integration_test）→ No issues found。

详见 `docs/bugs/BUG-2395-mobile-nav-bar-too-tall.md`。

https://claude.ai/code/session_018Fi6uGv2zV9zYN83PxnxL3
