### PR TITLE
feat(galgame): 手动校准收进「仅贴附层」模式，自动流程不再往游戏上盖框

### DIFF
--- a/fushi/lib/src/lookup/gal_attached_text_controller.dart
+++ b/fushi/lib/src/lookup/gal_attached_text_controller.dart
@@ -336,7 +336,15 @@ class GalAttachedTextController extends ChangeNotifier {
   bool get forceAttachedProvider => _forceAttachedProvider;
   GalLookupNormalizedRectV1? get draftBodyRect => _draftBodyRect;
   GalLookupTextLayoutV1? get draftLayout => _draftLayout;
+
+  /// 手动校准只在用户显式把模式切到「仅贴附层」之后才存在。自动模式下原生几何
+  /// 缺席时不再把校准入口推到用户面前——那条路的第一步就是往游戏正文上盖一个
+  /// 预置矩形，属于用户没要过的干扰。
+  bool get calibrationManuallyEnabled =>
+      (_profile?.mode ?? GalLookupSurfaceMode.auto) ==
+      GalLookupSurfaceMode.attachedOnly;
   bool get canCalibrate =>
+      calibrationManuallyEnabled &&
       _target != null &&
       _currentClient != null &&
       _exePath != null &&
@@ -662,6 +670,17 @@ class GalAttachedTextController extends ChangeNotifier {
     }
     if (profile == null) {
       _setAttachedProviderClaim(false);
+      // 没有档案时只有「仅贴附层」才提示去校准；其余模式安静挂起，不再引导用户
+      // 走那条会在游戏上画框的路。
+      if (mode != GalLookupSurfaceMode.attachedOnly) {
+        _activeVariant = null;
+        _surfaceVisible = false;
+        _setStatus(
+          GalAttachedTextStatus.suspended,
+          reason: 'evaluate_calibration_manual_only',
+        );
+        return;
+      }
       _setStatus(
         GalAttachedTextStatus.needsCalibration,
         reason: 'evaluate_profile_missing',
@@ -683,6 +702,17 @@ class GalAttachedTextController extends ChangeNotifier {
     );
     if (variant == null) {
       _setAttachedProviderClaim(false);
+      // 已有档案但当前客户区没有匹配 variant：同样只在手动模式下提示重新校准。
+      // 老用户已校准过的 variant 走的是上面 `variant != null` 那条，不受影响。
+      if (mode != GalLookupSurfaceMode.attachedOnly) {
+        _activeVariant = null;
+        _surfaceVisible = false;
+        _setStatus(
+          GalAttachedTextStatus.suspended,
+          reason: 'evaluate_variant_manual_only',
+        );
+        return;
+      }
       _setStatus(
         GalAttachedTextStatus.needsCalibration,
         reason: 'evaluate_no_variant_for_client',
@@ -823,6 +853,10 @@ class GalAttachedTextController extends ChangeNotifier {
     if (target == null || client == null || _latestSourceText.isEmpty) {
       return false;
     }
+    // UI 门控之外再守一道：校准只能由「仅贴附层」这一显式手动模式触发，
+    // 任何其它入口（自动模式下的残留回调、测试、真机驱动）都不得把游戏窗口
+    // 拖进校准态。
+    if (!calibrationManuallyEnabled) return false;
     if (!acceptUnsafeLeftClick) {
       _setStatus(
         GalAttachedTextStatus.needsRiskAcceptance,

--- a/fushi/lib/src/pages/implementations/gal_attached_lookup_workbench.dart
+++ b/fushi/lib/src/pages/implementations/gal_attached_lookup_workbench.dart
@@ -38,8 +38,14 @@ class GalAttachedLookupWorkbench extends StatelessWidget {
         final GalAttachedUnsafeRiskAcceptanceRequest? riskRequest =
             controller.unsafeRiskAcceptanceRequest;
         final bool riskPending = controller.needsUnsafeRiskAcceptance;
+        // 手动校准只在用户显式选了「仅贴附层」之后才露面：自动模式下工具条上
+        // 不再出现校准按钮，也不再挂「未选正文线程」这类只为校准服务的提示。
+        final bool calibrationExposed =
+            mode == GalLookupSurfaceMode.attachedOnly;
         final bool canOpenCalibration =
             hasSelectedBodyThread && controller.canCalibrate;
+        final bool showThreadRequiredPill =
+            calibrationExposed && !hasSelectedBodyThread;
 
         return Material(
           key: const ValueKey<String>('game-attached-lookup-workbench'),
@@ -133,7 +139,7 @@ class GalAttachedLookupWorkbench extends StatelessWidget {
                                 : t.game_lookup_attached_risk_safe,
                             warning: riskModeActive || riskPending,
                           ),
-                          if (!hasSelectedBodyThread) ...<Widget>[
+                          if (showThreadRequiredPill) ...<Widget>[
                             const SizedBox(width: 6),
                             _WorkbenchPill(
                               label: t.game_lookup_attached_calibrate,
@@ -146,21 +152,24 @@ class GalAttachedLookupWorkbench extends StatelessWidget {
                     ),
                   ),
                 ),
-                IconButton(
-                  key: const ValueKey<String>('game-attached-lookup-calibrate'),
-                  padding: EdgeInsets.zero,
-                  constraints: BoxConstraints.tightFor(
-                    width: tokens.density.compactControlHeight,
-                    height: tokens.density.compactControlHeight,
+                if (calibrationExposed)
+                  IconButton(
+                    key: const ValueKey<String>(
+                      'game-attached-lookup-calibrate',
+                    ),
+                    padding: EdgeInsets.zero,
+                    constraints: BoxConstraints.tightFor(
+                      width: tokens.density.compactControlHeight,
+                      height: tokens.density.compactControlHeight,
+                    ),
+                    tooltip: canOpenCalibration
+                        ? t.game_lookup_attached_calibrate
+                        : t.game_lookup_attached_thread_required,
+                    onPressed: canOpenCalibration
+                        ? () => _openCalibration(context)
+                        : null,
+                    icon: const Icon(Icons.crop_free_outlined, size: 20),
                   ),
-                  tooltip: canOpenCalibration
-                      ? t.game_lookup_attached_calibrate
-                      : t.game_lookup_attached_thread_required,
-                  onPressed: canOpenCalibration
-                      ? () => _openCalibration(context)
-                      : null,
-                  icon: const Icon(Icons.crop_free_outlined, size: 20),
-                ),
                 PopupMenuButton<String>(
                   key: const ValueKey<String>('game-attached-lookup-mode'),
                   tooltip: t.game_lookup_attached_mode,

--- a/fushi/test/lookup/gal_attached_text_controller_test.dart
+++ b/fushi/test/lookup/gal_attached_text_controller_test.dart
@@ -558,7 +558,18 @@ void main() {
     'missing profile calibrates only after unsafe risk and three probes',
     () async {
       await sync();
-      expect(controller.status, GalAttachedTextStatus.needsCalibration);
+      // 自动模式不再引导校准：没有档案时安静挂起，校准入口也不给。
+      expect(controller.status, GalAttachedTextStatus.suspended);
+      expect(controller.canCalibrate, isFalse);
+      expect(
+        await controller.beginCalibration(acceptUnsafeLeftClick: true),
+        isFalse,
+        reason: '自动模式下即便已接受风险也不得进入校准态',
+      );
+      // 切进手动模式：setMode 建出的档案风险位是 false，所以先卡在风险确认，
+      // 而不是直接报「未校准」——校准入口此时已经可用。
+      await controller.setMode(GalLookupSurfaceMode.attachedOnly);
+      expect(controller.status, GalAttachedTextStatus.needsRiskAcceptance);
       expect(controller.canCalibrate, isTrue);
       expect(
         await controller.beginCalibration(acceptUnsafeLeftClick: false),
@@ -606,7 +617,7 @@ void main() {
 
       expect(controller.status, GalAttachedTextStatus.activeAttached);
       expect(controller.profile?.variants.single.bodyRect, committed);
-      expect(controller.profile?.mode, GalLookupSurfaceMode.auto);
+      expect(controller.profile?.mode, GalLookupSurfaceMode.attachedOnly);
       expect(
         GalLookupSurfaceProfileV1.tryFromJson(
           jsonDecode(preferences[key()]! as String),
@@ -618,7 +629,12 @@ void main() {
 
   test('incomplete or invalid probe positions cannot commit', () async {
     await sync();
-    await controller.beginCalibration(acceptUnsafeLeftClick: true);
+    await controller.setMode(GalLookupSurfaceMode.attachedOnly);
+    expect(
+      await controller.beginCalibration(acceptUnsafeLeftClick: true),
+      isTrue,
+      reason: '手动模式下校准必须真起来，否则下面的断言全是空转',
+    );
     const GalAttachedCalibrationProbes invalid = GalAttachedCalibrationProbes(
       startIndex: 0,
       middleIndex: 0,
@@ -633,7 +649,12 @@ void main() {
 
   test('calibration updates accumulate partial probe confirmations', () async {
     await sync();
-    await controller.beginCalibration(acceptUnsafeLeftClick: true);
+    await controller.setMode(GalLookupSurfaceMode.attachedOnly);
+    expect(
+      await controller.beginCalibration(acceptUnsafeLeftClick: true),
+      isTrue,
+      reason: '手动模式下校准必须真起来，否则下面的断言全是空转',
+    );
     const GalAttachedCalibrationProbes startOnly = GalAttachedCalibrationProbes(
       startIndex: 0,
       middleIndex: 3,
@@ -663,6 +684,8 @@ void main() {
 
   test('empty selected thread waits and cannot start calibration', () async {
     await sync(text: '');
+    // 先切到手动模式，把「模式不对」这条门排除掉，剩下的唯一拦截理由才是空正文。
+    await controller.setMode(GalLookupSurfaceMode.attachedOnly);
     expect(controller.status, GalAttachedTextStatus.waitingForBodyThread);
     expect(controller.canCalibrate, isFalse);
     expect(
@@ -780,7 +803,9 @@ void main() {
 
     await sync();
 
-    expect(controller.status, GalAttachedTextStatus.needsCalibration);
+    // kind/id 配对不合法 → 不得赢下 auto；自动模式没有档案时安静挂起，
+    // 不再报 needsCalibration 去引导用户开校准。
+    expect(controller.status, GalAttachedTextStatus.suspended);
     expect(controller.surfaceVisible, isFalse);
     expect(port.calls, <String>['inspect']);
     expect(port.texts, isEmpty);
@@ -941,6 +966,9 @@ void main() {
         shield: GalAttachedShieldStatus(available: true, statusFlags: 0x02),
       );
       await sync(sessionEpoch: 9152);
+      // 校准只能从「仅贴附层」这一显式手动模式起步，所以竞态场景先切模式；
+      // 档案由 setMode 建出来，风险位仍是 false，竞态判据不变。
+      await controller.setMode(GalLookupSurfaceMode.attachedOnly);
       final GalAttachedUnsafeRiskAcceptanceRequest request =
           controller.unsafeRiskAcceptanceRequest!;
       preferenceWriteGate = Completer<void>();
@@ -949,7 +977,7 @@ void main() {
         request,
       );
       await pumpEventQueue();
-      expect(controller.profile, isNull);
+      expect(controller.profile?.unsafeLeftClickAccepted, isFalse);
       expect(controller.needsUnsafeRiskAcceptance, isTrue);
       expect(
         controller.unsafeRiskAcceptanceRequest,
@@ -966,7 +994,11 @@ void main() {
 
       expect(await accepting, isTrue);
       expect(controller.status, GalAttachedTextStatus.calibrating);
-      expect(controller.profile, isNull);
+      expect(
+        controller.profile?.unsafeLeftClickAccepted,
+        isFalse,
+        reason: '在途的风险持久化不得覆盖后起的校准会话',
+      );
       expect(controller.needsUnsafeRiskAcceptance, isFalse);
       expect(
         port.calls.where((String call) => call.startsWith('configure:')),
@@ -1238,13 +1270,16 @@ void main() {
       expect(controller.profile, isNull);
 
       stale = await beginRisk(9304);
+      // 校准只能从显式手动模式起步；setMode 会建出档案，但风险位仍是 false，
+      // 「陈旧请求不得追认」这条判据不变。
+      await controller.setMode(GalLookupSurfaceMode.attachedOnly);
       expect(
         await controller.beginCalibration(acceptUnsafeLeftClick: true),
         isTrue,
       );
       expect(controller.status, GalAttachedTextStatus.calibrating);
       expect(await controller.acceptUnsafeRiskAndRetry(stale), isFalse);
-      expect(controller.profile, isNull);
+      expect(controller.profile?.unsafeLeftClickAccepted, isFalse);
     },
   );
 

--- a/fushi/test/pages/gal_attached_lookup_workbench_test.dart
+++ b/fushi/test/pages/gal_attached_lookup_workbench_test.dart
@@ -77,41 +77,70 @@ void main() {
     );
   });
 
-  testWidgets('workbench is persistent and calibration is body-thread gated', (
-    WidgetTester tester,
-  ) async {
-    final GalAttachedTextController controller = GalAttachedTextController(
-      preferenceReader: (_) => null,
-      preferenceWriter: (_, __) async {},
-    );
-    addTearDown(controller.dispose);
+  testWidgets(
+    'workbench is persistent and calibration entry is manual-mode gated',
+    (WidgetTester tester) async {
+      final GalAttachedTextController controller = GalAttachedTextController(
+        preferenceReader: (_) => null,
+        preferenceWriter: (_, __) async {},
+        surfacePort: _PartialNativeSurfacePort(),
+      );
+      addTearDown(() async {
+        await controller.detach();
+        controller.dispose();
+      });
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: GalAttachedLookupWorkbench(
-            controller: controller,
-            hasSelectedBodyThread: false,
-            bodyPreview: '',
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GalAttachedLookupWorkbench(
+              controller: controller,
+              hasSelectedBodyThread: false,
+              bodyPreview: '',
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(
-      find.byKey(const ValueKey<String>('game-attached-lookup-workbench')),
-      findsOneWidget,
-    );
-    final IconButton calibrate = tester.widget<IconButton>(
-      find.byKey(const ValueKey<String>('game-attached-lookup-calibrate')),
-    );
-    expect(calibrate.onPressed, isNull);
-    expect(find.textContaining('Select one body-text thread'), findsOneWidget);
-    expect(
-      find.byKey(const ValueKey<String>('game-attached-lookup-risk-status')),
-      findsOneWidget,
-    );
-  });
+      expect(
+        find.byKey(const ValueKey<String>('game-attached-lookup-workbench')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('game-attached-lookup-calibrate')),
+        findsNothing,
+        reason: '自动模式下工具条不得再出现校准入口——那条路第一步就是往游戏上盖框',
+      );
+      expect(
+        find.textContaining('Select one body-text thread'),
+        findsNothing,
+        reason: '这条提示只为校准服务，校准不露面时它也不该占位',
+      );
+      expect(
+        find.byKey(const ValueKey<String>('game-attached-lookup-risk-status')),
+        findsOneWidget,
+      );
+
+      await controller.syncSession(
+        active: true,
+        sessionEpoch: 1,
+        targetPid: 2,
+        targetHwnd: 3,
+        sourceText: '本文です',
+      );
+      await controller.setMode(GalLookupSurfaceMode.attachedOnly);
+      await tester.pump();
+
+      final IconButton calibrate = tester.widget<IconButton>(
+        find.byKey(const ValueKey<String>('game-attached-lookup-calibrate')),
+      );
+      expect(calibrate.onPressed, isNull, reason: '手动模式下入口出现，但未选正文线程时仍然禁用');
+      expect(
+        find.textContaining('Select one body-text thread'),
+        findsOneWidget,
+      );
+    },
+  );
 
   testWidgets('partial native without profile exposes risk acceptance', (
     WidgetTester tester,
@@ -176,9 +205,9 @@ void main() {
       lessThan(
         tester
             .getTopLeft(
-              find.byKey(
-                const ValueKey<String>('game-attached-lookup-calibrate'),
-              ),
+              // 用常驻的模式菜单当右侧基准：校准入口已收进手动模式，
+              // 自动模式下它根本不存在，拿它当锚点会让本条恒为异常。
+              find.byKey(const ValueKey<String>('game-attached-lookup-mode')),
             )
             .dx,
       ),


### PR DESCRIPTION
本分支早已完成但从未开过 PR，现补开以便审查/合并。

提交：
- feat(galgame): 手动校准收进「仅贴附层」模式，自动流程不再往游戏上盖框

改动规模： 4 files changed, 164 insertions(+), 57 deletions(-)
分支基点：ff6afdcf1e（2026-09-06）

与当前 develop 的冲突块数：2 —— **需要先解冲突，PR 处于 CONFLICTING 时不会启动任何 CI check**。


https://claude.ai/code/session_01M3Uvn1LeRdu8J2mU4mZvAb