### PR TITLE
feat(asr): 模型生成字幕后自动再过一遍调轴

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77095 (4535 per locale)
+/// Strings: 77112 (4536 per locale)
 ///
-/// Built on 2026-09-09 at 07:12 UTC
+/// Built on 2026-09-09 at 18:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6293,6 +6293,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_shader_tier_ultra_hint_mobile =>
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   String get dialog_background_close => 'Close (task keeps running)';
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -16949,6 +16951,9 @@ class _StringsAr extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -27832,6 +27837,9 @@ class _StringsDe extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -38769,6 +38777,9 @@ class _StringsEs extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -49740,6 +49751,9 @@ class _StringsFr extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -60513,6 +60527,9 @@ class _StringsId extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -71378,6 +71395,9 @@ class _StringsIt extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -81624,6 +81644,9 @@ class _StringsJa extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -91880,6 +91903,9 @@ class _StringsKo extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -102702,6 +102728,9 @@ class _StringsNl extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -113577,6 +113606,9 @@ class _StringsPtBr extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -124429,6 +124461,9 @@ class _StringsRu extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -135081,6 +135116,9 @@ class _StringsTh extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -145849,6 +145887,9 @@ class _StringsTr extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -156588,6 +156629,9 @@ class _StringsVi extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 // Path: <root>
@@ -166451,6 +166495,9 @@ class _StringsZhCn extends _StringsEn {
       'Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。';
   @override
   String get dialog_background_close => '关闭（任务继续在后台运行）';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      '生成文字后会再运行一遍模型校准时间，再保存字幕。首次使用会下载所需的调轴模型。';
 }
 
 // Path: <root>
@@ -176383,6 +176430,9 @@ class _StringsZhHk extends _StringsEn {
       'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
   @override
   String get dialog_background_close => 'Close (task keeps running)';
+  @override
+  String get audiobook_transcribe_alignment_hint =>
+      'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
 }
 
 /// Flat map(s) containing all translations.
@@ -185713,6 +185763,8 @@ extension on _StringsEn {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -195038,6 +195090,8 @@ extension on _StringsAr {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -204408,6 +204462,8 @@ extension on _StringsDe {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -213769,6 +213825,8 @@ extension on _StringsEs {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -223139,6 +223197,8 @@ extension on _StringsFr {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -232480,6 +232540,8 @@ extension on _StringsId {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -241843,6 +241905,8 @@ extension on _StringsIt {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -251133,6 +251197,8 @@ extension on _StringsJa {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -260427,6 +260493,8 @@ extension on _StringsKo {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -269783,6 +269851,8 @@ extension on _StringsNl {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -279134,6 +279204,8 @@ extension on _StringsPtBr {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -288492,6 +288564,8 @@ extension on _StringsRu {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -297822,6 +297896,8 @@ extension on _StringsTh {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -307167,6 +307243,8 @@ extension on _StringsTr {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -316506,6 +316584,8 @@ extension on _StringsVi {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }
@@ -325764,6 +325844,8 @@ extension on _StringsZhCn {
         return 'Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。';
       case 'dialog_background_close':
         return '关闭（任务继续在后台运行）';
+      case 'audiobook_transcribe_alignment_hint':
+        return '生成文字后会再运行一遍模型校准时间，再保存字幕。首次使用会下载所需的调轴模型。';
       default:
         return null;
     }
@@ -335032,6 +335114,8 @@ extension on _StringsZhHk {
         return 'Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.';
       case 'dialog_background_close':
         return 'Close (task keeps running)';
+      case 'audiobook_transcribe_alignment_hint':
+        return 'Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K 去模糊（S），在片源原分辨率上跑。不含放大 pass，开销不随屏幕分辨率增长。手机建议从这一档开始。",
   "video_shader_tier_high_hint_mobile": "Anime4K 去模糊（M），在片源原分辨率上跑。kernel 比「中」更大，同样不含放大 pass。适合较快的手机 GPU。",
   "video_shader_tier_ultra_hint_mobile": "Anime4K 去模糊（M）加一道柔化修复，均在片源原分辨率上跑。手机端最强档，仍不含放大 pass。掉帧就往下退一档。",
-  "dialog_background_close": "关闭（任务继续在后台运行）"
+  "dialog_background_close": "关闭（任务继续在后台运行）",
+  "audiobook_transcribe_alignment_hint": "生成文字后会再运行一遍模型校准时间，再保存字幕。首次使用会下载所需的调轴模型。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4533,5 +4533,6 @@
   "video_shader_tier_medium_hint_mobile": "Anime4K deblur (S) at the source resolution. No upscaling passes, so the cost does not scale with your screen. Start here on phones.",
   "video_shader_tier_high_hint_mobile": "Anime4K deblur (M) at the source resolution. Larger kernel than Medium; still no upscaling passes. For faster phone GPUs.",
   "video_shader_tier_ultra_hint_mobile": "Anime4K deblur (M) plus an extra soft restore pass, both at the source resolution. Strongest phone tier; still no upscaling. Drop a tier if it drops frames.",
-  "dialog_background_close": "Close (task keeps running)"
+  "dialog_background_close": "Close (task keeps running)",
+  "audiobook_transcribe_alignment_hint": "Generated text is aligned to the audio in a second model pass before saving. The alignment model is downloaded if needed."
 }

--- a/fushi/lib/src/asr_host/asr_host.dart
+++ b/fushi/lib/src/asr_host/asr_host.dart
@@ -69,8 +69,11 @@ void installAsrHostBindings() {
 }
 
 /// 建一个装配好的转录服务。两个生产实例化点都调这里。
-asr.AsrTranscriptionService createAsrTranscriptionService() =>
+asr.AsrTranscriptionService createAsrTranscriptionService({
+  bool alignGeneratedSubtitles = true,
+}) =>
     asr.AsrTranscriptionService(
+      alignGeneratedSubtitles: alignGeneratedSubtitles,
       backend: fushiAsrBackend(),
       pcm: asr.FfmpegAsrPcmSource(backend: const FushiAsrFfmpegBackend()),
     );

--- a/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
+++ b/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
@@ -361,8 +361,8 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     if (plan == null) return;
     setState(() {
       _phase = _Phase.downloading;
-      _downloadTotal = plan.modelStatus.totalBytes;
-      _downloadReceived = plan.modelStatus.obtainedBytes;
+      _downloadTotal = plan.totalModelBytes;
+      _downloadReceived = plan.obtainedModelBytes;
       _downloadFile = '';
     });
     // 逐文件事件：把「之前文件」的字节累计起来展示总进度。
@@ -703,6 +703,8 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Text(t.audiobook_transcribe_intro, style: tokens.type.metadata),
+          Text(t.audiobook_transcribe_alignment_hint,
+              style: tokens.type.metadata),
           SizedBox(height: tokens.spacing.rowVertical),
           Text(
             t.audiobook_transcribe_language_label,

--- a/fushi/lib/src/settings/settings_schema_listening.dart
+++ b/fushi/lib/src/settings/settings_schema_listening.dart
@@ -99,8 +99,12 @@ SettingsDestination buildListeningDestination() {
           SettingsCustomItem(
             id: 'listening.asr_models',
             searchTitle: t.asr_models_section,
-            builder: (SettingsContext _) =>
-                AsrModelsSettingsSection(service: createAsrTranscriptionService()),
+            builder: (SettingsContext _) => AsrModelsSettingsSection(
+              // Each pack, including the shared aligner, is managed separately.
+              service: createAsrTranscriptionService(
+                alignGeneratedSubtitles: false,
+              ),
+            ),
           ),
         ],
       ),

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: 047bb9bb47667abb04b2ffea8a4c00163b620182
   # 字幕重定时（拿 ASR 转录当参照修好已有字幕的时间轴）。与 fushi_asr_core 同仓同 sha。
   #
   # 只依赖 fushi_asr_core，**不含** ONNX 后端：算法那半边住在 fushi_asr 包里的话会
@@ -28,7 +28,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_subtitles
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: 047bb9bb47667abb04b2ffea8a4c00163b620182
   archive: ^3.6.1
   async_zip: ^0.1.0
   basic_utils: ^5.7.0

--- a/fushi/test/asr/asr_host_ffmpeg_adapter_test.dart
+++ b/fushi/test/asr/asr_host_ffmpeg_adapter_test.dart
@@ -47,7 +47,17 @@ class _ThrowingBackend implements host.FfmpegBackend {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   const FushiAsrFfmpegBackend adapter = FushiAsrFfmpegBackend();
+
+  test('generated subtitles use a second model pass by default', () {
+    expect(createAsrTranscriptionService().alignGeneratedSubtitles, isTrue);
+    expect(
+      createAsrTranscriptionService(alignGeneratedSubtitles: false)
+          .alignGeneratedSubtitles,
+      isFalse,
+    );
+  });
 
   tearDown(() => host.setFfmpegBackendForTesting(null));
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,8 +885,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/asr_core"
-      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
-      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      ref: "047bb9bb47667abb04b2ffea8a4c00163b620182"
+      resolved-ref: "047bb9bb47667abb04b2ffea8a4c00163b620182"
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"
@@ -894,8 +894,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/asr_subtitles"
-      ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
-      resolved-ref: "78a5241b30feb9a45f76cca5d6b2907c4d13638b"
+      ref: "047bb9bb47667abb04b2ffea8a4c00163b620182"
+      resolved-ref: "047bb9bb47667abb04b2ffea8a4c00163b620182"
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,7 +145,7 @@ dependency_overrides:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: 78a5241b30feb9a45f76cca5d6b2907c4d13638b
+      ref: 047bb9bb47667abb04b2ffea8a4c00163b620182
 
 # Melos 7 的配置位置就是这里（7.0 起 melos.yaml 被废弃）。包列表不再重复声明：
 # 成员由上面的 workspace: 决定，melos 直接读它。


### PR DESCRIPTION
仅对本次自动生成、尚未调轴的字幕执行一次模型调轴，保留识别文字并校准句子与逐字时间。已完成调轴的任务结果直接复用，再次打开、使用或导出不会重复调轴。用户导入的现成字幕不因本改动自动调轴。旧版自动生成但未调轴的缓存目前使用独立任务目录隔离，不会误当成已调轴结果。

接入 fushi-subtitles 的二次 CTC 推理实现，同步应用依赖、根目录 override 和 lockfile。转录弹层统计两个模型的下载体积并提示调轴流程；模型设置仍逐包管理，避免共享调轴模型占用被重复统计。

验证：Flutter 全量 analyze 无问题，44 项定向测试通过；算法侧 85 项定向测试通过。首次 Flutter 测试因 PDFium 依赖下载超时未执行，经本机代理重跑通过。未做真实模型音频/设备 E2E，准确率、运行耗时和额外内存尚未验收。算法 PR 为 hajisensai/fushi-subtitles 的 fix/generated-subtitle-alignment 分支；本 PR 钉其实现提交 047bb9b。

