### PR TITLE
fix(lookup): 音调去重覆盖 pattern/IPA，并接通扩展与 Android 原生弹窗（BUG-2397）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2209 条。点号进各自文件。
+> 共 2210 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2397](bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md) | ✅ | ✅ | 音调去重对 pattern 式音调与 IPA 完全不生效 |
 | [BUG-2393](bugs/BUG-2393-reader-audio-chapter-anchor.md) | ✅ | ✅ | 有声书恢复只定位章节却当作句子恢复成功 |
 | [BUG-2392](bugs/BUG-2392-reader-audio-resume-priority.md) | ✅ | ✅ | 阅读进度异步快照在导航后仍写入位置与统计 |
 | [BUG-2391](bugs/BUG-2391-windows-fullscreen-render-stall.md) | ✅ | ✅ | Windows视频退出全屏后画面停滞需拖动窗口恢复 |

--- a/docs/bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md
+++ b/docs/bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md
@@ -1,6 +1,7 @@
 ## BUG-2397 · 音调去重对 pattern 式音调与 IPA 完全不生效
 - **报告**：2026-09-10（用户：「fushi 音调去重没用」）
-- **真实性**：✅ 真 bug，两条独立根因，都用 node 真执行 `createPitchSection` 复现过：
+- **真实性**：✅ 真 bug，**三条独立根因**（①用 node 真执行 `createPitchSection` 复现，
+  ②③沿真实代码路径定位到具体行）：
   - **根因①** `fushi/assets/popup/popup.js:2903`（去重分支）：`seen` 只收 **数字位置**
     `pitchPositions`，`patterns`（"heiban" 等 pattern 式音调）与 `transcriptions`（IPA 音标）
     一概不参与去重；保活守卫又写成 `group.transcriptions?.length` / `group.patterns?.length`
@@ -24,7 +25,7 @@
     `null == "true"` 判成 `false`。净效果：**设置页显示「开」，系统级弹窗里却是关的**，
     而绝大多数用户从没理由去点一个看起来已经开着的开关。同一处还连累另外两个 Dart 默认为
     `true` 的键（`harmonic_frequency` / `collapse_dictionaries`）。
-- **[x] ① 已修复** — `<pending>`
+- **[x] ① 已修复** — `6dda5c84cd`
   - 根因①：`createPitchSection` 的去重改成**逐类**：`seenPositions` / `seenPatterns` /
     `seenTranscriptions` 三个 Set 各自过滤，保活判据从「原始字段非空」改成「**去重后**
     还剩东西」，`Object.assign` 透传时三类可见条目都换成去重后的那份。三份 popup.js

--- a/docs/bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md
+++ b/docs/bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md
@@ -1,0 +1,72 @@
+## BUG-2397 · 音调去重对 pattern 式音调与 IPA 完全不生效
+- **报告**：2026-09-10（用户：「fushi 音调去重没用」）
+- **真实性**：✅ 真 bug，两条独立根因，都用 node 真执行 `createPitchSection` 复现过：
+  - **根因①** `fushi/assets/popup/popup.js:2903`（去重分支）：`seen` 只收 **数字位置**
+    `pitchPositions`，`patterns`（"heiban" 等 pattern 式音调）与 `transcriptions`（IPA 音标）
+    一概不参与去重；保活守卫又写成 `group.transcriptions?.length` / `group.patterns?.length`
+    这种「**原始**字段非空」，于是第二本词典哪怕一个字都不新，也照样整行渲染出来。
+    上游 BUG-2122 的 `mergeIdenticalPitchGroups` 只接得住「整份 payload 全等」那一种，
+    两本词典只要在任意一个字段上差一点（一本带 IPA、一本不带）合并就不成立，重复
+    全部落到去重这一步——而这一步对这两类视而不见。
+    复现（去重**打开**）：`d1{patterns:['heiban']}` + `d2{patterns:['heiban'],transcriptions:['ɡiꜜtaː']}`
+    → 渲染出 **两行** `[heiban]`；`d1{[1],ipa:X}` + `d2{[0],ipa:X}` → 同一段 IPA 打印 **两遍**。
+  - **根因②** `fushi/lib/src/models/app_model.dart:3252`（`browserExtensionThemeColors`）：
+    这个偏好从未被放进 app 下发给浏览器扩展的 theme 通道，`tools/browser-extension/content.js`
+    也没有任何一处给 `window.deduplicatePitchAccents` 赋值。扩展弹窗与 app 内弹窗跑的是
+    同一份 `popup.js`，它的去重分支读的就是这个全局 → 在扩展里恒 `undefined`（falsy），
+    **浏览器里的音调去重从上线起就没生效过**，与用户在 app 里的设置完全无关。
+  - **根因③** `fushi/android/app/src/main/java/app/fushi/reader/PopupDbReader.kt:202`：
+    Android 原生独立弹窗词典（`:popup` 进程的 `PopupDictActivity`，系统级选词/悬浮查词）
+    自己起 WebView 加载同一份 `popup.js`，偏好由 `readPrefs` 直接读 SQLite `preferences` 表，
+    写法是 `prefs["deduplicate_pitch_accents"] == "true"`。而 Dart 侧
+    `PreferencesRepository.getPref(key, defaultValue: true)`（`preferences_repository.dart:1752`）
+    的默认值**只活在 Dart 内存里、从不落库**——用户没主动点过这个开关时表里根本没有这一行，
+    `null == "true"` 判成 `false`。净效果：**设置页显示「开」，系统级弹窗里却是关的**，
+    而绝大多数用户从没理由去点一个看起来已经开着的开关。同一处还连累另外两个 Dart 默认为
+    `true` 的键（`harmonic_frequency` / `collapse_dictionaries`）。
+- **[x] ① 已修复** — `<pending>`
+  - 根因①：`createPitchSection` 的去重改成**逐类**：`seenPositions` / `seenPatterns` /
+    `seenTranscriptions` 三个 Set 各自过滤，保活判据从「原始字段非空」改成「**去重后**
+    还剩东西」，`Object.assign` 透传时三类可见条目都换成去重后的那份。三份 popup.js
+    镜像（app / 扩展 assets / 扩展 tools）同步，保持逐字节一致。
+  - 根因②：`app_model.dart` 的 theme 字典加 `--fushi-dedup-pitch`（'1'/'0'，非 CSS 变量、
+    仅 JS 消费，与 `--fushi-instant-scroll` 同法），两份 `content.js` 的 `fushiApplyTheme`
+    里据此设 `window.deduplicatePitchAccents`。缺该 key = 旧 app，保持关闭（向后兼容）。
+  - 根因③：`PopupDbReader` 加 `boolPref(prefs, key, default)`，四个布尔偏好全部改走它并
+    **显式写出与 Dart 一致的默认值**（缺行 = 跟 Dart 走默认，只有落库的值才覆盖）；
+    `PopupPrefs` data class 的构造默认值（DB 打不开那一档）一并对齐。
+  - 行为不回归：BUG-2122（五本同 `[1]` 塌成 1 行 5 枚来源药丸）与 TODO-688（纯 IPA 词典
+    在去重下仍渲染 IPA）都在新测试里显式钉住，逐字节不变。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.dart`
+  （+ 同名 `.js` 行为 harness）：
+  - 行为级：node 真执行 `createPitchSection` —— 同 pattern 只显示一次、同 IPA 只显示一次、
+    两个不同数字位置都保留、**关掉开关重复必须回来**（非恒真）、TODO-688 与 BUG-2122 不回归。
+    把三个 Set 里任何一个退回原来的单一 `seen`，对应 case 立刻红（已在上游原文上反向验证：
+    case 1 报 `got 2 copies`）。
+  - 源码级：扫三份 popup.js 镜像，钉住三个 Set、三条 filter、以及「保活判据用去重后的结果」。
+  - 接线级：钉住 `app_model` 下发 `--fushi-dedup-pitch` + **两份** content.js 消费它——
+    根因②那条链路上没有任何行为测试覆盖得到，只能靠这条守卫防它悄悄回来。
+  - 既有 `popup_pitch_transcriptions_test.dart` 的 TODO-688 静态守卫同步升级：判据从
+    「原始 transcriptions 非空」改成「去重后仍有独有 transcriptions」，并逐条钉住三类
+    收窄字段。
+  - 根因③：`fushi/test/pages/popup_native_pref_defaults_guard_test.dart`——从
+    `preferences_repository.dart` 正则抽出每个布尔偏好的 `defaultValue:`，与
+    `PopupDbReader.kt` 里 `boolPref(...)` 的默认值**逐键比对**，再钉住「不许退回裸
+    `== "true"`」和「data class 构造默认值同样对齐」。那条链路跑在独立进程 + 真
+    Android WebView 上，widget 测试够不到，只能在源码层钉不变式。反向验证：把
+    Kotlin 默认值翻成 false，守卫立刻报出 `defaults to true in Dart but false in
+    PopupDbReader`。
+- **备注**：
+  - 相邻缺口（**本次未修，另开**）：扩展侧同样从未赋值的还有 `harmonicFrequency`、
+    `showExpressionTags`、`collapseDictionaries` 等 popup 开关——它们在浏览器里同样恒
+    `undefined`。本次只按用户报告修音调去重，不扩大范围。（根因③那处不同：四个键是
+    **同一个表达式模式、同一次读取**，同一处代码的同一个缺陷，故一并修。）
+  - 制卡侧不受这个开关管（**本次未修**）：`popup.js` 的 `buildMinePayload` →
+    `constructPitchPositionHtml`（1571 行）/ `constructPitchCategories`（1610 行）只跑
+    `mergeIdenticalPitchGroups`，不做屏显那边的跨组位置去重，也不读
+    `window.deduplicatePitchAccents`。两本词典 payload 不全等但标了同一个位置数字时，
+    卡片字段里会出现两个同值 `<li>`。这个开关的 UI 在「查词」设置组、语义是屏显，
+    要不要连制卡一起管是产品决定，不在本次报告范围内。
+  - 观感相邻项（**本次未修**）：`DictionaryPopupWebViewState` 不 watch `appProvider`，
+    在设置页切这个开关后**已经打开**的弹窗不会立即重渲，要等下一次查词才吃到新值
+    （`_pushResults` 只在 `widget.result` 变化时重注入）。属独立的「设置热切换」缺口。

--- a/fushi/android/app/src/main/java/app/fushi/reader/PopupDbReader.kt
+++ b/fushi/android/app/src/main/java/app/fushi/reader/PopupDbReader.kt
@@ -47,9 +47,12 @@ class PopupDbReader {
     data class DictPath(val path: String, val type: String)
 
     data class PopupPrefs(
-        val deduplicatePitch: Boolean = false,
-        val harmonicFrequency: Boolean = false,
-        val collapseDictionaries: Boolean = false,
+        // 这四个的默认值必须与 Dart 侧 PreferencesRepository 的 `defaultValue:` 一致
+        // （lib/src/models/preferences_repository.dart 的同名 getter）——DB 读不出来
+        // 或整个 readPrefs 失败时走的就是这里，读错等于 :popup 进程与主 app 表现相反。
+        val deduplicatePitch: Boolean = true,
+        val harmonicFrequency: Boolean = true,
+        val collapseDictionaries: Boolean = true,
         val showExpressionTags: Boolean = false,
         val globalDictCSS: String = "",
         val customDictCSS: String = "{}",
@@ -177,6 +180,15 @@ class PopupDbReader {
         return collapsed
     }
 
+    /// 读一个布尔偏好：只有 `preferences` 表里真有这一行时才由它说了算，缺行时
+    /// 回落到 [default]（= Dart 侧 PreferencesRepository 同名 getter 的 defaultValue）。
+    /// 见 readPrefs 里的 BUG-2397 说明。
+    private fun boolPref(
+        prefs: Map<String, String>,
+        key: String,
+        default: Boolean,
+    ): Boolean = prefs[key]?.let { it == "true" } ?: default
+
     fun readPrefs(context: Context): PopupPrefs {
         val prefs = mutableMapOf<String, String>()
         var db: SQLiteDatabase? = null
@@ -199,10 +211,16 @@ class PopupDbReader {
         // AppModel.saveDictStyleRules 落下的缓存，见 dict_style_rules.dart。
         val compiledStyleCss = parseCompiledStyleCss(prefs["dict_style_rules_css"])
         return PopupPrefs(
-            deduplicatePitch = prefs["deduplicate_pitch_accents"] == "true",
-            harmonicFrequency = prefs["harmonic_frequency"] == "true",
-            collapseDictionaries = prefs["collapse_dictionaries"] == "true",
-            showExpressionTags = prefs["show_expression_tags"] == "true",
+            // BUG-2397：**不能**写成 `prefs[key] == "true"`。Dart 侧 getPref 的
+            // `defaultValue:` 只活在 Dart 内存里，从不落库——用户没主动点过开关时
+            // `preferences` 表里根本没有这一行。`null == "true"` 判成 false，于是
+            // 设置页明明显示「开」，:popup 进程（系统级选词弹窗）里却是关的：
+            // 音调去重就是这么「没用」的（默认 true 的三个键全中招）。
+            // 缺行 = 跟 Dart 走默认值，只有显式落库的值才覆盖它。
+            deduplicatePitch = boolPref(prefs, "deduplicate_pitch_accents", true),
+            harmonicFrequency = boolPref(prefs, "harmonic_frequency", true),
+            collapseDictionaries = boolPref(prefs, "collapse_dictionaries", true),
+            showExpressionTags = boolPref(prefs, "show_expression_tags", false),
             globalDictCSS = mergeCss(
                 compiledStyleCss.first,
                 prefs["global_dict_css"] ?: "",

--- a/fushi/assets/browser_extension/content.js
+++ b/fushi/assets/browser_extension/content.js
@@ -2558,6 +2558,12 @@ function fushiApplyTheme(c, theme, applyBox) {
   // BUG-2284：墨水屏「瞬时滚动」随 theme 下发（app popupInstantScroll）→ 设同名全局供
   // popup.js 的 wheel 监听器读（滚轮改成每次跳固定距离）。缺该 key = 旧 app，保持关闭。
   window.__fushiPopupInstantScroll = theme['--fushi-instant-scroll'] === '1';
+  // BUG-2397：「音调去重」随 theme 下发（app deduplicatePitchAccents）→ 设同名全局供
+  // popup.js 的 createPitchSection 去重分支读（content/popup 同隔离世界共享 window）。
+  // 扩展侧此前**从未有人给它赋值**，恒 undefined = falsy，于是无论用户在 app 里怎么设，
+  // 浏览器弹窗的音调去重永远是关的（同一个词的同一个调型被每本词典各画一行）。
+  // 缺该 key = 旧 app，保持关闭，与相邻两条同法。
+  window.deduplicatePitchAccents = theme['--fushi-dedup-pitch'] === '1';
   // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
   if (applyBox && fushiHost) {
     // 尺寸真相源是 app 下发的 theme（扩展设置页「查词框大小」写的也是它，经

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -2901,19 +2901,40 @@ function createPitchSection(pitches, reading) {
     const merged = mergeIdenticalPitchGroups(pitches);
     const groups = [];
     if (window.deduplicatePitchAccents) {
-        const seen = new Set();
+        // BUG-2397：去重必须覆盖**三类可见条目**，各自一套 seen。此前只有数字
+        // 位置进 seen，`patterns`（“heiban” 等 pattern 式音调）与 `transcriptions`（IPA）
+        // 一概不管：两本词典都标 heiban、或都给同一段 IPA 时，它们照样各占一行，
+        // 用户看到的就是「开了去重还是重复」。（mergeIdenticalPitchGroups 只能接住整份
+        // payload 全等的那一种；只要两本词典在另一个字段上差一点，合并就不成立，
+        // 重复全部落到这一步。）
+        //
+        // 三类各一个 Set、不合并成一个：位置是数字、另两类是字符串，混在一起
+        // `1` 与 `'1'` 会互相误杀（Set 按 SameValueZero 比，不会相等，但语义上
+        // 把三个值域摆进同一个命名空间本身就是错的）。
+        const seenPositions = new Set();
+        const seenPatterns = new Set();
+        const seenTranscriptions = new Set();
         merged.forEach(group => {
-            const unique = (group.pitchPositions || []).filter(pos => !seen.has(pos));
+            const unique = (group.pitchPositions || []).filter(pos => !seenPositions.has(pos));
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
             // Pattern-style accents (79c55c2) likewise keep the group alive.
-            const hasTranscriptions = group.transcriptions?.length;
-            const hasPatterns = group.patterns?.length;
-            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
-                unique.forEach(pos => seen.add(pos));
-                // 保留合并出来的 `dictionaries`，只把位置换成去重后的那份。
-                groups.push(Object.assign({}, group, { pitchPositions: unique }));
+            // BUG-2397：保活的判据从「原始字段非空」改成「**去重后**还剩东西」——
+            // 前者会把一整行已经显示过的 IPA / pattern 再画一遍。
+            const uniquePatterns = (group.patterns || []).filter(p => !seenPatterns.has(p));
+            const uniqueTranscriptions =
+                (group.transcriptions || []).filter(ipa => !seenTranscriptions.has(ipa));
+            if (unique.length > 0 || uniquePatterns.length > 0 || uniqueTranscriptions.length > 0) {
+                unique.forEach(pos => seenPositions.add(pos));
+                uniquePatterns.forEach(p => seenPatterns.add(p));
+                uniqueTranscriptions.forEach(ipa => seenTranscriptions.add(ipa));
+                // 保留合并出来的 `dictionaries`，只把三类可见条目换成去重后的那份。
+                groups.push(Object.assign({}, group, {
+                    pitchPositions: unique,
+                    patterns: uniquePatterns,
+                    transcriptions: uniqueTranscriptions,
+                }));
             }
         });
     } else {

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -2901,19 +2901,40 @@ function createPitchSection(pitches, reading) {
     const merged = mergeIdenticalPitchGroups(pitches);
     const groups = [];
     if (window.deduplicatePitchAccents) {
-        const seen = new Set();
+        // BUG-2397：去重必须覆盖**三类可见条目**，各自一套 seen。此前只有数字
+        // 位置进 seen，`patterns`（“heiban” 等 pattern 式音调）与 `transcriptions`（IPA）
+        // 一概不管：两本词典都标 heiban、或都给同一段 IPA 时，它们照样各占一行，
+        // 用户看到的就是「开了去重还是重复」。（mergeIdenticalPitchGroups 只能接住整份
+        // payload 全等的那一种；只要两本词典在另一个字段上差一点，合并就不成立，
+        // 重复全部落到这一步。）
+        //
+        // 三类各一个 Set、不合并成一个：位置是数字、另两类是字符串，混在一起
+        // `1` 与 `'1'` 会互相误杀（Set 按 SameValueZero 比，不会相等，但语义上
+        // 把三个值域摆进同一个命名空间本身就是错的）。
+        const seenPositions = new Set();
+        const seenPatterns = new Set();
+        const seenTranscriptions = new Set();
         merged.forEach(group => {
-            const unique = (group.pitchPositions || []).filter(pos => !seen.has(pos));
+            const unique = (group.pitchPositions || []).filter(pos => !seenPositions.has(pos));
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
             // Pattern-style accents (79c55c2) likewise keep the group alive.
-            const hasTranscriptions = group.transcriptions?.length;
-            const hasPatterns = group.patterns?.length;
-            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
-                unique.forEach(pos => seen.add(pos));
-                // 保留合并出来的 `dictionaries`，只把位置换成去重后的那份。
-                groups.push(Object.assign({}, group, { pitchPositions: unique }));
+            // BUG-2397：保活的判据从「原始字段非空」改成「**去重后**还剩东西」——
+            // 前者会把一整行已经显示过的 IPA / pattern 再画一遍。
+            const uniquePatterns = (group.patterns || []).filter(p => !seenPatterns.has(p));
+            const uniqueTranscriptions =
+                (group.transcriptions || []).filter(ipa => !seenTranscriptions.has(ipa));
+            if (unique.length > 0 || uniquePatterns.length > 0 || uniqueTranscriptions.length > 0) {
+                unique.forEach(pos => seenPositions.add(pos));
+                uniquePatterns.forEach(p => seenPatterns.add(p));
+                uniqueTranscriptions.forEach(ipa => seenTranscriptions.add(ipa));
+                // 保留合并出来的 `dictionaries`，只把三类可见条目换成去重后的那份。
+                groups.push(Object.assign({}, group, {
+                    pitchPositions: unique,
+                    patterns: uniquePatterns,
+                    transcriptions: uniqueTranscriptions,
+                }));
             }
         });
     } else {

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -3297,6 +3297,11 @@ class AppModel with ChangeNotifier {
       // content.js fushiRender 读它设 window.__fushiPopupInstantScroll（与 in-app 注入
       // 同名全局），popup.js 的 wheel 监听据此改走固定步长瞬跳。值 '1'/'0'。
       '--fushi-instant-scroll': popupInstantScroll ? '1' : '0',
+      // BUG-2397：「音调去重」下发给扩展 content.js（非 CSS 变量、仅 JS 消费）。扩展弹窗
+      // 与 in-app 弹窗跑同一份 popup.js，而它的去重分支读 `window.deduplicatePitchAccents`：
+      // in-app 由 popup_settings_injection 注入，扩展侧此前没有任何赋值路径，恒 undefined
+      // → 浏览器里的音调去重永远是关的。走 theme 通道与 --fushi-instant-scroll 同法。
+      '--fushi-dedup-pitch': deduplicatePitchAccents ? '1' : '0',
     };
   }
 

--- a/fushi/test/pages/popup_native_pref_defaults_guard_test.dart
+++ b/fushi/test/pages/popup_native_pref_defaults_guard_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2397 根因③：Android 原生独立弹窗词典（`:popup` 进程的 `PopupDictActivity`，
+/// 系统级选词/悬浮查词入口）自己起一个 WebView 加载同一份 `popup.js`，偏好由
+/// `PopupDbReader.readPrefs` 直接读 SQLite `preferences` 表。
+///
+/// 坑在于：Dart 侧 `PreferencesRepository.getPref(key, defaultValue: ...)` 的默认值
+/// **只活在 Dart 内存里，从不落库**——用户没主动点过某个开关时，`preferences` 表里
+/// 根本没有那一行。Kotlin 侧原来写的是 `prefs[key] == "true"`，缺行判成 `false`，
+/// 于是三个 Dart 默认为 `true` 的开关（音调去重 / 调和频率 / 折叠词典）在设置页上
+/// 显示「开」，在系统级弹窗里却全是关的——用户报的「音调去重没用」正是这一档。
+///
+/// 这条链路跑在独立进程 + 真 Android WebView 上，widget 测试够不到，只能在源码层
+/// 钉住不变式：**Kotlin 读到的每个布尔偏好，其缺行默认值必须等于 Dart 同名键的
+/// `defaultValue`**，且不许退回裸 `== "true"` 的写法。
+void main() {
+  final File dartPrefs = File('lib/src/models/preferences_repository.dart');
+  final File kotlinReader =
+      File('android/app/src/main/java/app/fushi/reader/PopupDbReader.kt');
+
+  // Kotlin data class 的构造默认值（DB 打不开 / readPrefs 抛异常时走它）也必须对齐，
+  // 否则「读失败」这一档又会退回相反的行为。字段名 → 偏好键。
+  const Map<String, String> fieldToKey = <String, String>{
+    'deduplicatePitch': 'deduplicate_pitch_accents',
+    'harmonicFrequency': 'harmonic_frequency',
+    'collapseDictionaries': 'collapse_dictionaries',
+    'showExpressionTags': 'show_expression_tags',
+  };
+
+  Map<String, bool> dartDefaults() {
+    final String src = dartPrefs.readAsStringSync();
+    final RegExp re = RegExp(
+      r"getPref\(\s*'([a-z0-9_]+)'\s*,\s*defaultValue:\s*(true|false)\s*\)",
+    );
+    return <String, bool>{
+      for (final RegExpMatch m in re.allMatches(src))
+        m.group(1)!: m.group(2) == 'true',
+    };
+  }
+
+  test('the native popup reader falls back to the SAME defaults as Dart', () {
+    expect(dartPrefs.existsSync(), isTrue);
+    expect(kotlinReader.existsSync(), isTrue);
+
+    final String kt = kotlinReader.readAsStringSync();
+    final Map<String, bool> dart = dartDefaults();
+    expect(
+      dart['deduplicate_pitch_accents'],
+      isNotNull,
+      reason: 'the regex must actually find Dart bool prefs; a silent zero '
+          'match would make this whole guard vacuous',
+    );
+
+    final RegExp re = RegExp(
+      r'boolPref\(prefs,\s*"([a-z0-9_]+)",\s*(true|false)\)',
+    );
+    final Iterable<RegExpMatch> reads = re.allMatches(kt);
+    expect(
+      reads.length,
+      greaterThanOrEqualTo(fieldToKey.length),
+      reason: 'every boolean preference the native popup reads must go through '
+          'boolPref(prefs, key, default)',
+    );
+
+    for (final RegExpMatch m in reads) {
+      final String key = m.group(1)!;
+      final bool ktDefault = m.group(2) == 'true';
+      expect(
+        dart.containsKey(key),
+        isTrue,
+        reason: 'the native popup reads "$key" but Dart has no getPref for it; '
+            'if Dart stopped owning this preference the native side must follow',
+      );
+      expect(
+        ktDefault,
+        dart[key],
+        reason: 'BUG-2397: "$key" defaults to ${dart[key]} in Dart but '
+            '$ktDefault in PopupDbReader. The Dart default never reaches the '
+            'preferences table, so a mismatch means the system-level popup '
+            'behaves the OPPOSITE of what the settings page shows.',
+      );
+    }
+  });
+
+  test('the native popup reader does not read bool prefs with a bare == "true"',
+      () {
+    final String kt = kotlinReader.readAsStringSync();
+    // 裸 `prefs["x"] == "true"` 就是本 bug 的原状：把「这一行不存在」和「用户显式
+    // 关掉了」混为一谈。所有布尔偏好必须走 boolPref 显式声明默认值。
+    final RegExp bare = RegExp(r'prefs\["[a-z0-9_]+"\]\s*==\s*"true"');
+    expect(
+      bare.allMatches(kt).map((RegExpMatch m) => m.group(0)).toList(),
+      isEmpty,
+      reason: 'a bare == "true" read treats a missing row as false, which is '
+          'wrong for every preference whose Dart default is true',
+    );
+  });
+
+  test('PopupPrefs construction defaults match Dart too (DB-failure path)', () {
+    final String kt = kotlinReader.readAsStringSync();
+    final Map<String, bool> dart = dartDefaults();
+    fieldToKey.forEach((String field, String key) {
+      final RegExpMatch? m =
+          RegExp('val $field: Boolean = (true|false)').firstMatch(kt);
+      expect(
+        m,
+        isNotNull,
+        reason: 'PopupPrefs must still declare $field with an explicit default',
+      );
+      expect(
+        m!.group(1) == 'true',
+        dart[key],
+        reason: 'PopupPrefs.$field is the value used when the database cannot '
+            'be opened at all; it must match the Dart default for "$key"',
+      );
+    });
+  });
+}

--- a/fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.dart
+++ b/fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.dart
@@ -1,0 +1,173 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2397：「音调去重」对 pattern 式音调与 IPA 完全不生效，且在浏览器扩展里
+/// **从来没生效过**。
+///
+/// 用户报告：设置里 Deduplicate pitch accents 开着，音高区照样出现一模一样的重复行。
+///
+/// 两条独立根因：
+/// ① `createPitchSection` 的去重分支只把**数字位置**收进 seen，`patterns`
+///    （"heiban" 等 pattern 式音调）与 `transcriptions`（IPA）一概不参与；保活守卫
+///    又用「原始字段非空」，于是第二本词典一个字都不新也照样整行渲染。上游的
+///    `mergeIdenticalPitchGroups` 只接得住「整份 payload 全等」那一种，两本词典
+///    只要差一个字段（一本带 IPA、一本不带）就合并不了，重复全落到去重这一步。
+/// ② 浏览器扩展里 `window.deduplicatePitchAccents` **从未有人赋值**：这个偏好没被
+///    放进 app 下发给扩展的 theme 通道，扩展 content.js 也没有消费它，于是恒
+///    undefined = falsy，去重分支恒不执行——用户在 app 里怎么设都没用。
+///
+/// 三层守护：
+/// ① 行为级——用 Node 真执行 popup.js 的 `createPitchSection`（见同名 .js）。
+/// ② 源码级——扫描**三份 popup.js 镜像**，钉住三类可见条目各自入 seen、保活判据
+///    用去重后的结果。无 node 时也能守住回归。
+/// ③ 接线级——钉住 app 侧下发 `--fushi-dedup-pitch` 与**两份** content.js 消费它，
+///    否则根因②会悄悄回来（那条链路上没有任何行为测试能覆盖）。
+void main() {
+  const Map<String, String> jsMirrors = <String, String>{
+    'app popup': 'assets/popup/popup.js',
+    'extension vendor (assets)': 'assets/browser_extension/vendor/popup.js',
+    'extension vendor (tools)': '../tools/browser-extension/vendor/popup.js',
+  };
+  const Map<String, String> contentMirrors = <String, String>{
+    'extension content (assets)': 'assets/browser_extension/content.js',
+    'extension content (tools)': '../tools/browser-extension/content.js',
+  };
+
+  test(
+    'pattern accents and IPA transcriptions are deduplicated across dictionaries '
+    '(executes createPitchSection via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+            'node not found on PATH; skipping JS behavior execution');
+        return;
+      }
+
+      final File jsTest =
+          File('test/pages/popup_pitch_dedup_patterns_ipa_test.js');
+      expect(
+        jsTest.existsSync(),
+        isTrue,
+        reason: 'behavior harness ${jsTest.path} must exist',
+      );
+
+      final ProcessResult result = await Process.run(
+        nodeExe,
+        <String>[jsTest.path],
+        workingDirectory: Directory.current.path,
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'pitch dedup (patterns / IPA) JS behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(
+        result.stdout.toString(),
+        contains('all assertions passed'),
+        reason: 'behavior harness must reach its success marker',
+      );
+    },
+  );
+
+  jsMirrors.forEach((String name, String relPath) {
+    test('[$name] pitch dedup covers positions, patterns AND transcriptions',
+        () {
+      final File file = File(relPath);
+      expect(file.existsSync(), isTrue, reason: '$relPath must exist');
+      final String js = file.readAsStringSync();
+
+      final int dedup = js.indexOf('if (window.deduplicatePitchAccents)');
+      expect(dedup, greaterThanOrEqualTo(0),
+          reason: 'the dedup branch must exist');
+
+      // 三类可见条目各有自己的 seen。少一个 = 那一类永远不去重（本 bug 的原状）。
+      for (final String seen in <String>[
+        'const seenPositions = new Set();',
+        'const seenPatterns = new Set();',
+        'const seenTranscriptions = new Set();',
+      ]) {
+        expect(
+          js.indexOf(seen, dedup),
+          greaterThan(dedup),
+          reason: 'the dedup branch must keep a dedicated set: $seen',
+        );
+      }
+
+      // 非恒真：三个 Set 建了却没人过滤等于没改。三类都必须真的按 seen 过滤。
+      for (final String filter in <String>[
+        '.filter(pos => !seenPositions.has(pos))',
+        '.filter(p => !seenPatterns.has(p))',
+        '.filter(ipa => !seenTranscriptions.has(ipa))',
+      ]) {
+        expect(
+          js.indexOf(filter, dedup),
+          greaterThan(dedup),
+          reason: 'each class of visible entry must be filtered: $filter',
+        );
+      }
+
+      // 保活判据必须是「去重后还剩东西」。写成原始字段非空（`group.patterns?.length`）
+      // 的那一刻，一整行已经显示过的 pattern / IPA 又会被画第二遍。
+      final int guard = js.indexOf(
+        'if (unique.length > 0 || uniquePatterns.length > 0 || '
+        'uniqueTranscriptions.length > 0)',
+        dedup,
+      );
+      expect(
+        guard,
+        greaterThan(dedup),
+        reason: 'the keep-alive guard must test the DEDUPED entries, not the '
+            'raw fields — testing the raw fields is exactly BUG-2397',
+      );
+    });
+  });
+
+  test('the pitch dedup preference is wired through to the browser extension',
+      () {
+    // 根因②的守卫。app 侧把偏好放进查词响应的 theme 字典（非 CSS 变量、仅 JS 消费，
+    // 与 --fushi-instant-scroll 同法），扩展 content.js 据此设 popup.js 读的全局。
+    final String appModel =
+        File('lib/src/models/app_model.dart').readAsStringSync();
+    expect(
+      appModel,
+      contains("'--fushi-dedup-pitch': deduplicatePitchAccents ? '1' : '0',"),
+      reason:
+          'app_model must send the pitch-dedup preference to the extension; '
+          'without it window.deduplicatePitchAccents is undefined in the '
+          'browser and the dedup branch never runs',
+    );
+
+    contentMirrors.forEach((String name, String relPath) {
+      final File file = File(relPath);
+      expect(file.existsSync(), isTrue, reason: '$relPath must exist');
+      expect(
+        file.readAsStringSync(),
+        contains(
+            "window.deduplicatePitchAccents = theme['--fushi-dedup-pitch'] === '1';"),
+        reason: '[$name] content.js must publish the preference on the shared '
+            'window that popup.js reads',
+      );
+    });
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates =
+      Platform.isWindows ? <String>['node.exe', 'node'] : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) {
+        return name;
+      }
+    } on ProcessException {
+      // Not found; try next candidate.
+    }
+  }
+  return null;
+}

--- a/fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.js
+++ b/fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.js
@@ -1,0 +1,129 @@
+// BUG-2397 behavior test: 「音调去重」对 pattern 式音调与 IPA 完全不生效。
+//
+// 用户报告：设置里「Deduplicate pitch accents」开着，音高区照样出现一模一样的重复行。
+//
+// 根因：createPitchSection 的去重分支只把**数字位置**（pitchPositions）收进 seen，
+// `patterns`（"heiban" 等 pattern 式音调）与 `transcriptions`（IPA 音标）一概不参与去重，
+// 而且「保活守卫」用的是「原始字段非空」——于是第二本词典即使一个字都不新，也照样整行
+// 渲染出来。上游的 mergeIdenticalPitchGroups 只能接住「整份 payload 全等」的那一种；
+// 两本词典只要在任意一个字段上差一点（一本带 IPA、一本不带），合并就不成立，重复
+// 全部落到去重这一步，而这一步以前对这两类视而不见。
+//
+// 本测试 EXECUTES 真实的 popup.js（vm + 极简假 DOM），驱动真实的 createPitchSection，
+// 然后在产出的元素树里数「同一个可见条目出现了几次」。把三个 seen 里的任何一个退回
+// 原来的单一 seen，对应 case 立刻变红。
+//
+// Cases covered:
+//   1. 两本词典同标 pattern `heiban`、其中一本另带 IPA（合并不成立）→ `[heiban]` 只出现一次。
+//   2. 两本词典给出同一段 IPA、数字位置不同（合并不成立）→ 该 IPA 只出现一次，两个位置都在。
+//   3. 去重关闭时，重复的 pattern / IPA 全部保留（开关必须仍然有意义，非恒真）。
+//   4. 不回归 TODO-688：唯一的 IPA-only 词典（无数字位置）仍然渲染出它的 IPA。
+//   5. 不回归 BUG-2122：五本同标 [1] 的词典塌成 1 行、5 枚来源药丸。
+//
+// Run: node fushi/test/pages/popup_pitch_dedup_patterns_ipa_test.js
+// (also driven from popup_pitch_dedup_patterns_ipa_test.dart so it executes inside
+//  `flutter test`).
+
+const assert = require('assert');
+const {
+  loadPopup,
+  collectByClass,
+  collectText,
+} = require('./_popup_dom_host.js');
+
+function dict(name, positions, patterns, transcriptions) {
+  return {
+    dictionary: name,
+    pitchPositions: positions || [],
+    patterns: patterns || [],
+    transcriptions: transcriptions || [],
+  };
+}
+
+function render(pitches, dedup, reading) {
+  const sb = loadPopup();
+  sb.window.deduplicatePitchAccents = dedup;
+  return sb.window.__test.createPitchSection(pitches, reading || 'ギター');
+}
+
+// 整棵树里某段可见文本出现了几次。pattern 式音调渲染成裸文本节点 `[heiban]`，
+// IPA 渲染成 .pitch-transcription-tag 的 `[ipa]`——数「用户眼睛看到几次」，
+// 所以统一在文本层数，而不是数元素类型。
+function occurrences(section, needle) {
+  const text = collectText(section);
+  let count = 0;
+  let from = 0;
+  for (;;) {
+    const at = text.indexOf(needle, from);
+    if (at < 0) return count;
+    count += 1;
+    from = at + needle.length;
+  }
+}
+
+function ipaTags(section) {
+  return collectByClass(section, 'pitch-transcription-tag').map(n => n.textContent);
+}
+
+(function run() {
+  // Case 1: 用户报告的主形态——两本词典都说 heiban，其中一本另带 IPA。
+  // 整份 payload 不全等 ⇒ mergeIdenticalPitchGroups 合并不了 ⇒ 全靠去重这一步。
+  {
+    const section = render(
+      [dict('d1', [], ['heiban']), dict('d2', [], ['heiban'], ['ɡiꜜtaː'])],
+      true,
+    );
+    assert.ok(section, 'pattern-only pitch groups must still render a section');
+    const heiban = occurrences(section, '[heiban]');
+    assert.strictEqual(heiban, 1,
+      'with dedup ON, the same pattern accent must be shown ONCE across '
+        + 'dictionaries; got ' + heiban + ' copies');
+    // 第二本词典独有的 IPA 不能被误杀——去重删的是重复，不是整行。
+    assert.deepStrictEqual(ipaTags(section), ['[ɡiꜜtaː]'],
+      'the second dictionary\'s unique IPA must survive dedup');
+  }
+
+  // Case 2: 两本 IPA 词典给出同一串音标，数字位置不同（同样合并不了）。
+  {
+    const section = render(
+      [dict('d1', [1], [], ['ɡiꜜtaː']), dict('d2', [0], [], ['ɡiꜜtaː'])],
+      true,
+    );
+    assert.deepStrictEqual(ipaTags(section), ['[ɡiꜜtaː]'],
+      'with dedup ON, an identical IPA transcription must be shown ONCE');
+    // 两个数字位置都是新的，必须都留下（去重不是「只留第一本词典」）。
+    const text = collectText(section);
+    assert.ok(text.includes('[1]') && text.includes('[0]'),
+      'both distinct pitch positions must survive; got: ' + text);
+  }
+
+  // Case 3: 非恒真——关掉开关，重复必须回来。否则上面两条即使去重代码整块删掉也能过。
+  {
+    const section = render(
+      [dict('d1', [], ['heiban']), dict('d2', [], ['heiban'], ['ɡiꜜtaː'])],
+      false,
+    );
+    assert.strictEqual(occurrences(section, '[heiban]'), 2,
+      'with dedup OFF the duplicate pattern must still be rendered twice '
+        + '(otherwise the setting would be meaningless)');
+  }
+
+  // Case 4: TODO-688 不回归——纯 IPA 词典（无数字位置）在去重打开时仍要渲染 IPA。
+  {
+    const section = render([dict('d1', [1]), dict('ipa', [], [], ['neꜜko'])], true);
+    assert.deepStrictEqual(ipaTags(section), ['[neꜜko]'],
+      'an IPA-only dictionary must still render under dedup (TODO-688)');
+  }
+
+  // Case 5: BUG-2122 不回归——五本同标 [1] 塌成一行、五枚来源药丸。
+  {
+    const five = ['d1', 'd2', 'd3', 'd4', 'd5'].map(n => dict(n, [1]));
+    const section = render(five, true);
+    assert.strictEqual(collectByClass(section, 'pitch-group').length, 1,
+      'five dictionaries agreeing on [1] must stay collapsed into one row');
+    assert.strictEqual(collectByClass(section, 'pitch-dict-label').length, 5,
+      'all five source labels must survive (BUG-2122)');
+  }
+
+  console.log('all assertions passed');
+})();

--- a/fushi/test/pages/popup_pitch_transcriptions_test.dart
+++ b/fushi/test/pages/popup_pitch_transcriptions_test.dart
@@ -99,28 +99,45 @@ void main() {
     expect(dedup, greaterThanOrEqualTo(0));
     // BUG-2122 起合并跑在去重之前，去重分支遍历的是合并结果 `group`（此前是原始
     // `pitch`）。判据钉的是「IPA-only 组在去重分支里被保住」，与变量名无关。
-    final int hasTranscriptions = js.indexOf('.transcriptions?.length', dedup);
+    //
+    // BUG-2397 起判据再升一级：保活条件不能是「原始 transcriptions 非空」，必须是
+    // 「**去重后**还剩 transcriptions」。前者会把一段已经显示过的 IPA 再画一遍
+    // （两本 IPA 词典给同一串音标 = 用户看到两行一样的），后者既保住真正独有的
+    // IPA-only 组，又不放过重复。
+    final int keptByUniqueIpa =
+        js.indexOf('uniqueTranscriptions.length > 0', dedup);
     expect(
-      hasTranscriptions,
+      keptByUniqueIpa,
       greaterThan(dedup),
-      reason:
-          'the dedup branch must keep IPA-only groups (transcriptions guard)',
+      reason: 'the dedup branch must keep groups that still have UNIQUE '
+          'transcriptions after dedup (IPA-only dicts), not groups whose raw '
+          'transcriptions are merely non-empty',
     );
     // 判据从「逐字段列出 transcriptions」升级成「整组透传」：BUG-2122 之后去重分支
-    // 拿到的是合并结果，用 `Object.assign({}, group, {pitchPositions: unique})`
-    // 只替换位置、其余字段（transcriptions / patterns / dictionaries）**按构造**全部
-    // 保留。这比列举字段更强——将来再加字段也不会被悄悄漏掉。
-    final int forwarded = js.indexOf(
-      'Object.assign({}, group, { pitchPositions: unique })',
-      dedup,
-    );
+    // 拿到的是合并结果，用 `Object.assign({}, group, {...})` 只替换**可见条目**、
+    // 其余字段（dictionaries 等）按构造全部保留。这比列举字段更强——将来再加字段
+    // 也不会被悄悄漏掉。BUG-2397 起被收窄的可见条目是三类而非一类。
+    final int forwarded = js.indexOf('Object.assign({}, group, {', dedup);
     expect(
       forwarded,
       greaterThan(dedup),
       reason: 'the dedup branch must pass the merged group through intact '
-          '(only pitchPositions may be narrowed), or transcriptions / patterns '
-          '/ source labels get dropped',
+          '(only the visible entries may be narrowed), or transcriptions / '
+          'patterns / source labels get dropped',
     );
+    for (final String narrowed in <String>[
+      'pitchPositions: unique,',
+      'patterns: uniquePatterns,',
+      'transcriptions: uniqueTranscriptions,',
+    ]) {
+      expect(
+        js.indexOf(narrowed, forwarded),
+        greaterThan(forwarded),
+        reason: 'BUG-2397: the dedup branch must forward the deduped $narrowed '
+            '— a class of visible entry that is not narrowed here is a class '
+            'that never gets deduplicated at all',
+      );
+    }
   });
 }
 

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -2558,6 +2558,12 @@ function fushiApplyTheme(c, theme, applyBox) {
   // BUG-2284：墨水屏「瞬时滚动」随 theme 下发（app popupInstantScroll）→ 设同名全局供
   // popup.js 的 wheel 监听器读（滚轮改成每次跳固定距离）。缺该 key = 旧 app，保持关闭。
   window.__fushiPopupInstantScroll = theme['--fushi-instant-scroll'] === '1';
+  // BUG-2397：「音调去重」随 theme 下发（app deduplicatePitchAccents）→ 设同名全局供
+  // popup.js 的 createPitchSection 去重分支读（content/popup 同隔离世界共享 window）。
+  // 扩展侧此前**从未有人给它赋值**，恒 undefined = falsy，于是无论用户在 app 里怎么设，
+  // 浏览器弹窗的音调去重永远是关的（同一个词的同一个调型被每本词典各画一行）。
+  // 缺该 key = 旧 app，保持关闭，与相邻两条同法。
+  window.deduplicatePitchAccents = theme['--fushi-dedup-pitch'] === '1';
   // BUG-688：尺寸盒 + zoom 落到 host（视口坐标，确定宽度 → header 满宽、按钮右推、不再全屏铺开）。
   if (applyBox && fushiHost) {
     // 尺寸真相源是 app 下发的 theme（扩展设置页「查词框大小」写的也是它，经

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2901,19 +2901,40 @@ function createPitchSection(pitches, reading) {
     const merged = mergeIdenticalPitchGroups(pitches);
     const groups = [];
     if (window.deduplicatePitchAccents) {
-        const seen = new Set();
+        // BUG-2397：去重必须覆盖**三类可见条目**，各自一套 seen。此前只有数字
+        // 位置进 seen，`patterns`（“heiban” 等 pattern 式音调）与 `transcriptions`（IPA）
+        // 一概不管：两本词典都标 heiban、或都给同一段 IPA 时，它们照样各占一行，
+        // 用户看到的就是「开了去重还是重复」。（mergeIdenticalPitchGroups 只能接住整份
+        // payload 全等的那一种；只要两本词典在另一个字段上差一点，合并就不成立，
+        // 重复全部落到这一步。）
+        //
+        // 三类各一个 Set、不合并成一个：位置是数字、另两类是字符串，混在一起
+        // `1` 与 `'1'` 会互相误杀（Set 按 SameValueZero 比，不会相等，但语义上
+        // 把三个值域摆进同一个命名空间本身就是错的）。
+        const seenPositions = new Set();
+        const seenPatterns = new Set();
+        const seenTranscriptions = new Set();
         merged.forEach(group => {
-            const unique = (group.pitchPositions || []).filter(pos => !seen.has(pos));
+            const unique = (group.pitchPositions || []).filter(pos => !seenPositions.has(pos));
             // TODO-688: a group with no unique pitch positions but with IPA
             // transcriptions (Yomitan `ipa`-mode dicts have no pitch positions)
             // must still render, or the transcriptions are silently dropped.
             // Pattern-style accents (79c55c2) likewise keep the group alive.
-            const hasTranscriptions = group.transcriptions?.length;
-            const hasPatterns = group.patterns?.length;
-            if (unique.length > 0 || hasTranscriptions || hasPatterns) {
-                unique.forEach(pos => seen.add(pos));
-                // 保留合并出来的 `dictionaries`，只把位置换成去重后的那份。
-                groups.push(Object.assign({}, group, { pitchPositions: unique }));
+            // BUG-2397：保活的判据从「原始字段非空」改成「**去重后**还剩东西」——
+            // 前者会把一整行已经显示过的 IPA / pattern 再画一遍。
+            const uniquePatterns = (group.patterns || []).filter(p => !seenPatterns.has(p));
+            const uniqueTranscriptions =
+                (group.transcriptions || []).filter(ipa => !seenTranscriptions.has(ipa));
+            if (unique.length > 0 || uniquePatterns.length > 0 || uniqueTranscriptions.length > 0) {
+                unique.forEach(pos => seenPositions.add(pos));
+                uniquePatterns.forEach(p => seenPatterns.add(p));
+                uniqueTranscriptions.forEach(ipa => seenTranscriptions.add(ipa));
+                // 保留合并出来的 `dictionaries`，只把三类可见条目换成去重后的那份。
+                groups.push(Object.assign({}, group, {
+                    pitchPositions: unique,
+                    patterns: uniquePatterns,
+                    transcriptions: uniqueTranscriptions,
+                }));
             }
         });
     } else {


### PR DESCRIPTION
用户报「音调去重没用」：设置里 **Deduplicate pitch accents** 开着，音高区照样出现一模一样的重复行。

沿真实代码路径查下来是**三条独立根因**，三条都会单独造成「开了没用」，所以一起修。

## 根因与修法

### ① 去重只管数字位置，pattern 式音调与 IPA 完全不参与
`fushi/assets/popup/popup.js` 的 `createPitchSection`：`seen` 只收 `pitchPositions`，`patterns`（`heiban` 等）与 `transcriptions`（IPA）一概不管；保活守卫又写成「**原始**字段非空」（`group.patterns?.length`），于是第二本词典哪怕一个字都不新，也照样整行渲染。

BUG-2122 的 `mergeIdenticalPitchGroups` 只接得住「整份 payload 全等」那一种——两本词典只要在任意一个字段上差一点（一本带 IPA、一本不带），合并就不成立，重复全部落到去重这一步。

用 node 真执行 `createPitchSection` 复现（去重**打开**）：
- `d1{patterns:['heiban']}` + `d2{patterns:['heiban'],transcriptions:['ɡiꜜtaː']}` → 渲染出**两行** `[heiban]`
- `d1{[1],ipa:X}` + `d2{[0],ipa:X}` → 同一段 IPA 打印**两遍**

**修**：改成三类各一套 `seen`（位置 / pattern / IPA），保活判据换成「**去重后**还剩东西」，`Object.assign` 透传时三类可见条目都换成去重后的那份。三份 popup.js 镜像同步，保持逐字节一致。

### ② 浏览器扩展里这个开关从未被下发
扩展弹窗与 app 内弹窗跑同一份 `popup.js`，去重分支读 `window.deduplicatePitchAccents`——in-app 由 `popup_settings_injection` 注入，**扩展侧从未有人赋值**：这个偏好没进 `AppModel.browserExtensionThemeColors()` 的 theme 通道，`content.js` 也没消费它。于是在浏览器里恒 `undefined`（falsy），**去重从上线起就没生效过**，与用户在 app 里的设置无关。

**修**：theme 字典加 `--fushi-dedup-pitch`（`'1'/'0'`，非 CSS 变量、仅 JS 消费，与既有的 `--fushi-instant-scroll` 同法），两份 `content.js` 的 `fushiApplyTheme` 据此设同名全局。缺该 key = 旧 app，保持关闭（向后兼容）。

### ③ Android 原生弹窗词典把「缺行」读成 false，与 Dart 默认值相反
`PopupDbReader.readPrefs` 用 `prefs["deduplicate_pitch_accents"] == "true"` 读偏好；而 Dart 侧 `getPref(key, defaultValue: true)` 的默认值**只活在内存里、从不落库**——用户没主动点过这个开关时 `preferences` 表里根本没有这一行，`null == "true"` 判成 `false`。

净效果：**设置页显示「开」，`:popup` 进程（系统级选词/悬浮查词）里却是关的**，而绝大多数用户从没理由去点一个看起来已经开着的开关。同一处还连累另外两个 Dart 默认为 `true` 的键（`harmonic_frequency` / `collapse_dictionaries`）。

**修**：加 `boolPref(prefs, key, default)`，四个布尔偏好全部改走它并显式写出与 Dart 一致的默认值；`PopupPrefs` data class 的构造默认值（DB 打不开那一档）一并对齐。

## 测试

- `test/pages/popup_pitch_dedup_patterns_ipa_test.dart` + 同名 `.js`
  - 行为级（node 真执行 `createPitchSection`）：同 pattern 只显示一次、同 IPA 只显示一次、两个不同位置都保留、**关掉开关重复必须回来**（非恒真）、TODO-688 与 BUG-2122 不回归
  - 源码级：扫三份 popup.js 镜像，钉住三个 Set、三条 filter、保活判据用去重后的结果
  - 接线级：钉住 app 下发 `--fushi-dedup-pitch` + 两份 content.js 消费它（根因②那条链路没有行为测试覆盖得到）
- `test/pages/popup_native_pref_defaults_guard_test.dart`：从 `preferences_repository.dart` 正则抽出每个布尔偏好的 `defaultValue:`，与 `PopupDbReader.kt` 的 `boolPref(...)` 默认值逐键比对；并钉住「不许退回裸 `== \"true\"`」「data class 构造默认值同样对齐」
- 既有 `popup_pitch_transcriptions_test.dart` 的 TODO-688 静态守卫同步升级

**反向验证**（两条都做过）：把 popup.js 还原成本分支基点，新测试立刻报 `got 2 copies`；把 Kotlin 默认值翻成 `false`，守卫报 `defaults to true in Dart but false in PopupDbReader`。

**验证结果**：`flutter analyze` 全量 0 issue；相关定向测试 20 条全绿；`:app:compileDebugKotlin` 通过。

## 本次故意没做

- 扩展侧同样从未赋值的还有 `harmonicFrequency` / `showExpressionTags` / `collapseDictionaries` 等 popup 开关——同类缺口，但不在本次报告范围内。（根因③那四个键不同：同一个表达式、同一次读取、同一处代码的同一个缺陷，故一并修。）
- 制卡侧（`constructPitchPositionHtml` / `constructPitchCategories`）不读这个开关，卡片字段里仍可能出现同值重复 `<li>`。这个开关的 UI 在「查词」组、语义是屏显，要不要连制卡一起管是产品决定。
- `DictionaryPopupWebViewState` 不 watch `appProvider`，切开关后**已经打开**的弹窗要等下一次查词才吃到新值。独立的「设置热切换」缺口。

详见 `docs/bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md`。

https://claude.ai/code/session_01Nzey3mmZnXajhKnuBbGxVR