### PR TITLE
fix(reader): 防止跨章节晚到进度污染阅读速度和位置

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2181 条。点号进各自文件。
+> 共 2182 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2399](bugs/BUG-2399-reader-chapter-stale-progress.md) | ✅ | ✅ | 小说跨章节晚到进度污染阅读字数和速度 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |

--- a/docs/bugs/BUG-2399-reader-chapter-stale-progress.md
+++ b/docs/bugs/BUG-2399-reader-chapter-stale-progress.md
@@ -1,0 +1,6 @@
+## BUG-2399 · 小说跨章节晚到进度污染阅读字数和速度
+- **报告**：2026-09-10（用户：小说越过新章节时速度直接变成100多万）
+- **真实性**：✅ 真 bug（代码路径确认）；`fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart:1074` 的 `_refreshProgress` 在 JS 往返前检查恢复状态，返回后原来只检查 mounted。请求途中跨章或重载后，旧文档的章内起止偏移会按新 `_currentChapter` 换算，污染账本、阅读速度及恢复锚。同文件 `_syncPositionFromWebViewProgress` 和 `chrome.part.dart` 的 `_reloadWithCurrentSettings` 也消费无文档身份校验的晚到快照。
+- **[x] ① 已修复** — 三个入口捕获请求时的 controller、章节和导航代次，返回后先核对再消费；统计入口还复核恢复/歌词状态。实现提交见本文件所在 Git 提交。StudyClock 和速度公式未改，未设置速度上限。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/reader_read_ledger_wiring_guard_static_test.dart` 新增四项源码接线守卫，覆盖身份捕获和消费前拒绝；原有恢复锚错误边界守卫同步变量名。统计基础回归119项、阅读器扩展回归281项通过；flutter analyze --no-pub 无问题。
+- **备注**：尚未取得用户的平台、版本和原书复现路径，未完成真实设备跨章节复测；确认的是晚到快照竞态，不能据此断言用户的百万速度已在设备上消失。初次测试因 GitHub PDFium 依赖下载失败而零执行，配置本机代理后正常通过。不修改既有统计数据。

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -2124,19 +2124,31 @@ extension _ReaderChrome on _ReaderFushiPageState {
       await _loadLyricsPage();
       return;
     }
+    final InAppWebViewController controller = _controller!;
+    final int generation = _navigateGeneration;
+    final int chapter = _currentChapter;
     final dynamic result;
     try {
-      result = await _controller!.evaluateJavascript(
+      result = await controller.evaluateJavascript(
         source: ReaderPaginationScripts.stableProgressInvocation(),
       );
     } catch (e, stack) {
       // 半销毁的 WebView 上 evaluateJavascript 抛 PlatformException；此处尚未改
       // 任何恢复状态，安全 no-op 返回（此前这是 try 块外的孤儿 await，会逃 zone）。
-      ErrorLogService.instance
-          .log('ReaderFushi.reloadWithCurrentSettings.eval', e, stack);
+      ErrorLogService.instance.log(
+        'ReaderFushi.reloadWithCurrentSettings.eval',
+        e,
+        stack,
+      );
       return;
     }
-    if (!mounted || _controller == null) return;
+    if (!mounted ||
+        generation != _navigateGeneration ||
+        chapter != _currentChapter ||
+        !identical(controller, _controller) ||
+        _lyricsMode) {
+      return;
+    }
     final ReaderStableProgressDetails? snapshot =
         parseReaderStableProgressDetails(result);
     final bool hasSameChapterCache = _lastProgressSection == _currentChapter;
@@ -2144,7 +2156,8 @@ extension _ReaderChrome on _ReaderFushiPageState {
         snapshot?.progress ?? (hasSameChapterCache ? _lastProgressValue : 0.0);
     // BUG-162 / TODO-219: reload 是同章程序化重建，优先沿用稳定精确锚；
     // stable gate 暂时不给快照时保留同章缓存，避免把瞬态章首 0 当新位置。
-    _initialCharOffset = snapshot?.charOffset ??
+    _initialCharOffset =
+        snapshot?.charOffset ??
         (hasSameChapterCache ? _lastProgressCharOffset : -1);
     _lastProgressSection = _currentChapter;
     _lastProgressValue = _initialProgress;
@@ -2157,9 +2170,11 @@ extension _ReaderChrome on _ReaderFushiPageState {
     }
     _restoreCompleter = Completer<bool>();
     _restoreInFlight = true;
-    debugPrint('[ReaderFushi] reloadWithCurrentSettings: '
-        'chapter=$_currentChapter progress=$_initialProgress '
-        'generation=$gen continuous=${_settings?.isContinuousMode}');
+    debugPrint(
+      '[ReaderFushi] reloadWithCurrentSettings: '
+      'chapter=$_currentChapter progress=$_initialProgress '
+      'generation=$gen continuous=${_settings?.isContinuousMode}',
+    );
 
     _rebuild(() {
       _readerContentReady = false;
@@ -2169,8 +2184,11 @@ extension _ReaderChrome on _ReaderFushiPageState {
     try {
       await _loadChapterDirectly(_currentChapter);
     } catch (e, stack) {
-      ErrorLogService.instance
-          .log('ReaderFushi.reloadWithCurrentSettings', e, stack);
+      ErrorLogService.instance.log(
+        'ReaderFushi.reloadWithCurrentSettings',
+        e,
+        stack,
+      );
       debugPrint('[ReaderFushi] reloadWithCurrentSettings failed: $e');
       _restoreInFlight = false;
       if (_restoreCompleter != null && !_restoreCompleter!.isCompleted) {

--- a/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/navigation.part.dart
@@ -1078,9 +1078,12 @@ extension _ReaderNavigation on _ReaderFushiPageState {
     // （_onRestoreComplete）与失败（_failNavigation / reload catch）都清旗，之后的
     // 首发刷新、onReanchorSettled 补刷都在清旗之后到达，不受这条门影响。
     if (_controller == null || _lyricsMode || _restoreInFlight) return;
+    final InAppWebViewController controller = _controller!;
+    final int generation = _navigateGeneration;
+    final int chapter = _currentChapter;
     final dynamic result;
     try {
-      result = await _controller!.evaluateJavascript(
+      result = await controller.evaluateJavascript(
         source: ReaderPaginationScripts.stableProgressInvocation(),
       );
     } catch (e, stack) {
@@ -1095,6 +1098,17 @@ extension _ReaderNavigation on _ReaderFushiPageState {
         e,
         stack,
       );
+      return;
+    }
+    // JS 往返期间可能已经翻章、重载或替换 WebView。旧文档的章内偏移不能
+    // 按新章的累计字数入账，也不能覆盖新章恢复锚/落库位置。代际同时拦住
+    // A → B → A 和同章重载，不能只检查章号或此刻是否仍在恢复。
+    if (!mounted ||
+        generation != _navigateGeneration ||
+        chapter != _currentChapter ||
+        !identical(controller, _controller) ||
+        _restoreInFlight ||
+        _lyricsMode) {
       return;
     }
     if (result == null) {
@@ -1243,9 +1257,12 @@ extension _ReaderNavigation on _ReaderFushiPageState {
       return;
     }
 
+    final InAppWebViewController controller = _controller!;
+    final int generation = _navigateGeneration;
+    final int chapter = _currentChapter;
     final dynamic result;
     try {
-      result = await _controller!.evaluateJavascript(
+      result = await controller.evaluateJavascript(
         source: ReaderPaginationScripts.stableProgressInvocation(),
       );
     } catch (e, stack) {
@@ -1257,7 +1274,16 @@ extension _ReaderNavigation on _ReaderFushiPageState {
       debugPrint('[ReaderFushi] syncPositionFromWebViewProgress failed: $e');
       return;
     }
-    if (!mounted) return;
+    // 退出/后台刷新同样不能把旧文档快照写进新章节的恢复锚。
+    if (!mounted ||
+        generation != _navigateGeneration ||
+        chapter != _currentChapter ||
+        !identical(controller, _controller) ||
+        _restoreInFlight ||
+        _lyricsMode ||
+        !_readerContentReady) {
+      return;
+    }
 
     final ReaderStableProgressDetails? snapshot =
         parseReaderStableProgressDetails(result);

--- a/fushi/test/reader/reader_read_ledger_wiring_guard_static_test.dart
+++ b/fushi/test/reader/reader_read_ledger_wiring_guard_static_test.dart
@@ -28,11 +28,89 @@ void main() {
   final String corpus = readReaderPageSource();
   final String masked = maskComments(corpus);
 
+  for (final String method in <String>[
+    'Future<void> _syncPositionFromWebViewProgress() async',
+    'Future<void> _reloadWithCurrentSettings() async',
+  ]) {
+    test('$method 不把旧文档快照写进新章恢复锚', () {
+      final String code = maskComments(methodBody(corpus, method));
+      final int request = code.indexOf('await controller.evaluateJavascript(');
+      expect(request, isNonNegative);
+      for (final String capture in <String>[
+        'final InAppWebViewController controller = _controller!;',
+        'final int generation = _navigateGeneration;',
+        'final int chapter = _currentChapter;',
+      ]) {
+        expect(code.indexOf(capture), inInclusiveRange(0, request - 1));
+      }
+      final int gate = code.indexOf('if (!mounted ||', request);
+      expect(gate, greaterThan(request));
+      final int gateEnd = code.indexOf('}', gate);
+      final String guard = code.substring(gate, gateEnd);
+      for (final String rejection in <String>[
+        'generation != _navigateGeneration',
+        'chapter != _currentChapter',
+        '!identical(controller, _controller)',
+        '_lyricsMode',
+        'return;',
+      ]) {
+        expect(guard, contains(rejection));
+      }
+      expect(
+        code.indexOf('parseReaderStableProgressDetails(result)'),
+        greaterThan(gateEnd),
+      );
+    });
+  }
+
   group('arrive：_refreshProgress 是唯一记字入口', () {
     final String body = methodBody(
       corpus,
       'Future<void> _refreshProgress() async',
     );
+
+    test('跨章 JS 请求捕获发起时的文档身份', () {
+      final String code = maskComments(body);
+      final int request = code.indexOf('await controller.evaluateJavascript(');
+      expect(request, isNonNegative);
+      for (final String capture in <String>[
+        'final InAppWebViewController controller = _controller!;',
+        'final int generation = _navigateGeneration;',
+        'final int chapter = _currentChapter;',
+      ]) {
+        final int at = code.indexOf(capture);
+        expect(at, isNonNegative);
+        expect(at, lessThan(request));
+      }
+    });
+
+    test('旧章晚到结果在解析、图片兜底、记账和保存之前被丢弃', () {
+      final String code = maskComments(body);
+      final int request = code.indexOf('await controller.evaluateJavascript(');
+      final int gate = code.indexOf('if (!mounted ||', request);
+      expect(gate, greaterThan(request));
+      final int gateEnd = code.indexOf('}', gate);
+      final String guard = code.substring(gate, gateEnd);
+      for (final String rejection in <String>[
+        'generation != _navigateGeneration',
+        'chapter != _currentChapter',
+        '!identical(controller, _controller)',
+        '_restoreInFlight',
+        '_lyricsMode',
+        'return;',
+      ]) {
+        expect(guard, contains(rejection));
+      }
+      for (final String consumer in <String>[
+        'parseReaderStableProgressDetails(result)',
+        '_applyImagePageProgressFallback()',
+        '_lastProgressSection =',
+        '_readLedger.arrive(',
+        '_debouncedSavePosition(',
+      ]) {
+        expect(code.indexOf(consumer), greaterThan(gateEnd));
+      }
+    });
 
     test('起 / 止都经 absoluteCharOffsetOf 换算，止点取 snapshot.charOffsetEnd', () {
       expect(containsCodeLine(body, 'absoluteCharOffsetOf('), isTrue);
@@ -226,7 +304,8 @@ void main() {
       expect(
         containsCodeLine(body, '_studyClock?.detach();'),
         isTrue,
-        reason: 'dispose 是同步的：停表必须走 detach（内部零 IO，'
+        reason:
+            'dispose 是同步的：停表必须走 detach（内部零 IO，'
             '攒下的写交给 ExitFlushRegistry.defer），不许自己起事务',
       );
       expect(
@@ -250,7 +329,10 @@ void main() {
         );
       }
       expect(
-        containsCodeLine(body, 'ExitFlushRegistry.instance.defer(_flushPosition);'),
+        containsCodeLine(
+          body,
+          'ExitFlushRegistry.instance.defer(_flushPosition);',
+        ),
         isTrue,
         reason: '退出那一刻的位置改为登记到退出汇合点，由退出路径统一 await',
       );
@@ -295,21 +377,18 @@ void main() {
       expect(containsCodeLine(body, 'await _studyClock?.flushNow();'), isTrue);
     });
 
-    test(
-      'leave 恰五处：跳句 + _beginNavigation + 三个同章跳转入口；'
-      '关书三条路（dispose / onSourcePagePop / 进程退出）零账本动作',
-      () {
-        expect('_readLedger.leave('.allMatches(masked), hasLength(5));
-        // BUG-2264：关书不是翻走。dispose 只 detach() 停表；`settle` 已从账本删除，
-        // 任何形式的「关书结算当前页」回潮都会让开关一次涨一次。
-        expect('_studyClock?.detach();'.allMatches(masked), hasLength(1));
-        expect(
-          masked.contains('_readLedger.settle'),
-          isFalse,
-          reason: 'ReadUnitLedger.settle 已删；关书 / 退后台 / 退出不结算站着的页',
-        );
-      },
-    );
+    test('leave 恰五处：跳句 + _beginNavigation + 三个同章跳转入口；'
+        '关书三条路（dispose / onSourcePagePop / 进程退出）零账本动作', () {
+      expect('_readLedger.leave('.allMatches(masked), hasLength(5));
+      // BUG-2264：关书不是翻走。dispose 只 detach() 停表；`settle` 已从账本删除，
+      // 任何形式的「关书结算当前页」回潮都会让开关一次涨一次。
+      expect('_studyClock?.detach();'.allMatches(masked), hasLength(1));
+      expect(
+        masked.contains('_readLedger.settle'),
+        isFalse,
+        reason: 'ReadUnitLedger.settle 已删；关书 / 退后台 / 退出不结算站着的页',
+      );
+    });
   });
 
   group('搜索跳转不对账本做动作（只滚动、不 notifyRestoreComplete，落点首个 arrive 结算旧页）', () {

--- a/fushi/test/reader/reader_restore_anchor_wiring_guard_test.dart
+++ b/fushi/test/reader/reader_restore_anchor_wiring_guard_test.dart
@@ -111,7 +111,7 @@ void main() {
 
       final int tryIdx = code.indexOf('try {');
       final int evalIdx =
-          code.indexOf('await _controller!.evaluateJavascript(');
+          code.indexOf('await controller.evaluateJavascript(');
       final int catchIdx = code.indexOf('} catch (e, stack) {');
 
       expect(tryIdx, greaterThanOrEqualTo(0),


### PR DESCRIPTION
跨章节时，旧文档的进度请求可能晚于新章节返回，随后按新章节坐标入账，污染阅读字数、速度和恢复位置。

三个进度消费入口现在捕获并核对请求时的章节、导航代次和 WebView，丢弃失效快照；同时覆盖退出位置保存和设置重载。保持原有速度公式，未加入速度上限。

验证：
- 统计基础回归 119 项通过。
- 阅读器及相邻功能回归 281 项通过。
- flutter analyze --no-pub 无问题；BUG 索引检查通过。
- 未完成用户原书、原设备跨章节复测；尚不能确认用户报告的百万速度完全由此竞态引起。全量测试交由 CI。

跟踪：BUG-2399。