### PR TITLE
fix(mobile): 收紧书架页头与资源筛选布局

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2181 条。点号进各自文件。
+> 共 2182 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2402](bugs/BUG-2402-mobile-library-layout.md) | ✅ | ✅ | 手机标签页头留白与筛选工具堆叠 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |

--- a/docs/bugs/BUG-2402-mobile-library-layout.md
+++ b/docs/bugs/BUG-2402-mobile-library-layout.md
@@ -1,0 +1,8 @@
+## BUG-2402 · 手机标签页头留白与筛选工具堆叠
+- **报告**：2026-09-10（用户：手机顶部留白过大，书架工具和发现筛选占用内容空间）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_page.dart:1379` 已由 SafeArea 避让系统栏，`fushi/lib/src/utils/components/fushi_material_components.dart:1820` 又给手机自定义标签页头添加 page 顶距；书架 `tag_filter_bar.dart` 把排序、多选放在标签横滚列表末端；`video_discovery_page.dart` 在窄屏用 Wrap 常驻年份、国家、类型和排序，产生多行控件。
+- **[x] ① 已实现** — 手机自定义标签页头移除额外顶距；搜索旁保留标签设置入口，排序/多选固定尾栏；同步保留实际进度但使用紧凑文字。手机发现页的高级筛选迁入可滚动底部面板，草稿应用后统一重新查询，取消不改现值。按真实视口宽度选择手机布局，避免界面缩放改变布局档位。
+- **[x] ② 已加自动化测试** — `mobile_navigation_header_spacing_test.dart` 覆盖安全区/缩放/宽窗/显式 padding；`reader_library_toolbar_test.dart` 覆盖标签滚动、动作回调、命中区域、同步进度；`video_discovery_page_test.dart` 覆盖面板应用/取消/重置。
+- **验证**：顶部及相邻页头测试 13 项通过；发现页 12 项通过；精确引用改动文件的邻接批共 611 项，610 项首轮通过，旧同步接线断言适配 compact 参数后该组 13 项通过（对账后无失败）。全量 `flutter analyze --no-pub` 无问题。Android 14 emulator-5554 真 app 焦点驱动用例通过：safeTop=49.45，header/tabs top=49.45；搜索/设置中心一致，排序/多选同排；Tab/Enter 可切至视频资源并打开筛选。证据位于 `.codex-test/mobile-layout-0910/`。未验证原 iOS 设备；Android 推荐内容截图仍处加载态，在线结果和卡片仅有 widget 数据回归。
+- **关联窄屏问题**：发现页格子原固定宽高比 `.50` 把文字空间与封面宽度绑定，390px 长标题产生 24px 纵向溢出。现保留原列数，用 2:3 封面高度加实测两行标题、一行元数据和内边距计算格子高度；320/390px 带内容回归通过。
+- **设计边界**：保留原底部导航、配色、数据来源和桌面工具布局；面板复用既有筛选键与查询契约，无新增持久化配置。

--- a/fushi/integration_test/mobile_library_layout_itest.dart
+++ b/fushi/integration_test/mobile_library_layout_itest.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/home_page.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/focus_driver.dart';
+import 'helpers/library_fixture.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+void main() {
+  final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  testWidgets('mobile library toolbar and resource filter sheet',
+      (WidgetTester tester) async {
+    final FlutterExceptionHandler? originalHandler = FlutterError.onError;
+    try {
+      await launchFushiTestApp();
+      expect(await waitForHome(tester), isTrue);
+      await enableFocusNavigation(tester);
+      await seedReaderBook(tester);
+      final FocusDriver driver = FocusDriver(tester);
+      await showBooksTab(tester);
+      for (int i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final Finder search =
+          find.byKey(const ValueKey<String>('shelf_search_field'));
+      final Finder settings =
+          find.byKey(const ValueKey<String>('library_tag_settings'));
+      expect(tester.getCenter(search).dy, tester.getCenter(settings).dy);
+      final Finder sort = find.widgetWithIcon(IconButton, Icons.sort);
+      final Finder select =
+          find.widgetWithIcon(IconButton, Icons.checklist_outlined);
+      expect(tester.getCenter(sort).dy, tester.getCenter(select).dy);
+      expect(tester.getSize(select).height, greaterThanOrEqualTo(44));
+      debugPrint(
+          '[mobile-layout] search=${tester.getRect(search)} settings=${tester.getRect(settings)} sort=${tester.getRect(sort)}');
+      final Finder header = find.byType(FushiPageHeader).first;
+      final FushiPageHeader headerWidget =
+          tester.widget<FushiPageHeader>(header);
+      final double safeTop =
+          tester.view.padding.top / tester.view.devicePixelRatio;
+      final Rect headerBounds = tester.getRect(header);
+      final Rect tabsBounds =
+          tester.getRect(find.byWidget(headerWidget.titleWidget!));
+      debugPrint(
+          '[mobile-layout] safeTop=$safeTop header=$headerBounds tabs=$tabsBounds');
+      expect(headerBounds.top, inInclusiveRange(safeTop, safeTop + 8));
+      expect(tabsBounds.top - headerBounds.top, lessThanOrEqualTo(4));
+      await binding.convertFlutterSurfaceToImage();
+      await tester.pump();
+      await binding.takeScreenshot('mobile-book-library');
+
+      HomePage.debugSelectTab!(HomeTab.downloads);
+      for (int i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final Finder picker =
+          find.byKey(const ValueKey<String>('downloads-resource-type-picker'));
+      debugPrint(
+          '[mobile-layout] resource picker visible=${picker.evaluate().length}');
+      final Finder videoSegment = find.ancestor(
+        of: find.descendant(of: picker, matching: find.text(t.nav_video)),
+        matching: find.byType(TextButton),
+      );
+      expect(await driver.focusWidget(videoSegment), isTrue,
+          reason: 'video resource segment must receive focus');
+      await driver.activate();
+      for (int i = 0; i < 8; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final Finder filters =
+          find.byKey(const ValueKey<String>('video-discovery-open-filters'));
+      debugPrint(
+          '[mobile-layout] filters visible=${filters.evaluate().length}');
+      expect(filters, findsOneWidget);
+      await binding.takeScreenshot('mobile-video-resources');
+      expect(await driver.focusWidget(filters), isTrue);
+      await driver.activate();
+      expect(find.byKey(const ValueKey<String>('video-discovery-filter-sheet')),
+          findsOneWidget);
+      for (int i = 0; i < 4; i++) {
+        await tester.pump(const Duration(milliseconds: 250));
+      }
+      final Rect sheetBounds = tester.getRect(find.byKey(
+        const ValueKey<String>('video-discovery-filter-sheet'),
+      ));
+      debugPrint('[mobile-layout] filterSheet=$sheetBounds');
+      expect(
+          sheetBounds.top,
+          lessThan(
+              tester.view.physicalSize.height / tester.view.devicePixelRatio));
+      await binding.takeScreenshot('mobile-resource-filters');
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump(const Duration(milliseconds: 300));
+    } catch (error, stack) {
+      debugPrint('[mobile-layout] FAILURE $error\n$stack');
+      rethrow;
+    } finally {
+      FlutterError.onError = originalHandler;
+    }
+  });
+}

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -581,7 +581,7 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
                 _buildSearchBar(),
                 _buildTagBar(allTags.valueOrNull ?? const []),
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
-                const SyncProgressBanner(),
+                SyncProgressBanner(compact: _compactLibraryToolbar),
                 Expanded(
                   // 多选态才接管长按：长按落在卡上 = 起手扫选，不抬手滑动即刷出
                   // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单）。
@@ -688,9 +688,18 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     );
   }
 
+  bool get _compactLibraryToolbar =>
+      windowSizeClassReal(
+        MediaQuery.sizeOf(context).width,
+        FushiAppUiScale.of(context),
+      ) ==
+      WindowSizeClass.compact;
+
   Widget _buildTagBar(List<BookTagRow> allTags) {
     return FushiTagFilterBar(
       tags: allTags,
+      pinActions: _compactLibraryToolbar,
+      showTagManagement: !_compactLibraryToolbar,
       onToggleFilter: _toggleFilter,
       onReorder: _reorderTags,
       selectionMode: _selectionMode,
@@ -870,34 +879,67 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
 
   /// P5-A 书架搜索框。形态与游戏库页工具条一致（三个库页搜索长一个样），
   /// 搜索词只影响本次会话、不落库。
+  Future<void> _openTagManagement() async {
+    await Navigator.push<void>(
+      context,
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (_) => const TagManagementPage(),
+      ),
+    );
+    if (!mounted) return;
+    ref.invalidate(allTagsProvider);
+    ref.invalidate(bookTagMapProvider);
+  }
+
   Widget _buildSearchBar() {
+    final Widget search = SizedBox(
+      height: _compactLibraryToolbar ? 44 : 40,
+      child: TextField(
+        key: const ValueKey<String>('shelf_search_field'),
+        controller: _searchController,
+        decoration: InputDecoration(
+          isDense: true,
+          prefixIcon: const Icon(Icons.search, size: 18),
+          hintText: t.library_search,
+          border: const OutlineInputBorder(),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 8,
+            vertical: 4,
+          ),
+          suffixIcon: _searchQuery.isEmpty
+              ? null
+              : IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  onPressed: () {
+                    _searchController.clear();
+                    setState(() => _searchQuery = '');
+                  },
+                ),
+        ),
+        onChanged: (String value) => setState(() => _searchQuery = value),
+      ),
+    );
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-      child: SizedBox(
-        height: 40,
-        child: TextField(
-          key: const ValueKey<String>('shelf_search_field'),
-          controller: _searchController,
-          decoration: InputDecoration(
-            isDense: true,
-            prefixIcon: const Icon(Icons.search, size: 18),
-            hintText: t.library_search,
-            border: const OutlineInputBorder(),
-            contentPadding:
-                const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            suffixIcon: _searchQuery.isEmpty
-                ? null
-                : IconButton(
-                    icon: const Icon(Icons.close, size: 18),
-                    onPressed: () {
-                      _searchController.clear();
-                      setState(() => _searchQuery = '');
-                    },
+      child: _compactLibraryToolbar
+          ? Row(
+              children: <Widget>[
+                Expanded(child: search),
+                const SizedBox(width: 8),
+                IconButton(
+                  key: const ValueKey<String>('library_tag_settings'),
+                  tooltip: t.tag_manage,
+                  constraints: const BoxConstraints(
+                    minWidth: 44,
+                    minHeight: 44,
                   ),
-          ),
-          onChanged: (String value) => setState(() => _searchQuery = value),
-        ),
-      ),
+                  icon: const Icon(Icons.settings_outlined, size: 22),
+                  onPressed: _openTagManagement,
+                ),
+              ],
+            )
+          : search,
     );
   }
 
@@ -1352,8 +1394,7 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
     // _mangaOnly 分架过滤：漫画架只来 format='manga'+hasMangaContent 的条目）。
     // 「同步与备份 + 互联」模块关掉 → 远端占位卡（含其下载按钮与长按面板）整块不
     // 渲染。取数侧由 [_shouldLoadRemoteBooks] 同门挡住，两处合起来做到零网络请求。
-    final bool showRemote =
-        remoteState != null &&
+    final bool showRemote = remoteState != null &&
         !remoteState.failed &&
         !hasActiveFilter &&
         appModel.prefsRepo.showRemoteEntries &&
@@ -2331,9 +2372,8 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
           label: isManga
               ? t.book_convert_to_book_action
               : t.book_convert_to_manga_action,
-          icon: isManga
-              ? Icons.menu_book_outlined
-              : Icons.auto_stories_outlined,
+          icon:
+              isManga ? Icons.menu_book_outlined : Icons.auto_stories_outlined,
           onPressed: () => _convertBookFormat(
             bookKey,
             isManga ? BookFormatTarget.book : BookFormatTarget.manga,

--- a/fushi/lib/src/pages/implementations/tag_filter_bar.dart
+++ b/fushi/lib/src/pages/implementations/tag_filter_bar.dart
@@ -22,6 +22,8 @@ class FushiTagFilterBar extends ConsumerStatefulWidget {
     required this.onToggleFilter,
     required this.onReorder,
     this.selectionMode = false,
+    this.pinActions = false,
+    this.showTagManagement = true,
     this.onToggleSelectionMode,
     this.sortMode,
     this.sortModeLabel,
@@ -29,6 +31,10 @@ class FushiTagFilterBar extends ConsumerStatefulWidget {
     this.onTagsChanged,
     super.key,
   });
+
+  /// Keep actions visible while tags scroll on compact library layouts.
+  final bool pinActions;
+  final bool showTagManagement;
 
   final List<BookTagRow> tags;
   final void Function(int tagId) onToggleFilter;
@@ -68,7 +74,7 @@ class _FushiTagFilterBarState extends ConsumerState<FushiTagFilterBar> {
 
     // 末尾动作：先「管理标签」（有标签才显示），再可选「批量选择」。
     final List<Widget> trailing = <Widget>[
-      if (widget.tags.isNotEmpty)
+      if (widget.showTagManagement && widget.tags.isNotEmpty)
         _tagBarAction(
           icon: Icons.settings_outlined,
           tooltip: t.tag_manage,
@@ -102,8 +108,82 @@ class _FushiTagFilterBarState extends ConsumerState<FushiTagFilterBar> {
         _sortMenuAction(tokens),
     ];
 
+    final Widget tags = HorizontalDragScrollable(
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.rowHorizontal,
+          vertical: tokens.spacing.gap * 0.75,
+        ),
+        itemCount:
+            widget.tags.length + (widget.pinActions ? 0 : trailing.length),
+        separatorBuilder: (_, __) => SizedBox(width: tokens.spacing.gap * 0.75),
+        itemBuilder: (context, index) {
+          if (index >= widget.tags.length) {
+            return trailing[index - widget.tags.length];
+          }
+          final BookTagRow tag = widget.tags[index];
+          final bool isSelected = selectedIds.contains(tag.id);
+          if (widget.selectionMode) {
+            return _tagFilterChip(
+              tag: tag,
+              isSelected: isSelected,
+              isDimmed: false,
+              onTap: () => widget.onToggleFilter(tag.id),
+            );
+          }
+          return LongPressDraggable<BookTagRow>(
+            data: tag,
+            feedback: Material(
+              color: Colors.transparent,
+              elevation: 4,
+              shape: RoundedRectangleBorder(
+                borderRadius: tokens.radii.chipRadius,
+              ),
+              clipBehavior: Clip.antiAlias,
+              child: _tagFilterChip(
+                tag: tag,
+                isSelected: true,
+                isDimmed: false,
+              ),
+            ),
+            childWhenDragging: Opacity(
+              opacity: 0.3,
+              child: _tagFilterChip(
+                tag: tag,
+                isSelected: isSelected,
+                isDimmed: false,
+              ),
+            ),
+            child: DragTarget<BookTagRow>(
+              onWillAcceptWithDetails: (details) => details.data.id != tag.id,
+              onAcceptWithDetails: (details) {
+                final BookTagRow draggedTag = details.data;
+                final int oldIdx = widget.tags.indexWhere(
+                  (t) => t.id == draggedTag.id,
+                );
+                final int newIdx = widget.tags.indexWhere(
+                  (t) => t.id == tag.id,
+                );
+                if (oldIdx != -1 && newIdx != -1) {
+                  widget.onReorder(oldIdx, newIdx);
+                }
+              },
+              builder: (context, candidateData, rejectedData) {
+                return _tagFilterChip(
+                  tag: tag,
+                  isSelected: isSelected,
+                  isDimmed: candidateData.isNotEmpty,
+                  onTap: () => widget.onToggleFilter(tag.id),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
     return Container(
-      height: tokens.spacing.gap * 5.5,
+      height: widget.pinActions ? 48 : tokens.spacing.gap * 5.5,
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
@@ -117,78 +197,15 @@ class _FushiTagFilterBarState extends ConsumerState<FushiTagFilterBar> {
       // 标签多了必须横向拖动才够用，而桌面默认 dragDevices 不含鼠标（拖不动，
       // 只能滚轮）。放开鼠标拖动与区内标签 chip 的 LongPressDraggable 不冲突：
       // 按下即动归滚动、按住不动满 kLongPressTimeout 归拖标签。
-      child: HorizontalDragScrollable(
-        child: ListView.separated(
-          scrollDirection: Axis.horizontal,
-          padding: EdgeInsets.symmetric(
-            horizontal: tokens.spacing.rowHorizontal,
-            vertical: tokens.spacing.gap * 0.75,
-          ),
-          itemCount: widget.tags.length + trailing.length,
-          separatorBuilder: (_, __) =>
-              SizedBox(width: tokens.spacing.gap * 0.75),
-          itemBuilder: (context, index) {
-            if (index >= widget.tags.length) {
-              return trailing[index - widget.tags.length];
-            }
-            final BookTagRow tag = widget.tags[index];
-            final bool isSelected = selectedIds.contains(tag.id);
-            if (widget.selectionMode) {
-              return _tagFilterChip(
-                tag: tag,
-                isSelected: isSelected,
-                isDimmed: false,
-                onTap: () => widget.onToggleFilter(tag.id),
-              );
-            }
-            return LongPressDraggable<BookTagRow>(
-              data: tag,
-              feedback: Material(
-                color: Colors.transparent,
-                elevation: 4,
-                shape: RoundedRectangleBorder(
-                  borderRadius: tokens.radii.chipRadius,
-                ),
-                clipBehavior: Clip.antiAlias,
-                child: _tagFilterChip(
-                  tag: tag,
-                  isSelected: true,
-                  isDimmed: false,
-                ),
-              ),
-              childWhenDragging: Opacity(
-                opacity: 0.3,
-                child: _tagFilterChip(
-                  tag: tag,
-                  isSelected: isSelected,
-                  isDimmed: false,
-                ),
-              ),
-              child: DragTarget<BookTagRow>(
-                onWillAcceptWithDetails: (details) => details.data.id != tag.id,
-                onAcceptWithDetails: (details) {
-                  final BookTagRow draggedTag = details.data;
-                  final int oldIdx =
-                      widget.tags.indexWhere((t) => t.id == draggedTag.id);
-                  final int newIdx =
-                      widget.tags.indexWhere((t) => t.id == tag.id);
-                  if (oldIdx != -1 && newIdx != -1) {
-                    widget.onReorder(oldIdx, newIdx);
-                  }
-                },
-                builder: (context, candidateData, rejectedData) {
-                  return _tagFilterChip(
-                    tag: tag,
-                    isSelected: isSelected,
-                    isDimmed: candidateData.isNotEmpty,
-                    onTap: () => widget.onToggleFilter(tag.id),
-                  );
-                },
-              ),
-            );
-          },
-        ),
-      ),
+      child: widget.pinActions
+          ? Row(
+              children: <Widget>[
+                Expanded(child: tags),
+                ...trailing,
+                const SizedBox(width: 12),
+              ],
+            )
+          : tags,
     );
   }
 
@@ -199,6 +216,15 @@ class _FushiTagFilterBarState extends ConsumerState<FushiTagFilterBar> {
     bool selected = false,
   }) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    if (widget.pinActions) {
+      return IconButton(
+        tooltip: tooltip,
+        constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+        icon: Icon(icon, size: 20),
+        color: selected ? tokens.surfaces.primary : tokens.surfaces.onVariant,
+        onPressed: onTap,
+      );
+    }
     return FushiIconButton(
       icon: icon,
       tooltip: tooltip,
@@ -220,8 +246,9 @@ class _FushiTagFilterBarState extends ConsumerState<FushiTagFilterBar> {
       controller: _sortMenu,
       style: MenuStyle(
         backgroundColor: WidgetStatePropertyAll<Color>(tokens.surfaces.overlay),
-        surfaceTintColor:
-            const WidgetStatePropertyAll<Color>(Colors.transparent),
+        surfaceTintColor: const WidgetStatePropertyAll<Color>(
+          Colors.transparent,
+        ),
         shape: WidgetStatePropertyAll<OutlinedBorder>(
           RoundedRectangleBorder(borderRadius: tokens.radii.menuRadius),
         ),

--- a/fushi/lib/src/pages/implementations/video_discovery_page.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:fushi/src/utils/net/app_http_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show SliverConstraints;
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/media/external_provider.dart';
 import 'package:fushi/src/media/video/cover_ui/portrait_cover_image.dart';
@@ -401,6 +402,15 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
 
   Widget _buildControls() {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return _buildControlsForWidth(tokens, constraints.maxWidth);
+      },
+    );
+  }
+
+  Widget _buildControlsForWidth(FushiDesignTokens tokens, double width) {
+    final bool compact = width * FushiAppUiScale.of(context) < 600;
     return Padding(
       padding: EdgeInsets.fromLTRB(
         tokens.spacing.page,
@@ -415,8 +425,9 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
             builder: (BuildContext context, BoxConstraints constraints) {
               final Widget search = FushiSearchField(
                 fieldKey: const ValueKey<String>('video-discovery-search'),
-                clearButtonKey:
-                    const ValueKey<String>('video-discovery-search-clear'),
+                clearButtonKey: const ValueKey<String>(
+                  'video-discovery-search-clear',
+                ),
                 focusId: const FushiFocusId('video-discovery-search'),
                 controller: _searchController,
                 focusNode: _searchFocusNode,
@@ -425,7 +436,33 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
                 onSubmitted: _submitSearch,
                 onClear: _clearSearch,
               );
-              if (constraints.maxWidth < 900) return search;
+              if (compact) {
+                return Row(
+                  children: <Widget>[
+                    Expanded(child: search),
+                    SizedBox(width: tokens.spacing.gap),
+                    IconButton.filledTonal(
+                      constraints:
+                          const BoxConstraints(minWidth: 44, minHeight: 44),
+                      key: const ValueKey<String>(
+                        'video-discovery-open-filters',
+                      ),
+                      tooltip: t.game_filter,
+                      onPressed: _openFilterSheet,
+                      icon: Badge.count(
+                        count: (_year != 0 ? 1 : 0) +
+                            (_region.isNotEmpty ? 1 : 0) +
+                            (_genre.isNotEmpty ? 1 : 0),
+                        isLabelVisible: _year != 0 ||
+                            _region.isNotEmpty ||
+                            _genre.isNotEmpty,
+                        child: const Icon(Icons.tune_rounded),
+                      ),
+                    ),
+                  ],
+                );
+              }
+              if (width < 900) return search;
               return Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
@@ -443,40 +480,50 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
             },
           ),
           SizedBox(height: tokens.spacing.gap),
-          HorizontalDragScrollable(
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: <Widget>[
-                  for (final discovery.VideoDiscoveryCategory? category
-                      in <discovery.VideoDiscoveryCategory?>[
-                    null,
-                    ...discovery.VideoDiscoveryCategory.values,
-                  ]) ...<Widget>[
-                    FushiSelectableChip(
-                      key: ValueKey<String>(
-                        'video-discovery-category-${category?.name ?? 'all'}',
-                      ),
-                      label: _categoryLabel(category),
-                      selected: _category == category,
-                      focusId: FushiFocusId(
-                        'video-discovery-category-${category?.name ?? 'all'}',
-                      ),
-                      onSelected: (_) {
-                        if (_category == category) return;
-                        setState(() => _category = category);
-                        unawaited(_reload());
-                      },
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: HorizontalDragScrollable(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: <Widget>[
+                        for (final discovery.VideoDiscoveryCategory? category
+                            in <discovery.VideoDiscoveryCategory?>[
+                          null,
+                          ...discovery.VideoDiscoveryCategory.values,
+                        ]) ...<Widget>[
+                          FushiSelectableChip(
+                            key: ValueKey<String>(
+                              'video-discovery-category-${category?.name ?? 'all'}',
+                            ),
+                            label: _categoryLabel(category),
+                            selected: _category == category,
+                            focusId: FushiFocusId(
+                              'video-discovery-category-${category?.name ?? 'all'}',
+                            ),
+                            onSelected: (_) {
+                              if (_category == category) return;
+                              setState(() => _category = category);
+                              unawaited(_reload());
+                            },
+                          ),
+                          if (category !=
+                              discovery.VideoDiscoveryCategory.values.last)
+                            SizedBox(width: tokens.spacing.gap),
+                        ],
+                      ],
                     ),
-                    if (category !=
-                        discovery.VideoDiscoveryCategory.values.last)
-                      SizedBox(width: tokens.spacing.gap),
-                  ],
-                ],
+                  ),
+                ),
               ),
-            ),
+              if (compact) ...<Widget>[
+                SizedBox(width: tokens.spacing.gap),
+                _buildSortMenu(compact: true),
+              ],
+            ],
           ),
-          if (MediaQuery.sizeOf(context).width < 900) ...<Widget>[
+          if (!compact && width < 900) ...<Widget>[
             SizedBox(height: tokens.spacing.gap),
             Wrap(
               spacing: tokens.spacing.gap,
@@ -494,72 +541,176 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
     );
   }
 
-  Widget _buildYearField() {
+  Future<void> _openFilterSheet() async {
+    int year = _year;
+    String region = _region;
+    String genre = _genre;
+    final bool? apply = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (BuildContext sheetContext) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setSheetState) {
+          final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+          return SafeArea(
+            top: false,
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(
+                tokens.spacing.page,
+                0,
+                tokens.spacing.page,
+                tokens.spacing.page,
+              ),
+              child: Column(
+                key: const ValueKey<String>('video-discovery-filter-sheet'),
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Text(
+                    t.game_filter,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  SizedBox(height: tokens.spacing.gap),
+                  Text(t.video_filter_year),
+                  _buildYearField(
+                    value: year,
+                    onChanged: (int value) => setSheetState(() => year = value),
+                  ),
+                  SizedBox(height: tokens.spacing.gap),
+                  Text(t.video_work_countries),
+                  _buildRegionMenu(
+                    value: region,
+                    onChanged: (String value) =>
+                        setSheetState(() => region = value),
+                  ),
+                  SizedBox(height: tokens.spacing.gap),
+                  Text(t.video_work_genres),
+                  _buildGenreMenu(
+                    value: genre,
+                    onChanged: (String value) =>
+                        setSheetState(() => genre = value),
+                  ),
+                  SizedBox(height: tokens.spacing.gap),
+                  Wrap(
+                    alignment: WrapAlignment.end,
+                    spacing: tokens.spacing.gap,
+                    children: <Widget>[
+                      TextButton(
+                        key: const ValueKey<String>(
+                          'video-discovery-reset-filters',
+                        ),
+                        onPressed: () => setSheetState(() {
+                          year = 0;
+                          region = '';
+                          genre = '';
+                        }),
+                        child: Text(t.reset),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(sheetContext, false),
+                        child: Text(t.dialog_cancel),
+                      ),
+                      FilledButton(
+                        key: const ValueKey<String>(
+                          'video-discovery-apply-filters',
+                        ),
+                        onPressed: () => Navigator.pop(sheetContext, true),
+                        child: Text(t.dialog_done),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    if (!mounted ||
+        apply != true ||
+        (year == _year && region == _region && genre == _genre)) {
+      return;
+    }
+    setState(() {
+      _year = year;
+      _region = region;
+      _genre = genre;
+    });
+    unawaited(_reload());
+  }
+
+  Widget _buildYearField({int? value, ValueChanged<int>? onChanged}) {
+    final int selected = value ?? _year;
     final int newestYear = DateTime.now().year + 2;
     return PopupMenuButton<int>(
       key: const ValueKey<String>('video-discovery-filter-year'),
       tooltip: t.video_filter_year,
-      initialValue: _year,
-      onSelected: _applyYearFilter,
+      initialValue: selected,
+      onSelected: onChanged ?? _applyYearFilter,
       itemBuilder: (_) => <PopupMenuEntry<int>>[
         PopupMenuItem<int>(value: 0, child: Text(t.home_filter_all)),
         for (int year = newestYear; year >= 1900; year--)
           PopupMenuItem<int>(value: year, child: Text('$year')),
       ],
       child: _filterButton(
-        label: _year == 0 ? t.video_filter_year : '$_year',
-        active: _year != 0,
+        label: selected == 0 ? t.video_filter_year : '$selected',
+        active: selected != 0,
       ),
     );
   }
 
-  Widget _buildRegionMenu() {
+  Widget _buildRegionMenu({String? value, ValueChanged<String>? onChanged}) {
+    final String selected = value ?? _region;
     const List<String> regions = <String>['CN', 'JP', 'KR', 'US', 'GB', 'FR'];
     return PopupMenuButton<String>(
       key: const ValueKey<String>('video-discovery-filter-region'),
       tooltip: t.video_work_countries,
-      initialValue: _region,
-      onSelected: (String value) {
-        setState(() => _region = value);
-        unawaited(_reload());
-      },
+      initialValue: selected,
+      onSelected: onChanged ??
+          (String value) {
+            setState(() => _region = value);
+            unawaited(_reload());
+          },
       itemBuilder: (_) => <PopupMenuEntry<String>>[
         PopupMenuItem<String>(value: '', child: Text(t.home_filter_all)),
         for (final String region in regions)
           PopupMenuItem<String>(value: region, child: Text(region)),
       ],
       child: _filterButton(
-        label: _region.isEmpty ? t.video_work_countries : _region,
-        active: _region.isNotEmpty,
+        label: selected.isEmpty ? t.video_work_countries : selected,
+        active: selected.isNotEmpty,
       ),
     );
   }
 
-  Widget _buildGenreMenu() {
+  Widget _buildGenreMenu({String? value, ValueChanged<String>? onChanged}) {
+    final String selected = value ?? _genre;
     return PopupMenuButton<String>(
       key: const ValueKey<String>('video-discovery-filter-genre'),
       tooltip: t.video_work_genres,
-      initialValue: _genre,
-      onSelected: (String value) {
-        setState(() => _genre = value);
-        unawaited(_reload());
-      },
+      initialValue: selected,
+      onSelected: onChanged ??
+          (String value) {
+            setState(() => _genre = value);
+            unawaited(_reload());
+          },
       itemBuilder: (_) => <PopupMenuEntry<String>>[
         PopupMenuItem<String>(value: '', child: Text(t.home_filter_all)),
         for (final String genre in _availableGenres)
           PopupMenuItem<String>(value: genre, child: Text(genre)),
       ],
       child: _filterButton(
-        label: _genre.isEmpty ? t.video_work_genres : _genre,
-        active: _genre.isNotEmpty,
+        label: selected.isEmpty ? t.video_work_genres : selected,
+        active: selected.isNotEmpty,
       ),
     );
   }
 
-  Widget _buildSortMenu() {
+  Widget _buildSortMenu({bool compact = false}) {
     return PopupMenuButton<discovery.VideoDiscoverySort>(
       key: const ValueKey<String>('video-discovery-filter-sort'),
-      tooltip: t.sort_by,
+      tooltip: '${t.sort_by}: ${_sortLabel(_sort)}',
       initialValue: _sort,
       onSelected: (discovery.VideoDiscoverySort value) {
         setState(() => _sort = value);
@@ -575,12 +726,23 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
               child: Text(_sortLabel(sort)),
             ),
       ],
-      child: _filterButton(
-        label: _sort == discovery.VideoDiscoverySort.popularity
-            ? t.sort_by
-            : _sortLabel(_sort),
-        active: _sort != discovery.VideoDiscoverySort.popularity,
-      ),
+      child: compact
+          ? SizedBox(
+              width: 48,
+              height: 48,
+              child: Icon(
+                Icons.sort_rounded,
+                color: _sort == discovery.VideoDiscoverySort.popularity
+                    ? null
+                    : Theme.of(context).colorScheme.primary,
+              ),
+            )
+          : _filterButton(
+              label: _sort == discovery.VideoDiscoverySort.popularity
+                  ? t.sort_by
+                  : _sortLabel(_sort),
+              active: _sort != discovery.VideoDiscoverySort.popularity,
+            ),
     );
   }
 
@@ -590,9 +752,7 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
     return SizedBox(
       height: _filterControlHeight,
       child: FushiCard(
-        padding: EdgeInsets.symmetric(
-          horizontal: tokens.spacing.rowHorizontal,
-        ),
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing.rowHorizontal),
         color: active ? tokens.surfaces.selected : tokens.surfaces.page,
         borderColor: active ? colors.primary : tokens.surfaces.outline,
         child: Row(
@@ -679,26 +839,41 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
         else
           SliverPadding(
             padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
-            sliver: SliverGrid(
-              gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-                maxCrossAxisExtent: readerShelfGridExtentForWidth(
+            sliver: SliverLayoutBuilder(
+              builder: (BuildContext context, SliverConstraints constraints) {
+                final double maxExtent = readerShelfGridExtentForWidth(
                   MediaQuery.sizeOf(context).width,
-                ),
-                mainAxisSpacing: tokens.spacing.gap,
-                crossAxisSpacing: tokens.spacing.gap,
-                // BUG-1527：0.52 在长标题 + 当前 UI scale 下让海报+两行标题+元数据
-                // 比网格格子高约 2.4px；0.50 留出稳定正文余量且保持海报密度。
-                childAspectRatio: 0.50,
-              ),
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => _DiscoveryMediaCard(
-                  item: _works[index],
-                  landscape: false,
-                  imageResolver: widget.imageResolver,
-                  onTap: () => _openItem(_works[index]),
-                ),
-                childCount: _works.length,
-              ),
+                );
+                // Keep the existing maximum-extent delegate's column count.
+                final int desiredColumns = (constraints.crossAxisExtent /
+                        (maxExtent + tokens.spacing.gap))
+                    .ceil();
+                final int columns = desiredColumns < 1 ? 1 : desiredColumns;
+                final double coverWidth = (constraints.crossAxisExtent -
+                        tokens.spacing.gap * (columns - 1)) /
+                    columns;
+                // Text does not shrink with the cover width. Reserve its
+                // measured space instead of squeezing it into an aspect ratio.
+                final double textHeight = _cardTextHeight(tokens);
+                return SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: columns,
+                    mainAxisSpacing: tokens.spacing.gap,
+                    crossAxisSpacing: tokens.spacing.gap,
+                    mainAxisExtent:
+                        coverWidth * 1.5 + tokens.spacing.gap * 2 + textHeight,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext context, int index) => _DiscoveryMediaCard(
+                      item: _works[index],
+                      landscape: false,
+                      imageResolver: widget.imageResolver,
+                      onTap: () => _openItem(_works[index]),
+                    ),
+                    childCount: _works.length,
+                  ),
+                );
+              },
             ),
           ),
         if (_loadingMore)
@@ -714,6 +889,23 @@ class _VideoDiscoveryPageState extends State<VideoDiscoveryPage> {
           ),
       ],
     );
+  }
+
+  double _cardTextHeight(FushiDesignTokens tokens) {
+    double measure(String text, TextStyle style) {
+      final TextPainter painter = TextPainter(
+        text: TextSpan(text: text, style: style),
+        textDirection: Directionality.of(context),
+        textScaler: MediaQuery.textScalerOf(context),
+      )..layout();
+      final double height = painter.height;
+      painter.dispose();
+      return height;
+    }
+
+    return (measure('国M\n国M', tokens.type.listTitle) +
+            measure('2026 · ★ 8.4', tokens.type.metadata))
+        .ceilToDouble();
   }
 
   Widget _buildProviderWarning() {

--- a/fushi/lib/src/sync/sync_progress_banner.dart
+++ b/fushi/lib/src/sync/sync_progress_banner.dart
@@ -18,7 +18,10 @@ import 'package:fushi/src/sync/sync_progress.dart';
 ///
 /// 没有同步在跑时收成零高度（[SizedBox.shrink]），不占布局、不改现有几何。
 class SyncProgressBanner extends StatelessWidget {
-  const SyncProgressBanner({super.key});
+  const SyncProgressBanner({this.compact = false, super.key});
+
+  /// Use the compact status strip in mobile book libraries.
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -42,12 +45,17 @@ class SyncProgressBanner extends StatelessWidget {
                   children: <Widget>[
                     if (line != null)
                       Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+                        padding: compact
+                            ? const EdgeInsets.fromLTRB(12, 0, 12, 2)
+                            : const EdgeInsets.fromLTRB(16, 0, 16, 4),
                         child: Text(
                           line,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodySmall?.copyWith(
+                          style: (compact
+                                  ? theme.textTheme.labelSmall
+                                  : theme.textTheme.bodySmall)
+                              ?.copyWith(
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -662,9 +662,8 @@ class FushiSelectableChip extends StatelessWidget {
     // 于是选中态既没有填充差异、边框还从 outlineVariant 变成了底色——选中的
     // chip 比未选中的更没有边，是个负信号。反色填充是墨水屏上唯一稳定可辨的
     // 选中通道（与 segmentedButtonTheme / chipTheme 的处理同源）。
-    final Color selectedFill = eink
-        ? colors.onSurface
-        : colors.primaryContainer;
+    final Color selectedFill =
+        eink ? colors.onSurface : colors.primaryContainer;
     final Color foreground = selected
         ? (eink ? colors.surface : colors.onPrimaryContainer)
         : tokens.surfaces.onSurface;
@@ -674,9 +673,9 @@ class FushiSelectableChip extends StatelessWidget {
     final Widget? effectiveAvatar = effectiveIconOnly
         ? null
         : (avatar ??
-              (leadingIcon == null
-                  ? null
-                  : Icon(leadingIcon, size: 18, color: foreground)));
+            (leadingIcon == null
+                ? null
+                : Icon(leadingIcon, size: 18, color: foreground)));
     final Widget labelWidget = effectiveIconOnly
         ? Icon(leadingIcon, size: 18, color: foreground)
         : Text(
@@ -1817,9 +1816,13 @@ class FushiPageHeader extends StatelessWidget {
           FushiAppUiScale.of(context),
         ) ==
         WindowSizeClass.compact;
-    final double resolvedTop = compact
-        ? tokens.spacing.gap
-        : (narrowWindow ? tokens.spacing.page : tokens.spacing.page + 8);
+    // Embedded tabs already own a touch-height row; the home shell owns SafeArea.
+    // A second title margin pushes phone navigation away from the status bar.
+    final double resolvedTop = narrowWindow && titleWidget != null
+        ? 0
+        : compact
+            ? tokens.spacing.gap
+            : (narrowWindow ? tokens.spacing.page : tokens.spacing.page + 8);
     final EdgeInsetsGeometry resolvedPadding = padding ??
         EdgeInsets.fromLTRB(
           tokens.spacing.page,

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.3.0+1274
+version: 2.3.0+1275
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/pages/reader_library_toolbar_test.dart
+++ b/fushi/test/pages/reader_library_toolbar_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/collections/shelf_sort.dart';
+import 'package:fushi/src/pages/implementations/tag_filter_bar.dart';
+import 'package:fushi/src/sync/sync_auto_trigger.dart';
+import 'package:fushi/src/sync/sync_progress.dart';
+import 'package:fushi/src/sync/sync_progress_banner.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+Widget host(Widget child) => ProviderScope(
+      child: TranslationProvider(
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+
+void main() {
+  testWidgets('mobile library actions stay visible while many tags scroll', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    bool selected = false;
+    ShelfSortMode? chosen;
+    await tester.pumpWidget(
+      host(
+        FushiTagFilterBar(
+          tags: List<BookTagRow>.generate(
+            20,
+            (int i) => BookTagRow(
+              id: i,
+              name: 'Long tag $i',
+              colorValue: 0xFF2196F3,
+              sortOrder: i,
+              createdAt: 0,
+            ),
+          ),
+          pinActions: true,
+          showTagManagement: false,
+          onToggleFilter: (_) {},
+          onReorder: (_, __) async {},
+          onToggleSelectionMode: () => selected = true,
+          sortMode: ShelfSortMode.recent,
+          sortModeLabel: (ShelfSortMode mode) => mode.name,
+          onSortModeChanged: (ShelfSortMode mode) => chosen = mode,
+        ),
+      ),
+    );
+    final Finder select = find.widgetWithIcon(
+      IconButton,
+      Icons.checklist_outlined,
+    );
+    final Finder sort = find.widgetWithIcon(IconButton, Icons.sort);
+    final Offset before = tester.getCenter(sort);
+    expect(tester.getCenter(select).dy, before.dy);
+    expect(tester.getSize(select).width, greaterThanOrEqualTo(44));
+    expect(tester.getSize(sort).height, greaterThanOrEqualTo(44));
+    await tester.drag(find.byType(ListView), const Offset(-700, 0));
+    await tester.pumpAndSettle();
+    expect(tester.getCenter(sort), before);
+    await tester.tap(select);
+    expect(selected, isTrue);
+    await tester.tap(sort);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(ShelfSortMode.title.name));
+    await tester.pumpAndSettle();
+    expect(chosen, ShelfSortMode.title);
+    expect(find.byIcon(Icons.settings_outlined), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('compact sync strip preserves progress and collapses when idle', (
+    WidgetTester tester,
+  ) async {
+    addTearDown(() {
+      syncInProgress.value = false;
+      syncProgress.value = null;
+    });
+    syncInProgress.value = true;
+    syncProgress.value = const SyncProgress(
+      phase: SyncPhase.dictionaries,
+      itemIndex: 0,
+      itemTotal: 2,
+      title: 'Dictionary',
+    );
+    await tester.pumpWidget(host(const SyncProgressBanner(compact: true)));
+    final double compactHeight =
+        tester.getSize(find.byType(SyncProgressBanner)).height;
+    expect(find.textContaining('Dictionary'), findsOneWidget);
+    expect(
+      tester
+          .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+          .value,
+      0.5,
+    );
+    await tester.pumpWidget(host(const SyncProgressBanner()));
+    expect(
+      tester.getSize(find.byType(SyncProgressBanner)).height,
+      greaterThan(compactHeight),
+    );
+    syncInProgress.value = false;
+    await tester.pump();
+    expect(tester.getSize(find.byType(SyncProgressBanner)).height, 0);
+  });
+}

--- a/fushi/test/pages/video_discovery_page_test.dart
+++ b/fushi/test/pages/video_discovery_page_test.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart'
     as discovery;
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/pages/implementations/video_discovery_page.dart';
+import 'package:fushi/src/utils/app_ui_scale.dart';
 
 typedef _LoadHandler = Future<ProviderBatchResult<discovery.VideoDiscoveryPage>>
     Function(
@@ -78,9 +79,14 @@ ProviderBatchResult<discovery.VideoDiscoveryPage> _result(
 Widget _harness(
   VideoDiscoveryController controller, {
   ValueChanged<discovery.VideoDiscoveryItem>? onOpenItem,
+  double scale = 1,
 }) {
   return TranslationProvider(
     child: MaterialApp(
+      builder: (BuildContext context, Widget? child) => FushiAppUiScale(
+        scale: scale,
+        child: child!,
+      ),
       theme: ThemeData.dark(useMaterial3: true),
       home: Scaffold(
         body: VideoDiscoveryPage(
@@ -232,14 +238,14 @@ void main() {
     );
   });
 
-  testWidgets('紧凑布局将搜索与筛选分行且不溢出', (WidgetTester tester) async {
-    tester.view.physicalSize = const Size(480, 800);
+  testWidgets('手机保留分类和排序，高级筛选在底部面板统一应用', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     final _FakeDiscoveryController controller = _FakeDiscoveryController(
       (_) async => _result(<discovery.VideoDiscoveryItem>[
-        _item('compact', '紧凑布局作品'),
+        _item('compact', '窄屏里仍然完整容纳两行的作品标题'),
       ]),
     );
 
@@ -252,8 +258,125 @@ void main() {
     );
     expect(
       find.byKey(const ValueKey<String>('video-discovery-filter-year')),
-      findsOneWidget,
+      findsNothing,
     );
+    final Finder search = find.byKey(
+      const ValueKey<String>('video-discovery-search'),
+    );
+    final Finder sort = find.byKey(
+      const ValueKey<String>('video-discovery-filter-sort'),
+    );
+    final Finder category = find.byKey(
+      const ValueKey<String>('video-discovery-category-all'),
+    );
+    expect(
+      tester.getCenter(sort).dy,
+      closeTo(tester.getCenter(category).dy, 1),
+    );
+    expect(
+      tester.getBottomRight(sort).dy - tester.getTopLeft(search).dy,
+      lessThan(140),
+    );
+    final int originalRequests = controller.requests.length;
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-discovery-open-filters')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-discovery-filter-year')),
+    );
+    await tester.pumpAndSettle();
+    final int year = DateTime.now().year + 1;
+    await tester.tap(find.text('$year').last);
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-discovery-filter-region')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('JP').last);
+    await tester.pumpAndSettle();
+    expect(controller.requests, hasLength(originalRequests));
+    await tester.tap(
+      find.byKey(const ValueKey<String>('video-discovery-apply-filters')),
+    );
+    await tester.pumpAndSettle();
+    expect(controller.requests, hasLength(originalRequests + 1));
+    expect(controller.requests.last.year, year);
+    expect(controller.requests.last.region, 'JP');
+    expect(
+      find.byKey(const ValueKey<String>('video-discovery-filter-sheet')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('手机筛选重置可取消，再次打开保留已应用值', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final _FakeDiscoveryController controller = _FakeDiscoveryController(
+      (_) async => _result(<discovery.VideoDiscoveryItem>[
+        _item('narrow', '更窄屏幕也容纳两行标题和年份评分'),
+      ]),
+    );
+    await tester.pumpWidget(_harness(controller));
+    await tester.pumpAndSettle();
+    final Finder openFilters = find.byKey(
+      const ValueKey<String>('video-discovery-open-filters'),
+    );
+    final Finder region = find.byKey(
+      const ValueKey<String>('video-discovery-filter-region'),
+    );
+    final Finder apply = find.byKey(
+      const ValueKey<String>('video-discovery-apply-filters'),
+    );
+    final Finder reset = find.byKey(
+      const ValueKey<String>('video-discovery-reset-filters'),
+    );
+    await tester.tap(openFilters);
+    await tester.pumpAndSettle();
+    await tester.tap(region);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('JP').last);
+    await tester.pumpAndSettle();
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    final int appliedRequests = controller.requests.length;
+
+    await tester.tap(openFilters);
+    await tester.pumpAndSettle();
+    await tester.tap(reset);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.dialog_cancel));
+    await tester.pumpAndSettle();
+    expect(controller.requests, hasLength(appliedRequests));
+    await tester.tap(openFilters);
+    await tester.pumpAndSettle();
+    expect(tester.widget<PopupMenuButton<String>>(region).initialValue, 'JP');
+    await tester.tap(reset);
+    await tester.pumpAndSettle();
+    await tester.tap(apply);
+    await tester.pumpAndSettle();
+    expect(controller.requests.last.region, isNull);
+    expect(controller.requests.last.year, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('手机缩小界面后仍将高级筛选收进面板', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final _FakeDiscoveryController controller = _FakeDiscoveryController(
+      (_) async => _result(const <discovery.VideoDiscoveryItem>[]),
+    );
+    await tester.pumpWidget(_harness(controller, scale: 0.6));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey<String>('video-discovery-open-filters')),
+        findsOneWidget);
+    expect(find.byKey(const ValueKey<String>('video-discovery-filter-year')),
+        findsNothing);
     expect(tester.takeException(), isNull);
   });
 

--- a/fushi/test/sync/pull_to_sync_wiring_guard_test.dart
+++ b/fushi/test/sync/pull_to_sync_wiring_guard_test.dart
@@ -108,7 +108,9 @@ void main() {
     ]) {
       expect(
         read(file),
-        contains('const SyncProgressBanner()'),
+        contains(file.endsWith('reader_fushi_history_page.dart')
+            ? 'SyncProgressBanner(compact: _compactLibraryToolbar)'
+            : 'const SyncProgressBanner()'),
         reason: '$file 缺同步进度条：光一个 RefreshIndicator 转圈看不出跑到哪一步',
       );
     }

--- a/fushi/test/widgets/mobile_navigation_header_spacing_test.dart
+++ b/fushi/test/widgets/mobile_navigation_header_spacing_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/app_ui_scale.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+
+void main() {
+  const Key tabsKey = ValueKey<String>('navigation-tabs');
+
+  Future<void> pumpHeader(
+    WidgetTester tester, {
+    double width = 393,
+    double scale = 1,
+    double inset = 47,
+    EdgeInsets? padding,
+  }) async {
+    await tester.binding.setSurfaceSize(Size(width, 852));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(
+            size: Size(width, 852),
+            padding: EdgeInsets.only(top: inset),
+            viewPadding: EdgeInsets.only(top: inset),
+          ),
+          child: FushiAppUiScale(
+            scale: scale,
+            child: Scaffold(
+              body: SafeArea(
+                child: Column(
+                  children: <Widget>[
+                    FushiPageHeader.customTitle(
+                      padding: padding,
+                      title: const SizedBox(
+                        key: tabsKey,
+                        height: 48,
+                        child: Text('书架　发现　导入　设置'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  for (final double scale in <double>[0.6, 1, 1.3]) {
+    testWidgets('phone navigation starts at safe area at UI scale $scale', (
+      WidgetTester tester,
+    ) async {
+      await pumpHeader(tester, scale: scale);
+      expect(tester.getTopLeft(find.byKey(tabsKey)).dy, closeTo(47, 0.01));
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('zero inset does not leave an empty title band', (
+    WidgetTester tester,
+  ) async {
+    await pumpHeader(tester, inset: 0);
+    expect(tester.getTopLeft(find.byKey(tabsKey)).dy, 0);
+  });
+
+  testWidgets('wide header retains its title margin', (
+    WidgetTester tester,
+  ) async {
+    await pumpHeader(tester, width: 900);
+    expect(tester.getTopLeft(find.byKey(tabsKey)).dy, greaterThan(47));
+  });
+
+  testWidgets('explicit header padding still takes precedence', (
+    WidgetTester tester,
+  ) async {
+    await pumpHeader(tester, padding: const EdgeInsets.only(top: 12));
+    expect(tester.getTopLeft(find.byKey(tabsKey)).dy, 59);
+  });
+}

--- a/fushi/test_driver/mobile_layout_driver.dart
+++ b/fushi/test_driver/mobile_layout_driver.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+Future<void> main() async {
+  final Directory dir =
+      Directory('../.codex-test/mobile-layout-0910/screenshots');
+  await dir.create(recursive: true);
+  await integrationDriver(onScreenshot: (String name, List<int> bytes,
+      [Map<String, Object?>? args]) async {
+    await File('${dir.path}/$name.png').writeAsBytes(bytes);
+    return true;
+  });
+}


### PR DESCRIPTION
手机标签页头在系统安全区之外重复留出顶部边距，书架操作随标签横滚、发现高级筛选多行常驻，挤占内容区域。

本变更让窄屏自定义标签页头从安全区下沿开始；书架设置移到搜索旁，排序/多选固定同排，同步状态使用紧凑条；发现页保留分类与排序，把年份、国家、类型收进支持应用/取消/重置的底部面板。布局按真实视口宽度适配界面缩放，原底部导航和桌面控件保留。同时按封面与文字高度计算发现卡片高度，消除窄屏长标题溢出。

验证：
- 全量 flutter analyze --no-pub 无问题。
- 页头定向 13 项、发现页 12 项通过。
- 相邻测试共 611 项：610 项首轮通过，旧同步接线源码断言更新后该组 13 项通过，对账无剩余失败。
- Android 14 emulator-5554 真 app 焦点驱动测试通过，验证安全区位置、书架操作对齐、切视频资源和打开筛选面板。
- BUG-2402 编号及索引检查通过。

未覆盖：原 iOS 设备；Android 在线推荐结果在截图时仍加载中，真实结果与卡片设备验收未完成（带内容窄屏卡片有 widget 回归）。完整测试套件由 CI 执行。版本构建号 +1275。
