### PR TITLE
fix(browser-extension): 抽屉面板改用 SW 能力票据，修 drag 泄漏与触屏单列锁死

### DIFF
--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -19,6 +19,63 @@ const lookupPerfReady = chrome.storage.local.get(LOOKUP_PERF_STORAGE_KEY)
   })
   .catch(() => { lookupPerfLogs = []; });
 
+// ── 字幕抽屉的能力票据（详见下方 drawerFrameTicket/drawerFrameAuth 两个分支）──
+// 票只活在 SW 内存里：发票到验票就是一次 iframe 加载（毫秒级，且全程有消息
+// 在途、SW 不会被回收），无需也不应落盘。TTL 只是道保险丝，顺手清掉没被领走的死票。
+const DRAWER_TICKET_TTL_MS = 60000;
+const drawerTickets = new Map(); // ticket -> { tabId, hostOrigin, expiresAt }
+
+function pruneDrawerTickets(now) {
+  for (const [key, rec] of drawerTickets) if (rec.expiresAt <= now) drawerTickets.delete(key);
+}
+
+// 票号必须不可预测：拿不到真随机源宁可不发票（抽屉不能用），
+// 也绝不回退到 Date.now() 之类可猜的值——那等于把锁的钥匙写在门上。
+function newDrawerTicketId() {
+  try {
+    if (crypto && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+    if (crypto && typeof crypto.getRandomValues === 'function') {
+      const buf = new Uint8Array(32);
+      crypto.getRandomValues(buf);
+      return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+    }
+  } catch (_) {}
+  return null;
+}
+
+function senderTabId(sender) {
+  return sender && sender.tab && Number.isInteger(sender.tab.id) ? sender.tab.id : null;
+}
+
+function mintDrawerTicket(sender) {
+  const tabId = senderTabId(sender);
+  let hostOrigin = '';
+  try { hostOrigin = new URL(sender && (sender.origin || sender.url) || '').origin; } catch (_) { hostOrigin = ''; }
+  const ticket = newDrawerTicketId();
+  // 没标签身份/没真 origin（opaque 的 'null' 也算）/没随机源——一律不发票。
+  if (tabId == null || !hostOrigin || hostOrigin === 'null' || !ticket) return { ok: false };
+  const now = Date.now();
+  pruneDrawerTickets(now);
+  drawerTickets.set(ticket, { tabId, hostOrigin, expiresAt: now + DRAWER_TICKET_TTL_MS });
+  return { ok: true, ticket };
+}
+
+function verifyDrawerTicket(ticket, sender) {
+  const now = Date.now();
+  pruneDrawerTickets(now);
+  const rec = typeof ticket === 'string' && ticket ? drawerTickets.get(ticket) : null;
+  if (rec) drawerTickets.delete(ticket); // 一次性：取完即焚，重放一概不认
+  const panelUrl = chrome.runtime.getURL('side-panel.html');
+  const fromOwnPanel = !!(sender && typeof sender.url === 'string' && sender.url.indexOf(panelUrl) === 0);
+  if (!rec || !fromOwnPanel) return { ok: false };
+  // 真正的锁是那张不可预测的一次性票：它只交给发票那一页的 content script，别的上下文
+  // 拿不到，也就伪造不出这条回问。标签比对是加固层，**存在才比对**——扩展 iframe 的
+  // sender.tab 在主流内核上都有，但没有的话不该把抽屉整个锁死（那是把加固层当唯一锁）。
+  const askerTabId = senderTabId(sender);
+  if (askerTabId != null && askerTabId !== rec.tabId) return { ok: false };
+  return { ok: true, tabId: rec.tabId, hostOrigin: rec.hostOrigin };
+}
+
 function nextLookupPerfId() {
   try {
     if (crypto && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
@@ -516,14 +573,23 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 另外：open() 必须是拿到激活后的第一句——原实现先 `await setOptions(...)`，其 resolve 落在
   // 新的宏任务里，激活早已过期，等于自己把仅有的机会也丢掉了。setOptions 不需要激活，挪到
   // open() 之后补（manifest 的 side_panel.default_path 已足以让 open() 用对页面）。
-  // 字幕抽屉（mobile-drawer.js）：iframe 里的扩展页拿不到宿主标签身份，content script
-  // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
-  // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
-  if (msg && msg.type === 'drawerSelfTab') {
-    sendResponse({
-      ok: true,
-      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
-    });
+  // 字幕抽屉（mobile-drawer.js）的能力票据——发票端。
+  // 抽屉把 side-panel.html 嵌进网页，它因此必须是 web_accessible_resource；
+  // 于是**任何站点**都能凭同一个 URL 嵌入这份持完整扩展权限的文档。
+  // 身份不能写在 URL 参数里（嵌入方自证等于没校验）：真凭据只能由 SW 发放。
+  // content script 请票 → SW 记下浏览器给的 sender.tab.id 与宿主 origin（伪造不了）。
+  if (msg && msg.type === 'drawerFrameTicket') {
+    sendResponse(mintDrawerTicket(_sender));
+    return true;
+  }
+  // —— 验票端：由 iframe 里的面板文档回问。
+  // 校验全基于浏览器提供的 sender 与 SW 自己发的票，谁都冒充不了：
+  //   ① 票存在且未过期（一次性，取完即焚）；
+  //   ② 回问者确实是本扩展的 side-panel 页（sender.url）；
+  //   ③ 回问者所在标签 == 发票时那一页（加固层，见 verifyDrawerTicket）。
+  // 通过才如实回报标签 id 与宿主 origin（面板拿它们当唯一真值）。
+  if (msg && msg.type === 'drawerFrameAuth') {
+    sendResponse(verifyDrawerTicket(msg.ticket, _sender));
     return true;
   }
   if (msg && msg.type === 'openSubtitleSidePanel') {

--- a/fushi/assets/browser_extension/manifest.json
+++ b/fushi/assets/browser_extension/manifest.json
@@ -44,8 +44,7 @@
     }
   ],
   "web_accessible_resources": [
-    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] },
-    { "resources": ["side-panel.html", "side-panel.css", "side-panel.js", "popup-size.js", "auto-read.js", "ruby-render.js", "vendor/selection.js", "vendor/dict-media.js", "vendor/popup.js"], "matches": ["<all_urls>"] }
+    { "resources": ["vendor/content.css", "side-panel.html"], "matches": ["<all_urls>"] }
   ],
   "options_page": "options.html",
   "side_panel": { "default_path": "side-panel.html" },

--- a/fushi/assets/browser_extension/mobile-drawer.js
+++ b/fushi/assets/browser_extension/mobile-drawer.js
@@ -2,13 +2,16 @@
 // 安卓系浏览器没有 chrome.sidePanel——那是桌面独有 API，字幕列表（side-panel.html 整套 UI）
 // 在手机上原本没有任何显示面。本脚本在「触屏设备 + 页面里有视频」时挂一条贴边拉条：
 //   · 轻点拉条 → 抽屉滑入：横屏从右缘抽出、竖屏从底部升起；内容是一份 iframe，指向
-//     side-panel.html?fushiEmbed=1&fushiTabId=N —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
+//     side-panel.html?fushiTicket=<一次性票据> —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
 //     搜字幕/制卡/面板查词全部原样复用，零复制逻辑；
 //   · 按住拉条直接左右/上下拖 → 抽屉跟手；松手按露出比例吸附开/关，开态拖过当前尺寸
 //     即顺手加宽/加高并存进 mobileSubtitleDrawerGeom（下次记住）——「可收可拉」；
-//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加），
-//     iframe 上下文里 tabs.query({currentWindow}) 不可靠，标签 id 由 background 的
-//     drawerSelfTab 如实回报 sender.tab.id；
+//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加）——
+//     这意味着**任何站点**都能凭同一个 URL 把这份持完整扩展权限的文档嵌进自己的页面，
+//     所以身份绝不能写在 URL 参数里（那是嵌入方自证）。建帧前先向 SW 现取一张一次性
+//     票据，SW 记下浏览器给的 sender.tab.id 与宿主 origin；面板拿票回问 SW 验明正身
+//     （见 background.js drawerFrameTicket/drawerFrameAuth 与 side-panel.js 的验票段）。
+//     标签 id 与宿主 origin 都由 SW 如实回报，iframe 上下文里 tabs.query 本就不可靠；
 //   · 收起不销毁 iframe（列表滚动位置、在途请求都保命），postMessage 通知面板暂停 300ms
 //     轮询，拉开即恢复；
 //   · 进全屏跟着进：节点迁 fullscreenElement 子树（与字幕覆盖层/查词弹窗同一策略）。
@@ -34,7 +37,6 @@
   var rootEl = null;
   var stripEl = null;
   var iframeEl = null;
-  var frameTabId; // undefined=未知，null=问过拿不到（回落 queryActiveTab）
 
   function coarsePointer() {
     try { return !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches); } catch (_) { return false; }
@@ -258,31 +260,33 @@
     } catch (_) {}
   }
 
+  function dropIframe() {
+    if (!iframeEl) return;
+    try { if (iframeEl.parentNode) iframeEl.parentNode.removeChild(iframeEl); } catch (_) {}
+    iframeEl = null;
+  }
   function ensureIframe() {
     if (iframeEl || !rootEl) return;
     iframeEl = document.createElement('iframe');
     iframeEl.id = 'fushi-drawer-frame';
     iframeEl.setAttribute('aria-label', '字幕列表');
-    var start = function (tid) {
-      var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
-      if (tid != null) url += '&fushiTabId=' + tid;
-      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
-      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
-      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
-      iframeEl.src = url;
-    };
-    if (frameTabId !== undefined) start(frameTabId);
-    else {
-      try {
-        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
-          var tid = null;
-          try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
-          frameTabId = tid;
-          start(tid);
-        });
-      } catch (_) { frameTabId = null; start(null); }
-    }
     rootEl.appendChild(iframeEl);
+    // 票据是这条 iframe 唯一的身份凭据：不带票的面板文档一律停摆（side-panel.js
+    // 验票段），所以拿不到票就干脆不加载它——留一个空转的扩展页毫无意义，下次
+    // 开抽屉自然重试。每建一帧现取一张（一次性、短 TTL），绝不缓存复用。
+    var frame = iframeEl;
+    try {
+      chrome.runtime.sendMessage({ type: 'drawerFrameTicket' }, function (resp) {
+        if (frame !== iframeEl) return; // 期间已卸除/重建
+        var ticket = '';
+        try {
+          if (!chrome.runtime.lastError && resp && resp.ok && typeof resp.ticket === 'string') ticket = resp.ticket;
+        } catch (_) {}
+        if (!ticket) { dropIframe(); return; }
+        frame.src = chrome.runtime.getURL('side-panel.html')
+          + '?fushiTicket=' + encodeURIComponent(ticket);
+      });
+    } catch (_) { dropIframe(); }
   }
 
   function setOpen(on) {
@@ -474,6 +478,10 @@
   function unmount() {
     if (!rootEl) return;
     endWindowDrag(); // 拖到一半被停用也不能留监听
+    // drag 是模块级状态，不随节点一起消失：卸除时不清，它就永久停在「拖拽中」。
+    // onResize 与 adopt 轮询头一句都是「if (drag) ...」——旋屏/分屏重排、播放器自重排
+    // 跟随从此全部短路，且重挂载也救不回（只有下一次真按住拉条才会被覆盖）。
+    drag = null;
     if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
     document.removeEventListener('fullscreenchange', onFullscreenChange);
     window.removeEventListener('resize', onResize);

--- a/fushi/assets/browser_extension/side-panel.js
+++ b/fushi/assets/browser_extension/side-panel.js
@@ -28,19 +28,30 @@
   window.__fushiRoot = lookupShadow;
   installDictMediaPlaceholderResolver(lookupShadow); // BUG-1718：兑现词条内图片/样式表占位
   var currentTabId = null;
-  // 抽屉嵌入模式（mobile-drawer.js 的 iframe 打开，?fushiEmbed=1）：
-  //   · 绑定来源页 tabId——网页内扩展 iframe 里 tabs.query 的 currentWindow 解析不可靠，
-  //     以 background drawerSelfTab 如实回报的 sender.tab.id 为准（缺参数仍走 queryActiveTab）；
+  // 抽屉嵌入模式（mobile-drawer.js 把本页当 iframe 嵌进宿主网页）：
+  //   · 判据是「我被嵌了吗」而不是 URL 参数——side-panel.html 必须是
+  //     web_accessible_resource（网页里的 iframe 才加载得了），**任何站点**都能把这份
+  //     持完整扩展权限的文档嵌进自己的页面，而且可以一个参数都不带；若按参数
+  //     分流，不带参数那条反而直接跑成完整侧板（轮询 + chrome.tabs + 查词全开）。
+  //     真侧板永远是顶层文档，被嵌 = 只可能是抽屉，因此被嵌就必须验票。
+  //   · 票据由 SW 现发（background.js drawerFrameTicket），面板拿票回问验明正身；
+  //     标签 id 与宿主 origin 只认 SW 回报的值（浏览器给的 sender.tab.id / sender.origin，
+  //     伪造不了），绝不读 URL 里的 tabId/hostOrigin——那是嵌入方自证。
+  //     验票未过 = 整页停摆：不轮询、不碰 chrome.tabs、不收宿主消息（fail-closed）。
   //   · 不挂 tabs.onActivated：抽屉只服务这一页，「跟着切的标签页走」语义在这里不存在；
   //   · 抽屉收起时宿主 postMessage pause → 暂停 300ms 轮询（省电），拉开立刻补一次；
   //   · html 根挂 .fushi-embed 类，side-panel.css 按触屏规格放大控件、补安全区。
-  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耽误。
+  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耐误。
   var EMBED_SEARCH = typeof location === 'undefined' ? '' : String(location.search || '');
-  var EMBED = /[?&]fushiEmbed=1/.test(EMBED_SEARCH);
-  var EMBED_TAB_ID = (function () {
-    var m = /[?&]fushiTabId=(\d+)/.exec(EMBED_SEARCH);
-    return m ? Number(m[1]) : null;
+  var EMBED = (function () {
+    // 跨源读 window.top 只是引用比较，浏览器里不会抛；抛了只可能是测试沙箱没 window。
+    try { return window.top !== window.self; } catch (_) { return false; }
   })();
+  var EMBED_TICKET = (function () {
+    var m = /[?&]fushiTicket=([^&]*)/.exec(EMBED_SEARCH);
+    try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+  })();
+  var embedAuth = null;  // {tabId, hostOrigin}；验票通过前嵌入模式下一切对外动作停摆
   var embedPaused = false;
   if (EMBED) document.documentElement.classList.add('fushi-embed');
   // 嵌入（手机抽屉）模式头部原本叠了标题+工具排+选轨+时轴偏移三四行，把列表挤得没法看。
@@ -706,7 +717,11 @@
   }
 
   function queryActiveTab() {
-    if (EMBED && EMBED_TAB_ID != null) return Promise.resolve({ id: EMBED_TAB_ID });
+    // 嵌入态只服务发票那一页，且该页 id 只认 SW 验票后回报的值；未验票就没有
+    // 「当前标签」，绝不回退到 tabs.query——那等于把用户正在看的任意标签送给嵌入方当靶子。
+    if (EMBED) {
+      return Promise.resolve(embedAuth && Number.isInteger(embedAuth.tabId) ? { id: embedAuth.tabId } : null);
+    }
     return new Promise(function (resolve) {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
@@ -894,6 +909,7 @@
   }
 
   async function refresh(forceCues) {
+    if (EMBED && !embedAuth) return; // 未验票的嵌入（= 站点自己嵌的）：整页停摆
     if (embedPaused) return; // 抽屉收起：不空转消息，resume 时立即补一次全量
     if (refreshBusy) return;
     refreshBusy = true;
@@ -1220,23 +1236,44 @@
     });
   } catch (_) {}
 
-  // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
-  if (EMBED) {
-    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
-    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
-    var EMBED_HOST_ORIGIN = (function () {
-      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
-      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
-    })();
+  // 验票 + 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立即全量刷新。
+  // 验票通过前不挂 message 监听、不刷新：站点自己嵌的面板拿不到票，就只是一页死文档。
+  function startEmbedSession(auth) {
+    embedAuth = auth;
     window.addEventListener('message', function (ev) {
-      if (ev.origin !== EMBED_HOST_ORIGIN) return;
+      // S5691 + 真信任链：宿主 origin 是 SW 从 sender 里读出来的，不是嵌入方声明的。
+      if (!embedAuth || ev.origin !== embedAuth.hostOrigin) return;
       var d = ev && ev.data;
       if (!d || d.source !== 'fushi-drawer') return;
       if (d.type === 'pause') embedPaused = true;
       else if (d.type === 'resume') { embedPaused = false; refresh(true); }
     });
+    refresh(true);
   }
-
-  refresh(true);
+  function denyEmbed() {
+    // 验票未过就把面板钉在拒绝态，并告诉看到的人为什么是空白（别漏一个无声白页）。
+    embedAuth = null;
+    statusEl.textContent = '未授权的嵌入';
+    listEl.innerHTML = '';
+    var deny = document.createElement('div');
+    deny.className = 'empty';
+    deny.textContent = '本页只能由 Fushi 字幕抽屉打开。';
+    listEl.appendChild(deny);
+  }
+  if (EMBED) {
+    try {
+      chrome.runtime.sendMessage({ type: 'drawerFrameAuth', ticket: EMBED_TICKET }, function (resp) {
+        try { if (chrome.runtime.lastError) resp = null; } catch (_) { resp = null; }
+        if (resp && resp.ok === true && Number.isInteger(resp.tabId)
+            && typeof resp.hostOrigin === 'string' && resp.hostOrigin) {
+          startEmbedSession({ tabId: resp.tabId, hostOrigin: resp.hostOrigin });
+          return;
+        }
+        denyEmbed();
+      });
+    } catch (_) { denyEmbed(); }
+  } else {
+    refresh(true);
+  }
   setInterval(function () { refresh(false); }, 300);
 })();

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -5075,9 +5075,13 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+const DICT_COLUMN_MIN_WIDTH_COARSE = 320; // 触屏指尖精度 + 手机字号下的每列可读下限
+// 触屏（手机/平板，主指针 coarse）上每列的可读下限比鼠标端高得多：170px 一列在手机
+// 弹窗里会把义项压成竖条完全没法读。但不能因此「一律单列」：那是把用户设置整个吞掉——
+// app 内置弹窗在安卓/触屏 Windows 上同样是 coarse，平板横屏与大屏触控一体机明明排
+// 得下多列，却被静默锁死、改设置毫无反应（既无提示也无出路）。正确做法是只抬高
+// 每列的可读下限，仍走同一条 min(用户设置, 装得下的列数) 收敛：手机宽度自然收到
+// 1 列，屏够宽时用户设的多列照旧生效。桌面鼠标主指针是 fine，不受牵连。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5094,6 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5101,8 +5104,11 @@ function effectiveDictColumns() {
     }
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
+    const minWidth = isCoarsePointerType()
+        ? DICT_COLUMN_MIN_WIDTH_COARSE
+        : DICT_COLUMN_MIN_WIDTH;
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / minWidth))
         : configured;
     return Math.min(configured, fit);
 }

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -5075,9 +5075,13 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+const DICT_COLUMN_MIN_WIDTH_COARSE = 320; // 触屏指尖精度 + 手机字号下的每列可读下限
+// 触屏（手机/平板，主指针 coarse）上每列的可读下限比鼠标端高得多：170px 一列在手机
+// 弹窗里会把义项压成竖条完全没法读。但不能因此「一律单列」：那是把用户设置整个吞掉——
+// app 内置弹窗在安卓/触屏 Windows 上同样是 coarse，平板横屏与大屏触控一体机明明排
+// 得下多列，却被静默锁死、改设置毫无反应（既无提示也无出路）。正确做法是只抬高
+// 每列的可读下限，仍走同一条 min(用户设置, 装得下的列数) 收敛：手机宽度自然收到
+// 1 列，屏够宽时用户设的多列照旧生效。桌面鼠标主指针是 fine，不受牵连。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5094,6 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5101,8 +5104,11 @@ function effectiveDictColumns() {
     }
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
+    const minWidth = isCoarsePointerType()
+        ? DICT_COLUMN_MIN_WIDTH_COARSE
+        : DICT_COLUMN_MIN_WIDTH;
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / minWidth))
         : configured;
     return Math.min(configured, fit);
 }

--- a/fushi/test/reader/popup_dict_masonry_guard_test.dart
+++ b/fushi/test/reader/popup_dict_masonry_guard_test.dart
@@ -46,10 +46,23 @@ void main() {
     expect(js.contains('DICT_COLUMN_MIN_WIDTH'), isTrue,
         reason: '有效列数必须按每列最小宽 DICT_COLUMN_MIN_WIDTH 收敛');
     expect(
-        RegExp(r'Math\.floor\(\s*width\s*/\s*DICT_COLUMN_MIN_WIDTH\s*\)')
-            .hasMatch(js),
+        RegExp(r'Math\.floor\(\s*width\s*/\s*minWidth\s*\)').hasMatch(js),
         isTrue,
         reason: '装得下的列数 = floor(视口宽 / 每列最小宽)');
+    // 触屏（含 app 内置弹窗所在的安卓/触屏 Windows）只抬高每列可读下限，绝不能拿
+    // `if (isCoarsePointerType()) return 1;` 把用户设的列数整个吞掉：平板横屏、大屏
+    // 触控一体机明明排得下多列，那样会被静默锁死单列且改设置毫无反应（无提示无出路）。
+    expect(
+        RegExp(r'isCoarsePointerType\(\)\s*\?\s*DICT_COLUMN_MIN_WIDTH_COARSE'
+                r'\s*:\s*DICT_COLUMN_MIN_WIDTH')
+            .hasMatch(js),
+        isTrue,
+        reason: '触屏差异只体现为每列最小宽，仍走同一条 min(用户设置, 装得下) 收敛');
+    expect(
+        RegExp(r'if\s*\(\s*isCoarsePointerType\(\)\s*\)\s*return\s+1\s*;')
+            .hasMatch(js),
+        isFalse,
+        reason: '触屏不得硬锁单列——那是把用户的列数设置整个吞掉');
     // dictColumns()（masonry 列数来源）必须委托给 effectiveDictColumns，而非读原始值。
     final int dcAt = js.indexOf('function dictColumns(');
     expect(dcAt, isNonNegative);

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -15,7 +15,7 @@ Anki 能力——一切经本机 Fushi 桌面 App 内置的 yomitan API server�
 | `side-panel.html/js/css` | 扩展页 | 浏览器原生 Side Panel 字幕列表；侧边栏内取词，默认把词交给宿主页用页面弹窗渲染（见「侧边栏查词跨出面板」），经 tabs 消息读取轨道并执行跳转/制卡/偏移，不把字幕列表注入网页 |
 | `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；每个动作独立开关，动作交 subtitle-panel 执行 |
 | `touch-lookup.js` | 隔离 | 触屏点按/长按查词：单指点正文=查词（默认开）、长按≈0.5s=查词（默认关）；复用 content.js 的 `fushiLookupAtPoint`，零新增查词链路，只认 touch 主指针，绝不影响鼠标行为 |
-| `mobile-drawer.js` | 隔离 | 移动端字幕列表抽屉：安卓无 chrome.sidePanel，触屏视频页挂边缘 ☰ 钮 + 隐形手势带（点=开关、按住=拖宽自由停位）；横屏右挂仅全屏（页面态让位形态太杂已禁用）、竖屏底挂，内容为 iframe 内嵌 `side-panel.html?fushiEmbed=1`（选轨/跳转/偏移/制卡/查词全套复用）；全屏态压播放器让位并以 adopt 跟随其自重排，几何存 `mobileSubtitleDrawerGeom` |
+| `mobile-drawer.js` | 隔离 | 移动端字幕列表抽屉：安卓无 chrome.sidePanel，触屏视频页挂边缘 ☰ 钮 + 隐形手势带（点=开关、按住=拖宽自由停位）；横屏右挂仅全屏（页面态让位形态太杂已禁用）、竖屏底挂，内容为 iframe 内嵌 `side-panel.html?fushiTicket=<SW 现发的一次性票据>`（选轨/跳转/偏移/制卡/查词全套复用；该页是 web_accessible_resource，任何站点都能嵌，故面板**被嵌即必须验票**，标签 id 与宿主 origin 只认 SW 从 `sender` 读出的值，验票不过整页停摆）；全屏态压播放器让位并以 adopt 跟随其自重排，几何存 `mobileSubtitleDrawerGeom` |
 | `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
 | `youtube-bridge.js` | MAIN | YouTube 专用：按 asbplayer 顺序读取播放器运行态 captionTracks（含 POT）→ Android Innertube → player response，并一次下载完整 srv3/json3 轨；只读、不改宿主 DOM |
 | `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -19,6 +19,63 @@ const lookupPerfReady = chrome.storage.local.get(LOOKUP_PERF_STORAGE_KEY)
   })
   .catch(() => { lookupPerfLogs = []; });
 
+// ── 字幕抽屉的能力票据（详见下方 drawerFrameTicket/drawerFrameAuth 两个分支）──
+// 票只活在 SW 内存里：发票到验票就是一次 iframe 加载（毫秒级，且全程有消息
+// 在途、SW 不会被回收），无需也不应落盘。TTL 只是道保险丝，顺手清掉没被领走的死票。
+const DRAWER_TICKET_TTL_MS = 60000;
+const drawerTickets = new Map(); // ticket -> { tabId, hostOrigin, expiresAt }
+
+function pruneDrawerTickets(now) {
+  for (const [key, rec] of drawerTickets) if (rec.expiresAt <= now) drawerTickets.delete(key);
+}
+
+// 票号必须不可预测：拿不到真随机源宁可不发票（抽屉不能用），
+// 也绝不回退到 Date.now() 之类可猜的值——那等于把锁的钥匙写在门上。
+function newDrawerTicketId() {
+  try {
+    if (crypto && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+    if (crypto && typeof crypto.getRandomValues === 'function') {
+      const buf = new Uint8Array(32);
+      crypto.getRandomValues(buf);
+      return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+    }
+  } catch (_) {}
+  return null;
+}
+
+function senderTabId(sender) {
+  return sender && sender.tab && Number.isInteger(sender.tab.id) ? sender.tab.id : null;
+}
+
+function mintDrawerTicket(sender) {
+  const tabId = senderTabId(sender);
+  let hostOrigin = '';
+  try { hostOrigin = new URL(sender && (sender.origin || sender.url) || '').origin; } catch (_) { hostOrigin = ''; }
+  const ticket = newDrawerTicketId();
+  // 没标签身份/没真 origin（opaque 的 'null' 也算）/没随机源——一律不发票。
+  if (tabId == null || !hostOrigin || hostOrigin === 'null' || !ticket) return { ok: false };
+  const now = Date.now();
+  pruneDrawerTickets(now);
+  drawerTickets.set(ticket, { tabId, hostOrigin, expiresAt: now + DRAWER_TICKET_TTL_MS });
+  return { ok: true, ticket };
+}
+
+function verifyDrawerTicket(ticket, sender) {
+  const now = Date.now();
+  pruneDrawerTickets(now);
+  const rec = typeof ticket === 'string' && ticket ? drawerTickets.get(ticket) : null;
+  if (rec) drawerTickets.delete(ticket); // 一次性：取完即焚，重放一概不认
+  const panelUrl = chrome.runtime.getURL('side-panel.html');
+  const fromOwnPanel = !!(sender && typeof sender.url === 'string' && sender.url.indexOf(panelUrl) === 0);
+  if (!rec || !fromOwnPanel) return { ok: false };
+  // 真正的锁是那张不可预测的一次性票：它只交给发票那一页的 content script，别的上下文
+  // 拿不到，也就伪造不出这条回问。标签比对是加固层，**存在才比对**——扩展 iframe 的
+  // sender.tab 在主流内核上都有，但没有的话不该把抽屉整个锁死（那是把加固层当唯一锁）。
+  const askerTabId = senderTabId(sender);
+  if (askerTabId != null && askerTabId !== rec.tabId) return { ok: false };
+  return { ok: true, tabId: rec.tabId, hostOrigin: rec.hostOrigin };
+}
+
 function nextLookupPerfId() {
   try {
     if (crypto && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
@@ -516,14 +573,23 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   // 另外：open() 必须是拿到激活后的第一句——原实现先 `await setOptions(...)`，其 resolve 落在
   // 新的宏任务里，激活早已过期，等于自己把仅有的机会也丢掉了。setOptions 不需要激活，挪到
   // open() 之后补（manifest 的 side_panel.default_path 已足以让 open() 用对页面）。
-  // 字幕抽屉（mobile-drawer.js）：iframe 里的扩展页拿不到宿主标签身份，content script
-  // 又没有 chrome.tabs 可用——由 SW 如实回报发信标签 id，抽屉拼进
-  // side-panel.html?fushiEmbed=1&fushiTabId=N（嵌入模式下绑死这一页，见 side-panel.js）。
-  if (msg && msg.type === 'drawerSelfTab') {
-    sendResponse({
-      ok: true,
-      tabId: _sender && _sender.tab && Number.isInteger(_sender.tab.id) ? _sender.tab.id : null,
-    });
+  // 字幕抽屉（mobile-drawer.js）的能力票据——发票端。
+  // 抽屉把 side-panel.html 嵌进网页，它因此必须是 web_accessible_resource；
+  // 于是**任何站点**都能凭同一个 URL 嵌入这份持完整扩展权限的文档。
+  // 身份不能写在 URL 参数里（嵌入方自证等于没校验）：真凭据只能由 SW 发放。
+  // content script 请票 → SW 记下浏览器给的 sender.tab.id 与宿主 origin（伪造不了）。
+  if (msg && msg.type === 'drawerFrameTicket') {
+    sendResponse(mintDrawerTicket(_sender));
+    return true;
+  }
+  // —— 验票端：由 iframe 里的面板文档回问。
+  // 校验全基于浏览器提供的 sender 与 SW 自己发的票，谁都冒充不了：
+  //   ① 票存在且未过期（一次性，取完即焚）；
+  //   ② 回问者确实是本扩展的 side-panel 页（sender.url）；
+  //   ③ 回问者所在标签 == 发票时那一页（加固层，见 verifyDrawerTicket）。
+  // 通过才如实回报标签 id 与宿主 origin（面板拿它们当唯一真值）。
+  if (msg && msg.type === 'drawerFrameAuth') {
+    sendResponse(verifyDrawerTicket(msg.ticket, _sender));
     return true;
   }
   if (msg && msg.type === 'openSubtitleSidePanel') {

--- a/tools/browser-extension/manifest.json
+++ b/tools/browser-extension/manifest.json
@@ -44,8 +44,7 @@
     }
   ],
   "web_accessible_resources": [
-    { "resources": ["vendor/content.css"], "matches": ["<all_urls>"] },
-    { "resources": ["side-panel.html", "side-panel.css", "side-panel.js", "popup-size.js", "auto-read.js", "ruby-render.js", "vendor/selection.js", "vendor/dict-media.js", "vendor/popup.js"], "matches": ["<all_urls>"] }
+    { "resources": ["vendor/content.css", "side-panel.html"], "matches": ["<all_urls>"] }
   ],
   "options_page": "options.html",
   "side_panel": { "default_path": "side-panel.html" },

--- a/tools/browser-extension/mobile-drawer.js
+++ b/tools/browser-extension/mobile-drawer.js
@@ -2,13 +2,16 @@
 // 安卓系浏览器没有 chrome.sidePanel——那是桌面独有 API，字幕列表（side-panel.html 整套 UI）
 // 在手机上原本没有任何显示面。本脚本在「触屏设备 + 页面里有视频」时挂一条贴边拉条：
 //   · 轻点拉条 → 抽屉滑入：横屏从右缘抽出、竖屏从底部升起；内容是一份 iframe，指向
-//     side-panel.html?fushiEmbed=1&fushiTabId=N —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
+//     side-panel.html?fushiTicket=<一次性票据> —— 选轨/点句跳转/时轴偏移/外挂字幕/Jimaku
 //     搜字幕/制卡/面板查词全部原样复用，零复制逻辑；
 //   · 按住拉条直接左右/上下拖 → 抽屉跟手；松手按露出比例吸附开/关，开态拖过当前尺寸
 //     即顺手加宽/加高并存进 mobileSubtitleDrawerGeom（下次记住）——「可收可拉」；
-//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加），
-//     iframe 上下文里 tabs.query({currentWindow}) 不可靠，标签 id 由 background 的
-//     drawerSelfTab 如实回报 sender.tab.id；
+//   · iframe 挂 chrome-extension:// 页必须走 web_accessible_resources（manifest 已加）——
+//     这意味着**任何站点**都能凭同一个 URL 把这份持完整扩展权限的文档嵌进自己的页面，
+//     所以身份绝不能写在 URL 参数里（那是嵌入方自证）。建帧前先向 SW 现取一张一次性
+//     票据，SW 记下浏览器给的 sender.tab.id 与宿主 origin；面板拿票回问 SW 验明正身
+//     （见 background.js drawerFrameTicket/drawerFrameAuth 与 side-panel.js 的验票段）。
+//     标签 id 与宿主 origin 都由 SW 如实回报，iframe 上下文里 tabs.query 本就不可靠；
 //   · 收起不销毁 iframe（列表滚动位置、在途请求都保命），postMessage 通知面板暂停 300ms
 //     轮询，拉开即恢复；
 //   · 进全屏跟着进：节点迁 fullscreenElement 子树（与字幕覆盖层/查词弹窗同一策略）。
@@ -34,7 +37,6 @@
   var rootEl = null;
   var stripEl = null;
   var iframeEl = null;
-  var frameTabId; // undefined=未知，null=问过拿不到（回落 queryActiveTab）
 
   function coarsePointer() {
     try { return !!(window.matchMedia && window.matchMedia('(pointer: coarse)').matches); } catch (_) { return false; }
@@ -258,31 +260,33 @@
     } catch (_) {}
   }
 
+  function dropIframe() {
+    if (!iframeEl) return;
+    try { if (iframeEl.parentNode) iframeEl.parentNode.removeChild(iframeEl); } catch (_) {}
+    iframeEl = null;
+  }
   function ensureIframe() {
     if (iframeEl || !rootEl) return;
     iframeEl = document.createElement('iframe');
     iframeEl.id = 'fushi-drawer-frame';
     iframeEl.setAttribute('aria-label', '字幕列表');
-    var start = function (tid) {
-      var url = chrome.runtime.getURL('side-panel.html') + '?fushiEmbed=1';
-      if (tid != null) url += '&fushiTabId=' + tid;
-      // 与 postToFrame 的接收端配对（S5691）：面板只认这个 origin 发来的宿主消息。
-      // content script 里 location.origin 就是宿主页 origin，也正是 postMessage 的投递源。
-      url += '&fushiHostOrigin=' + encodeURIComponent(location.origin);
-      iframeEl.src = url;
-    };
-    if (frameTabId !== undefined) start(frameTabId);
-    else {
-      try {
-        chrome.runtime.sendMessage({ type: 'drawerSelfTab' }, function (resp) {
-          var tid = null;
-          try { if (!chrome.runtime.lastError && resp && Number.isInteger(resp.tabId)) tid = resp.tabId; } catch (_) {}
-          frameTabId = tid;
-          start(tid);
-        });
-      } catch (_) { frameTabId = null; start(null); }
-    }
     rootEl.appendChild(iframeEl);
+    // 票据是这条 iframe 唯一的身份凭据：不带票的面板文档一律停摆（side-panel.js
+    // 验票段），所以拿不到票就干脆不加载它——留一个空转的扩展页毫无意义，下次
+    // 开抽屉自然重试。每建一帧现取一张（一次性、短 TTL），绝不缓存复用。
+    var frame = iframeEl;
+    try {
+      chrome.runtime.sendMessage({ type: 'drawerFrameTicket' }, function (resp) {
+        if (frame !== iframeEl) return; // 期间已卸除/重建
+        var ticket = '';
+        try {
+          if (!chrome.runtime.lastError && resp && resp.ok && typeof resp.ticket === 'string') ticket = resp.ticket;
+        } catch (_) {}
+        if (!ticket) { dropIframe(); return; }
+        frame.src = chrome.runtime.getURL('side-panel.html')
+          + '?fushiTicket=' + encodeURIComponent(ticket);
+      });
+    } catch (_) { dropIframe(); }
   }
 
   function setOpen(on) {
@@ -474,6 +478,10 @@
   function unmount() {
     if (!rootEl) return;
     endWindowDrag(); // 拖到一半被停用也不能留监听
+    // drag 是模块级状态，不随节点一起消失：卸除时不清，它就永久停在「拖拽中」。
+    // onResize 与 adopt 轮询头一句都是「if (drag) ...」——旋屏/分屏重排、播放器自重排
+    // 跟随从此全部短路，且重挂载也救不回（只有下一次真按住拉条才会被覆盖）。
+    drag = null;
     if (adoptTimer) { clearInterval(adoptTimer); adoptTimer = 0; }
     document.removeEventListener('fullscreenchange', onFullscreenChange);
     window.removeEventListener('resize', onResize);

--- a/tools/browser-extension/mobile-drawer.test.js
+++ b/tools/browser-extension/mobile-drawer.test.js
@@ -58,7 +58,7 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   const videoEl = makeNode('video');
   const htmlEl = makeNode('html');
   const body = makeNode('body');
-  const captured = { message: [], storage: {}, interval: null, intervals: [], rafs: [] };
+  const captured = { message: [], storage: {}, interval: null, intervals: [], rafs: [], ticketSeq: 0, ticketOk: true };
   const document = {
     fullscreenElement: null,
     body,
@@ -85,7 +85,7 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   const chrome = {
     runtime: {
       getURL: (p) => 'chrome-extension://aaa/' + p,
-      sendMessage(msg, cb) { captured.message.push(msg); if (msg.type === 'drawerSelfTab') cb && cb({ ok: true, tabId: 42 }); else cb && cb({}); },
+      sendMessage(msg, cb) { captured.message.push(msg); if (msg.type === 'drawerFrameTicket') cb && cb(captured.ticketOk === false ? { ok: false } : { ok: true, ticket: 'tkt-' + (++captured.ticketSeq) }); else cb && cb({}); },
       lastError: null,
     },
     storage: { local: storageArea, onChanged: storageArea.onChanged },
@@ -134,7 +134,9 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   tap(200, 790);
   const frame = root.children[1];
   if (!frame || frame.tag !== 'iframe') throw new Error('点开后 iframe 未建');
-  if (!/fushiEmbed=1&fushiTabId=42&fushiHostOrigin=https%3A%2F%2Fm\.test$/.test(frame.src)) throw new Error('src 参数不全: ' + frame.src);
+  // 身份只能是 SW 现发的一次性票据：绝不能再把 tabId/hostOrigin 写进 URL（嵌入方自证）。
+  if (frame.src !== 'chrome-extension://aaa/side-panel.html?fushiTicket=tkt-1') throw new Error('帧 URL 不是票据形态: ' + frame.src);
+  if (/fushiTabId|fushiHostOrigin/.test(frame.src)) throw new Error('URL 里再次出现了可伪造的身份参数: ' + frame.src);
   if (T() !== 'translateY(0px)') throw new Error('开态应贴零: ' + T());
   if (videoEl.style.width || videoEl.style.height || htmlEl.style.width || htmlEl.style.height) {
     throw new Error('非全屏竖屏绝不让位');
@@ -284,4 +286,45 @@ test('mobile-drawer 抽屉状态机全链（门控/底挂/让位/adopt/还原/�
   // 16. 设置关 → 整体卸除干净
   captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: false } }, 'local');
   if (body.children.length !== 0 || fsEl.children.length !== 0) throw new Error('停用后没卸干净');
+
+  // 17. 拖到一半被卸除（门翻转/停用）：drag 是模块级状态，不清就永久停在「拖拽中」，
+  //     而 onResize 头一句就是 `if (drag) return` —— 旋屏重排从此全部短路，重挂载也救不回。
+  captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: true } }, 'local');
+  win.innerWidth = 400; win.innerHeight = 800;
+  document.fullscreenElement = null;
+  syncUi();
+  bindRoot(body);
+  if (!root) throw new Error('17: 重新启用后没挂载');
+  down(200, 700); move(200, 640);            // 拖拽进行中（故意不松手）
+  win.innerWidth = 800; win.innerHeight = 400; // 转横屏非全屏 = 门翻转
+  syncUi();                                   // 900ms 轮询不看拖拽状态，该卸就卸
+  if (body.children.length !== 0) throw new Error('17: 门翻转没卸除');
+  win.innerWidth = 400; win.innerHeight = 800;
+  syncUi();
+  bindRoot(body);
+  if (!root) throw new Error('17: 没重挂');
+  win.innerHeight = 600;                      // 新上限 min(600×0.6, 600-160)=360
+  win.dispatch('resize', {});
+  flush();
+  if (Math.abs(parseFloat(root.style.height) - 360) > 1) {
+    throw new Error('17: 卸除没清 drag，重挂后旋屏重排永久失效: ' + root.style.height);
+  }
+
+  // 18. 拿不到票就不加载面板：不带票的 side-panel 文档在对端一律停摆，
+  //     留个空转的扩展页只是浪费；下次开抽屉重试即可。
+  captured.ticketOk = false;
+  captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: false } }, 'local'); // 卸除（iframe 一并丢）
+  captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: true } }, 'local');
+  syncUi();
+  bindRoot(body);
+  if (!root) throw new Error('18: 没重挂');
+  if (!root.classList.contains('is-open')) tap(200, 790);
+  if (root.children.length !== 1) throw new Error('18: 无票却留下了 iframe');
+  captured.ticketOk = true;
+  tap(200, 790); tap(200, 790); // 关再开：重试取票
+  const frame4 = root.children[1];
+  if (!frame4 || frame4.tag !== 'iframe') throw new Error('18: 取到票后没重建 iframe');
+  if (!/\?fushiTicket=tkt-\d+$/.test(frame4.src)) throw new Error('18: 重建帧没带新票: ' + frame4.src);
+  captured.storageOnChanged({ mobileSubtitleDrawer: { newValue: false } }, 'local');
+  if (body.children.length !== 0) throw new Error('18: 收尾没卸干净');
 });

--- a/tools/browser-extension/side-panel-embed-auth.test.js
+++ b/tools/browser-extension/side-panel-embed-auth.test.js
@@ -1,0 +1,228 @@
+// side-panel.html 嵌入态的信任链守卫（行为测试，非正则）。
+//
+// 背景：手机抽屉把 side-panel.html 当 iframe 嵌进宿主网页，它因此必须是
+// web_accessible_resource——于是**任何站点**都能凭同一个 URL 把这份持完整扩展
+// 权限的文档嵌进自己的页面，而且可以一个参数都不带。回归形状有两个：
+//   ① 把身份（tabId / hostOrigin）写在 URL 参数里——那是嵌入方自证，等于没校验；
+//   ② 按参数（?fushiEmbed=1）分流——不带参数那条反而跑成完整侧板，站点只要
+//      不写参数就能驱动它轮询 chrome.tabs。
+// 真侧板永远是顶层文档，所以判据只能是「我被嵌了吗」+ SW 现发的一次性票据。
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SIDE_PANEL = fs.readFileSync(path.join(__dirname, 'side-panel.js'), 'utf8');
+const POPUP_SIZE = fs.readFileSync(path.join(__dirname, 'popup-size.js'), 'utf8');
+const DICT_MEDIA = fs.readFileSync(path.join(__dirname, 'vendor', 'dict-media.js'), 'utf8');
+
+const flush = async () => { for (let i = 0; i < 6; i++) await new Promise((r) => setImmediate(r)); };
+
+function permissive() {
+  return new Proxy(function () {}, {
+    get(_t, key) {
+      if (key === 'then' || key === Symbol.toPrimitive) return undefined;
+      if (key === 'addListener' || key === 'removeListener') return function () {};
+      return permissive();
+    },
+    apply() { return Promise.resolve({}); },
+  });
+}
+
+function makeEl() {
+  return {
+    id: '', textContent: '', innerHTML: '', hidden: false, disabled: false, value: '',
+    dataset: {}, style: { setProperty() {}, removeProperty() {} }, children: [], handlers: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+    addEventListener(type, fn) { (this.handlers[type] = this.handlers[type] || []).push(fn); },
+    appendChild(child) { this.children.push(child); return child; },
+    removeChild(child) { this.children = this.children.filter((c) => c !== child); return child; },
+    setAttribute() {}, getAttribute() { return null; }, removeAttribute() {},
+    attachShadow() { return makeEl(); },
+    scrollIntoView() {}, focus() {},
+    getBoundingClientRect() { return { top: 0, left: 0, width: 100, height: 20 }; },
+  };
+}
+
+// 嵌入态面板（window.top !== window.self），验票结果由 authReply 决定。
+function loadEmbeddedPanel(options) {
+  options = options || {};
+  const els = new Map();
+  const runtimeMessages = [];
+  const tabQueries = [];
+  const tabMessages = [];
+  const intervals = [];
+  const winHandlers = Object.create(null);
+  const chromeMock = new Proxy({}, {
+    get(_t, key) {
+      if (key === 'runtime') {
+        return {
+          id: 'test-ext-id',
+          lastError: undefined,
+          getURL(p) { return 'chrome-extension://test/' + p; },
+          onMessage: { addListener() {} },
+          sendMessage(message, callback) {
+            runtimeMessages.push(message);
+            if (message && message.type === 'drawerFrameAuth') {
+              if (callback) callback(options.authReply);
+              return;
+            }
+            if (callback) callback(undefined);
+          },
+          openOptionsPage() {},
+        };
+      }
+      if (key === 'storage') {
+        return {
+          local: { get(_k, cb) { if (cb) cb({}); return Promise.resolve({}); }, set() { return Promise.resolve(); } },
+          onChanged: { addListener() {} },
+        };
+      }
+      if (key === 'tabs') {
+        return {
+          query(q, cb) { tabQueries.push(q); cb([{ id: 99, title: '攻击者的页' }]); },
+          get(_id, cb) { cb({ id: 7, title: '宿主页' }); },
+          sendMessage(tabId, message, cb) { tabMessages.push({ tabId, message }); if (cb) cb(undefined); },
+          onActivated: { addListener() {} },
+          onUpdated: { addListener() {} },
+        };
+      }
+      return permissive();
+    },
+  });
+  const windowObj = {
+    innerWidth: 360, innerHeight: 640,
+    addEventListener(type, fn) { (winHandlers[type] = winHandlers[type] || []).push(fn); },
+    removeEventListener() {},
+    getSelection: () => ({ isCollapsed: true }),
+    matchMedia: () => ({ matches: false, addListener() {}, addEventListener() {} }),
+  };
+  windowObj.window = windowObj;
+  windowObj.self = windowObj;
+  windowObj.top = { /* 宿主页的顶层窗口（跨源，只可比较引用） */ };
+  const sandbox = {
+    document: {
+      documentElement: makeEl(),
+      getElementById(id) { if (!els.has(id)) { const el = makeEl(); el.id = id; els.set(id, el); } return els.get(id); },
+      createElement() { return makeEl(); },
+      createDocumentFragment() { return makeEl(); },
+      elementFromPoint() { return null; },
+      addEventListener() {},
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      createRange() { return { setStart() {}, setEnd() {}, getBoundingClientRect() { return null; } }; },
+      body: makeEl(),
+    },
+    window: windowObj,
+    chrome: chromeMock,
+    location: { search: options.search === undefined ? '?fushiTicket=tkt-1' : options.search },
+    localStorage: { getItem() { return null; }, setItem() {} },
+    setTimeout() { return 0; },
+    clearTimeout() {},
+    setInterval(fn) { intervals.push(fn); return intervals.length; },
+    clearInterval() {},
+    requestAnimationFrame: () => 0,
+    performance: { now: () => 1000, timeOrigin: 1700000000000 },
+    console: { log() {}, warn() {}, error() {} },
+    navigator: { language: 'zh-CN' },
+    URL,
+  };
+  sandbox.self = windowObj;
+  vm.createContext(sandbox);
+  vm.runInContext(POPUP_SIZE, sandbox, { filename: 'popup-size.js' });
+  vm.runInContext(DICT_MEDIA, sandbox, { filename: 'vendor/dict-media.js' });
+  vm.runInContext(SIDE_PANEL, sandbox, { filename: 'side-panel.js' });
+  return {
+    els, runtimeMessages, tabQueries, tabMessages, intervals, winHandlers,
+    tick() { intervals.forEach((fn) => fn()); }, // 300ms 轮询
+    post(origin, data) { (winHandlers.message || []).forEach((fn) => fn({ origin, data })); },
+  };
+}
+
+test('站点自己嵌的面板（无票）一律停摆：不碰 chrome.tabs、不轮询、不收宿主消息', async () => {
+  const panel = loadEmbeddedPanel({ authReply: { ok: false } });
+  await flush();
+  panel.tick();
+  await flush();
+  assert.deepEqual(panel.tabQueries, [], '无票嵌入竟然去查了当前标签页');
+  assert.deepEqual(panel.tabMessages, [], '无票嵌入竟然向标签页发了消息');
+  assert.equal(panel.els.get('video-status').textContent, '未授权的嵌入');
+  // 嵌入方冒充任意 origin 发 resume 也拉不起来（根本没挂监听）。
+  panel.post('https://evil.test', { source: 'fushi-drawer', type: 'resume' });
+  panel.tick();
+  await flush();
+  assert.deepEqual(panel.tabMessages, [], 'resume 消息竟然把未授权面板叫醒了');
+});
+
+test('不带任何参数直接嵌（旧分流下会跑成完整侧板）同样停摆', async () => {
+  const panel = loadEmbeddedPanel({ search: '', authReply: { ok: false } });
+  await flush();
+  panel.tick();
+  await flush();
+  assert.deepEqual(panel.tabQueries, [], '无参数嵌入被当成了真侧板，已经开始轮询它看不到的标签页');
+  assert.deepEqual(panel.tabMessages, []);
+});
+
+test('验票通过：标签 id 与宿主 origin 只认 SW 回报值，冒充 origin 的宿主消息无效', async () => {
+  const panel = loadEmbeddedPanel({
+    search: '?fushiTicket=tkt-1',
+    authReply: { ok: true, tabId: 7, hostOrigin: 'https://m.test' },
+  });
+  await flush();
+  const auth = panel.runtimeMessages.find((m) => m && m.type === 'drawerFrameAuth');
+  assert.ok(auth && auth.ticket === 'tkt-1', '面板没拿 URL 里的票去验');
+  assert.ok(panel.tabMessages.length > 0, '验票通过后应该开始干活');
+  assert.equal(panel.tabMessages[0].tabId, 7, '标签 id 必须是 SW 回报的那一页');
+  assert.deepEqual(panel.tabQueries, [], '嵌入态绝不能回退到 tabs.query 拿任意活动标签');
+
+  // 冒充 origin 的 pause 必须被丢掉：否则任何站点都能遥控面板的可见性状态。
+  const before = panel.tabMessages.length;
+  panel.post('https://evil.test', { source: 'fushi-drawer', type: 'pause' });
+  panel.tick();
+  await flush();
+  assert.ok(panel.tabMessages.length > before, '冒充 origin 的 pause 竟然生效了');
+
+  // 真宿主 origin 的 pause 生效。
+  const mid = panel.tabMessages.length;
+  panel.post('https://m.test', { source: 'fushi-drawer', type: 'pause' });
+  panel.tick();
+  await flush();
+  assert.equal(panel.tabMessages.length, mid, '真宿主的 pause 没暂停轮询');
+});
+
+// SW 侧（发票/验票）没法在 vm 里单独跑（票据逻辑活在 background.js 的整体作用域里），
+// 下面三条钉住它的关键不变式——回归时至少不会无声退化成「谁问都给票」。
+const BACKGROUND = fs.readFileSync(path.join(__dirname, 'background.js'), 'utf8');
+
+test('SW 发票：票号必须来自真随机源，拿不到就不发票（绝不回退到可猜的值）', () => {
+  assert.match(
+    BACKGROUND,
+    /function newDrawerTicketId\(\)[\s\S]*?crypto\.randomUUID[\s\S]*?crypto\.getRandomValues[\s\S]*?return null;/,
+  );
+  // 没标签身份 / 没真 origin / 没随机源 —— 任一缺失都不发票。
+  assert.match(
+    BACKGROUND,
+    /if \(tabId == null \|\| !hostOrigin \|\| hostOrigin === 'null' \|\| !ticket\) return \{ ok: false \};/,
+  );
+});
+
+test('SW 验票：一次性 + 校验（票有效 / 回问者是本扩展面板 / 同标签加固）', () => {
+  assert.match(BACKGROUND, /if \(rec\) drawerTickets\.delete\(ticket\);/);
+  assert.match(BACKGROUND, /if \(!rec \|\| !fromOwnPanel\) return \{ ok: false \};/);
+  assert.match(BACKGROUND, /sender\.url\.indexOf\(panelUrl\) === 0/);
+  assert.match(
+    BACKGROUND,
+    /if \(askerTabId != null && askerTabId !== rec\.tabId\) return \{ ok: false \};/,
+  );
+});
+
+test('身份只经消息通道回报，绝不写进 iframe URL；manifest 只暴露入口 HTML', () => {
+  const drawer = fs.readFileSync(path.join(__dirname, 'mobile-drawer.js'), 'utf8');
+  assert.doesNotMatch(drawer, /fushiTabId|fushiHostOrigin/);
+  assert.doesNotMatch(SIDE_PANEL, /fushiTabId|fushiHostOrigin/);
+  // 子脚本是扩展页的同源子资源，不需要（也不该）对网页可见——参照 nested-popup.html。
+  const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, 'manifest.json'), 'utf8'));
+  const war = manifest.web_accessible_resources.reduce((acc, e) => acc.concat(e.resources), []);
+  assert.deepEqual(war.filter((r) => /side-panel|\.js$/.test(r)), ['side-panel.html']);
+});

--- a/tools/browser-extension/side-panel.js
+++ b/tools/browser-extension/side-panel.js
@@ -28,19 +28,30 @@
   window.__fushiRoot = lookupShadow;
   installDictMediaPlaceholderResolver(lookupShadow); // BUG-1718：兑现词条内图片/样式表占位
   var currentTabId = null;
-  // 抽屉嵌入模式（mobile-drawer.js 的 iframe 打开，?fushiEmbed=1）：
-  //   · 绑定来源页 tabId——网页内扩展 iframe 里 tabs.query 的 currentWindow 解析不可靠，
-  //     以 background drawerSelfTab 如实回报的 sender.tab.id 为准（缺参数仍走 queryActiveTab）；
+  // 抽屉嵌入模式（mobile-drawer.js 把本页当 iframe 嵌进宿主网页）：
+  //   · 判据是「我被嵌了吗」而不是 URL 参数——side-panel.html 必须是
+  //     web_accessible_resource（网页里的 iframe 才加载得了），**任何站点**都能把这份
+  //     持完整扩展权限的文档嵌进自己的页面，而且可以一个参数都不带；若按参数
+  //     分流，不带参数那条反而直接跑成完整侧板（轮询 + chrome.tabs + 查词全开）。
+  //     真侧板永远是顶层文档，被嵌 = 只可能是抽屉，因此被嵌就必须验票。
+  //   · 票据由 SW 现发（background.js drawerFrameTicket），面板拿票回问验明正身；
+  //     标签 id 与宿主 origin 只认 SW 回报的值（浏览器给的 sender.tab.id / sender.origin，
+  //     伪造不了），绝不读 URL 里的 tabId/hostOrigin——那是嵌入方自证。
+  //     验票未过 = 整页停摆：不轮询、不碰 chrome.tabs、不收宿主消息（fail-closed）。
   //   · 不挂 tabs.onActivated：抽屉只服务这一页，「跟着切的标签页走」语义在这里不存在；
   //   · 抽屉收起时宿主 postMessage pause → 暂停 300ms 轮询（省电），拉开立刻补一次；
   //   · html 根挂 .fushi-embed 类，side-panel.css 按触屏规格放大控件、补安全区。
-  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耽误。
+  // typeof 守卫：vm 行为测试沙箱里没有全局 location，扩展页里永远有——两不耐误。
   var EMBED_SEARCH = typeof location === 'undefined' ? '' : String(location.search || '');
-  var EMBED = /[?&]fushiEmbed=1/.test(EMBED_SEARCH);
-  var EMBED_TAB_ID = (function () {
-    var m = /[?&]fushiTabId=(\d+)/.exec(EMBED_SEARCH);
-    return m ? Number(m[1]) : null;
+  var EMBED = (function () {
+    // 跨源读 window.top 只是引用比较，浏览器里不会抛；抛了只可能是测试沙箱没 window。
+    try { return window.top !== window.self; } catch (_) { return false; }
   })();
+  var EMBED_TICKET = (function () {
+    var m = /[?&]fushiTicket=([^&]*)/.exec(EMBED_SEARCH);
+    try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
+  })();
+  var embedAuth = null;  // {tabId, hostOrigin}；验票通过前嵌入模式下一切对外动作停摆
   var embedPaused = false;
   if (EMBED) document.documentElement.classList.add('fushi-embed');
   // 嵌入（手机抽屉）模式头部原本叠了标题+工具排+选轨+时轴偏移三四行，把列表挤得没法看。
@@ -706,7 +717,11 @@
   }
 
   function queryActiveTab() {
-    if (EMBED && EMBED_TAB_ID != null) return Promise.resolve({ id: EMBED_TAB_ID });
+    // 嵌入态只服务发票那一页，且该页 id 只认 SW 验票后回报的值；未验票就没有
+    // 「当前标签」，绝不回退到 tabs.query——那等于把用户正在看的任意标签送给嵌入方当靶子。
+    if (EMBED) {
+      return Promise.resolve(embedAuth && Number.isInteger(embedAuth.tabId) ? { id: embedAuth.tabId } : null);
+    }
     return new Promise(function (resolve) {
       chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
         try { if (chrome.runtime.lastError) return resolve(null); } catch (_) { return resolve(null); }
@@ -894,6 +909,7 @@
   }
 
   async function refresh(forceCues) {
+    if (EMBED && !embedAuth) return; // 未验票的嵌入（= 站点自己嵌的）：整页停摆
     if (embedPaused) return; // 抽屉收起：不空转消息，resume 时立即补一次全量
     if (refreshBusy) return;
     refreshBusy = true;
@@ -1220,23 +1236,44 @@
     });
   } catch (_) {}
 
-  // 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立刻全量刷新。
-  if (EMBED) {
-    // S5691：宿主 origin 由 mobile-drawer 经 iframe URL 显式声明，收消息先验来源。
-    // 缺参数时 EMBED_HOST_ORIGIN='' 永远匹配不上任何真实 origin——天然 fail-closed。
-    var EMBED_HOST_ORIGIN = (function () {
-      var m = /[?&]fushiHostOrigin=([^&]*)/.exec(EMBED_SEARCH);
-      try { return m ? decodeURIComponent(m[1]) : ''; } catch (_) { return ''; }
-    })();
+  // 验票 + 抽屉宿主（mobile-drawer.js）的可见性协议：收起=暂停轮询，拉开=立即全量刷新。
+  // 验票通过前不挂 message 监听、不刷新：站点自己嵌的面板拿不到票，就只是一页死文档。
+  function startEmbedSession(auth) {
+    embedAuth = auth;
     window.addEventListener('message', function (ev) {
-      if (ev.origin !== EMBED_HOST_ORIGIN) return;
+      // S5691 + 真信任链：宿主 origin 是 SW 从 sender 里读出来的，不是嵌入方声明的。
+      if (!embedAuth || ev.origin !== embedAuth.hostOrigin) return;
       var d = ev && ev.data;
       if (!d || d.source !== 'fushi-drawer') return;
       if (d.type === 'pause') embedPaused = true;
       else if (d.type === 'resume') { embedPaused = false; refresh(true); }
     });
+    refresh(true);
   }
-
-  refresh(true);
+  function denyEmbed() {
+    // 验票未过就把面板钉在拒绝态，并告诉看到的人为什么是空白（别漏一个无声白页）。
+    embedAuth = null;
+    statusEl.textContent = '未授权的嵌入';
+    listEl.innerHTML = '';
+    var deny = document.createElement('div');
+    deny.className = 'empty';
+    deny.textContent = '本页只能由 Fushi 字幕抽屉打开。';
+    listEl.appendChild(deny);
+  }
+  if (EMBED) {
+    try {
+      chrome.runtime.sendMessage({ type: 'drawerFrameAuth', ticket: EMBED_TICKET }, function (resp) {
+        try { if (chrome.runtime.lastError) resp = null; } catch (_) { resp = null; }
+        if (resp && resp.ok === true && Number.isInteger(resp.tabId)
+            && typeof resp.hostOrigin === 'string' && resp.hostOrigin) {
+          startEmbedSession({ tabId: resp.tabId, hostOrigin: resp.hostOrigin });
+          return;
+        }
+        denyEmbed();
+      });
+    } catch (_) { denyEmbed(); }
+  } else {
+    refresh(true);
+  }
   setInterval(function () { refresh(false); }, 300);
 })();

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -5075,9 +5075,13 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
 // min(用户设置, 装得下的列数)，写 --dict-columns-effective 供 grid 消费；
 // resize 只改 CSS 变量（grid 自动 reflow，零重渲）。in-app 弹窗同规则受益。
 const DICT_COLUMN_MIN_WIDTH = 170;
-// 触屏设备（手机/平板，主指针 coarse）一律单列：移动端弹窗本就窄，多词典并排每列被
-// 挤到贴地板，义项互相压缩完全没法读——竖着堆叠才是手机上的正确形态。桌面触屏二合一
-// 主指针是 mouse（fine），不受牵连。CSS grid 与 JS masonry 都经本函数取列数，一处收口。
+const DICT_COLUMN_MIN_WIDTH_COARSE = 320; // 触屏指尖精度 + 手机字号下的每列可读下限
+// 触屏（手机/平板，主指针 coarse）上每列的可读下限比鼠标端高得多：170px 一列在手机
+// 弹窗里会把义项压成竖条完全没法读。但不能因此「一律单列」：那是把用户设置整个吞掉——
+// app 内置弹窗在安卓/触屏 Windows 上同样是 coarse，平板横屏与大屏触控一体机明明排
+// 得下多列，却被静默锁死、改设置毫无反应（既无提示也无出路）。正确做法是只抬高
+// 每列的可读下限，仍走同一条 min(用户设置, 装得下的列数) 收敛：手机宽度自然收到
+// 1 列，屏够宽时用户设的多列照旧生效。桌面鼠标主指针是 fine，不受牵连。
 function isCoarsePointerType() {
     try {
         return !!(window.matchMedia
@@ -5090,7 +5094,6 @@ function isCoarsePointerType() {
 // px 装得下的列数)。CSS grid 经 --dict-columns-effective 消费、masonry 经 dictColumns() 消费，
 // 两者都走此函数——绝不再分叉（历史上 masonry 漏了视口收敛，自动调整对方框布局不生效）。
 function effectiveDictColumns() {
-    if (isCoarsePointerType()) return 1;
     let configured = 1;
     try {
         configured = parseInt(
@@ -5101,8 +5104,11 @@ function effectiveDictColumns() {
     }
     if (!(configured > 0)) configured = 1;
     const width = __fushiViewportWidth();
+    const minWidth = isCoarsePointerType()
+        ? DICT_COLUMN_MIN_WIDTH_COARSE
+        : DICT_COLUMN_MIN_WIDTH;
     const fit = width > 0
-        ? Math.max(1, Math.floor(width / DICT_COLUMN_MIN_WIDTH))
+        ? Math.max(1, Math.floor(width / minWidth))
         : configured;
     return Math.min(configured, fit);
 }


### PR DESCRIPTION
本分支早已完成但从未开过 PR，现补开以便审查/合并。

提交：
- fix(browser-extension): 抽屉面板改用 SW 能力票据，修 drag 泄漏与触屏单列锁死

改动规模： 15 files changed, 651 insertions(+), 129 deletions(-)
分支基点：4fed2e4cae（2026-09-08）

与当前 develop 的冲突块数：13 —— **需要先解冲突，PR 处于 CONFLICTING 时不会启动任何 CI check**。


https://claude.ai/code/session_01M3Uvn1LeRdu8J2mU4mZvAb