### PR TITLE
fix(video): 统一发现与刮削搜索来源，补齐动画续季搜索

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2181 条。点号进各自文件。
+> 共 2182 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2398](bugs/BUG-2398-anime-season-search.md) | ✅ | ✅ | 搜索在AniList故障时缺少动画续季 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |

--- a/docs/bugs/BUG-2398-anime-season-search.md
+++ b/docs/bugs/BUG-2398-anime-season-search.md
@@ -4,3 +4,11 @@
 - **[x] ① 根因修复** — 复用既有 `VideoMetadataSearchDiscoveryProvider` 将 MAL 接入全部/番剧搜索，共享详情 provider 生命周期与 Jikan 限流。推荐 feed 保持既有能力，不伪造 MAL 推荐端点。
 - **[x] ② 自动化测试** — `fushi/test/media/video/video_metadata_discovery_provider_test.dart` 覆盖真实 MAL 解析、两季独立身份，以及 AniList 503 时全部/番剧搜索保留两季；`video_discovery_aggregated_sources_guard_test.dart` 覆盖生产装配。adapter/service/来源守卫/页面装配/详情选择五文件共 46 个测试通过（退出码 0）。首轮 pdfium 依赖下载超时零执行，通过代理重跑成功。
 - **备注**：2026-09-10 通过本机代理请求 Jikan 同名查询返回 504（Jikan 无法连接 MAL）；线上第二季搜索与用户设备 E2E 尚未验证。该修改补齐搜索来源，不能消除上游同时不可用。MAL 当前复用非分页搜索契约，不宣称完整分页目录覆盖。
+
+### 来源统一（用户后续要求）
+
+- 第一轮 `47c8fceb47` 只补齐 MAL 搜索入口，仍留下两份生产来源清单。
+- 统一由 `VideoMetadataProviderRegistry.production` 创建作品资料源；刮削全局/来源 locale 注册表与发现搜索共用该工厂。发现搜索的允许来源从同一注册表派生，不再单独维护 MAL/TMDB/AniList 清单。
+- AniList 继续提供发现推荐和历史条目详情兼容，不再参与生产作品搜索。发现页搜索使用 MAL/TMDB；刮削仍按用户主源偏好做精确匹配与兜底，搜索结果展示仍保留多候选。
+- TMDB 的发现分页/筛选适配器继续使用；MAL 复用 metadata 搜索 adapter。统一的是资料源注册与配置入口，推荐接口、搜索展示和自动绑定各自保留明确契约。
+- 验证：11 个定向测试文件共 135 项通过，覆盖统一注册表、搜索/推荐请求隔离、来源级 locale、识别及 MAL/TMDB 兜底。没有把离线回归当作线上 Jikan 恢复或用户设备 E2E。

--- a/docs/bugs/BUG-2398-anime-season-search.md
+++ b/docs/bugs/BUG-2398-anime-season-search.md
@@ -1,0 +1,6 @@
+## BUG-2398 · 搜索在AniList故障时缺少动画续季
+- **报告**：2026-09-10（用户截图：搜索 Seihantai na Kimi to Boku 只有一条，AniList 来源不可用）
+- **真实性**：✅ 真 bug。`fushi/lib/src/media/video/discovery/video_discovery_service.dart:38` 的生产搜索只装配 AniList/TMDB，已有 MAL provider 仅注册到详情查询。AniList 故障后，动画独立续季失去另一个作品目录搜索入口。截图来源故障已确认；未把静态路径验证当作用户设备复测。
+- **[x] ① 根因修复** — 复用既有 `VideoMetadataSearchDiscoveryProvider` 将 MAL 接入全部/番剧搜索，共享详情 provider 生命周期与 Jikan 限流。推荐 feed 保持既有能力，不伪造 MAL 推荐端点。
+- **[x] ② 自动化测试** — `fushi/test/media/video/video_metadata_discovery_provider_test.dart` 覆盖真实 MAL 解析、两季独立身份，以及 AniList 503 时全部/番剧搜索保留两季；`video_discovery_aggregated_sources_guard_test.dart` 覆盖生产装配。adapter/service/来源守卫/页面装配/详情选择五文件共 46 个测试通过（退出码 0）。首轮 pdfium 依赖下载超时零执行，通过代理重跑成功。
+- **备注**：2026-09-10 通过本机代理请求 Jikan 同名查询返回 504（Jikan 无法连接 MAL）；线上第二季搜索与用户设备 E2E 尚未验证。该修改补齐搜索来源，不能消除上游同时不可用。MAL 当前复用非分页搜索契约，不宣称完整分页目录覆盖。

--- a/fushi/lib/src/media/video/discovery/video_discovery_service.dart
+++ b/fushi/lib/src/media/video/discovery/video_discovery_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_adapters.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_metadata_discovery_provider.dart';
 import 'package:fushi/src/media/video/metadata/anilist_video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/tmdb_video_metadata_provider.dart';
@@ -45,19 +46,25 @@ class VideoDiscoveryService {
       language: config.locale,
     );
     final AniListVideoMetadataProvider anilist = AniListVideoMetadataProvider();
+    final MalVideoMetadataProvider mal = MalVideoMetadataProvider();
     return VideoDiscoveryService(
       providers: <VideoDiscoveryProvider>[
+        // MAL has separate anime season identities even when AniList is down.
+        // Share the detail provider; the service owns its lifetime.
+        VideoMetadataSearchDiscoveryProvider(
+          provider: mal,
+          categories: const <VideoDiscoveryCategory>{
+            VideoDiscoveryCategory.anime,
+          },
+          priority: 5,
+        ),
         AniListVideoDiscoveryProvider(),
         TmdbVideoDiscoveryProvider(
           apiKey: config.tmdbApiKey,
           language: config.locale,
         ),
       ],
-      metadataProviders: <VideoMetadataProvider>[
-        MalVideoMetadataProvider(),
-        tmdb,
-        anilist,
-      ],
+      metadataProviders: <VideoMetadataProvider>[mal, tmdb, anilist],
       closesProviders: true,
     );
   }

--- a/fushi/lib/src/media/video/discovery/video_discovery_service.dart
+++ b/fushi/lib/src/media/video/discovery/video_discovery_service.dart
@@ -7,8 +7,7 @@ import 'package:fushi/src/media/video/discovery/video_discovery_adapters.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_metadata_discovery_provider.dart';
 import 'package:fushi/src/media/video/metadata/anilist_video_metadata_provider.dart';
-import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart';
-import 'package:fushi/src/media/video/metadata/tmdb_video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_resolver.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_merge.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
@@ -25,6 +24,7 @@ class VideoDiscoveryService {
     Iterable<VideoMetadataProvider> metadataProviders =
         const <VideoMetadataProvider>[],
     bool closesProviders = false,
+    Set<String>? searchProviderIds,
   })  : _providers = List<VideoDiscoveryProvider>.unmodifiable(
           providers.toList()
             ..sort(
@@ -36,35 +36,44 @@ class VideoDiscoveryService {
           for (final VideoMetadataProvider provider in metadataProviders)
             provider.providerKind: provider,
         },
-        _closesProviders = closesProviders;
+        _closesProviders = closesProviders,
+        _searchProviderIds = searchProviderIds == null
+            ? null
+            : Set<String>.unmodifiable(searchProviderIds);
 
   factory VideoDiscoveryService.production(
     VideoSourceScrapeGlobalConfig config,
   ) {
-    final TmdbVideoMetadataProvider tmdb = TmdbVideoMetadataProvider(
-      apiKey: config.tmdbApiKey,
-      language: config.locale,
-    );
+    final VideoMetadataProviderRegistry catalog =
+        VideoMetadataProviderRegistry.production(config);
     final AniListVideoMetadataProvider anilist = AniListVideoMetadataProvider();
-    final MalVideoMetadataProvider mal = MalVideoMetadataProvider();
     return VideoDiscoveryService(
       providers: <VideoDiscoveryProvider>[
-        // MAL has separate anime season identities even when AniList is down.
-        // Share the detail provider; the service owns its lifetime.
-        VideoMetadataSearchDiscoveryProvider(
-          provider: mal,
-          categories: const <VideoDiscoveryCategory>{
-            VideoDiscoveryCategory.anime,
-          },
-          priority: 5,
-        ),
+        for (final VideoMetadataProvider provider in catalog.providers)
+          if (provider.providerKind == VideoMetadataProviderKind.tmdb)
+            // Preserve TMDB's discovery paging and filter capabilities.
+            TmdbVideoDiscoveryProvider(
+              apiKey: config.tmdbApiKey,
+              language: config.locale,
+            )
+          else
+            VideoMetadataSearchDiscoveryProvider(
+              provider: provider,
+              categories: const <VideoDiscoveryCategory>{
+                VideoDiscoveryCategory.anime,
+              },
+              priority: 5,
+            ),
         AniListVideoDiscoveryProvider(),
-        TmdbVideoDiscoveryProvider(
-          apiKey: config.tmdbApiKey,
-          language: config.locale,
-        ),
       ],
-      metadataProviders: <VideoMetadataProvider>[mal, tmdb, anilist],
+      metadataProviders: <VideoMetadataProvider>[
+        ...catalog.providers,
+        anilist,
+      ],
+      searchProviderIds: <String>{
+        for (final VideoMetadataProvider provider in catalog.providers)
+          provider.providerKind.name,
+      },
       closesProviders: true,
     );
   }
@@ -73,6 +82,7 @@ class VideoDiscoveryService {
   final Map<VideoMetadataProviderKind, VideoMetadataProvider>
       _metadataProviders;
   final bool _closesProviders;
+  final Set<String>? _searchProviderIds;
   bool _closed = false;
 
   /// 聚合来源清单（按 priority 排序后的 provider id）。
@@ -84,6 +94,16 @@ class VideoDiscoveryService {
   List<String> get providerIdsForTesting => _providers
       .map((VideoDiscoveryProvider provider) => provider.id)
       .toList(growable: false);
+
+  @visibleForTesting
+  Set<String> get searchProviderIdsForTesting => <String>{
+        for (final VideoDiscoveryProvider provider in _providers)
+          if (_supportsRequest(
+            provider,
+            const VideoDiscoveryRequest(query: 'catalog'),
+          ))
+            provider.id,
+      };
 
   Future<ProviderBatchResult<VideoDiscoveryPage>> load(
     VideoDiscoveryRequest request,
@@ -253,6 +273,10 @@ class VideoDiscoveryService {
       return false;
     }
     if (request.isSearch) {
+      if (_searchProviderIds != null &&
+          !_searchProviderIds.contains(provider.id)) {
+        return false;
+      }
       if (!capabilities.supportsSearch) return false;
       return true;
     }

--- a/fushi/lib/src/media/video/discovery/video_metadata_discovery_provider.dart
+++ b/fushi/lib/src/media/video/discovery/video_metadata_discovery_provider.dart
@@ -3,7 +3,7 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
 
-/// Search-only adapter for the existing TMDB and AniList metadata
+/// Search-only adapter for the existing metadata
 /// providers. Recommendation feeds remain a separate capability: the metadata
 /// contract has no trending/popular endpoint and this adapter does not invent
 /// one.
@@ -78,7 +78,10 @@ class VideoMetadataSearchDiscoveryProvider implements VideoDiscoveryProvider {
       return ProviderBatchResult<VideoDiscoveryPage>.success(
         <VideoDiscoveryPage>[
           VideoDiscoveryPage(
-              items: const <VideoDiscoveryItem>[], page: 1, hasMore: false),
+            items: const <VideoDiscoveryItem>[],
+            page: 1,
+            hasMore: false,
+          ),
         ],
       );
     }
@@ -133,9 +136,7 @@ class VideoMetadataSearchDiscoveryProvider implements VideoDiscoveryProvider {
     );
   }
 
-  List<VideoMetadataMediaKind> _requestedKinds(
-    VideoDiscoveryRequest request,
-  ) {
+  List<VideoMetadataMediaKind> _requestedKinds(VideoDiscoveryRequest request) {
     final VideoDiscoveryCategory? requested = request.category;
     if (requested != null && !capabilities.categories.contains(requested)) {
       return const <VideoMetadataMediaKind>[];

--- a/fushi/lib/src/media/video/metadata/video_metadata_resolver.dart
+++ b/fushi/lib/src/media/video/metadata/video_metadata_resolver.dart
@@ -9,6 +9,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/tmdb_video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_transport.dart';
@@ -87,6 +90,19 @@ class VideoMetadataResolution {
 }
 
 class VideoMetadataProviderRegistry {
+  /// Shared production work catalog for discovery search and scraping.
+  factory VideoMetadataProviderRegistry.production(
+    VideoSourceScrapeGlobalConfig config, {
+    String? locale,
+  }) =>
+      VideoMetadataProviderRegistry(<VideoMetadataProvider>[
+        MalVideoMetadataProvider(),
+        TmdbVideoMetadataProvider(
+          apiKey: config.tmdbApiKey,
+          language: locale ?? config.locale,
+        ),
+      ]);
+
   VideoMetadataProviderRegistry(Iterable<VideoMetadataProvider> providers)
       : _providers = <VideoMetadataProviderKind, VideoMetadataProvider>{
           for (final VideoMetadataProvider provider in providers)
@@ -94,6 +110,8 @@ class VideoMetadataProviderRegistry {
         };
 
   final Map<VideoMetadataProviderKind, VideoMetadataProvider> _providers;
+
+  Iterable<VideoMetadataProvider> get providers => _providers.values;
 
   VideoMetadataProvider? provider(VideoMetadataProviderKind kind) =>
       _providers[kind];

--- a/fushi/lib/src/media/video/metadata/video_source_scrape_coordinator.dart
+++ b/fushi/lib/src/media/video/metadata/video_source_scrape_coordinator.dart
@@ -13,11 +13,11 @@ import 'package:fushi/src/media/video/metadata/anidb_udp_file_client.dart';
 import 'package:fushi/src/media/video/metadata/anime_episode_relations.dart';
 import 'package:fushi/src/media/video/metadata/anime_identity_mapping.dart';
 import 'package:fushi/src/media/video/metadata/anime_offline_identity_resolver.dart';
-import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart'
+    show malIncompleteCreditEndpointsKey;
 import 'package:fushi/src/media/video/metadata/video_metadata_transport.dart';
 import 'package:fushi/src/media/source_library/source_library_row.dart';
 import 'package:fushi/src/media/video/metadata/anidb_video_metadata_provider.dart';
-import 'package:fushi/src/media/video/metadata/tmdb_video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_asset_downloader.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_database_store.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_merge.dart';
@@ -158,13 +158,7 @@ class VideoSourceScrapeCoordinator
     VideoSourceScrapeGlobalConfig config, {
     String? locale,
   }) =>
-      VideoMetadataProviderRegistry(<VideoMetadataProvider>[
-        MalVideoMetadataProvider(),
-        TmdbVideoMetadataProvider(
-          apiKey: config.tmdbApiKey,
-          language: locale ?? config.locale,
-        ),
-      ]);
+      VideoMetadataProviderRegistry.production(config, locale: locale);
 
   /// 对刚完成下载导入的单个作品执行身份受控的刮削。
   ///

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1274
+version: 2.3.0+1291
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/media/video/discovery/video_discovery_aggregated_sources_guard_test.dart
+++ b/fushi/test/media/video/discovery/video_discovery_aggregated_sources_guard_test.dart
@@ -7,7 +7,7 @@ import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
 
 import '../../../helpers/source_guard.dart';
 
-/// BUG-1538 守卫：发现页无论走不走代理都用同一份聚合来源（AniList + TMDB），
+/// BUG-1538 守卫：发现页无论走不走代理都用同一份聚合来源（MAL 搜索 + AniList + TMDB），
 /// 来源选择不随代理状态分叉降级。
 ///
 /// 两层钉法：
@@ -18,7 +18,7 @@ import '../../../helpers/source_guard.dart';
 ///    杜绝将来有人把来源选择接到代理状态上。下载域曾有的独立代理三态
 ///    （`DownloadNetworkProxy*`）已并入全局代理项，同样列入禁引清单防复活。
 void main() {
-  test('production discovery service aggregates only AniList + TMDB', () {
+  test('production discovery service aggregates MAL search + AniList + TMDB', () {
     final VideoDiscoveryService service = VideoDiscoveryService.production(
       const VideoSourceScrapeGlobalConfig(tmdbApiKey: 'test-key'),
     );
@@ -26,7 +26,7 @@ void main() {
     final Set<String> providerIds = service.providerIdsForTesting.toSet();
     expect(
       providerIds,
-      <String>{'anilist', 'tmdb'},
+      <String>{'mal', 'anilist', 'tmdb'},
     );
     expect(providerIds, isNot(contains('bangumi')));
   });

--- a/fushi/test/media/video/discovery/video_discovery_aggregated_sources_guard_test.dart
+++ b/fushi/test/media/video/discovery/video_discovery_aggregated_sources_guard_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fushi/src/media/video/discovery/video_discovery_service.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_resolver.dart';
 import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
 
 import '../../../helpers/source_guard.dart';
@@ -29,6 +31,18 @@ void main() {
       <String>{'mal', 'anilist', 'tmdb'},
     );
     expect(providerIds, isNot(contains('bangumi')));
+    final VideoMetadataProviderRegistry catalog =
+        VideoMetadataProviderRegistry.production(
+      const VideoSourceScrapeGlobalConfig(tmdbApiKey: 'test-key'),
+    );
+    addTearDown(catalog.close);
+    expect(
+      service.searchProviderIdsForTesting,
+      catalog.providers
+          .map((VideoMetadataProvider p) => p.providerKind.name)
+          .toSet(),
+    );
+    expect(service.searchProviderIdsForTesting, isNot(contains('anilist')));
   });
 
   test('discovery source selection has no dependency on proxy configuration',

--- a/fushi/test/media/video/discovery/video_discovery_service_test.dart
+++ b/fushi/test/media/video/discovery/video_discovery_service_test.dart
@@ -590,6 +590,40 @@ void main() {
   });
 
   group('VideoDiscoveryService', () {
+    test('catalog selection excludes AniList search but preserves its feed',
+        () async {
+      final _FakeProvider mal = _FakeProvider(
+        id: 'mal',
+        priority: 1,
+        response: ProviderBatchResult<VideoDiscoveryPage>.success(
+          <VideoDiscoveryPage>[
+            VideoDiscoveryPage(
+              items: const <VideoDiscoveryItem>[], page: 1, hasMore: false),
+          ],
+        ),
+      );
+      final _FakeProvider anilist = _FakeProvider(
+        id: 'anilist',
+        priority: 2,
+        response: ProviderBatchResult<VideoDiscoveryPage>.success(
+          <VideoDiscoveryPage>[
+            VideoDiscoveryPage(
+              items: const <VideoDiscoveryItem>[], page: 1, hasMore: false),
+          ],
+        ),
+      );
+      final VideoDiscoveryService service = VideoDiscoveryService(
+        providers: <VideoDiscoveryProvider>[mal, anilist],
+        searchProviderIds: <String>{'mal'},
+      );
+      addTearDown(service.close);
+      await service.load(const VideoDiscoveryRequest(query: 'Anime'));
+      expect(mal.searchCalls, 1);
+      expect(anilist.searchCalls, 0);
+      await service.load(const VideoDiscoveryRequest());
+      expect(anilist.discoverCalls, 1);
+    });
+
     test('preserves successful items when another provider fails', () async {
       final _FakeProvider success = _FakeProvider(
         id: 'success',
@@ -1197,6 +1231,7 @@ class _FakeProvider implements VideoDiscoveryProvider {
   final ProviderBatchResult<VideoDiscoveryPage> response;
   final bool supportsPaging;
   int searchCalls = 0;
+  int discoverCalls = 0;
 
   @override
   VideoDiscoveryCapabilities get capabilities => VideoDiscoveryCapabilities(
@@ -1207,8 +1242,10 @@ class _FakeProvider implements VideoDiscoveryProvider {
   @override
   Future<ProviderBatchResult<VideoDiscoveryPage>> discover(
     VideoDiscoveryRequest request,
-  ) async =>
-      response;
+  ) async {
+    discoverCalls++;
+    return response;
+  }
 
   @override
   Future<ProviderBatchResult<VideoDiscoveryPage>> search(

--- a/fushi/test/media/video/metadata/video_metadata_production_registry_test.dart
+++ b/fushi/test/media/video/metadata/video_metadata_production_registry_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/video/metadata/tmdb_video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_resolver.dart';
+import 'package:fushi/src/media/video/metadata/video_source_scrape_config.dart';
+
+void main() {
+  test('production work catalog contains MAL and TMDB', () {
+    final VideoMetadataProviderRegistry registry =
+        VideoMetadataProviderRegistry.production(
+          const VideoSourceScrapeGlobalConfig(),
+        );
+    addTearDown(registry.close);
+    expect(
+      registry.providers.map((VideoMetadataProvider p) => p.providerKind),
+      <VideoMetadataProviderKind>[
+        VideoMetadataProviderKind.mal,
+        VideoMetadataProviderKind.tmdb,
+      ],
+    );
+    expect(
+      registry.provider(VideoMetadataProviderKind.mal)!.isAvailable,
+      isTrue,
+    );
+    expect(
+      registry.provider(VideoMetadataProviderKind.tmdb)!.isAvailable,
+      isFalse,
+    );
+  });
+
+  test(
+    'production TMDB receives API configuration and selected metadata locale',
+    () {
+      for (final String? locale in <String?>[null, 'ja']) {
+        final VideoMetadataProviderRegistry registry =
+            VideoMetadataProviderRegistry.production(
+              const VideoSourceScrapeGlobalConfig(
+                tmdbApiKey: 'test-key',
+                locale: 'zh-CN',
+              ),
+              locale: locale,
+            );
+        addTearDown(registry.close);
+        final TmdbVideoMetadataProvider tmdb =
+            registry.provider(VideoMetadataProviderKind.tmdb)!
+                as TmdbVideoMetadataProvider;
+        expect(tmdb.isAvailable, isTrue);
+        expect(tmdb.language, locale ?? 'zh-CN');
+      }
+    },
+  );
+}

--- a/fushi/test/media/video/metadata/video_source_scrape_metadata_locale_test.dart
+++ b/fushi/test/media/video/metadata/video_source_scrape_metadata_locale_test.dart
@@ -106,6 +106,10 @@ class _FakeRegistry implements VideoMetadataProviderRegistry {
   bool closed = false;
 
   @override
+  Iterable<VideoMetadataProvider> get providers =>
+      const <VideoMetadataProvider>[];
+
+  @override
   void close() => closed = true;
 
   @override

--- a/fushi/test/media/video/video_metadata_discovery_provider_test.dart
+++ b/fushi/test/media/video/video_metadata_discovery_provider_test.dart
@@ -1,12 +1,152 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_adapters.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_service.dart';
 import 'package:fushi/src/media/video/discovery/video_metadata_discovery_provider.dart';
+import 'package:fushi/src/media/video/metadata/mal_video_metadata_provider.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_provider.dart';
 
 void main() {
+  test(
+    'MAL search adapts distinct seasons with canonical detail lookups',
+    () async {
+      final MalVideoMetadataProvider metadata = _malSeasonsProvider();
+      addTearDown(metadata.close);
+      final VideoMetadataSearchDiscoveryProvider provider =
+          VideoMetadataSearchDiscoveryProvider(
+        provider: metadata,
+        categories: const <VideoDiscoveryCategory>{
+          VideoDiscoveryCategory.anime,
+        },
+      );
+
+      final ProviderBatchResult<VideoDiscoveryPage> result =
+          await provider.search(
+        const VideoDiscoveryRequest(
+          category: VideoDiscoveryCategory.anime,
+          query: 'Seihantai na Kimi to Boku',
+        ),
+      );
+
+      expect(result.failures, isEmpty);
+      final List<VideoDiscoveryItem> items = result.items.single.items;
+      expect(items, hasLength(2));
+      expect(
+        items.map((VideoDiscoveryItem item) => item.reference.title),
+        <String>[
+          'Seihantai na Kimi to Boku',
+          'Seihantai na Kimi to Boku 2nd Season',
+        ],
+      );
+      expect(
+        items.map(
+          (VideoDiscoveryItem item) => item.confirmedLookup!.externalId,
+        ),
+        <String>['100', '101'],
+      );
+      expect(
+        items.map((VideoDiscoveryItem item) => item.confirmedLookup!.provider),
+        everyElement(VideoMetadataProviderKind.mal),
+      );
+      expect(
+        items.map((VideoDiscoveryItem item) => item.reference.mediaKind),
+        everyElement(VideoMetadataMediaKind.tv),
+      );
+      expect(provider.capabilities.feeds, isEmpty);
+      expect(provider.capabilities.supportsSearch, isTrue);
+    },
+  );
+
+  for (final VideoDiscoveryCategory? category in <VideoDiscoveryCategory?>[
+    null,
+    VideoDiscoveryCategory.anime,
+  ]) {
+    test(
+      'MAL keeps both seasons in ${category?.name ?? 'all'} search when AniList fails',
+      () async {
+        final MalVideoMetadataProvider metadata = _malSeasonsProvider();
+        final VideoDiscoveryService service = VideoDiscoveryService(
+          providers: <VideoDiscoveryProvider>[
+            VideoMetadataSearchDiscoveryProvider(
+              provider: metadata,
+              categories: const <VideoDiscoveryCategory>{
+                VideoDiscoveryCategory.anime,
+              },
+              priority: 5,
+            ),
+            AniListVideoDiscoveryProvider(
+              client: MockClient(
+                (http.Request request) async => http.Response('', 503),
+              ),
+            ),
+            TmdbVideoDiscoveryProvider(
+              apiKey: 'test-key',
+              client: MockClient(
+                (http.Request request) async => http.Response(
+                  jsonEncode(<String, Object?>{
+                    'page': 1,
+                    'total_pages': 1,
+                    'results': <Object?>[
+                      if (request.url.path.endsWith('/tv'))
+                        <String, Object?>{
+                          'id': 42,
+                          'name': 'Seihantai na Kimi to Boku',
+                          'first_air_date': '2026-01-11',
+                          'genre_ids': <int>[16],
+                        },
+                    ],
+                  }),
+                  200,
+                ),
+              ),
+            ),
+          ],
+          metadataProviders: <VideoMetadataProvider>[metadata],
+          closesProviders: true,
+        );
+        addTearDown(service.close);
+
+        final ProviderBatchResult<VideoDiscoveryPage> result =
+            await service.load(
+          VideoDiscoveryRequest(
+            category: category,
+            query: 'Seihantai na Kimi to Boku',
+          ),
+        );
+
+        expect(result.isPartial, isTrue);
+        expect(result.failures.single.providerId, 'anilist');
+        final List<VideoDiscoveryItem> items = result.items.single.items;
+        expect(
+          items
+              .where(
+                (VideoDiscoveryItem item) =>
+                    item.confirmedLookup?.provider ==
+                    VideoMetadataProviderKind.mal,
+              )
+              .map(
+                (VideoDiscoveryItem item) => item.confirmedLookup!.externalId,
+              ),
+          containsAll(<String>['100', '101']),
+        );
+        expect(
+          items.where(
+            (VideoDiscoveryItem item) =>
+                item.reference.title == 'Seihantai na Kimi to Boku 2nd Season',
+          ),
+          hasLength(1),
+        );
+      },
+    );
+  }
+
   test('adapts anime metadata search without changing canonical media kind',
       () async {
     final _FakeMetadataProvider metadata = _FakeMetadataProvider();
@@ -59,6 +199,30 @@ void main() {
     expect(provider.capabilities.feeds, isEmpty);
   });
 }
+
+MalVideoMetadataProvider _malSeasonsProvider() => MalVideoMetadataProvider(
+      requestGate: MalVideoMetadataRequestGate(interval: Duration.zero),
+      client: MockClient((http.Request request) async {
+        expect(request.url.path, '/v4/anime');
+        expect(request.url.queryParameters['q'], 'Seihantai na Kimi to Boku');
+        return http.Response(
+          jsonEncode(<String, Object?>{
+            'data': <Object?>[
+              if (request.url.queryParameters['type'] != 'movie')
+                for (final int season in <int>[1, 2])
+                  <String, Object?>{
+                    'mal_id': season == 1 ? 100 : 101,
+                    'title':
+                        'Seihantai na Kimi to Boku${season == 1 ? '' : ' 2nd Season'}',
+                    'type': 'TV',
+                    'year': 2026,
+                  },
+            ],
+          }),
+          200,
+        );
+      }),
+    );
 
 class _FakeMetadataProvider implements VideoMetadataProvider {
   final List<VideoMetadataMediaKind> requestedKinds =


### PR DESCRIPTION
搜索 Seihantai na Kimi to Boku 时，AniList 故障后只剩 TMDB 基础条目，发现搜索未使用刮削已接入的 MAL，导致独立续季缺少搜索入口。

统一由 VideoMetadataProviderRegistry.production 注册 MAL/TMDB，发现搜索与刮削复用来源及配置。AniList 保留推荐和历史详情兼容。保留 TMDB 分页/筛选、刮削主源偏好和精确匹配兜底；MAL 两季身份独立保留。记录 BUG-2398，构建号 2.3.0+1291。

验证：11 个定向文件共 135 项测试通过，最终 flutter analyze --no-pub 无问题，diff check 和 bug check 通过。首次 pdfium 下载超时，配置代理后测试重跑通过。

未验证：实时 Jikan 查询返回 504，不能宣称线上搜索恢复；未跑用户设备 E2E、安装包构建或本地全量测试，全量由 PR CI 承接。MAL 复用现有非分页搜索契约，不承诺完整目录分页。
