### PR TITLE
fix(video): 作品资料页拉回前台不再闪回加载态（BUG-2010）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1861 条。点号进各自文件。
+> 共 1862 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2010](bugs/BUG-2010-work-detail-foreground-rebuild-flash.md) | ✅ | ✅ | 作品资料页一拉到前台就闪回加载态 |
 | [BUG-2005](bugs/BUG-2005-recent-added-portrait-slot.md) | ✅ | ✅ | 首页「最近添加」行视频卡恒竖槽，横版截帧被模糊垫底成白条 |
 | [BUG-1983](bugs/BUG-1983-gal-layout-whitespace-fold.md) | ✅ | ✅ | Gal 同句换行快照未原地折叠导致换行错乱 |
 | [BUG-1982](bugs/BUG-1982-global-lookup-stale-route-flash.md) | 🚧 | ✅ | 全局查词旧尺寸消息冒充新查询导致首次闪跳 |

--- a/docs/bugs/BUG-2010-work-detail-foreground-rebuild-flash.md
+++ b/docs/bugs/BUG-2010-work-detail-foreground-rebuild-flash.md
@@ -3,7 +3,7 @@
 - **真实性**：✅ 真 bug。根因是 `fushi/lib/src/pages/implementations/video_work_detail_page.dart:57` 把 `FutureBuilder.future` 写在 `build()` 里现取（`database.getMediaCollectionById(collectionId)`），`VideoWorkDetailPage` 当时还是 `StatelessWidget`。于是**每次重建都产生一个新 Future**，FutureBuilder 走 `didUpdateWidget` → `_snapshot.inState(ConnectionState.none)` → 该 builder 判的 `snapshot.connectionState != ConnectionState.done` 成立 → 整页落回 `Scaffold(body: Center(adaptiveIndicator))`；同时子页 `MediaCollectionDetailPage` 从树上消失、以**全新 State** 重建，它自己的 `_loading`（`media_collection_detail_page.dart:115`，全文件只有初值 `true` 与 `:358` 置 `false` 两个赋值点）一并复位 → 剧集列表整份重查。用户截到的正是这一帧。
   - **重建从哪来**：`fushi/lib/main.dart:780` 在 `AppLifecycleState.resumed` 调 `AppModel.refreshSystemPalette()`，而桌面端每次窗口激活都会走一遍 resumed；`theme_notifier.dart:462` 当时是**无条件** `notifyListeners()`（只要 `appThemeKey == 'system-theme'`，即动态取色主题），系统色一动没动也照发 → 主题变更 → 全树重建。两者叠加 = 「一拉到前台就闪」。
   - **同形状但不闪的两处**（一并修，但性质不同，勿混记）：`collection_detail_shared.dart:59`（标签 chip 行）与 `collection_relations_section.dart:267`（相关作品区）也把 future 写在 build 里，但它们的 builder 只读 `snap.data`，而上面那个 `inState(ConnectionState.none)` **保留 data**，所以旧结果继续渲染、并不闪。它们的代价是**每次重建都白查一次库**。这点经变异实测确认：最初按「也会闪」写的断言在变异下不红，判断已纠正。
-- **[x] ① 已修复** — `PENDING_COMMIT`：
+- **[x] ① 已修复** — `969f2d43e7`：
   1. `VideoWorkDetailPage` 由 `StatelessWidget` 改为 `StatefulWidget`，合集行查询缓存在 State，身份只由 `(collectionId, database)` 决定，`didUpdateWidget` 里才重取；
   2. `collection_relations_section.dart` 把查询提进 State（`initState` / `didUpdateWidget` / 绑定成功后重取），顺带消除了只为翻 `key` 而存在的 `_refresh` 计数器——future 的身份变化本身就是「该重取」的信号；
   3. `collection_detail_shared.dart` 的标签查询改记忆化 getter，身份 = `(合集 id, detailTagsRefresh)`；

--- a/docs/bugs/BUG-2010-work-detail-foreground-rebuild-flash.md
+++ b/docs/bugs/BUG-2010-work-detail-foreground-rebuild-flash.md
@@ -1,0 +1,17 @@
+## BUG-2010 · 作品资料页一拉到前台就闪回加载态
+- **报告**：2026-09-01（用户：「一直闪烁啊」+「现在的 fushi 一拉到前台就闪」，附两张「作品资料」页截图：AppBar 正常渲染，内容区整片空白、只剩正中一个极小的加载指示点）
+- **真实性**：✅ 真 bug。根因是 `fushi/lib/src/pages/implementations/video_work_detail_page.dart:57` 把 `FutureBuilder.future` 写在 `build()` 里现取（`database.getMediaCollectionById(collectionId)`），`VideoWorkDetailPage` 当时还是 `StatelessWidget`。于是**每次重建都产生一个新 Future**，FutureBuilder 走 `didUpdateWidget` → `_snapshot.inState(ConnectionState.none)` → 该 builder 判的 `snapshot.connectionState != ConnectionState.done` 成立 → 整页落回 `Scaffold(body: Center(adaptiveIndicator))`；同时子页 `MediaCollectionDetailPage` 从树上消失、以**全新 State** 重建，它自己的 `_loading`（`media_collection_detail_page.dart:115`，全文件只有初值 `true` 与 `:358` 置 `false` 两个赋值点）一并复位 → 剧集列表整份重查。用户截到的正是这一帧。
+  - **重建从哪来**：`fushi/lib/main.dart:780` 在 `AppLifecycleState.resumed` 调 `AppModel.refreshSystemPalette()`，而桌面端每次窗口激活都会走一遍 resumed；`theme_notifier.dart:462` 当时是**无条件** `notifyListeners()`（只要 `appThemeKey == 'system-theme'`，即动态取色主题），系统色一动没动也照发 → 主题变更 → 全树重建。两者叠加 = 「一拉到前台就闪」。
+  - **同形状但不闪的两处**（一并修，但性质不同，勿混记）：`collection_detail_shared.dart:59`（标签 chip 行）与 `collection_relations_section.dart:267`（相关作品区）也把 future 写在 build 里，但它们的 builder 只读 `snap.data`，而上面那个 `inState(ConnectionState.none)` **保留 data**，所以旧结果继续渲染、并不闪。它们的代价是**每次重建都白查一次库**。这点经变异实测确认：最初按「也会闪」写的断言在变异下不红，判断已纠正。
+- **[x] ① 已修复** — `PENDING_COMMIT`：
+  1. `VideoWorkDetailPage` 由 `StatelessWidget` 改为 `StatefulWidget`，合集行查询缓存在 State，身份只由 `(collectionId, database)` 决定，`didUpdateWidget` 里才重取；
+  2. `collection_relations_section.dart` 把查询提进 State（`initState` / `didUpdateWidget` / 绑定成功后重取），顺带消除了只为翻 `key` 而存在的 `_refresh` 计数器——future 的身份变化本身就是「该重取」的信号；
+  3. `collection_detail_shared.dart` 的标签查询改记忆化 getter，身份 = `(合集 id, detailTagsRefresh)`；
+  4. `theme_notifier.dart` 的 `refreshSystemPalette` 加幂等判据：系统调色板/强调色没变就不广播（`CorePalette` 与 `Color` 都实现了 `operator ==`）。这是放大器修复——少一次无谓全树重建，任何同类页面都少一次被打回加载态的机会。
+- **[x] ② 已加自动化测试** — 两个文件，**四处变异全部实测必红**：
+  - `fushi/test/pages/detail_future_identity_test.dart`（3 条）：用 builder 式 `_RebuildHarness` 模拟「主题通知 → 全树重建」（**必须经 builder 现造 child**，直接复用同一个 child 实例会被 Flutter 的 `identical` 短路，测不到重建），钉 ①「重建后子页仍在树上且 State 原地复用、不退回加载态」②「重建后不许再对库发查询」——后者用 drift `QueryInterceptor` 数 `runSelect`，不按表名过滤（`pumpAndSettle` 后树已静止，此后任何 select 都只能来自重建）。
+  - `fushi/test/models/theme_notifier_palette_idempotence_test.dart`（4 条）：mock `io.material.plugins/dynamic_color` channel，钉「首次取色广播 / 同色重复刷新不广播 / 真变了照常广播」。变异（删 `if (unchanged) return;`）实测 `Expected: <1> Actual: <4>`。
+- **备注**：
+  - **未做真机复测**。修复与测试都在 widget 层验证；「切走再切回 Fushi 主窗不再闪」这一条没有 Windows 真机证据，按纪律不得记为已验证。
+  - 触发条件依赖主题设为**动态取色**（`appThemeKey == 'system-theme'`，也是默认值）。固定主题的用户走不到 `notifyListeners()`，本来就不该闪——如果有用户在固定主题下仍报闪，那是另一条重建源，不能并入本条。
+  - `theme_system_accent_test.dart:84` 那条源码扫描守卫取 `refreshSystemPalette` 函数体查 `getCorePalette`/`getAccentColor`，本次改动未触碰这两处，已实测仍绿。

--- a/fushi/lib/src/models/theme_notifier.dart
+++ b/fushi/lib/src/models/theme_notifier.dart
@@ -457,8 +457,17 @@ class ThemeNotifier extends ChangeNotifier {
         accent = null;
       }
     }
+    // 值没变就不广播（BUG-2010）。本方法挂在 `AppLifecycleState.resumed` 上，而
+    // 桌面端每次窗口激活都会走一遍 resumed，于是「无条件 notifyListeners」＝
+    // 「每把 Fushi 拉到前台一次就让整棵树重建一次」。重建本身无害，但它会引爆
+    // 任何把 FutureBuilder 的 future 写在 build 里的页面——那种页面会退回
+    // waiting、内容整块消失一帧（用户报的「一拉到前台就闪」）。系统调色板本就
+    // 极少变，这里只在真变了时才通知；订阅方少一次无谓重建，闪的放大器就没了。
+    final bool unchanged =
+        palette == _systemPalette && accent == _systemAccentColor;
     _systemPalette = palette;
     _systemAccentColor = accent;
+    if (unchanged) return;
     if (appThemeKey == 'system-theme') notifyListeners();
   }
 

--- a/fushi/lib/src/pages/implementations/collection_detail_shared.dart
+++ b/fushi/lib/src/pages/implementations/collection_detail_shared.dart
@@ -24,6 +24,32 @@ mixin CollectionDetailShared<T extends StatefulWidget> on State<T> {
   /// 标签 chip 行强制重取计数（编辑标签返回后自增）。
   int detailTagsRefresh = 0;
 
+  Future<List<BookTagRow>>? _detailTagsFuture;
+  int? _detailTagsToken;
+  int? _detailTagsCollectionId;
+
+  /// 标签查询，身份 = (合集 id, [detailTagsRefresh])。
+  ///
+  /// **不能在 build 里现取**（BUG-2010）：那样每次重建都对库多发一次查询，而
+  /// 重建源不受本页控制——app 一拉到前台就走 `AppLifecycleState.resumed` → 重取
+  /// 系统调色板 → 通知主题 → 全树重建。
+  ///
+  /// 注意 chip 行**不会**因此闪：builder 只读 `snap.data`，而 FutureBuilder 换
+  /// future 时走的是 `_snapshot.inState(ConnectionState.none)`——data 会保留，
+  /// 只有像 `VideoWorkDetailPage` 那样判 `connectionState` 的才会退回加载态。
+  /// 记忆化省下的是白查库，不是闪。
+  Future<List<BookTagRow>> get _detailTags {
+    final int collectionId = detailCollection.id;
+    if (_detailTagsFuture == null ||
+        _detailTagsToken != detailTagsRefresh ||
+        _detailTagsCollectionId != collectionId) {
+      _detailTagsToken = detailTagsRefresh;
+      _detailTagsCollectionId = collectionId;
+      _detailTagsFuture = detailDatabase.getTagsForCollection(collectionId);
+    }
+    return _detailTagsFuture!;
+  }
+
   /// 重命名合集：命名弹窗 → renameMediaCollection → setState 更新页题。
   Future<void> renameDetailCollection() async {
     final String? newName = await showCollectionNameDialog(
@@ -55,8 +81,7 @@ mixin CollectionDetailShared<T extends StatefulWidget> on State<T> {
   Widget buildDetailTagChips() {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     return FutureBuilder<List<BookTagRow>>(
-      key: ValueKey<int>(detailTagsRefresh),
-      future: detailDatabase.getTagsForCollection(detailCollection.id),
+      future: _detailTags,
       builder: (BuildContext context, AsyncSnapshot<List<BookTagRow>> snap) {
         final List<BookTagRow> tags = snap.data ?? const <BookTagRow>[];
         if (tags.isEmpty) return const SizedBox.shrink();

--- a/fushi/lib/src/pages/implementations/collection_relations_section.dart
+++ b/fushi/lib/src/pages/implementations/collection_relations_section.dart
@@ -48,8 +48,35 @@ class _CollectionRelationsSectionState
 
   final ScrollController _controller = ScrollController();
 
-  /// 绑定后自增，强制 FutureBuilder 重取（与 detailTagsRefresh 同范式）。
-  int _refresh = 0;
+  /// 关系边查询。**必须持久化在 State 里，不能写在 build 里现取**（BUG-2010）：
+  /// 写在 build 里 = 每次重建都对库多发一次查询，而重建源不受本页控制——app 一
+  /// 拉到前台就走 `AppLifecycleState.resumed` → 重取系统调色板 → 通知主题 →
+  /// 全树重建。
+  ///
+  /// 注意本区**不会**因此闪：builder 只读 `snap.data`，而 FutureBuilder 换
+  /// future 时走的是 `_snapshot.inState(ConnectionState.none)`——data 会保留，
+  /// 只有像 `VideoWorkDetailPage` 那样判 `connectionState` 的才会退回加载态。
+  /// 这里省下的是白查库，不是闪。future 的身份只由 collectionId 决定。
+  late Future<List<CollectionRelationRow>> _relationsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _relationsFuture = widget.database.getCollectionRelations(
+      widget.collectionId,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant CollectionRelationsSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.collectionId != widget.collectionId ||
+        oldWidget.database != widget.database) {
+      _relationsFuture = widget.database.getCollectionRelations(
+        widget.collectionId,
+      );
+    }
+  }
 
   @override
   void dispose() {
@@ -154,7 +181,13 @@ class _CollectionRelationsSectionState
       msg: t.collection_relation_bound(name: chosen.name),
       severity: ToastSeverity.success,
     );
-    setState(() => _refresh++);
+    // 重取即刷新：future 的身份变化本身就是「该重建」的信号，不再需要一个只为
+    // 翻 key 而存在的计数器。
+    setState(() {
+      _relationsFuture = widget.database.getCollectionRelations(
+        widget.collectionId,
+      );
+    });
   }
 
   Widget _buildCard(
@@ -263,8 +296,7 @@ class _CollectionRelationsSectionState
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     return FutureBuilder<List<CollectionRelationRow>>(
-      key: ValueKey<int>(_refresh),
-      future: widget.database.getCollectionRelations(widget.collectionId),
+      future: _relationsFuture,
       builder: (
         BuildContext context,
         AsyncSnapshot<List<CollectionRelationRow>> snap,

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -27,7 +27,7 @@ class VideoWorkRef {
 
 /// Unified work-level route. Collection works retain the mature episode and
 /// management surface; standalone works use the same canonical v77 data.
-class VideoWorkDetailPage extends StatelessWidget {
+class VideoWorkDetailPage extends StatefulWidget {
   const VideoWorkDetailPage({
     required this.database,
     required this.repository,
@@ -50,11 +50,48 @@ class VideoWorkDetailPage extends StatelessWidget {
   final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
 
   @override
+  State<VideoWorkDetailPage> createState() => _VideoWorkDetailPageState();
+}
+
+class _VideoWorkDetailPageState extends State<VideoWorkDetailPage> {
+  /// 合集行查询。**必须持久化在 State 里，不能写在 build 里现取**（BUG-2010）：
+  /// 写在 build 里 = 每次重建都换一个新 Future，FutureBuilder 认出 future 变了就
+  /// 丢弃旧 snapshot 退回 waiting，整页落回加载指示器；更糟的是下面的
+  /// [MediaCollectionDetailPage] 会被当成新子树重建，它自己的 `_loading` 一并复
+  /// 位 → 剧集列表整份重查。而重建源不受本页控制：app 一拉到前台就走
+  /// `AppLifecycleState.resumed` → 重取系统调色板 → 通知主题 → 全树重建，于是
+  /// 「切回 Fushi 就闪一下」。future 的身份必须只由 (collectionId, database) 决定。
+  ///
+  /// 独立作品（[VideoWorkRef.book]）没有合集行要查，此处恒 null。
+  Future<MediaCollectionRow?>? _collectionFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _collectionFuture = _loadCollection();
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoWorkDetailPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.workRef.collectionId != widget.workRef.collectionId ||
+        oldWidget.database != widget.database) {
+      _collectionFuture = _loadCollection();
+    }
+  }
+
+  Future<MediaCollectionRow?>? _loadCollection() {
+    final int? collectionId = widget.workRef.collectionId;
+    if (collectionId == null) return null;
+    return widget.database.getMediaCollectionById(collectionId);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final int? collectionId = workRef.collectionId;
+    final int? collectionId = widget.workRef.collectionId;
     if (collectionId != null) {
       return FutureBuilder<MediaCollectionRow?>(
-        future: database.getMediaCollectionById(collectionId),
+        future: _collectionFuture,
         builder: (BuildContext context,
             AsyncSnapshot<MediaCollectionRow?> snapshot) {
           final MediaCollectionRow? collection = snapshot.data;
@@ -72,16 +109,16 @@ class VideoWorkDetailPage extends StatelessWidget {
             );
           }
           return MediaCollectionDetailPage(
-            database: database,
+            database: widget.database,
             collection: collection,
             // 成员解析走共享的 [loadCollectionEpisodeSlots]：合集清单是跨端 union，
             // 「本机没有这一行」不等于「这一集不存在」（BUG-1704）。
             loadEpisodes: () => loadCollectionEpisodeSlots(
-              repository: repository,
+              repository: widget.repository,
               collectionId: collection.id,
-              loadRemoteVideos: remote?.loadRemoteVideos,
+              loadRemoteVideos: widget.remote?.loadRemoteVideos,
             ),
-            remote: remote,
+            remote: widget.remote,
             onOpenEpisode: (VideoBookRow episode) {
               Navigator.push<void>(
                 context,
@@ -89,23 +126,23 @@ class VideoWorkDetailPage extends StatelessWidget {
                   context: context,
                   builder: (_) => VideoFushiPage.neutralized(
                     bookUid: episode.bookUid,
-                    repo: repository,
+                    repo: widget.repository,
                     playlistCollectionId: collection.id,
                   ),
                 ),
               );
             },
-            onChanged: onChanged,
-            onDeleteMembersMedia: onDeleteMembersMedia,
+            onChanged: widget.onChanged,
+            onDeleteMembersMedia: widget.onDeleteMembersMedia,
           );
         },
       );
     }
     return _StandaloneVideoWorkDetail(
-      database: database,
-      repository: repository,
-      bookUid: workRef.bookUid!,
-      onChanged: onChanged,
+      database: widget.database,
+      repository: widget.repository,
+      bookUid: widget.workRef.bookUid!,
+      onChanged: widget.onChanged,
     );
   }
 }

--- a/fushi/test/models/theme_notifier_palette_idempotence_test.dart
+++ b/fushi/test/models/theme_notifier_palette_idempotence_test.dart
@@ -1,0 +1,92 @@
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// BUG-2010 守卫：[ThemeNotifier.refreshSystemPalette] 必须**幂等**——系统色没变
+/// 就不许广播。
+///
+/// 为什么这条值得一个测试：这个方法挂在 `AppLifecycleState.resumed` 上，而桌面端
+/// 每次窗口激活都会走一遍 resumed。无条件 `notifyListeners()` ＝ 「每把 Fushi 拉
+/// 到前台一次，就让整棵 widget 树重建一次」。重建本身无害，但它是「一拉到前台就
+/// 闪」的放大器：任何把 `FutureBuilder.future` 写在 `build()` 里、且判
+/// `connectionState` 的页面都会被它打回加载态（见
+/// `test/pages/detail_future_identity_test.dart`）。
+///
+/// 系统调色板本就极少变，代价几乎为零。
+///
+/// 变异有效性（已实测）：删掉 `if (unchanged) return;` 这条判据，「同色重复刷新」
+/// 用例立刻红。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel =
+      MethodChannel('io.material.plugins/dynamic_color');
+
+  TextTheme textThemeBuilder() => const TextTheme();
+
+  late FushiDatabase db;
+  late ThemeNotifier notifier;
+  late int notifications;
+  int? accentArgb;
+
+  setUp(() {
+    db = FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    notifier = ThemeNotifier(db, textThemeBuilder);
+    notifications = 0;
+    notifier.addListener(() => notifications++);
+    // 桌面端形状：没有完整 CorePalette（那是 Android 独有），只有一个强调色。
+    accentArgb = 0xFF112233;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      if (call.method == 'getAccentColor') return accentArgb;
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    await db.close();
+  });
+
+  test('默认主题就是 system-theme（本守卫的前提）', () {
+    expect(notifier.appThemeKey, 'system-theme');
+  });
+
+  test('首次取到强调色 → 广播一次', () async {
+    await notifier.refreshSystemPalette();
+    expect(notifications, 1);
+    expect(notifier.systemPrimaryColor, const Color(0xFF112233));
+  });
+
+  test('同色重复刷新 → 不再广播（每次拉到前台都会走这里）', () async {
+    await notifier.refreshSystemPalette();
+    expect(notifications, 1, reason: '首次是真变化，应当广播');
+
+    // 模拟「用户把 Fushi 切走又切回来」若干次：系统色一动没动。
+    await notifier.refreshSystemPalette();
+    await notifier.refreshSystemPalette();
+    await notifier.refreshSystemPalette();
+
+    expect(
+      notifications,
+      1,
+      reason: '系统色没变却广播 = 每次拉到前台就把整棵树重建一遍',
+    );
+  });
+
+  test('强调色真的变了 → 照常广播', () async {
+    await notifier.refreshSystemPalette();
+    expect(notifications, 1);
+
+    accentArgb = 0xFF445566;
+    await notifier.refreshSystemPalette();
+
+    expect(notifications, 2, reason: '幂等判据不许把真实变更也吞掉');
+    expect(notifier.systemPrimaryColor, const Color(0xFF445566));
+  });
+}

--- a/fushi/test/pages/detail_future_identity_test.dart
+++ b/fushi/test/pages/detail_future_identity_test.dart
@@ -1,0 +1,259 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/video/video_book_repository.dart';
+import 'package:fushi/src/pages/implementations/collection_detail_shared.dart';
+import 'package:fushi/src/pages/implementations/collection_relations_section.dart';
+import 'package:fushi/src/pages/implementations/media_collection_detail_page.dart';
+import 'package:fushi/src/pages/implementations/video_work_detail_page.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// BUG-2010 守卫：详情页链路上的 `FutureBuilder.future` 必须有**稳定身份**。
+///
+/// 用户症状是「Fushi 一拉到前台就闪」。桌面端每次窗口激活都会走一遍
+/// `AppLifecycleState.resumed` → 重取系统调色板 → 通知主题 → 整棵树重建。重建
+/// 本身无害，害的是把 future 写在 `build()` 里：那样每次重建都是一个新 Future。
+///
+/// 后果分两档，**不要混为一谈**：
+///
+/// ① 判 `connectionState` 的（[VideoWorkDetailPage]）＝ 真的闪。换 future 后
+///    FutureBuilder 走 `_snapshot.inState(ConnectionState.none)`，状态不再是
+///    done → 整页落回加载指示器，子页 [MediaCollectionDetailPage] 从树上消失、
+///    以全新 State 重建，它自己的 `_loading` 一并复位 → 剧集列表重查一遍。
+/// ② 只读 `snap.data` 的（相关作品区、标签 chip 行）＝ **不闪**。上面那个
+///    `inState` 保留 data，旧结果继续渲染。代价是每次重建都白查一次库。
+///
+/// 所以这里钉两条不同的不变式：①「重建后不许退回加载态、State 必须原地复用」，
+/// ②「重建后不许再对库发查询」。
+///
+/// 变异有效性（已实测）：把任一处 future 改回 `build()` 里现取，对应用例即红。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _SelectCounter counter;
+  late FushiDatabase db;
+  late int collectionId;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    counter = _SelectCounter();
+    db = FushiDatabase.forTesting(
+      NativeDatabase.memory().interceptWith(counter),
+    );
+    collectionId =
+        await db.createMediaCollection('作品', collectionType: 'playlist');
+  });
+
+  tearDown(() => db.close());
+
+  testWidgets(
+    '作品资料页：祖先重建后子页 State 原地复用，不退回加载态',
+    (WidgetTester tester) async {
+      final _RebuildHarness harness = _RebuildHarness(
+        builder: (BuildContext context) => VideoWorkDetailPage(
+          database: db,
+          repository: VideoBookRepository(db),
+          workRef: VideoWorkRef.collection(collectionId),
+          onChanged: () {},
+        ),
+      );
+      await tester.pumpWidget(
+        TranslationProvider(child: MaterialApp(home: harness)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MediaCollectionDetailPage), findsOneWidget);
+      final State<StatefulWidget> before =
+          tester.state(find.byType(MediaCollectionDetailPage));
+      final int selectsBefore = counter.selects;
+
+      // 模拟「主题通知 → 全树重建」：widget 换新实例，位置与类型不变。
+      _RebuildHarness.of(tester).rebuild();
+      // 只 pump 一帧、不 settle：闪就发生在这一帧里，settle 会把它重新加载完、
+      // 把证据抹掉。
+      await tester.pump();
+
+      expect(
+        find.byType(MediaCollectionDetailPage),
+        findsOneWidget,
+        reason: '退回 waiting 会让整个子页从树上消失 = 用户看到的那一下闪',
+      );
+      expect(
+        identical(tester.state(find.byType(MediaCollectionDetailPage)), before),
+        isTrue,
+        reason: 'State 被换掉 = _loading 复位 + 剧集列表重查一遍',
+      );
+      expect(
+        counter.selects,
+        selectsBefore,
+        reason: '纯重建不该产生任何新查询',
+      );
+    },
+  );
+
+  testWidgets(
+    '相关作品区：祖先重建后不重查库',
+    (WidgetTester tester) async {
+      await db.replaceCollectionRelations(
+        collectionId,
+        <CollectionRelationsCompanion>[
+          CollectionRelationsCompanion.insert(
+            collectionId: collectionId,
+            relationType: 'sequel',
+            sortIndex: const Value<int>(0),
+            targetCollectionId: const Value<int?>(null),
+            source: 'bangumi',
+            subjectId: '200',
+            title: '某作品 第二季',
+          ),
+        ],
+      );
+
+      final _RebuildHarness harness = _RebuildHarness(
+        builder: (BuildContext context) => SingleChildScrollView(
+          child: CollectionRelationsSection(
+            database: db,
+            collectionId: collectionId,
+            onOpenCollection: (int _) {},
+            onDownload: (CollectionRelationRow _) {},
+          ),
+        ),
+      );
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(home: Scaffold(body: harness)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('某作品 第二季'), findsOneWidget);
+      final int selectsBefore = counter.selects;
+
+      _RebuildHarness.of(tester).rebuild();
+      await tester.pump();
+
+      expect(
+        counter.selects,
+        selectsBefore,
+        reason: 'future 写在 build 里 = 每次重建都对 collection_relations 重查一遍',
+      );
+      // 数据仍在（drift 的 inState 保留 data，本区本来就不闪）。
+      expect(find.text('某作品 第二季'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    '标签 chip 行：祖先重建后不重查库',
+    (WidgetTester tester) async {
+      final MediaCollectionRow collection =
+          (await db.getMediaCollectionById(collectionId))!;
+
+      final _RebuildHarness harness = _RebuildHarness(
+        builder: (BuildContext context) =>
+            _TagChipsHost(db: db, collection: collection),
+      );
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MaterialApp(home: Scaffold(body: harness)),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final int selectsBefore = counter.selects;
+
+      _RebuildHarness.of(tester).rebuild();
+      await tester.pump();
+
+      expect(
+        counter.selects,
+        selectsBefore,
+        reason: 'future 写在 build 里 = 每次重建都把本合集标签重查一遍',
+      );
+    },
+  );
+}
+
+/// 数 `runSelect`，用来钉「纯重建不产生查询」。
+///
+/// 不按表名过滤：pumpAndSettle 之后这棵树已经静止，此后任何一条 select 都只能
+/// 来自重建本身，正是要抓的东西。
+class _SelectCounter extends QueryInterceptor {
+  int selects = 0;
+
+  @override
+  Future<List<Map<String, Object?>>> runSelect(
+    QueryExecutor executor,
+    String statement,
+    List<Object?> args,
+  ) {
+    selects++;
+    return executor.runSelect(statement, args);
+  }
+}
+
+/// 祖先重建 harness。
+///
+/// **必须经 builder 现造 child**，不能持有一个 child 实例直接返回：Flutter 对
+/// `identical` 的 widget 会短路掉子树重建，那样这些用例会在有 bug 的代码上照样
+/// 绿——测的就不是重建了。
+class _RebuildHarness extends StatefulWidget {
+  const _RebuildHarness({required this.builder});
+
+  final WidgetBuilder builder;
+
+  static _RebuildHarnessState of(WidgetTester tester) =>
+      tester.state(find.byType(_RebuildHarness)) as _RebuildHarnessState;
+
+  @override
+  State<_RebuildHarness> createState() => _RebuildHarnessState();
+}
+
+class _RebuildHarnessState extends State<_RebuildHarness> {
+  int _tick = 0;
+
+  void rebuild() => setState(() => _tick++);
+
+  @override
+  Widget build(BuildContext context) {
+    // _tick 只是让 build 的产物每次都是新实例。
+    assert(_tick >= 0);
+    return widget.builder(context);
+  }
+}
+
+/// [CollectionDetailShared] 的最小宿主：mixin 的 chip 行离不开一个 State 宿主，
+/// 但整个 [MediaCollectionDetailPage] 只在成员非空时才渲染 chip 行，太重。
+class _TagChipsHost extends StatefulWidget {
+  const _TagChipsHost({required this.db, required this.collection});
+
+  final FushiDatabase db;
+  final MediaCollectionRow collection;
+
+  @override
+  State<_TagChipsHost> createState() => _TagChipsHostState();
+}
+
+class _TagChipsHostState extends State<_TagChipsHost>
+    with CollectionDetailShared<_TagChipsHost> {
+  String _name = '';
+
+  @override
+  FushiDatabase get detailDatabase => widget.db;
+
+  @override
+  MediaCollectionRow get detailCollection => widget.collection;
+
+  @override
+  String get detailName => _name;
+
+  @override
+  set detailName(String value) => _name = value;
+
+  @override
+  VoidCallback get detailOnChanged => () {};
+
+  @override
+  Widget build(BuildContext context) => buildDetailTagChips();
+}


### PR DESCRIPTION
本分支早已完成但从未开过 PR，现补开以便审查/合并。

提交：
- docs(bug): 回填 BUG-2010 修复提交哈希
- fix(video): 作品资料页一拉到前台就闪回加载态

改动规模： 8 files changed, 494 insertions(+), 22 deletions(-)
分支基点：70ee5ebb26（2026-09-01）

与当前 develop 的冲突块数：2 —— **需要先解冲突，PR 处于 CONFLICTING 时不会启动任何 CI check**。


https://claude.ai/code/session_01M3Uvn1LeRdu8J2mU4mZvAb