### PR TITLE
feat(dict): 词典/书卡改名——显示名覆盖列，真名冻结（schema v95）

### DIFF
--- a/fushi/assets/browser_extension/background.js
+++ b/fushi/assets/browser_extension/background.js
@@ -198,7 +198,7 @@ async function diagnoseConnectionCapped(base, timeoutMs = 750) {
 // 响应拿。但它体量大（实测整库 285 KB，单本 OALDPE 就 210 KB），不能每次 hover 查词都传，
 // 故走 revision 门控：请求里带上已缓存的 revision，server 只在指纹变了（用户导入/删词典、
 // 改自定义 CSS）时才回全量，其余时候只回指纹。SW 被回收后缓存清空，下次查词自动重取一次。
-let fushiPopupCss = { revision: null, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {} };
+let fushiPopupCss = { revision: null, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {}, dictionaryDisplayNames: {} };
 
 // 把服务端这次查词响应里的 CSS 尾段并进缓存，并把**完整**尾段回填进 data，
 // 让 content.js / side-panel.js 无论命中缓存与否都能拿到同一份可直接赋给 window.* 的值。
@@ -214,14 +214,20 @@ function fushiMergePopupCss(data) {
       globalDictCSS: typeof data.globalDictCSS === 'string' ? data.globalDictCSS : '',
       customDictCSS: (data.customDictCSS && typeof data.customDictCSS === 'object')
         ? data.customDictCSS : {},
+      // 词典改名（v95）：真名 -> 显示名。与 CSS 同一条 revision 门控，改名会改
+      // 指纹 → 下次查词全量重取一次。
+      dictionaryDisplayNames:
+        (data.dictionaryDisplayNames && typeof data.dictionaryDisplayNames === 'object')
+          ? data.dictionaryDisplayNames : {},
     };
   } else if (fushiPopupCss.revision !== revision) {
     // 指纹变了但这次响应没带正文（不该发生；真发生时宁可清空也不能用陈旧样式）。
-    fushiPopupCss = { revision, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {} };
+    fushiPopupCss = { revision, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {}, dictionaryDisplayNames: {} };
   }
   data.dictionaryStyles = fushiPopupCss.dictionaryStyles;
   data.globalDictCSS = fushiPopupCss.globalDictCSS;
   data.customDictCSS = fushiPopupCss.customDictCSS;
+  data.dictionaryDisplayNames = fushiPopupCss.dictionaryDisplayNames;
   return data;
 }
 

--- a/fushi/assets/browser_extension/vendor/dict-media.js
+++ b/fushi/assets/browser_extension/vendor/dict-media.js
@@ -272,4 +272,9 @@ function applyFushiPopupCss(data) {
     window.customDictCSS =
         (data.customDictCSS && typeof data.customDictCSS === 'object')
             ? data.customDictCSS : {};
+    // 词典改名（v95）：popup.js 的 __fushiDictDisplayName 读这张表。缺了不会崩
+    // （回落真名），但改名在扩展里就不生效。
+    window.dictionaryDisplayNames =
+        (data.dictionaryDisplayNames && typeof data.dictionaryDisplayNames === 'object')
+            ? data.dictionaryDisplayNames : {};
 }

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -1155,6 +1155,13 @@ function constructSingleGlossaryHtml(entryIndex) {
         rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
+        /* 词典改名（v95）刻意**不**翻这里：本行进的是导出到 Anki 的卡片正文。
+           卡片是历史存档，改名不回溯——翻了之后同一个牌组里旧卡显示真名、新卡
+           显示新名，比统一显示真名更难认。同一段 HTML 里的 data-dictionary
+           属性也必须是真名（Lapis 模板 CSS 靠它命中），文本与属性不一致会让
+           排查变难。
+           上游 Yomitan 同位置放的是 dictionaryAlias，所以「跟着改名走」是个
+           合理的反向选择；要改就只翻这一行的 label 文本，别碰下面的属性。 */
         if (dictChanged) {
             label = tags ? `(${tags}, ${dictName})` : `(${dictName})`;
         } else {

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -18,6 +18,22 @@ function __fushiRootNode(){ return window.__fushiRoot || document; }
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
+/* 词典改名（v95）：把**真名**翻成用户起的显示名，只用于渲染给人看的文本。
+   宿主在 popup_settings_injection 注入 window.dictionaryDisplayNames = {真名: 显示名}，
+   只含真正改过名的条目；没改过 / 表不存在 → 原样返回真名。
+
+   ⚠️ 绝不能拿它去替换 dictName 变量本身。同一个真名在本文件里还承担 6 种非显示
+   职责：`data-dictionary` CSS 作用域属性、window.dictionaryStyles 查表、隐藏/折叠
+   过滤、释义语言查表、词典媒体 URL 的 dictionary= 参数（要对上磁盘目录名）、
+   glossaries 分组 key（Anki `{single-glossary-<名>}` token 靠它对齐）。翻译了那些
+   就是：用户样式静默失效、词典图/音 404、已配置的制卡字段对不上。
+   只在 textContent 处调用本函数。 */
+function __fushiDictDisplayName(name){
+    var map = window.dictionaryDisplayNames;
+    if (!map || typeof name !== 'string') return name;
+    var shown = map[name];
+    return (typeof shown === 'string' && shown.length > 0) ? shown : name;
+}
 // 注意：scrollHeight 是**未乘 CSS zoom 的 layout px**。要和宿主几何（host CSS px）同单位，
 // 用下面的 __fushiReportedContentHeight()（BUG-1651 ②）。
 function __fushiScrollHeight(){ var c = __fushiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
@@ -2327,7 +2343,7 @@ function createDeinflectionTag(tag) {
 function createFrequencyGroup(freqGroup) {
     const values = freqGroup.frequencies.map(f => f.displayValue || f.value).join(', ');
     return el('span', { className: 'frequency-group', 'data-details': freqGroup.dictionary }, [
-        el('span', { className: 'frequency-dict-label', textContent: freqGroup.dictionary }),
+        el('span', { className: 'frequency-dict-label', textContent: __fushiDictDisplayName(freqGroup.dictionary) }),
         el('span', { className: 'frequency-values', textContent: values })
     ]);
 }
@@ -2429,7 +2445,7 @@ function createTranscriptionsHtml(transcriptions) {
 
 function createPitchGroup(pitchData, reading) {
     const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: __fushiDictDisplayName(pitchData.dictionary) }));
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -3649,7 +3665,7 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
     }
 
     const summary = el('summary', { className: 'dict-label' });
-    summary.appendChild(el('span', { className: 'dict-name', textContent: dictName }));
+    summary.appendChild(el('span', { className: 'dict-name', textContent: __fushiDictDisplayName(dictName) }));
     details.appendChild(summary);
 
     let longPressTimer = null;
@@ -4191,7 +4207,7 @@ function createKanjiCard(kanji) {
     }
 
     if (kanji.dictName) {
-        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: kanji.dictName }));
+        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: __fushiDictDisplayName(kanji.dictName) }));
     }
 
     return card;

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -1155,6 +1155,13 @@ function constructSingleGlossaryHtml(entryIndex) {
         rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
+        /* 词典改名（v95）刻意**不**翻这里：本行进的是导出到 Anki 的卡片正文。
+           卡片是历史存档，改名不回溯——翻了之后同一个牌组里旧卡显示真名、新卡
+           显示新名，比统一显示真名更难认。同一段 HTML 里的 data-dictionary
+           属性也必须是真名（Lapis 模板 CSS 靠它命中），文本与属性不一致会让
+           排查变难。
+           上游 Yomitan 同位置放的是 dictionaryAlias，所以「跟着改名走」是个
+           合理的反向选择；要改就只翻这一行的 label 文本，别碰下面的属性。 */
         if (dictChanged) {
             label = tags ? `(${tags}, ${dictName})` : `(${dictName})`;
         } else {

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -18,6 +18,22 @@ function __fushiRootNode(){ return window.__fushiRoot || document; }
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
+/* 词典改名（v95）：把**真名**翻成用户起的显示名，只用于渲染给人看的文本。
+   宿主在 popup_settings_injection 注入 window.dictionaryDisplayNames = {真名: 显示名}，
+   只含真正改过名的条目；没改过 / 表不存在 → 原样返回真名。
+
+   ⚠️ 绝不能拿它去替换 dictName 变量本身。同一个真名在本文件里还承担 6 种非显示
+   职责：`data-dictionary` CSS 作用域属性、window.dictionaryStyles 查表、隐藏/折叠
+   过滤、释义语言查表、词典媒体 URL 的 dictionary= 参数（要对上磁盘目录名）、
+   glossaries 分组 key（Anki `{single-glossary-<名>}` token 靠它对齐）。翻译了那些
+   就是：用户样式静默失效、词典图/音 404、已配置的制卡字段对不上。
+   只在 textContent 处调用本函数。 */
+function __fushiDictDisplayName(name){
+    var map = window.dictionaryDisplayNames;
+    if (!map || typeof name !== 'string') return name;
+    var shown = map[name];
+    return (typeof shown === 'string' && shown.length > 0) ? shown : name;
+}
 // 注意：scrollHeight 是**未乘 CSS zoom 的 layout px**。要和宿主几何（host CSS px）同单位，
 // 用下面的 __fushiReportedContentHeight()（BUG-1651 ②）。
 function __fushiScrollHeight(){ var c = __fushiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
@@ -2327,7 +2343,7 @@ function createDeinflectionTag(tag) {
 function createFrequencyGroup(freqGroup) {
     const values = freqGroup.frequencies.map(f => f.displayValue || f.value).join(', ');
     return el('span', { className: 'frequency-group', 'data-details': freqGroup.dictionary }, [
-        el('span', { className: 'frequency-dict-label', textContent: freqGroup.dictionary }),
+        el('span', { className: 'frequency-dict-label', textContent: __fushiDictDisplayName(freqGroup.dictionary) }),
         el('span', { className: 'frequency-values', textContent: values })
     ]);
 }
@@ -2429,7 +2445,7 @@ function createTranscriptionsHtml(transcriptions) {
 
 function createPitchGroup(pitchData, reading) {
     const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: __fushiDictDisplayName(pitchData.dictionary) }));
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -3649,7 +3665,7 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
     }
 
     const summary = el('summary', { className: 'dict-label' });
-    summary.appendChild(el('span', { className: 'dict-name', textContent: dictName }));
+    summary.appendChild(el('span', { className: 'dict-name', textContent: __fushiDictDisplayName(dictName) }));
     details.appendChild(summary);
 
     let longPressTimer = null;
@@ -4191,7 +4207,7 @@ function createKanjiCard(kanji) {
     }
 
     if (kanji.dictName) {
-        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: kanji.dictName }));
+        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: __fushiDictDisplayName(kanji.dictName) }));
     }
 
     return card;

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 70057 (4121 per locale)
 ///
-/// Built on 2026-09-02 at 04:24 UTC
+/// Built on 2026-09-02 at 04:43 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -158902,17 +158902,17 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
   @override
-  String get media_source_rename => 'Rename';
+  String get media_source_rename => '重命名';
   @override
-  String get media_source_rename_label => 'Source name';
+  String get media_source_rename_label => '來源名稱';
   @override
-  String get book_rename => 'Rename';
+  String get book_rename => '重命名';
   @override
-  String get book_rename_label => 'Title';
+  String get book_rename_label => '標題';
   @override
-  String get dict_rename => 'Rename';
+  String get dict_rename => '重命名';
   @override
-  String get dict_rename_label => 'Dictionary name';
+  String get dict_rename_label => '詞典名稱';
 }
 
 /// Flat map(s) containing all translations.
@@ -302684,17 +302684,17 @@ extension on _StringsZhHk {
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
       case 'media_source_rename':
-        return 'Rename';
+        return '重命名';
       case 'media_source_rename_label':
-        return 'Source name';
+        return '來源名稱';
       case 'book_rename':
-        return 'Rename';
+        return '重命名';
       case 'book_rename_label':
-        return 'Title';
+        return '標題';
       case 'dict_rename':
-        return 'Rename';
+        return '重命名';
       case 'dict_rename_label':
-        return 'Dictionary name';
+        return '詞典名稱';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 70023 (4119 per locale)
+/// Strings: 70057 (4121 per locale)
 ///
-/// Built on 2026-09-02 at 04:11 UTC
+/// Built on 2026-09-02 at 04:24 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5651,6 +5651,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get media_source_rename_label => 'Source name';
   String get book_rename => 'Rename';
   String get book_rename_label => 'Title';
+  String get dict_rename => 'Rename';
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -15240,6 +15242,10 @@ class _StringsAr extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -25051,6 +25057,10 @@ class _StringsDe extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -34911,6 +34921,10 @@ class _StringsEs extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -44806,6 +44820,10 @@ class _StringsFr extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -54518,6 +54536,10 @@ class _StringsId extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -64314,6 +64336,10 @@ class _StringsIt extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -73516,6 +73542,10 @@ class _StringsJa extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -82729,6 +82759,10 @@ class _StringsKo extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -92479,6 +92513,10 @@ class _StringsNl extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -102285,6 +102323,10 @@ class _StringsPtBr extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -112067,6 +112109,10 @@ class _StringsRu extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -121650,6 +121696,10 @@ class _StringsTh extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -131348,6 +131398,10 @@ class _StringsTr extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -141022,6 +141076,10 @@ class _StringsVi extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 // Path: <root>
@@ -149927,6 +149985,10 @@ class _StringsZhCn extends _StringsEn {
   String get book_rename => '重命名';
   @override
   String get book_rename_label => '标题';
+  @override
+  String get dict_rename => '重命名';
+  @override
+  String get dict_rename_label => '词典名称';
 }
 
 // Path: <root>
@@ -158847,6 +158909,10 @@ class _StringsZhHk extends _StringsEn {
   String get book_rename => 'Rename';
   @override
   String get book_rename_label => 'Title';
+  @override
+  String get dict_rename => 'Rename';
+  @override
+  String get dict_rename_label => 'Dictionary name';
 }
 
 /// Flat map(s) containing all translations.
@@ -167298,6 +167364,10 @@ extension on _StringsEn {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -175744,6 +175814,10 @@ extension on _StringsAr {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -184234,6 +184308,10 @@ extension on _StringsDe {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -192716,6 +192794,10 @@ extension on _StringsEs {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -201206,6 +201288,10 @@ extension on _StringsFr {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -209668,6 +209754,10 @@ extension on _StringsId {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -218151,6 +218241,10 @@ extension on _StringsIt {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -226563,6 +226657,10 @@ extension on _StringsJa {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -234978,6 +235076,10 @@ extension on _StringsKo {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -243455,6 +243557,10 @@ extension on _StringsNl {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -251927,6 +252033,10 @@ extension on _StringsPtBr {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -260405,6 +260515,10 @@ extension on _StringsRu {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -268856,6 +268970,10 @@ extension on _StringsTh {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -277322,6 +277440,10 @@ extension on _StringsTr {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -285782,6 +285904,10 @@ extension on _StringsVi {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }
@@ -294171,6 +294297,10 @@ extension on _StringsZhCn {
         return '重命名';
       case 'book_rename_label':
         return '标题';
+      case 'dict_rename':
+        return '重命名';
+      case 'dict_rename_label':
+        return '词典名称';
       default:
         return null;
     }
@@ -302561,6 +302691,10 @@ extension on _StringsZhHk {
         return 'Rename';
       case 'book_rename_label':
         return 'Title';
+      case 'dict_rename':
+        return 'Rename';
+      case 'dict_rename_label':
+        return 'Dictionary name';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 69955 (4115 per locale)
+/// Strings: 70023 (4119 per locale)
 ///
-/// Built on 2026-09-01 at 16:45 UTC
+/// Built on 2026-09-02 at 04:11 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -5647,6 +5647,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get network_proxy_p2p_mode_direct => 'Direct';
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  String get media_source_rename => 'Rename';
+  String get media_source_rename_label => 'Source name';
+  String get book_rename => 'Rename';
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -15228,6 +15232,14 @@ class _StringsAr extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -25031,6 +25043,14 @@ class _StringsDe extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -34883,6 +34903,14 @@ class _StringsEs extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -44770,6 +44798,14 @@ class _StringsFr extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -54474,6 +54510,14 @@ class _StringsId extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -64262,6 +64306,14 @@ class _StringsIt extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -73456,6 +73508,14 @@ class _StringsJa extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -82661,6 +82721,14 @@ class _StringsKo extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -92403,6 +92471,14 @@ class _StringsNl extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -102201,6 +102277,14 @@ class _StringsPtBr extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -111975,6 +112059,14 @@ class _StringsRu extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -121550,6 +121642,14 @@ class _StringsTh extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -131240,6 +131340,14 @@ class _StringsTr extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -140906,6 +141014,14 @@ class _StringsVi extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 // Path: <root>
@@ -149803,6 +149919,14 @@ class _StringsZhCn extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => '走代理';
   @override
   String get network_proxy_p2p_mode_mixed => '混合';
+  @override
+  String get media_source_rename => '重命名';
+  @override
+  String get media_source_rename_label => '来源名称';
+  @override
+  String get book_rename => '重命名';
+  @override
+  String get book_rename_label => '标题';
 }
 
 // Path: <root>
@@ -158715,6 +158839,14 @@ class _StringsZhHk extends _StringsEn {
   String get network_proxy_p2p_mode_proxy => 'Via proxy';
   @override
   String get network_proxy_p2p_mode_mixed => 'Mixed';
+  @override
+  String get media_source_rename => 'Rename';
+  @override
+  String get media_source_rename_label => 'Source name';
+  @override
+  String get book_rename => 'Rename';
+  @override
+  String get book_rename_label => 'Title';
 }
 
 /// Flat map(s) containing all translations.
@@ -167158,6 +167290,14 @@ extension on _StringsEn {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -175596,6 +175736,14 @@ extension on _StringsAr {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -184078,6 +184226,14 @@ extension on _StringsDe {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -192552,6 +192708,14 @@ extension on _StringsEs {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -201034,6 +201198,14 @@ extension on _StringsFr {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -209488,6 +209660,14 @@ extension on _StringsId {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -217963,6 +218143,14 @@ extension on _StringsIt {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -226367,6 +226555,14 @@ extension on _StringsJa {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -234774,6 +234970,14 @@ extension on _StringsKo {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -243243,6 +243447,14 @@ extension on _StringsNl {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -251707,6 +251919,14 @@ extension on _StringsPtBr {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -260177,6 +260397,14 @@ extension on _StringsRu {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -268620,6 +268848,14 @@ extension on _StringsTh {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -277078,6 +277314,14 @@ extension on _StringsTr {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -285530,6 +285774,14 @@ extension on _StringsVi {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }
@@ -293911,6 +294163,14 @@ extension on _StringsZhCn {
         return '走代理';
       case 'network_proxy_p2p_mode_mixed':
         return '混合';
+      case 'media_source_rename':
+        return '重命名';
+      case 'media_source_rename_label':
+        return '来源名称';
+      case 'book_rename':
+        return '重命名';
+      case 'book_rename_label':
+        return '标题';
       default:
         return null;
     }
@@ -302293,6 +302553,14 @@ extension on _StringsZhHk {
         return 'Via proxy';
       case 'network_proxy_p2p_mode_mixed':
         return 'Mixed';
+      case 'media_source_rename':
+        return 'Rename';
+      case 'media_source_rename_label':
+        return 'Source name';
+      case 'book_rename':
+        return 'Rename';
+      case 'book_rename_label':
+        return 'Title';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "未能在 AniDB 识别该作品：仍会正常下载，导入后在待确认列表等待手动指定身份。",
   "network_proxy_p2p_mode_direct": "直连",
   "network_proxy_p2p_mode_proxy": "走代理",
-  "network_proxy_p2p_mode_mixed": "混合"
+  "network_proxy_p2p_mode_mixed": "混合",
+  "media_source_rename": "重命名",
+  "media_source_rename_label": "来源名称",
+  "book_rename": "重命名",
+  "book_rename_label": "标题"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "重命名",
   "media_source_rename_label": "来源名称",
   "book_rename": "重命名",
-  "book_rename_label": "标题"
+  "book_rename_label": "标题",
+  "dict_rename": "重命名",
+  "dict_rename_label": "词典名称"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4113,5 +4113,9 @@
   "video_discovery_anidb_identity_not_found": "Could not identify this work on AniDB. It will download normally and wait in the pending list for manual identification.",
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
-  "network_proxy_p2p_mode_mixed": "Mixed"
+  "network_proxy_p2p_mode_mixed": "Mixed",
+  "media_source_rename": "Rename",
+  "media_source_rename_label": "Source name",
+  "book_rename": "Rename",
+  "book_rename_label": "Title"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4114,10 +4114,10 @@
   "network_proxy_p2p_mode_direct": "Direct",
   "network_proxy_p2p_mode_proxy": "Via proxy",
   "network_proxy_p2p_mode_mixed": "Mixed",
-  "media_source_rename": "Rename",
-  "media_source_rename_label": "Source name",
-  "book_rename": "Rename",
-  "book_rename_label": "Title",
-  "dict_rename": "Rename",
-  "dict_rename_label": "Dictionary name"
+  "media_source_rename": "重命名",
+  "media_source_rename_label": "來源名稱",
+  "book_rename": "重命名",
+  "book_rename_label": "標題",
+  "dict_rename": "重命名",
+  "dict_rename_label": "詞典名稱"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4117,5 +4117,7 @@
   "media_source_rename": "Rename",
   "media_source_rename_label": "Source name",
   "book_rename": "Rename",
-  "book_rename_label": "Title"
+  "book_rename_label": "Title",
+  "dict_rename": "Rename",
+  "dict_rename_label": "Dictionary name"
 }

--- a/fushi/lib/src/creator/fields/meaning_field.dart
+++ b/fushi/lib/src/creator/fields/meaning_field.dart
@@ -43,6 +43,10 @@ class MeaningField extends Field {
 
     entriesByDictionaryName.forEach((dictionaryName, singleDictionaryEntries) {
       if (prependDictionaryNames) {
+        // 词典改名（v95）刻意**不**翻这里：写进 Anki 卡片的正文是历史存档，改名
+        // 不回溯——翻了之后同牌组里旧卡真名、新卡新名，比统一真名更难认。而且这个
+        // 变量同时是上面 groupBy 的分组 key（与 {single-glossary-<名>} 模板 token
+        // 对齐），要翻必须先把「分组键」和「显示文本」拆开。
         meaningBuffer.writeln('【$dictionaryName】');
       }
 

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -2947,17 +2947,26 @@ class AppModel with ChangeNotifier {
     // popup.js 在两个宿主里呈现不一致。
     final String globalCss = effectiveGlobalDictCSS;
     final Map<String, String> customCss = effectiveCustomDictCSS;
+    // 词典改名（v95）：真名 -> 显示名，只含真正改过名的。必须一并进下面的缓存
+    // 判定——否则改完名命中旧实例、revision 不变，扩展永远拉不到新名。
+    final Map<String, String> displayNames = <String, String>{
+      for (final Dictionary d in dictionaries)
+        if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+          d.name: d.displayName!.trim(),
+    };
     final RemotePopupDictionaryCss? cached = _browserExtensionPopupCss;
     if (cached != null &&
         identical(cached.dictionaryStyles, styles) &&
         cached.globalDictCss == globalCss &&
-        _sameStringMap(cached.customDictCss, customCss)) {
+        _sameStringMap(cached.customDictCss, customCss) &&
+        _sameStringMap(cached.dictionaryDisplayNames, displayNames)) {
       return cached;
     }
     return _browserExtensionPopupCss = RemotePopupDictionaryCss(
       dictionaryStyles: styles,
       globalDictCss: globalCss,
       customDictCss: customCss,
+      dictionaryDisplayNames: displayNames,
     );
   }
 
@@ -4915,6 +4924,9 @@ class AppModel with ChangeNotifier {
   /// 用户手动指定词典内容语言（BCP-47），null = 恢复自动（读 index.json 声明）。
   void setDictionaryLanguageOverride(Dictionary dictionary, String? language) =>
       dictRepo.setDictionaryLanguageOverride(dictionary, language);
+
+  void setDictionaryDisplayName(Dictionary dictionary, String? displayName) =>
+      dictRepo.setDictionaryDisplayName(dictionary, displayName);
 
   void toggleDictionaryCollapsed(Dictionary dictionary) =>
       dictRepo.toggleDictionaryCollapsed(

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1500,14 +1500,12 @@ class AppModel with ChangeNotifier {
           } else {
             meta.remove('hasKanji');
           }
-          final updated = Dictionary(
-            name: d.name,
-            formatKey: d.formatKey,
-            order: d.order,
+          // copyWith 而不是 new：构造器漏填的用户设置列会被
+          // _dictionaryToCompanion 显式写成 NULL（不是 absent），这里只想换
+          // type/metadata，却曾把用户手动指定的内容语言和改名一起抹掉。
+          final updated = d.copyWith(
             type: DictionaryType.term,
             metadata: meta,
-            hiddenLanguages: d.hiddenLanguages,
-            collapsedLanguages: d.collapsedLanguages,
           );
           dictRepo.persistDictionary(updated);
           debugPrint('[Fushi] reclassified kanji→term (mixed dict): ${d.name}');
@@ -1540,15 +1538,8 @@ class AppModel with ChangeNotifier {
         final DictionaryType? detected = decodeDictTypeFromBlobHeader(head);
         if (detected == null) continue;
 
-        final updated = Dictionary(
-          name: d.name,
-          formatKey: d.formatKey,
-          order: d.order,
-          type: detected,
-          metadata: d.metadata,
-          hiddenLanguages: d.hiddenLanguages,
-          collapsedLanguages: d.collapsedLanguages,
-        );
+        // 同上：只换 type，用户设置列必须原样带过（见 Dictionary.copyWith）。
+        final updated = d.copyWith(type: detected);
         dictRepo.persistDictionary(updated);
         debugPrint('[Fushi] migrated dict type: ${d.name} → ${detected.name}');
       } catch (e, stack) {

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1455,6 +1455,15 @@ class AppModel with ChangeNotifier {
   // ── dictionary delegates (DictionaryRepository) ────────────────────
 
   List<Dictionary> get dictionaries => dictRepo.dictionaries;
+
+  /// 词典改名投影（真名 -> 显示名，只含改过名的）。推导在
+  /// [dictionaryDisplayNameOverridesOf] 单点完成。
+  ///
+  /// 走 [dictionaries] 而不是直接读 `dictRepo`：那个 getter 是子类的覆盖点
+  /// （测试替身靠它喂词典列表），绕过去就会在 `dictRepo` 这个 late 字段上炸
+  /// LateInitializationError——实测过。
+  Map<String, String> get dictionaryDisplayNameOverrides =>
+      dictionaryDisplayNameOverridesOf(dictionaries);
   List<Dictionary> get termDictionaries => dictRepo.termDictionaries;
   List<Dictionary> get freqDictionaries => dictRepo.freqDictionaries;
   List<Dictionary> get pitchDictionaries => dictRepo.pitchDictionaries;
@@ -2938,13 +2947,9 @@ class AppModel with ChangeNotifier {
     // popup.js 在两个宿主里呈现不一致。
     final String globalCss = effectiveGlobalDictCSS;
     final Map<String, String> customCss = effectiveCustomDictCSS;
-    // 词典改名（v95）：真名 -> 显示名，只含真正改过名的。必须一并进下面的缓存
-    // 判定——否则改完名命中旧实例、revision 不变，扩展永远拉不到新名。
-    final Map<String, String> displayNames = <String, String>{
-      for (final Dictionary d in dictionaries)
-        if (d.displayName != null && d.displayName!.trim().isNotEmpty)
-          d.name: d.displayName!.trim(),
-    };
+    // 词典改名（v95）：必须一并进下面的缓存判定——否则改完名命中旧实例、
+    // revision 不变，扩展永远拉不到新名。
+    final Map<String, String> displayNames = dictionaryDisplayNameOverrides;
     final RemotePopupDictionaryCss? cached = _browserExtensionPopupCss;
     if (cached != null &&
         identical(cached.dictionaryStyles, styles) &&

--- a/fushi/lib/src/models/dictionary_import_manager.dart
+++ b/fushi/lib/src/models/dictionary_import_manager.dart
@@ -308,6 +308,9 @@ class DictionaryImportManager {
           // 用户手动指定的内容语言属于用户设置，重导必须继承——metadata 会被包内
           // index.json 整体重建，塞那里等于每次更新都被抹掉。
           languageOverride: preservedSettings?.languageOverride,
+          // 同理：用户给词典起的显示名重导后必须还在，否则「在线更新一次就变回
+          // 包里那个丑名字」。
+          displayName: preservedSettings?.displayName,
         ));
 
         progressNotifier.value = t.import_complete;
@@ -568,6 +571,8 @@ class DictionaryImportManager {
         collapsedLanguages: preservedSettings?.collapsedLanguages ?? const [],
         // 同上：用户手动指定的内容语言随 preservedSettings 继承，不被重导冲掉。
         languageOverride: preservedSettings?.languageOverride,
+        // 同上：用户起的显示名也继承，在线更新不把名字打回原形。
+        displayName: preservedSettings?.displayName,
       ));
 
       progressNotifier.value = t.import_complete;

--- a/fushi/lib/src/models/dictionary_repository.dart
+++ b/fushi/lib/src/models/dictionary_repository.dart
@@ -74,6 +74,11 @@ class DictionaryRepository {
 
   List<Dictionary> get dictionaries => List.unmodifiable(_dictionariesCache);
 
+  /// 改名投影（真名 -> 显示名，只含改过名的）。推导在
+  /// [dictionaryDisplayNameOverridesOf] 单点完成。
+  Map<String, String> get displayNameOverrides =>
+      dictionaryDisplayNameOverridesOf(_dictionariesCache);
+
   List<Dictionary> get termDictionaries =>
       _dictionariesCache.where((d) => d.type == DictionaryType.term).toList();
 

--- a/fushi/lib/src/models/dictionary_repository.dart
+++ b/fushi/lib/src/models/dictionary_repository.dart
@@ -152,6 +152,7 @@ class DictionaryRepository {
       hiddenLanguages: hiddenLanguages,
       collapsedLanguages: collapsedLanguages,
       languageOverride: r.languageOverride,
+      displayName: r.displayName,
     );
   }
 
@@ -165,6 +166,7 @@ class DictionaryRepository {
       hiddenLanguagesJson: Value(jsonEncode(d.hiddenLanguages)),
       collapsedLanguagesJson: Value(jsonEncode(d.collapsedLanguages)),
       languageOverride: Value(d.languageOverride),
+      displayName: Value(d.displayName),
     );
   }
 
@@ -217,6 +219,23 @@ class DictionaryRepository {
   void setDictionaryLanguageOverride(Dictionary dictionary, String? language) {
     final String trimmed = language?.trim() ?? '';
     dictionary.languageOverride = trimmed.isEmpty ? null : trimmed;
+    persistDictionary(dictionary);
+    clearDictionaryResultsCache();
+  }
+
+  /// 改词典显示名。空 / 与真名相同 → 存 null（回到「没改过」，避免留一行等值
+  /// 冗余，也让 `window.dictionaryDisplayNames` 的映射表只装真正改过的）。
+  ///
+  /// 只动 [Dictionary.displayName]。真名 [Dictionary.name] 是主键 + 磁盘目录名 +
+  /// 引擎装载路径 + CSS/媒体/Anki token 的键，一律不动（见 `tables.dart` 的
+  /// `displayName` 注释）。
+  ///
+  /// 仍清查词缓存：弹窗 HTML 是缓存产物，里面的词典名标题已经渲染进去了，不清
+  /// 的话改完名要等缓存自然失效才看得到新名。
+  void setDictionaryDisplayName(Dictionary dictionary, String? displayName) {
+    final String trimmed = displayName?.trim() ?? '';
+    dictionary.displayName =
+        (trimmed.isEmpty || trimmed == dictionary.name) ? null : trimmed;
     persistDictionary(dictionary);
     clearDictionaryResultsCache();
   }

--- a/fushi/lib/src/pages/implementations/collection_name_dialog.dart
+++ b/fushi/lib/src/pages/implementations/collection_name_dialog.dart
@@ -1,139 +1,54 @@
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
 import 'package:fushi/src/pages/implementations/series_shelf_card.dart';
 import 'package:fushi/utils.dart';
 
 /// 统一合集 UI v2 Phase E：合集命名/重命名对话框（原 series_detail_page 的
 /// `showSeriesNameDialog`，随死掉的 SeriesDetailPage 整页删除迁居至此）。
 /// 供「组合成合集」「合集重命名」共用；[previewCovers] 非空时铺成员封面缩略预览。
+///
+/// 弹窗壳本身已收敛进通用的 [showNameInputDialog]（库内全部改名入口共用一份）；
+/// 这里只剩合集专属的两处差异：书签图标和封面网格预览头部。
 Future<String?> showCollectionNameDialog({
   required BuildContext context,
   required String title,
   String initialName = '',
   List<Widget> previewCovers = const <Widget>[],
 }) {
-  return showAppDialog<String>(
+  return showNameInputDialog(
     context: context,
-    builder: (_) => _CollectionNameDialog(
-      title: title,
-      initialName: initialName,
-      previewCovers: previewCovers,
-    ),
+    title: title,
+    labelText: t.series_name_hint,
+    initialName: initialName,
+    leadingIcon: Icons.collections_bookmark_outlined,
+    header: previewCovers.isEmpty
+        ? null
+        : _CollectionCoverPreview(covers: previewCovers),
   );
 }
 
-class _CollectionNameDialog extends StatefulWidget {
-  const _CollectionNameDialog({
-    required this.title,
-    required this.initialName,
-    this.previewCovers = const <Widget>[],
-  });
+/// TODO-947：多选「组合成合集」命名弹窗里，把选中的前 N 本封面铺成手机文件夹式
+/// 网格缩略预览，让用户在命名/确认时就直观看到「我把哪几本合并进去了」。
+class _CollectionCoverPreview extends StatelessWidget {
+  const _CollectionCoverPreview({required this.covers});
 
-  final String title;
-  final String initialName;
-
-  /// TODO-947：多选「组合成合集」命名弹窗里，把选中的前 N 本封面铺成手机文件夹式
-  /// 网格缩略预览，让用户在命名/确认时就直观看到「我把哪几本合并进去了」。空则不渲染。
-  final List<Widget> previewCovers;
-
-  @override
-  State<_CollectionNameDialog> createState() => _CollectionNameDialogState();
-}
-
-class _CollectionNameDialogState extends State<_CollectionNameDialog> {
-  late final TextEditingController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = TextEditingController(text: widget.initialName);
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _submit() {
-    final String name = _controller.text.trim();
-    if (name.isEmpty) return;
-    Navigator.pop(context, name);
-  }
+  final List<Widget> covers;
 
   @override
   Widget build(BuildContext context) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-    return FushiDialogFrame(
-      maxWidth: 420,
-      maxHeightFactor: 0.74,
-      scrollable: false,
-      child: FushiModalSheetFrame(
-        title: widget.title,
-        leadingIcon: Icons.collections_bookmark_outlined,
-        // TODO-1389：外层 FushiDialogFrame(maxHeightFactor:0.74, scrollable:false) 给有界
-        // 高度；body 是含 92x120 封面大图 + 输入框的非滚动 Column，最小窗高 480（客户区
-        // ≈440）下会顶破 0.74 界底部溢出（尤其更大字号 / 紧凑间距）。scrollable:true 提供
-        // 滚动兜底，矮窗可滚不溢出。
-        scrollable: true,
-        bodyPadding: EdgeInsets.fromLTRB(
-          tokens.spacing.card,
-          0,
-          tokens.spacing.card,
-          tokens.spacing.gap,
-        ),
-        footerPadding: EdgeInsets.fromLTRB(
-          tokens.spacing.card,
-          tokens.spacing.gap,
-          tokens.spacing.card,
-          tokens.spacing.card,
-        ),
-        body: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            if (widget.previewCovers.isNotEmpty) ...<Widget>[
-              Center(
-                child: SizedBox(
-                  width: 92,
-                  height: 120,
-                  child: FushiCard(
-                    padding: EdgeInsets.zero,
-                    margin: EdgeInsets.zero,
-                    child: ClipRRect(
-                      borderRadius: tokens.radii.cardRadius,
-                      child: SeriesFolderCover(covers: widget.previewCovers),
-                    ),
-                  ),
-                ),
-              ),
-              SizedBox(height: tokens.spacing.gap),
-            ],
-            FushiTextField(
-              controller: _controller,
-              labelText: t.series_name_hint,
-              autofocus: true,
-              onSubmitted: (_) => _submit(),
-            ),
-          ],
-        ),
-        footer: Wrap(
-          alignment: WrapAlignment.end,
-          spacing: tokens.spacing.gap,
-          runSpacing: tokens.spacing.gap,
-          children: <Widget>[
-            adaptiveDialogAction(
-              context: context,
-              onPressed: () => Navigator.pop(context),
-              child: Text(t.dialog_cancel),
-            ),
-            adaptiveDialogAction(
-              context: context,
-              isDefaultAction: true,
-              onPressed: _submit,
-              child: Text(t.dialog_ok),
-            ),
-          ],
+    return Center(
+      child: SizedBox(
+        width: 92,
+        height: 120,
+        child: FushiCard(
+          padding: EdgeInsets.zero,
+          margin: EdgeInsets.zero,
+          child: ClipRRect(
+            borderRadius: tokens.radii.cardRadius,
+            child: SeriesFolderCover(covers: covers),
+          ),
         ),
       ),
     );

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -422,11 +422,15 @@ class _DictionaryDialogPageState extends BasePageState {
 
   Future<void> showDictionaryDeleteDialog(Dictionary dictionary) {
     return _showDictionaryActionConfirmDialog(
-      title: t.dialog_title_dictionary_delete(name: dictionary.name),
+      // 确认框与进度页都是给人看的，用显示名；真正的删除按 `dictionary` 对象走
+      // （deleteDictionary 内部用真名找磁盘目录）。
+      title: t.dialog_title_dictionary_delete(
+        name: dictionary.effectiveDisplayName,
+      ),
       content: t.dialog_content_dictionary_delete,
       confirmLabel: t.dialog_delete,
       run: () => appModel.deleteDictionary(dictionary),
-      progressName: dictionary.name,
+      progressName: dictionary.effectiveDisplayName,
     );
   }
 
@@ -1797,7 +1801,10 @@ class _DictionaryDialogPageState extends BasePageState {
     required DictionaryDownloadJob job,
     required Map<String, String> sourceOverride,
   }) async {
-    final String name = dictionary.name;
+    // 只喂文案（进度行 / 导入阶段提示 / 完成 toast），无身份用途——身份走
+    // `dictionary` 对象本身（downloadUrl / 目录名）。所以这里用显示名：用户改过名
+    // 之后，进度条里还蹦出那个又长又带日期的原名会让人以为在更新别的东西。
+    final String name = dictionary.effectiveDisplayName;
     final ValueNotifier<String> progressNotifier = job.message;
     final ValueNotifier<double> downloadProgress = job.progress;
     final Directory tempDir = Directory(
@@ -1869,7 +1876,8 @@ class _DictionaryDialogPageState extends BasePageState {
             },
           );
           return DictionaryDownloadOutcome(
-            message: t.dict_update_done(name: dictionary.name),
+            message: t.dict_update_done(
+                name: dictionary.effectiveDisplayName),
             severity: ToastSeverity.success,
           );
         } catch (e, stack) {
@@ -1942,7 +1950,8 @@ class _DictionaryDialogPageState extends BasePageState {
     if (!mounted) return;
 
     await _runWithDownloadProgressDialog(
-      initialMessage: t.dict_update_updating(name: dictionary.name),
+      initialMessage:
+          t.dict_update_updating(name: dictionary.effectiveDisplayName),
       body: (DictionaryDownloadJob job) async {
         // 本地文件覆盖更新**全程都是导入阶段**（没有下载），故整条路径不可取消：
         // 进入 body 就切 importing，取消按钮从头到尾是灰的（BUG-1499）。
@@ -1957,7 +1966,8 @@ class _DictionaryDialogPageState extends BasePageState {
           );
           // 覆盖导入没抛异常即成功。
           return DictionaryDownloadOutcome(
-            message: t.dict_update_done(name: dictionary.name),
+            message: t.dict_update_done(
+                name: dictionary.effectiveDisplayName),
             severity: ToastSeverity.success,
           );
         } catch (e, stack) {

--- a/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -14,6 +14,7 @@ import 'package:fushi/src/media/drag_drop/fushi_file_drop_target.dart';
 import 'package:fushi/src/models/dictionary_download_controller.dart';
 import 'package:fushi/src/models/dictionary_import_manager.dart';
 import 'package:fushi/src/models/dictionary_repository.dart';
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
 import 'package:fushi/src/utils/misc/channel_constants.dart';
 import 'package:fushi/utils.dart';
 
@@ -395,6 +396,28 @@ class _DictionaryDialogPageState extends BasePageState {
         setState(() {});
       },
     );
+  }
+
+  /// 给词典改个显示名。落的是 `dictionary_metadata.display_name` 覆盖列，**真名
+  /// 不动**——真名是主键、磁盘目录名、C++ 引擎装载路径，还被每词典 CSS、样式规则、
+  /// 弹窗 `data-dictionary` 选择器、词典媒体 URL、Anki `{single-glossary-<名>}`
+  /// token、存储占用条目 id、同步资产名当键用。改真名会让这些全部静默失配（用户
+  /// 样式丢失、图/音 404、已配置的制卡字段失效）。
+  ///
+  /// 因此改名只贯通「给人看的地方」：本列表、查词弹窗里的词典名标题/频率/音高/
+  /// 汉字标签、存储占用明细、CSS 作用域下拉、同步对比对话框。
+  Future<void> _renameDictionary(Dictionary dictionary) async {
+    final String current = dictionary.effectiveDisplayName;
+    final String? name = await showNameInputDialog(
+      context: context,
+      title: t.dict_rename,
+      labelText: t.dict_rename_label,
+      initialName: current,
+      leadingIcon: Icons.drive_file_rename_outline,
+    );
+    if (!mounted || name == null || name == current) return;
+    appModel.setDictionaryDisplayName(dictionary, name);
+    setState(() {});
   }
 
   Future<void> showDictionaryDeleteDialog(Dictionary dictionary) {
@@ -1450,7 +1473,8 @@ class _DictionaryDialogPageState extends BasePageState {
     // 情况，四个 tab（term/kanji/frequency/pitch）共用本 tile 一处修复全覆盖。
     final bool compact = MediaQuery.sizeOf(context).width < 480;
     final Text nameText = Text(
-      dictionary.name,
+      // 用户可见的词典名一律走 effectiveDisplayName（改过名用改的，否则真名）。
+      dictionary.effectiveDisplayName,
       style: textTheme.bodyLarge?.copyWith(
         color: titleColor,
         fontWeight: FontWeight.w600,
@@ -1574,6 +1598,16 @@ class _DictionaryDialogPageState extends BasePageState {
           onTap: onMoveDown,
         ),
         _buildDictionaryVisibilityButton(dictionary, enabled),
+        SizedBox(width: tokens.spacing.gap / 2),
+        // 改名：导入包里的 index.json title 常常又长又带日期（`JMdict [2026-05-17]`），
+        // 而它同时是主键/目录名/引擎键，改不得——所以这里改的是显示名覆盖层。
+        FushiIconButton(
+          key: ValueKey<String>('dict_rename_${dictionary.name}'),
+          icon: Icons.drive_file_rename_outline,
+          size: 20,
+          tooltip: t.dict_rename,
+          onTap: () => _renameDictionary(dictionary),
+        ),
         // TODO-839：每本词典行尾恒显示一个「更新」按钮（消除「这本能更新那本不能」
         // 的视觉断层）。按 isUpdatable 分流：
         //   - 在线来源（isUpdatable 三条件满足）→ 走 _updateSingleDictionary（拉远端

--- a/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
-import 'package:fushi/models.dart';
 import 'package:fushi/utils.dart';
 
 class _GroupedEntry {
@@ -38,9 +37,19 @@ class DictionaryPopupNative extends ConsumerStatefulWidget {
     super.key,
     this.onTextSelected,
     this.onMineEntry,
+    this.dictionaryDisplayNames = const <String, String>{},
   });
 
   final DictionarySearchResult result;
+
+  /// 词典改名（v95）：真名 -> 显示名，只含改过名的。**由调用方传入**，而不是
+  /// 在这里 `ref.read(appProvider)` 去捞——本 widget 虽是 ConsumerStatefulWidget，
+  /// 但在此之前从没真正用过 ref，于是它的测试一直不套 ProviderScope。渲染路径
+  /// 里读全局容器会当场 `Bad state: No ProviderScope found`，而且那是把一个
+  /// 隐式的全局依赖塞进纯展示组件。数据从外面单向流进来，测试也不用陪着改。
+  ///
+  /// 空表 = 没人改过名 = 全部显示真名（与 v95 前逐字节一致）。
+  final Map<String, String> dictionaryDisplayNames;
   final void Function(String text)? onTextSelected;
   final void Function(Map<String, String> fields)? onMineEntry;
 
@@ -56,17 +65,9 @@ class _DictionaryPopupNativeState extends ConsumerState<DictionaryPopupNative> {
   /// 分组 key（[_GroupedEntry] / `byDict`）一律仍是真名——它对齐 CSS 作用域、
   /// 隐藏/折叠集合与 Anki token，翻译了就全错位。
   ///
-  /// `dictRepo` 是 late 字段，悬浮词典窗这条精简初始化路径上存在「DB 就绪但词典
-  /// 仓库还没建」的窗口，直接读会抛 LateInitializationError——未就绪时原样返回
-  /// 真名（与改名前逐字节一致），不崩。
-  String _dictDisplayName(String rawName) {
-    final AppModel appModel = ref.read(appProvider);
-    if (!appModel.isDictionaryRepoReady) return rawName;
-    for (final Dictionary d in appModel.dictionaries) {
-      if (d.name == rawName) return d.effectiveDisplayName;
-    }
-    return rawName;
-  }
+  /// 查不到就原样返回真名（没改过名 / 调用方没传表），不崩。
+  String _dictDisplayName(String rawName) =>
+      widget.dictionaryDisplayNames[rawName] ?? rawName;
 
   @override
   void initState() {

--- a/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_native.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
+import 'package:fushi/models.dart';
 import 'package:fushi/utils.dart';
 
 class _GroupedEntry {
@@ -50,6 +51,22 @@ class DictionaryPopupNative extends ConsumerStatefulWidget {
 
 class _DictionaryPopupNativeState extends ConsumerState<DictionaryPopupNative> {
   List<_GroupedEntry> _grouped = [];
+
+  /// 词典改名（v95）：把查词结果里的**真名**翻成用户起的显示名，只用于渲染。
+  /// 分组 key（[_GroupedEntry] / `byDict`）一律仍是真名——它对齐 CSS 作用域、
+  /// 隐藏/折叠集合与 Anki token，翻译了就全错位。
+  ///
+  /// `dictRepo` 是 late 字段，悬浮词典窗这条精简初始化路径上存在「DB 就绪但词典
+  /// 仓库还没建」的窗口，直接读会抛 LateInitializationError——未就绪时原样返回
+  /// 真名（与改名前逐字节一致），不崩。
+  String _dictDisplayName(String rawName) {
+    final AppModel appModel = ref.read(appProvider);
+    if (!appModel.isDictionaryRepoReady) return rawName;
+    for (final Dictionary d in appModel.dictionaries) {
+      if (d.name == rawName) return d.effectiveDisplayName;
+    }
+    return rawName;
+  }
 
   @override
   void initState() {
@@ -332,7 +349,7 @@ class _DictionaryPopupNativeState extends ConsumerState<DictionaryPopupNative> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              dictName,
+              _dictDisplayName(dictName),
               style: tokens.type.metadata.copyWith(color: subColor),
             ),
             SizedBox(height: tokens.spacing.gap / 4),

--- a/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_settings_dialog_page.dart
@@ -584,6 +584,10 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
   late int _selectedIndex;
   late TextEditingController _cssController;
   late List<String> _dictNames;
+
+  /// 与 [_dictNames] 同序的**显示名**，只喂给下拉的 label。作用域主键、CSS
+  /// 选择器、草稿里存的 selectedDictionaryName 一律仍用 [_dictNames] 的真名。
+  late List<String> _dictDisplayNames;
   late AppModel _appModel;
   late ProfileDraftCoordinator _profileDraftCoordinator;
   late _DictCssDraftSession _draft;
@@ -605,6 +609,8 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
     ).read(profileDraftCoordinatorProvider);
     final Object profileDraftScope = _profileDraftCoordinator.draftScope;
     _dictNames = _appModel.dictionaries.map((d) => d.name).toList();
+    _dictDisplayNames =
+        _appModel.dictionaries.map((d) => d.effectiveDisplayName).toList();
     final _DictCssDraftSession? existingDraft = _dictCssDraftSession;
     if (existingDraft != null &&
         identical(existingDraft.appModel, _appModel) &&
@@ -938,7 +944,7 @@ class _DictCssEditorDialogState extends State<DictCssEditorDialog> {
       entries: <GamepadDropdownEntry<int>>[
         (value: 0, label: t.custom_dict_css_global),
         for (int i = 0; i < _dictNames.length; i++)
-          (value: i + 1, label: _dictNames[i]),
+          (value: i + 1, label: _dictDisplayNames[i]),
       ],
     );
   }

--- a/fushi/lib/src/pages/implementations/floating_dict_page.dart
+++ b/fushi/lib/src/pages/implementations/floating_dict_page.dart
@@ -209,6 +209,16 @@ class _FloatingDictPageState extends ConsumerState<FloatingDictPage> {
     return DictionaryPopupNative(
       result: _result!,
       onMineEntry: _exportToAnki,
+      // 词典改名（v95）：真名 -> 显示名，只含改过名的。悬浮窗走的是精简初始化
+      // 路径，词典仓库可能还没建好（dictRepo 是 late 字段，直接读会抛），未就绪
+      // 时给空表 = 全部显示真名。
+      dictionaryDisplayNames: appModel.isDictionaryRepoReady
+          ? <String, String>{
+              for (final Dictionary d in appModel.dictionaries)
+                if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+                  d.name: d.displayName!.trim(),
+            }
+          : const <String, String>{},
     );
   }
 

--- a/fushi/lib/src/pages/implementations/floating_dict_page.dart
+++ b/fushi/lib/src/pages/implementations/floating_dict_page.dart
@@ -213,11 +213,7 @@ class _FloatingDictPageState extends ConsumerState<FloatingDictPage> {
       // 路径，词典仓库可能还没建好（dictRepo 是 late 字段，直接读会抛），未就绪
       // 时给空表 = 全部显示真名。
       dictionaryDisplayNames: appModel.isDictionaryRepoReady
-          ? <String, String>{
-              for (final Dictionary d in appModel.dictionaries)
-                if (d.displayName != null && d.displayName!.trim().isNotEmpty)
-                  d.name: d.displayName!.trim(),
-            }
+          ? appModel.dictionaryDisplayNameOverrides
           : const <String, String>{},
     );
   }

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -94,6 +94,7 @@ import 'package:fushi/utils.dart';
 import 'package:fushi/src/utils/components/batch_tag_dialog_frame.dart';
 import 'package:fushi/src/utils/cover_image.dart';
 import 'package:fushi/src/pages/implementations/collection_name_dialog.dart';
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
 import 'package:fushi/src/media/video/video_filename_parser.dart';
 import 'package:fushi/src/utils/misc/shelf_ordering.dart';
 import 'package:fushi/src/media/source_library/add_local_folder_source.dart';
@@ -2482,35 +2483,21 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 重命名视频/播放列表（C 需求③）：弹输入框预填当前标题 → 落库 → 刷新列表。
   /// 空白标题不提交（保持原名）。
+  ///
+  /// 弹窗走库内共享的 [showNameInputDialog]：此前这里是一个**裸 AlertDialog**
+  /// （全库唯一没走 Fushi 设计系统的改名框），且 controller 在 `await` 返回后
+  /// 立即 dispose——那时弹窗还没拆完，属于过早释放（游戏改名踩过同一个坑并留了
+  /// 注释）。收编后 trim / 空名短路 / controller 生命周期都由原语统一负责。
   Future<void> _renameVideo(VideoBookRow book) async {
-    final TextEditingController controller =
-        TextEditingController(text: book.title);
-    final String? newTitle = await showAppDialog<String>(
+    final String? newTitle = await showNameInputDialog(
       context: context,
-      builder: (BuildContext ctx) => AlertDialog(
-        title: Text(t.video_rename),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          decoration: InputDecoration(hintText: t.video_rename_hint),
-          onSubmitted: (String v) => Navigator.pop(ctx, v),
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: Text(t.dialog_cancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, controller.text),
-            child: Text(t.dialog_save),
-          ),
-        ],
-      ),
+      title: t.video_rename,
+      labelText: t.video_rename_hint,
+      initialName: book.title,
+      leadingIcon: Icons.drive_file_rename_outline,
     );
-    controller.dispose();
-    final String? trimmed = newTitle?.trim();
-    if (trimmed == null || trimmed.isEmpty || trimmed == book.title) return;
-    await widget.repo.updateTitle(book.bookUid, trimmed);
+    if (newTitle == null || newTitle == book.title) return;
+    await widget.repo.updateTitle(book.bookUid, newTitle);
     if (mounted) _refresh();
   }
 

--- a/fushi/lib/src/pages/implementations/media_sources_view.dart
+++ b/fushi/lib/src/pages/implementations/media_sources_view.dart
@@ -40,6 +40,7 @@ import 'package:fushi/src/sync/sftp_sync_backend.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
 import 'package:fushi/src/sync/webdav_sync_backend.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
 import 'package:fushi/src/utils/misc/fushi_share.dart';
 import 'package:fushi/src/utils/net/url_input_normalizer.dart';
 import 'package:fushi/utils.dart';
@@ -450,6 +451,15 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
                 enabled: !busy,
                 padding: EdgeInsets.all(tokens.spacing.gap / 2),
                 onTap: () => _rescan(row),
+              ),
+              FushiIconButton(
+                key: ValueKey<String>('media_source_rename_${row.id}'),
+                icon: Icons.drive_file_rename_outline,
+                size: 18,
+                tooltip: t.media_source_rename,
+                enabled: !busy,
+                padding: EdgeInsets.all(tokens.spacing.gap / 2),
+                onTap: () => _rename(row),
               ),
               if (isVideo && widget.onScrapeSource != null)
                 FushiIconButton(
@@ -1168,6 +1178,26 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   /// 移除来源：确认对话框强调移除来源不会删除已导入的媒体（FK setNull 自动
   /// 把归属媒体的 source_id 归 NULL，条目保留）→ 确认则 deleteMediaSource +
   /// 清除该来源的网络凭据 → 刷新。
+  /// 改扫描根的显示名。只动 `media_sources.label` 这一列——身份是自增 `id`，
+  /// 扫描、凭据、刮削设置、条目归属全都按 id 走，改名不牵动任何一处。
+  ///
+  /// 添加本地文件夹时 label 是从 rootPath 末段推导的（`defaultLabelFromRoot`），
+  /// 同名文件夹挂多个根时全叫一样的名字；网络来源的可选显示名也只能在添加时填
+  /// 一次。这里是事后唯一的修改入口。
+  Future<void> _rename(SourceLibraryRow row) async {
+    final String? name = await showNameInputDialog(
+      context: context,
+      title: t.media_source_rename,
+      labelText: t.media_source_rename_label,
+      initialName: row.label,
+      leadingIcon: Icons.drive_file_rename_outline,
+    );
+    // 弹窗已 trim 且拒绝空名，这里只需短路「没改」。
+    if (!mounted || name == null || name == row.label) return;
+    await _db.updateMediaSourceLabel(row.id, name);
+    await _load();
+  }
+
   Future<void> _remove(SourceLibraryRow row) async {
     final bool? confirmed = await showAppDialog<bool>(
       context: context,

--- a/fushi/lib/src/pages/implementations/name_input_dialog.dart
+++ b/fushi/lib/src/pages/implementations/name_input_dialog.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+
+import 'package:fushi/utils.dart';
+
+/// 通用「输入一个名字」对话框——库内**全部**改名/命名入口的唯一弹窗实现。
+///
+/// 在此之前，每个域各自复制了一份形状相同的命名弹窗：合集走
+/// `showCollectionNameDialog`、游戏走私有 `_RenameGameDialog`、视频走一个**裸**
+/// `AlertDialog`（连设计系统都没走）、Profile 走 `ProfileNameDialog`。四份实现
+/// 四种壳、四套 trim/空名规则，其中视频那份还踩过「`showDialog` 返回后立刻
+/// dispose controller」的过早释放坑。再往里加词典/扫描根就是第五、第六份。
+///
+/// 所以这里收成一个原语：**壳、令牌间距、trim、空名短路、controller 生命周期
+/// 只有一处**，各域只传自己的差异（标题、输入框标签、图标、可选头部预览）。
+/// 域专属的语义包装（如合集的封面网格预览）留在各自的薄 wrapper 里，本文件
+/// 因此零域依赖。
+///
+/// 返回值语义：`null` = 用户取消；非空 = 已 trim 的新名字。**空名不会返回**
+/// （输入框留空时确认键直接不响应），调用方无需再判空。
+Future<String?> showNameInputDialog({
+  required BuildContext context,
+  required String title,
+  required String labelText,
+  String initialName = '',
+  IconData? leadingIcon,
+  Widget? header,
+}) {
+  return showAppDialog<String>(
+    context: context,
+    builder: (_) => _NameInputDialog(
+      title: title,
+      labelText: labelText,
+      initialName: initialName,
+      leadingIcon: leadingIcon,
+      header: header,
+    ),
+  );
+}
+
+class _NameInputDialog extends StatefulWidget {
+  const _NameInputDialog({
+    required this.title,
+    required this.labelText,
+    required this.initialName,
+    this.leadingIcon,
+    this.header,
+  });
+
+  final String title;
+  final String labelText;
+  final String initialName;
+  final IconData? leadingIcon;
+
+  /// 输入框上方的可选预览块（合集命名用它铺成员封面）。空则不占位。
+  final Widget? header;
+
+  @override
+  State<_NameInputDialog> createState() => _NameInputDialogState();
+}
+
+class _NameInputDialogState extends State<_NameInputDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialName);
+  }
+
+  @override
+  void dispose() {
+    // controller 由 State 持有并在此释放。调用方**不要**在 await 弹窗返回后
+    // 自己 dispose：那时 widget 树还没拆完，属于过早释放。
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String name = _controller.text.trim();
+    if (name.isEmpty) return;
+    Navigator.pop(context, name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+    return FushiDialogFrame(
+      maxWidth: 420,
+      maxHeightFactor: 0.74,
+      scrollable: false,
+      child: FushiModalSheetFrame(
+        title: widget.title,
+        leadingIcon: widget.leadingIcon,
+        // TODO-1389 起沿用：外层给的是有界高度，body 又是非滚动 Column，最小窗高
+        // 480（客户区 ≈440）下带 header 时会顶破界底。scrollable 提供滚动兜底。
+        scrollable: true,
+        bodyPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          0,
+          tokens.spacing.card,
+          tokens.spacing.gap,
+        ),
+        footerPadding: EdgeInsets.fromLTRB(
+          tokens.spacing.card,
+          tokens.spacing.gap,
+          tokens.spacing.card,
+          tokens.spacing.card,
+        ),
+        body: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            if (widget.header != null) ...<Widget>[
+              widget.header!,
+              SizedBox(height: tokens.spacing.gap),
+            ],
+            FushiTextField(
+              controller: _controller,
+              labelText: widget.labelText,
+              autofocus: true,
+              onSubmitted: (_) => _submit(),
+            ),
+          ],
+        ),
+        footer: Wrap(
+          alignment: WrapAlignment.end,
+          spacing: tokens.spacing.gap,
+          runSpacing: tokens.spacing.gap,
+          children: <Widget>[
+            adaptiveDialogAction(
+              context: context,
+              onPressed: () => Navigator.pop(context),
+              child: Text(t.dialog_cancel),
+            ),
+            adaptiveDialogAction(
+              context: context,
+              isDefaultAction: true,
+              onPressed: _submit,
+              child: Text(t.dialog_ok),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/pages/implementations/name_input_dialog.dart
+++ b/fushi/lib/src/pages/implementations/name_input_dialog.dart
@@ -16,7 +16,11 @@ import 'package:fushi/utils.dart';
 /// 因此零域依赖。
 ///
 /// 返回值语义：`null` = 用户取消；非空 = 已 trim 的新名字。**空名不会返回**
-/// （输入框留空时确认键直接不响应），调用方无需再判空。
+/// （留空时确认键置灰），调用方无需再判空。
+///
+/// 收编进度：合集 / 视频 / 书 / 扫描根 / 词典五处已走本原语；游戏的
+/// `_RenameGameDialog` 与 `ProfileNameDialog` 仍是各自的独立实现（它们的空名
+/// 规则是「照样 pop 空串、由调用点各自判空」），尚未收编。
 Future<String?> showNameInputDialog({
   required BuildContext context,
   required String title,
@@ -65,10 +69,22 @@ class _NameInputDialogState extends State<_NameInputDialog> {
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.initialName);
+    // 空名时把确认键**置灰**，而不是让它可点但按下去毫无反应。后者是这个原语
+    // 第一版的行为：弹窗不关、无提示、回车也静默——用户只会以为程序卡了。
+    _controller.addListener(_syncCanSubmit);
+    _canSubmit = _controller.text.trim().isNotEmpty;
+  }
+
+  bool _canSubmit = false;
+
+  void _syncCanSubmit() {
+    final bool next = _controller.text.trim().isNotEmpty;
+    if (next != _canSubmit) setState(() => _canSubmit = next);
   }
 
   @override
   void dispose() {
+    _controller.removeListener(_syncCanSubmit);
     // controller 由 State 持有并在此释放。调用方**不要**在 await 弹窗返回后
     // 自己 dispose：那时 widget 树还没拆完，属于过早释放。
     _controller.dispose();
@@ -135,7 +151,8 @@ class _NameInputDialogState extends State<_NameInputDialog> {
             adaptiveDialogAction(
               context: context,
               isDefaultAction: true,
-              onPressed: _submit,
+              // null = 各平台原生置灰态。空名不可提交这件事因此是**看得见**的。
+              onPressed: _canSubmit ? _submit : null,
               child: Text(t.dialog_ok),
             ),
           ],

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -719,11 +719,8 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
   // 恒为真名（它同时是 CSS 作用域 key、媒体 URL 参数、隐藏/折叠/排序 key 和
   // Anki `{single-glossary-<名>}` token 的 key，替换它会静默打断上述全部），
   // popup.js 只在**渲染词典名文本**的那几处查这张表。只装真正改过名的条目。
-  final String dictionaryDisplayNames = jsonEncode(<String, String>{
-    for (final Dictionary d in appModel.dictionaries)
-      if (d.displayName != null && d.displayName!.trim().isNotEmpty)
-        d.name: d.displayName!.trim(),
-  });
+  final String dictionaryDisplayNames =
+      jsonEncode(appModel.dictionaryDisplayNameOverrides);
   // effective* = 可视化规则的编译产物 + 用户手写（产物在前、手写在后）。这里
   // 绝不能用裸 globalDictCSS / customDictCSS——那是编辑器回填用的原文。
   final String globalDictCSS = appModel.effectiveGlobalDictCSS;

--- a/fushi/lib/src/pages/implementations/popup_settings_injection.dart
+++ b/fushi/lib/src/pages/implementations/popup_settings_injection.dart
@@ -610,6 +610,7 @@ class _PopupStaticSettingsMemo {
     required this.autoExpandRows,
     required this.collapsedNames,
     required this.hiddenNames,
+    required this.dictionaryDisplayNames,
     required this.stylesJson,
     required this.globalDictCSS,
     required this.customDictCSSJson,
@@ -634,6 +635,7 @@ class _PopupStaticSettingsMemo {
   final int autoExpandRows;
   final String collapsedNames;
   final String hiddenNames;
+  final String dictionaryDisplayNames;
   final String stylesJson;
   final String globalDictCSS;
   final String customDictCSSJson;
@@ -713,6 +715,15 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
   final String hiddenNames = jsonEncode(
     appModel.hiddenDictionaryNames.toList(),
   );
+  // 词典改名：真名 -> 显示名的**旁路映射表**。popupJson 里的 `dictionary` 字段
+  // 恒为真名（它同时是 CSS 作用域 key、媒体 URL 参数、隐藏/折叠/排序 key 和
+  // Anki `{single-glossary-<名>}` token 的 key，替换它会静默打断上述全部），
+  // popup.js 只在**渲染词典名文本**的那几处查这张表。只装真正改过名的条目。
+  final String dictionaryDisplayNames = jsonEncode(<String, String>{
+    for (final Dictionary d in appModel.dictionaries)
+      if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+        d.name: d.displayName!.trim(),
+  });
   // effective* = 可视化规则的编译产物 + 用户手写（产物在前、手写在后）。这里
   // 绝不能用裸 globalDictCSS / customDictCSS——那是编辑器回填用的原文。
   final String globalDictCSS = appModel.effectiveGlobalDictCSS;
@@ -741,6 +752,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
       cached.autoExpandRows == appModel.popupAutoExpandDictionaries &&
       cached.collapsedNames == collapsedNames &&
       cached.hiddenNames == hiddenNames &&
+      cached.dictionaryDisplayNames == dictionaryDisplayNames &&
       identical(cached.stylesJson, stylesJson) &&
       cached.globalDictCSS == globalDictCSS &&
       cached.customDictCSSJson == customDictCSSJson) {
@@ -834,6 +846,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     window.autoExpandRows = ${appModel.popupAutoExpandDictionaries};
     window.collapsedDictionaryNames = $collapsedNames;
     window.hiddenDictionaryNames = $hiddenNames;
+    window.dictionaryDisplayNames = $dictionaryDisplayNames;
 ''';
   final String tail =
       '''    window.dictionaryStyles = $stylesJson;
@@ -864,6 +877,7 @@ PopupStaticSettingsJs buildPopupStaticSettingsJs({
     autoExpandRows: appModel.popupAutoExpandDictionaries,
     collapsedNames: collapsedNames,
     hiddenNames: hiddenNames,
+    dictionaryDisplayNames: dictionaryDisplayNames,
     stylesJson: stylesJson,
     globalDictCSS: globalDictCSS,
     customDictCSSJson: customDictCSSJson,

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -36,6 +36,7 @@ import 'package:fushi/src/media/video/video_import_dialog.dart';
 import 'package:fushi/src/pages/implementations/book_drag_target.dart';
 import 'package:fushi/src/pages/implementations/media_library_shell.dart';
 import 'package:fushi/src/pages/implementations/collection_name_dialog.dart';
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
 import 'package:fushi/src/pages/implementations/tag_filter_bar.dart';
 import 'package:fushi_core/fushi_core.dart';
 // BUG-813：构造 ReaderPositionsCompanion 回填下载书的阅读进度需要 drift 的 Value（
@@ -2216,6 +2217,12 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
         icon: Icons.headphones_outlined,
         onPressed: () => _openAudiobookImport(item, bookKey),
       ),
+      // 三库页对称：视频卡/游戏卡的菜单里「重命名」都排在列表项首位，书卡对齐。
+      DialogListAction(
+        label: t.book_rename,
+        icon: Icons.drive_file_rename_outline,
+        onPressed: () => _renameBook(context, item),
+      ),
       // 桌面才有文件管理器契约（[currentRevealHost] 在移动端返回 null）——整条隐藏，
       // 而不是画一个点了没反应的按钮。漫画卷要手改 mokuro 数据时，这一条直接把书目录
       // 里的 manga.json 选中，省掉「书在哪个 bookKey 目录」这层猜。
@@ -2330,6 +2337,44 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 单卡「在线刮削封面」（统一三库页刮削入口）：先收起长按菜单，弹既有
   /// [BookCoverScrapeDialog]（Bangumi 书籍条目，选中即下载临时文件），选中后
   /// 立即走与「编辑信息」保存完全相同的 override 通道落封面，卡面即时刷新。
+  /// 书卡菜单直达「重命名」（EPUB / 漫画 / PDF / SRT 有声书共用——身份换算全在
+  /// [MediaSource] 里，这一层只认 [MediaItem]）。
+  ///
+  /// 与上面「在线刮削封面」同一形状的入口下沉：改名的**能力**一直都在，但只长在
+  /// 「编辑信息」弹窗的标题字段里，用户得先想到那是个改名入口再点进两层；视频卡和
+  /// 游戏卡的菜单第一项就是「重命名」。书卡此前缺这一档，纯属三库页不对称。
+  ///
+  /// 落点是**显示名覆盖偏好**（`override_title://`），绝不写 `epub_books.title`：
+  /// 那一列派生出主键 `bookKey`，改列等于换身份、十来张子表连坐重键（理由见
+  /// `override_title_key.dart` 的文件头）。清空改名仍然只在「编辑信息」里做——本
+  /// 弹窗按共享原语的约定拒绝空名，避免「确认键点不动」被误读成改名失败。
+  ///
+  /// [dialogContext] 是**要关掉的那个菜单**的 context：EPUB 卡菜单由页面 context
+  /// 承载，SRT 卡菜单自带一个 dialogContext，两者不能混用（拿页面 context 去 pop
+  /// SRT 菜单会连页面一起弹掉）。
+  Future<void> _renameBook(BuildContext dialogContext, MediaItem item) async {
+    Navigator.pop(dialogContext);
+    final MediaSource mediaSource = item.getMediaSource(appModel: appModel);
+    // 初值取**当前显示名**（override ?? 原名）而不是原始 title：否则改过一次名的
+    // 书再次打开改名框会闪回原名，用户以为改名丢了。统一走显示名门面。
+    final String current = displayTitleForBook(item: item, rawTitle: item.title);
+    final String? name = await showNameInputDialog(
+      context: context,
+      title: t.book_rename,
+      labelText: t.book_rename_label,
+      initialName: current,
+      leadingIcon: Icons.drive_file_rename_outline,
+    );
+    if (!mounted || name == null || name == current) return;
+    await mediaSource.setOverrideTitleFromMediaItem(item: item, title: name);
+    if (!mounted) return;
+    // BUG-1018 同款刷新纪律：书架的响应式源按 key 集合去重，纯覆盖层写入不会
+    // 自动重发，只 refreshTab 会拿旧的缓存 MediaItem 重绘、看着像"没保存"。
+    ref.invalidate(fushiBooksProvider(JapaneseLanguage.instance));
+    ref.invalidate(srtBooksProvider);
+    _rebuild(() {});
+  }
+
   Future<void> _scrapeEpubCover(MediaItem item) async {
     Navigator.pop(context);
     final MediaSource mediaSource = item.getMediaSource(appModel: appModel);

--- a/fushi/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_history/books.part.dart
@@ -216,6 +216,13 @@ extension _ReaderHistoryBooks on _ReaderFushiHistoryPageState {
           await _confirmDeleteSrtBook(book);
         },
       ),
+      // 三库页对称：与 EPUB / 视频 / 游戏卡一样，「重命名」排在列表项首位。落的是
+      // 显示名覆盖层，SrtBooks.title 不动（同 bookKey 换身份的理由）。
+      DialogListAction(
+        label: t.book_rename,
+        icon: Icons.drive_file_rename_outline,
+        onPressed: () => _renameBook(dialogContext, item),
+      ),
       // 合集详情页成员卡：给可聚焦长按对话框补「移出合集」（键盘/手柄移出入口）。
       if (removeFromCollection != null)
         DialogListAction(

--- a/fushi/lib/src/pages/implementations/storage_usage_view.dart
+++ b/fushi/lib/src/pages/implementations/storage_usage_view.dart
@@ -30,6 +30,7 @@ class StorageUsageView extends ConsumerStatefulWidget {
     required this.service,
     required this.booksProvider,
     required this.dictionaryNamesProvider,
+    this.dictionaryDisplayNamesProvider,
     required this.deleteBook,
     required this.deleteSrtBook,
     required this.deleteDictionary,
@@ -47,6 +48,10 @@ class StorageUsageView extends ConsumerStatefulWidget {
 
   /// 词典名清单取数（真实现读 `AppModel.dictionaries`）。
   final Future<List<String>> Function() dictionaryNamesProvider;
+
+  /// 词典改名（v95）：真名 -> 显示名。可选——不传（测试 seam / 旧调用点）就按
+  /// 真名显示，与改名前逐字节一致。条目 id 与磁盘路径始终是真名，只有 label 翻译。
+  final Future<Map<String, String>> Function()? dictionaryDisplayNamesProvider;
 
   /// 删除一本书（真实现 `ReaderFushiSource.instance.deleteBook`）。
   /// 返回 null = 成功，非 null = 失败原因。
@@ -131,9 +136,13 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     unawaited(_loadExtras());
     List<StorageBookRef> books = const <StorageBookRef>[];
     List<String> dictNames = const <String>[];
+    Map<String, String> dictDisplayNames = const <String, String>{};
     try {
       books = await widget.booksProvider();
       dictNames = await widget.dictionaryNamesProvider();
+      dictDisplayNames =
+          await widget.dictionaryDisplayNamesProvider?.call() ??
+              const <String, String>{};
     } catch (e) {
       debugPrint('[storage] listing failed: $e');
     }
@@ -141,7 +150,11 @@ class _StorageUsageViewState extends ConsumerState<StorageUsageView> {
     await _scanSub?.cancel();
     if (!mounted || epoch != _scanEpoch) return;
     _scanSub = widget.service
-        .scanCategories(books: books, dictionaryNames: dictNames)
+        .scanCategories(
+          books: books,
+          dictionaryNames: dictNames,
+          dictionaryDisplayNames: dictDisplayNames,
+        )
         .listen(
       (StorageCategoryUsage usage) {
         if (!mounted || epoch != _scanEpoch) return;

--- a/fushi/lib/src/settings/settings_schema_storage.dart
+++ b/fushi/lib/src/settings/settings_schema_storage.dart
@@ -102,11 +102,8 @@ SettingsDestination buildStorageDestination() {
         for (final Dictionary d in c.appModel.dictionaries) d.name,
       ],
       // 只翻译明细行的 label；上面那份真名列表照旧驱动目录扫描与删除路由。
-      dictionaryDisplayNamesProvider: () async => <String, String>{
-        for (final Dictionary d in c.appModel.dictionaries)
-          if (d.displayName != null && d.displayName!.trim().isNotEmpty)
-            d.name: d.displayName!.trim(),
-      },
+      dictionaryDisplayNamesProvider: () async =>
+          c.appModel.dictionaryDisplayNameOverrides,
       deleteBook: (String bookKey) async {
         final DeleteBookResult result =
             await ReaderFushiSource.instance.deleteBook(

--- a/fushi/lib/src/settings/settings_schema_storage.dart
+++ b/fushi/lib/src/settings/settings_schema_storage.dart
@@ -101,6 +101,12 @@ SettingsDestination buildStorageDestination() {
       dictionaryNamesProvider: () async => <String>[
         for (final Dictionary d in c.appModel.dictionaries) d.name,
       ],
+      // 只翻译明细行的 label；上面那份真名列表照旧驱动目录扫描与删除路由。
+      dictionaryDisplayNamesProvider: () async => <String, String>{
+        for (final Dictionary d in c.appModel.dictionaries)
+          if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+            d.name: d.displayName!.trim(),
+      },
       deleteBook: (String bookKey) async {
         final DeleteBookResult result =
             await ReaderFushiSource.instance.deleteBook(

--- a/fushi/lib/src/storage/storage_usage_service.dart
+++ b/fushi/lib/src/storage/storage_usage_service.dart
@@ -530,6 +530,9 @@ class StorageUsageService {
   Stream<StorageCategoryUsage> scanCategories({
     required final List<StorageBookRef> books,
     required final List<String> dictionaryNames,
+    /// 词典改名（v95）：真名 -> 显示名，只含改过名的。**只翻译给人看的 label**；
+    /// 条目 `id` 与磁盘路径一律仍用真名（真名就是磁盘目录名，也是删除路由主键）。
+    final Map<String, String> dictionaryDisplayNames = const <String, String>{},
   }) async* {
     final Directory docs = await _documentsRoot();
     final Directory support = await _supportRoot();
@@ -541,7 +544,8 @@ class StorageUsageService {
         case StorageCategoryId.books:
           yield await _scanBooks(docs, books);
         case StorageCategoryId.dictionaries:
-          yield await _scanDictionaries(docs, dictionaryNames);
+          yield await _scanDictionaries(
+              docs, dictionaryNames, dictionaryDisplayNames);
         case StorageCategoryId.database:
           yield await _scanDatabase(support);
         case StorageCategoryId.ocrModels:
@@ -621,6 +625,7 @@ class StorageUsageService {
   Future<StorageCategoryUsage> _scanDictionaries(
     final Directory docs,
     final List<String> dictionaryNames,
+    final Map<String, String> dictionaryDisplayNames,
   ) async {
     final List<String> categoryRoots = <String>[
       for (final String child
@@ -640,8 +645,9 @@ class StorageUsageService {
     final List<StorageEntryUsage> entries = <StorageEntryUsage>[
       for (int i = 0; i < dictionaryNames.length; i++)
         StorageEntryUsage(
+          // id 必须是真名：删除路由（settings_schema_storage）按它找目录。
           id: dictionaryNames[i],
-          label: dictionaryNames[i],
+          label: dictionaryDisplayNames[dictionaryNames[i]] ?? dictionaryNames[i],
           bytes: sizes[i + 1],
           paths: <String>[perDictPaths[i]],
           kind: StorageEntryKind.dictionary,

--- a/fushi/lib/src/sync/fushi_remote_api_handlers.dart
+++ b/fushi/lib/src/sync/fushi_remote_api_handlers.dart
@@ -34,11 +34,20 @@ class RemotePopupDictionaryCss {
     required this.dictionaryStyles,
     required this.globalDictCss,
     required this.customDictCss,
+    this.dictionaryDisplayNames = const <String, String>{},
   });
 
   final Map<String, String> dictionaryStyles;
   final String globalDictCss;
   final Map<String, String> customDictCss;
+
+  /// 词典改名（v95）：真名 -> 显示名，只含真正改过名的条目。搭 popup.js 的
+  /// `__fushiDictDisplayName` 用，**只翻译渲染出来的词典名文本**；`dictionary`
+  /// 字段、`data-dictionary` 属性、媒体 URL 参数一律仍是真名。
+  ///
+  /// 挂在本类而不是另开一条通道：它与 CSS 三件套同属「弹窗渲染用的旁路数据」，
+  /// 共用下面的 revision 门控——改名改 revision，扩展下次查词即拉到新表。
+  final Map<String, String> dictionaryDisplayNames;
 
   late final String revision = _computeRevision();
 
@@ -51,7 +60,12 @@ class RemotePopupDictionaryCss {
     for (final MapEntry<String, String> e in customDictCss.entries) {
       h = Object.hash(h, e.key, e.value.length, e.value.hashCode);
     }
+    // 改名必须进 revision，否则扩展会一直命中旧缓存、改了不生效。
+    for (final MapEntry<String, String> e in dictionaryDisplayNames.entries) {
+      h = Object.hash(h, e.key, e.value.hashCode);
+    }
     return '${dictionaryStyles.length}.${customDictCss.length}.'
+        '${dictionaryDisplayNames.length}.'
         '${h.toUnsigned(32).toRadixString(16)}';
   }
 }
@@ -113,6 +127,7 @@ Future<Map<String, dynamic>> buildRemoteDictionaryLookupResponse(
       'dictionaryStyles': popupCss.dictionaryStyles,
       'globalDictCSS': popupCss.globalDictCss,
       'customDictCSS': popupCss.customDictCss,
+      'dictionaryDisplayNames': popupCss.dictionaryDisplayNames,
     },
   };
   final String term = body['term']?.toString() ?? '';

--- a/fushi/lib/src/sync/sync_asset_package_service.dart
+++ b/fushi/lib/src/sync/sync_asset_package_service.dart
@@ -118,18 +118,14 @@ class SyncAssetPackageService {
     final Map<String, Object?> dictionary = _mapValue(manifest, 'dictionary');
     final String name = _stringValue(dictionary, 'name');
 
-    // `upsertDictionaryMeta` 是**整行覆盖**：companion 里没列的列会被写成默认值
-    // （这里是 NULL）。而 manifest 只带随包走的那几列——用户设置列（改名、手动
-    // 指定的内容语言）本来就不属于词典包，它们是本机的。不先捞出来带上，从同步
-    // 重新导入一本已有的同名词典就会把用户的改名和语言指定静默清空。
-    DictionaryMetaRow? existing;
-    for (final DictionaryMetaRow row in await _db.getAllDictionaryMetadata()) {
-      if (row.name == name) {
-        existing = row;
-        break;
-      }
-    }
-
+    // 这里**只列 manifest 带的列**，用户设置列（改名 display_name、手动指定的
+    // 内容语言 language_override）刻意留 absent：`upsertDictionaryMeta` 走的是
+    // drift 的 `insertOnConflictUpdate`，companion 里 absent 的列在冲突更新时
+    // **保持原值不变**，于是重新导入一本已有的同名词典不会动本机的这两项。
+    //
+    // 危险的从来不是 absent，而是显式 `Value(null)`——那才是真的写 NULL。本仓
+    // 踩过的丢数据路径长这样：new 一个模型对象漏填字段 → 每列都 Value(...) 的
+    // companion → 静默抹掉用户设置（见 `Dictionary.copyWith` 的注释）。
     await _db.upsertDictionaryMeta(DictionaryMetadataCompanion.insert(
       name: name,
       formatKey: _stringValue(dictionary, 'formatKey'),
@@ -140,10 +136,6 @@ class SyncAssetPackageService {
           Value(_stringValue(dictionary, 'hiddenLanguagesJson')),
       collapsedLanguagesJson:
           Value(_stringValue(dictionary, 'collapsedLanguagesJson')),
-      // 与本地重导 / 在线更新的 `preservedSettings` 同一条继承通道：新装（existing
-      // 为 null）时两者都是 null，与改动前逐字节一致。
-      languageOverride: Value<String?>(existing?.languageOverride),
-      displayName: Value<String?>(existing?.displayName),
     ));
 
     final Directory targetDir = Directory(

--- a/fushi/lib/src/sync/sync_asset_package_service.dart
+++ b/fushi/lib/src/sync/sync_asset_package_service.dart
@@ -118,6 +118,18 @@ class SyncAssetPackageService {
     final Map<String, Object?> dictionary = _mapValue(manifest, 'dictionary');
     final String name = _stringValue(dictionary, 'name');
 
+    // `upsertDictionaryMeta` 是**整行覆盖**：companion 里没列的列会被写成默认值
+    // （这里是 NULL）。而 manifest 只带随包走的那几列——用户设置列（改名、手动
+    // 指定的内容语言）本来就不属于词典包，它们是本机的。不先捞出来带上，从同步
+    // 重新导入一本已有的同名词典就会把用户的改名和语言指定静默清空。
+    DictionaryMetaRow? existing;
+    for (final DictionaryMetaRow row in await _db.getAllDictionaryMetadata()) {
+      if (row.name == name) {
+        existing = row;
+        break;
+      }
+    }
+
     await _db.upsertDictionaryMeta(DictionaryMetadataCompanion.insert(
       name: name,
       formatKey: _stringValue(dictionary, 'formatKey'),
@@ -128,6 +140,10 @@ class SyncAssetPackageService {
           Value(_stringValue(dictionary, 'hiddenLanguagesJson')),
       collapsedLanguagesJson:
           Value(_stringValue(dictionary, 'collapsedLanguagesJson')),
+      // 与本地重导 / 在线更新的 `preservedSettings` 同一条继承通道：新装（existing
+      // 为 null）时两者都是 null，与改动前逐字节一致。
+      languageOverride: Value<String?>(existing?.languageOverride),
+      displayName: Value<String?>(existing?.displayName),
     ));
 
     final Directory targetDir = Directory(

--- a/fushi/lib/src/sync/sync_compare_dialog.dart
+++ b/fushi/lib/src/sync/sync_compare_dialog.dart
@@ -110,10 +110,20 @@ class SyncDictEntry {
     required this.name,
     required this.hasLocal,
     this.remoteAssetId,
+    this.displayName,
   });
 
   final String name;
   final bool hasLocal;
+
+  /// 词典改名（v95）：本地那本改过名时的显示名，只用于渲染这一行的标题。
+  /// [name] 是身份（远端资产名 `<name>.fushidict`、本地删除的键），永不翻译。
+  /// 远端独有的条目本地没有元数据行 → null → 显示 [name]。
+  final String? displayName;
+
+  String get shownName => (displayName?.trim().isNotEmpty ?? false)
+      ? displayName!.trim()
+      : name;
 
   /// 远端词典资产（`<name>.fushidict`）定位符；远端没有则 null。
   final String? remoteAssetId;
@@ -327,9 +337,15 @@ Future<List<SyncDictEntry>> _fetchDictEntries(
           e.id;
     }
   }
+  final List<DictionaryMetaRow> localRows = await db.getAllDictionaryMetadata();
   final Set<String> localNames = <String>{
-    for (final DictionaryMetaRow d in await db.getAllDictionaryMetadata())
-      d.name,
+    for (final DictionaryMetaRow d in localRows) d.name,
+  };
+  // 只用于这张列表的显示；同步身份仍是真名。
+  final Map<String, String> localDisplayNames = <String, String>{
+    for (final DictionaryMetaRow d in localRows)
+      if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+        d.name: d.displayName!.trim(),
   };
 
   final Set<String> allNames = <String>{...localNames, ...remoteByName.keys};
@@ -339,6 +355,7 @@ Future<List<SyncDictEntry>> _fetchDictEntries(
         name: n,
         hasLocal: localNames.contains(n),
         remoteAssetId: remoteByName[n],
+        displayName: localDisplayNames[n],
       ),
   ];
   // 纯本地项（远端没有、这里没得删）曾被「词典同步开关关着」过滤掉，理由是别用
@@ -1335,7 +1352,7 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
           const SizedBox(width: 6),
           Expanded(
             child: Text(
-              d.name,
+              d.shownName,
               style: theme.textTheme.titleSmall,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,

--- a/fushi/test/database/collection_relations_test.dart
+++ b/fushi/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final FushiDatabase db = await openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/fushi/test/database/migration_test.dart
+++ b/fushi/test/database/migration_test.dart
@@ -1080,7 +1080,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 paired peers 表). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1157,7 +1157,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1315,7 +1315,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1366,7 +1366,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
     });
 
     test(
@@ -1375,7 +1375,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1409,7 +1409,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 94,
+      expect(db.schemaVersion, 95,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1449,7 +1449,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1480,7 +1480,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1514,7 +1514,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1526,7 +1526,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1562,7 +1562,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 94);
+      expect(db.schemaVersion, 95);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/fushi/test/database/migration_v40_collections_test.dart
+++ b/fushi/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v51_pdf_format_test.dart
+++ b/fushi/test/database/migration_v51_pdf_format_test.dart
@@ -109,6 +109,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/fushi/test/database/migration_v53_manga_reading_mode_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/fushi/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
   });
 }

--- a/fushi/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/fushi/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v57_naming_unification_test.dart
+++ b/fushi/test/database/migration_v57_naming_unification_test.dart
@@ -191,7 +191,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/fushi/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/fushi/test/database/migration_v60_reading_pages_test.dart
+++ b/fushi/test/database/migration_v60_reading_pages_test.dart
@@ -64,7 +64,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 95, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/fushi/test/database/migration_v61_collection_cover_path_test.dart
+++ b/fushi/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/fushi/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/fushi/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -305,7 +305,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
+    expect(version.read<int>('user_version'), 95);
   });
 
   test(
@@ -336,7 +336,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/fushi/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,7 +105,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
     expect(await _userVersion(db), db.schemaVersion);
 
     // v63 真跑了：两处废弃偏好都没了。

--- a/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
+++ b/fushi/test/database/migration_v75_galgame_japanese_locale_mode_test.dart
@@ -77,7 +77,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v75 给 galgames 加 japanese_locale_mode（每游戏转区档位）');
 
     final List<QueryRow> columns =

--- a/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
+++ b/fushi/test/database/migration_v76_lookup_counter_identity_test.dart
@@ -86,7 +86,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v76 给 lookup_mining_counters 的 book_key 进唯一键');
 
     final List<LookupMiningCounterRow> rows =

--- a/fushi/test/database/migration_v79_tag_assignments_test.dart
+++ b/fushi/test/database/migration_v79_tag_assignments_test.dart
@@ -114,7 +114,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
 
     final List<TagAssignmentRow> rows = await db.getAllTagAssignments();
     expect(rows, hasLength(5), reason: '5 张表各 1 行有效映射（孤儿 srt 行丢弃）');

--- a/fushi/test/database/migration_v80_media_open_history_test.dart
+++ b/fushi/test/database/migration_v80_media_open_history_test.dart
@@ -61,7 +61,7 @@ CREATE TABLE media_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94);
+    expect(db.schemaVersion, 95);
 
     final rows = await db.getAllMediaOpenHistory();
     expect(rows, hasLength(2), reason: '迁移零丢行');

--- a/fushi/test/database/migration_v82_subtable_uid_test.dart
+++ b/fushi/test/database/migration_v82_subtable_uid_test.dart
@@ -131,7 +131,7 @@ CREATE TABLE revealed_images (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94, reason: 'v82 = 四子表书键切 uid');
+    expect(db.schemaVersion, 95, reason: 'v82 = 四子表书键切 uid');
 
     // ── reader_positions：跨书族，epub 命中换 uid，SRT 照抄 ──
     expect(await count(db, 'reader_positions'), 2, reason: '迁移零丢行');

--- a/fushi/test/database/migration_v83_entrykey_uid_test.dart
+++ b/fushi/test/database/migration_v83_entrykey_uid_test.dart
@@ -128,7 +128,7 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 94,
+    expect(db.schemaVersion, 95,
         reason: 'v83 = shelf_entries / media_collection_items epub 键切 uid');
 
     // ── shelf_entries：epub 命中换 uid、透传照抄、非 epub 照抄、零丢行 ──

--- a/fushi/test/database/migration_v84_preferences_updated_at_test.dart
+++ b/fushi/test/database/migration_v84_preferences_updated_at_test.dart
@@ -53,8 +53,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     // 存量行零丢失——改名是用户数据，迁移丢一行就是丢一个书名。
     expect(await db.getPref(_overrideKey), 's:母设备改的名');

--- a/fushi/test/database/migration_v85_video_last_played_at_test.dart
+++ b/fushi/test/database/migration_v85_video_last_played_at_test.dart
@@ -94,8 +94,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(4), reason: '迁移丢一行就是丢一部视频的观看记录');

--- a/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
+++ b/fushi/test/database/migration_v86_secondary_subtitle_delay_test.dart
@@ -87,8 +87,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     final List<VideoBookRow> rows = await db.select(db.videoBooks).get();
     expect(rows, hasLength(2), reason: '迁移丢一行就是丢一部视频的记录');

--- a/fushi/test/database/migration_v88_content_language_rest_test.dart
+++ b/fushi/test/database/migration_v88_content_language_rest_test.dart
@@ -94,7 +94,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(hasColumn(probe, 'video_books', 'language'), isTrue);
       expect(hasColumn(probe, 'srt_books', 'language'), isTrue);
       expect(hasColumn(probe, 'galgames', 'language'), isTrue);

--- a/fushi/test/database/migration_v90_download_proxy_merge_test.dart
+++ b/fushi/test/database/migration_v90_download_proxy_merge_test.dart
@@ -129,8 +129,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 94);
-    expect(db.schemaVersion, 94);
+    expect(version.read<int>('user_version'), 95);
+    expect(db.schemaVersion, 95);
 
     expect(await _prefs(db), <String, String>{
       'theme': 's:dark',

--- a/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
+++ b/fushi/test/database/migration_v91_collection_subtitle_prefs_test.dart
@@ -95,7 +95,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(
           hasColumn(probe, 'media_collections', 'subtitle_language'), isTrue);
       expect(hasColumn(probe, 'media_collections', 'subtitle_release_group'),

--- a/fushi/test/database/migration_v94_download_identity_json_test.dart
+++ b/fushi/test/database/migration_v94_download_identity_json_test.dart
@@ -99,7 +99,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
       expect(hasColumn(probe, 'video_download_jobs', 'identity_json'), isTrue);
       expect(hasColumn(probe, 'video_download_subscriptions', 'identity_json'),
           isTrue);

--- a/fushi/test/database/migration_v95_dictionary_display_name_test.dart
+++ b/fushi/test/database/migration_v95_dictionary_display_name_test.dart
@@ -1,0 +1,148 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+/// v95（词典改名）：`dictionary_metadata` 加 `display_name`——用户给词典起的
+/// 显示名。真名 `name` 是主键 + 磁盘目录名 + C++ 引擎装载路径，还被每词典 CSS、
+/// 样式规则、弹窗 `data-dictionary` 选择器、词典媒体 URL、Anki
+/// `{single-glossary-<名>}` token、存储占用条目 id 和同步资产名当键，冻结不动。
+///
+/// 守三件事：从真实 v94 库出发列会补上；存量词典行无损（尤其 name 一个字节
+/// 都不许动——动了就是全库换身份）；新列默认 NULL = 没改过名 = 显示真名 =
+/// 逐字节保留 v95 前的渲染。
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('fushi_v95_display_name');
+    dbPath = '${tempDir.path}${Platform.pathSeparator}v94-source.db';
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  /// 建一个真实的 v94 形状库：当前 schema 建满，摘掉 display_name，版本写回 94。
+  Future<void> seedV94() async {
+    final FushiDatabase fresh =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await fresh.customStatement(
+      'INSERT INTO dictionary_metadata (name, format_key, "order", type, '
+      'metadata_json, hidden_languages_json, collapsed_languages_json, '
+      'language_override) '
+      "VALUES ('JMdict [2026-05-17]', 'yomitan', 0, 'term', "
+      '\'{"revision":"2026-05-17"}\', \'["en"]\', \'["ja"]\', \'ja\')',
+    );
+    await fresh.close();
+
+    final sqlite3.Database raw = sqlite3.sqlite3.open(dbPath);
+    try {
+      raw.execute('ALTER TABLE dictionary_metadata DROP COLUMN display_name');
+      raw.execute('PRAGMA user_version = 94');
+    } finally {
+      raw.dispose();
+    }
+  }
+
+  bool hasColumn(sqlite3.Database db, String table, String column) {
+    final sqlite3.ResultSet rows = db.select('PRAGMA table_info($table)');
+    return rows.any((sqlite3.Row r) => r['name'] == column);
+  }
+
+  test('v94 库确实缺 display_name（前提自检）', () async {
+    await seedV94();
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 94);
+      expect(
+        hasColumn(probe, 'dictionary_metadata', 'display_name'),
+        isFalse,
+        reason: '前提不成立的话下面那条迁移断言测的是空气',
+      );
+    } finally {
+      probe.dispose();
+    }
+  });
+
+  test('v94 -> v95：补列、默认 NULL、存量词典行无损', () async {
+    await seedV94();
+
+    final FushiDatabase migrated =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    final List<DictionaryMetaRow> rows =
+        await migrated.getAllDictionaryMetadata();
+    expect(rows, hasLength(1), reason: '迁移丢一行就是丢一本词典');
+
+    final DictionaryMetaRow row = rows.single;
+    expect(
+      row.name,
+      'JMdict [2026-05-17]',
+      reason: '真名是主键+磁盘目录名+引擎装载路径，迁移一个字节都不许动',
+    );
+    expect(
+      row.displayName,
+      isNull,
+      reason: 'NULL = 没改过名 → 显示真名 → 逐字节保留 v95 前的渲染',
+    );
+    // 同属「用户设置」的邻居列不能被这一步碰掉。
+    expect(row.languageOverride, 'ja');
+    expect(row.hiddenLanguagesJson, '["en"]');
+    expect(row.collapsedLanguagesJson, '["ja"]');
+    expect(row.metadataJson, '{"revision":"2026-05-17"}');
+    await migrated.close();
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 95);
+      expect(hasColumn(probe, 'dictionary_metadata', 'display_name'), isTrue);
+    } finally {
+      probe.dispose();
+    }
+  });
+
+  test('迁移后能真的写进改名，且真名仍是那把键', () async {
+    await seedV94();
+
+    final FushiDatabase migrated =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await migrated.upsertDictionaryMeta(
+      DictionaryMetadataCompanion.insert(
+        name: 'JMdict [2026-05-17]',
+        formatKey: 'yomitan',
+        order: 0,
+        displayName: const Value<String?>('日汉大辞典'),
+      ),
+    );
+    final List<DictionaryMetaRow> rows =
+        await migrated.getAllDictionaryMetadata();
+    expect(
+      rows,
+      hasLength(1),
+      reason: '按主键 upsert：改名走同一行，不留孤儿',
+    );
+    expect(rows.single.displayName, '日汉大辞典');
+    expect(rows.single.name, 'JMdict [2026-05-17]');
+    await migrated.close();
+  });
+
+  test('重复打开幂等：第二次开库不因列已存在而报错', () async {
+    await seedV94();
+
+    final FushiDatabase first =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    await first.close();
+    final FushiDatabase second =
+        FushiDatabase.atFile(dbPath, isMainProcess: false);
+    expect(await second.getAllDictionaryMetadata(), hasLength(1));
+    await second.close();
+  });
+}

--- a/fushi/test/dictionary/dictionary_rename_popup_guard_test.dart
+++ b/fushi/test/dictionary/dictionary_rename_popup_guard_test.dart
@@ -1,0 +1,184 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 词典改名（v95）在查词弹窗里的注入边界守卫。
+///
+/// 弹窗里的 `dictName` 是**一个字符串扛七种职责**：一份给人看的标题，另外六份
+/// 是键——`data-dictionary` CSS 作用域属性、`window.dictionaryStyles` 查表、
+/// 隐藏/折叠过滤、释义语言查表、词典媒体 URL 的 `dictionary=` 参数（要对上磁盘
+/// 目录名）、`glossaries` 分组 key（Anki `{single-glossary-<名>}` token 靠它
+/// 对齐）。
+///
+/// 所以改名的正确做法是**旁路翻译**：只在渲染文本的地方把真名换成显示名，其余
+/// 六处一律保持真名。这个守卫的重点不是「翻译有没有接上」（那一眼能看出来），
+/// 而是**负向**的那半——顺手把某个键也翻译了，表现是用户样式静默失效 / 词典图
+/// 音 404 / 已配置的制卡字段对不上，全都不会抛错，只会安静地错。
+String _readPopupJs() {
+  final File file = File('assets/popup/popup.js');
+  expect(file.existsSync(), isTrue, reason: '找不到 assets/popup/popup.js');
+  // 掩掉注释：本文件的锚点全是代码标识符，没有一条要读注释内容。不掩的话在注释
+  // 里写一句 `__fushiDictDisplayName(dictName)` 就能把整组正向断言骗绿。
+  return maskJsComments(file.readAsStringSync());
+}
+
+/// 取 [source] 中 [needle] 所在那一行（已掩码的源码上定位）。
+String _lineContaining(String source, String needle) {
+  final int at = source.indexOf(needle);
+  expect(at, isNot(-1), reason: '锚点消失了，需要重新确认渲染点：$needle');
+  final int start = source.lastIndexOf('\n', at) + 1;
+  int end = source.indexOf('\n', at);
+  if (end < 0) end = source.length;
+  return source.substring(start, end);
+}
+
+void main() {
+  group('词典显示名只翻译文本、不翻译键', () {
+    test('翻译函数存在，且回落真名而不是空', () {
+      final String js = _readPopupJs();
+      expect(
+        js.contains('function __fushiDictDisplayName('),
+        isTrue,
+        reason: '真名 -> 显示名的唯一入口',
+      );
+      // 表不存在 / 没改过名时必须原样返回真名。少了这条回落，扩展侧（映射表可能
+      // 还没下发）和悬浮窗会渲染出 undefined。
+      final String body = methodBody(
+        js,
+        'function __fushiDictDisplayName(',
+        lexicon: SourceLexicon.js,
+      );
+      expect(
+        body.contains('return name'),
+        isTrue,
+        reason: '无映射时必须回落真名',
+      );
+    });
+
+    test('四个给人看的词典名都过翻译', () {
+      final String js = _readPopupJs();
+      for (final (String what, String anchor) in <(String, String)>[
+        ('释义分组标题', "className: 'dict-name'"),
+        ('频率标签', "className: 'frequency-dict-label'"),
+        ('音高标签', "className: 'pitch-dict-label'"),
+        ('汉字卡词典名', "className: 'kanji-card-dict'"),
+      ]) {
+        final String line = _lineContaining(js, anchor);
+        expect(
+          line.contains('__fushiDictDisplayName('),
+          isTrue,
+          reason: '$what 是给人看的文本，必须显示用户改的名字（$anchor）',
+        );
+      }
+    });
+
+    test('负向：当键用的那几处一律不许翻译', () {
+      final String js = _readPopupJs();
+
+      // `data-dictionary` 是 CSS 作用域属性，必须与样式规则编译出的选择器
+      // （dictionary_style_css.dart）和 Anki 导出 HTML 里的属性同源=真名。
+      // 翻译它 = 用户的每词典样式全部失配，且已导出的卡片对不上。
+      for (final String line in js
+          .split('\n')
+          .where((String l) => l.contains("'data-dictionary'"))) {
+        expect(
+          line.contains('__fushiDictDisplayName('),
+          isFalse,
+          reason: 'data-dictionary 是 CSS 作用域键，翻译了用户样式会静默失效：$line',
+        );
+      }
+
+      // 样式查表、媒体路径改写、分组 key：三者都要对上真名（磁盘目录名 / Anki
+      // token）。这里按调用点扫，任何一处混进翻译都算破坏。
+      for (final String needle in <String>[
+        'window.dictionaryStyles[',
+        'rewriteDictionaryMediaPath(',
+      ]) {
+        for (final String line in js
+            .split('\n')
+            .where((String l) => l.contains(needle))) {
+          expect(
+            line.contains('__fushiDictDisplayName('),
+            isFalse,
+            reason: '$needle 用的是真名（磁盘目录 / 样式表键），不能翻译：$line',
+          );
+        }
+      }
+    });
+
+    test('宿主与两个扩展镜像装的是同一份翻译', () {
+      // parity 守卫已经钉了三份 popup.js 逐字节相同；这里只钉「翻译确实进了
+      // 三份」，免得有人只改了 assets 那一份就以为扩展也生效了。
+      for (final String path in <String>[
+        'assets/popup/popup.js',
+        'assets/browser_extension/vendor/popup.js',
+        '../tools/browser-extension/vendor/popup.js',
+      ]) {
+        final File file = File(path);
+        expect(file.existsSync(), isTrue, reason: '缺镜像：$path');
+        expect(
+          file.readAsStringSync().contains('function __fushiDictDisplayName('),
+          isTrue,
+          reason: '$path 没有翻译函数——该宿主里的改名不生效',
+        );
+      }
+    });
+
+    test('扩展侧真的会拿到映射表', () {
+      // popup.js 读 window.dictionaryDisplayNames；扩展里这个全局只可能由
+      // dict-media.js 的 applyFushiPopupCss 赋值。少这一步，改名在扩展里静默
+      // 无效（不报错，只是永远显示真名）。
+      for (final String path in <String>[
+        'assets/browser_extension/vendor/dict-media.js',
+        '../tools/browser-extension/vendor/dict-media.js',
+      ]) {
+        final String js = maskJsComments(File(path).readAsStringSync());
+        expect(
+          js.contains('window.dictionaryDisplayNames'),
+          isTrue,
+          reason: '$path 没把映射表落到 window，扩展里改名不生效',
+        );
+      }
+      // 且 SW 侧必须把它并进 revision 门控缓存，否则命中缓存的那些查词回包里
+      // 没有这个字段 → 上面那步赋成空表 → 改名忽有忽无。
+      for (final String path in <String>[
+        'assets/browser_extension/background.js',
+        '../tools/browser-extension/background.js',
+      ]) {
+        final String js = maskJsComments(File(path).readAsStringSync());
+        expect(
+          js.contains('dictionaryDisplayNames'),
+          isTrue,
+          reason: '$path 的 popup CSS 缓存没带上映射表，命中缓存时改名会丢',
+        );
+      }
+    });
+  });
+
+  group('宿主侧注入', () {
+    test('注入了映射表，且它进了 memo 判定', () {
+      final String source =
+          File('lib/src/pages/implementations/popup_settings_injection.dart')
+              .readAsStringSync();
+      // 注入语句本身住在一段 JS 模板**字符串字面量**里，所以这一条只能掩注释
+      // （掩了字符串就什么都找不到——这正是本守卫第一版的假红）。
+      final String withStrings = maskComments(source);
+      expect(
+        withStrings.contains('window.dictionaryDisplayNames'),
+        isTrue,
+        reason: 'popup.js 读这个全局，宿主必须注入',
+      );
+      // memo 判定是真代码，掩掉字符串再找，免得被注释/字面量骗绿。
+      final String dart = maskCommentsAndStrings(source);
+      // 静态设置块是 memo 过的：不把映射表纳入命中判定，改完名会一直命中旧
+      // memo，表现就是「改了没反应」——与 languageFingerprint 当年同一个坑。
+      expect(
+        dart.contains('cached.dictionaryDisplayNames == dictionaryDisplayNames'),
+        isTrue,
+        reason: '映射表必须进 memo 判定，否则改名不生效',
+      );
+    });
+  });
+}

--- a/fushi/test/dictionary/dictionary_rename_popup_guard_test.dart
+++ b/fushi/test/dictionary/dictionary_rename_popup_guard_test.dart
@@ -74,37 +74,63 @@ void main() {
       }
     });
 
-    test('负向：当键用的那几处一律不许翻译', () {
+    test('负向：翻译只许出现在那 4 个渲染点，别处一律真名', () {
+      // 白名单而不是黑名单。黑名单要枚举所有「当键用」的写法——`data-dictionary`
+      // 有单引号属性名和模板串两种形态、还有 `dataset.dictionary`，样式查表是可选
+      // 链 `window.dictionaryStyles?.[`，另有隐藏/折叠过滤、释义语言查表、媒体
+      // URL、glossaries 分组 key——枚举一定漏，而本守卫第一版就漏了：needle 写成
+      // `window.dictionaryStyles[`（无可选链），在文件里命中 0 行，那半组断言一次
+      // 都没执行过。
+      //
+      // 反过来钉「允许出现的位置」就没有这个问题：调用点是有限且明确的 4 个，
+      // 任何新增的翻译——包括顺手加到 data-dictionary 上的——都会落在白名单外
+      // 而被当场抓住。
       final String js = _readPopupJs();
+      const List<String> allowedAnchors = <String>[
+        "className: 'dict-name'",
+        "className: 'frequency-dict-label'",
+        "className: 'pitch-dict-label'",
+        "className: 'kanji-card-dict'",
+      ];
 
-      // `data-dictionary` 是 CSS 作用域属性，必须与样式规则编译出的选择器
-      // （dictionary_style_css.dart）和 Anki 导出 HTML 里的属性同源=真名。
-      // 翻译它 = 用户的每词典样式全部失配，且已导出的卡片对不上。
-      for (final String line in js
-          .split('\n')
-          .where((String l) => l.contains("'data-dictionary'"))) {
+      final List<String> offenders = <String>[];
+      int callSites = 0;
+      for (final String line in js.split('\n')) {
+        if (!line.contains('__fushiDictDisplayName(')) continue;
+        // 函数自身的定义与递归无关的内部引用不算调用点。
+        if (line.contains('function __fushiDictDisplayName(')) continue;
+        callSites++;
+        if (!allowedAnchors.any(line.contains)) offenders.add(line.trim());
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: '词典显示名只能进 textContent。这些行把它用在了别处——那个字符串'
+            '同时是 CSS 作用域键 / 媒体目录键 / 分组键 / Anki token 键，翻译了'
+            '会让用户样式静默失效、词典图音 404、已配置的制卡字段对不上：$offenders',
+      );
+      expect(
+        callSites,
+        allowedAnchors.length,
+        reason: '调用点数量应恰好等于允许的渲染点数量',
+      );
+    });
+
+    test('负向：CSS 作用域键的每一种写法都仍是真名', () {
+      // data-dictionary 单独再钉一遍：它是最危险的一个（要与样式规则编译出的
+      // 选择器、以及已导出 Anki 卡片里的属性同源），且有属性名和模板串两种形态。
+      final String js = _readPopupJs();
+      for (final String line in js.split('\n')) {
+        final bool mentionsScopeKey = line.contains("'data-dictionary'") ||
+            line.contains('data-dictionary=') ||
+            line.contains('dataset.dictionary');
+        if (!mentionsScopeKey) continue;
         expect(
           line.contains('__fushiDictDisplayName('),
           isFalse,
-          reason: 'data-dictionary 是 CSS 作用域键，翻译了用户样式会静默失效：$line',
+          reason: 'CSS 作用域键必须是真名：$line',
         );
-      }
-
-      // 样式查表、媒体路径改写、分组 key：三者都要对上真名（磁盘目录名 / Anki
-      // token）。这里按调用点扫，任何一处混进翻译都算破坏。
-      for (final String needle in <String>[
-        'window.dictionaryStyles[',
-        'rewriteDictionaryMediaPath(',
-      ]) {
-        for (final String line in js
-            .split('\n')
-            .where((String l) => l.contains(needle))) {
-          expect(
-            line.contains('__fushiDictDisplayName('),
-            isFalse,
-            reason: '$needle 用的是真名（磁盘目录 / 样式表键），不能翻译：$line',
-          );
-        }
       }
     });
 

--- a/fushi/test/dictionary/dictionary_rename_test.dart
+++ b/fushi/test/dictionary/dictionary_rename_test.dart
@@ -137,6 +137,50 @@ void main() {
       expect(back.effectiveDisplayName, '日汉');
     });
 
+    test('copyWith 只换指定字段，用户设置列原样带过', () {
+      // 防真数据丢失：构造器把 languageOverride / displayName 设成可选默认 null，
+      // 而 _dictionaryToCompanion 对每列都写 Value(...)（不是 absent）——「new 一个
+      // Dictionary 再 persist」漏填一个参数就是显式往 DB 写 NULL。类型自愈迁移
+      // （AppModel._migrateDictionaryTypes）曾这么把用户的改名和内容语言一起抹掉。
+      final Dictionary original = Dictionary(
+        name: 'JMdict',
+        formatKey: 'yomitan',
+        order: 5,
+        type: DictionaryType.kanji,
+        metadata: const <String, String>{'revision': '1'},
+        hiddenLanguages: <String>['en'],
+        collapsedLanguages: <String>['ja'],
+        languageOverride: 'ja',
+        displayName: '日汉大辞典',
+      );
+
+      final Dictionary migrated = original.copyWith(
+        type: DictionaryType.term,
+        metadata: const <String, String>{'revision': '2'},
+      );
+
+      // 换掉的
+      expect(migrated.type, DictionaryType.term);
+      expect(migrated.metadata, const <String, String>{'revision': '2'});
+      // 必须原样带过的——这两条是丢数据的那两列
+      expect(
+        migrated.displayName,
+        '日汉大辞典',
+        reason: '类型自愈只想换 type，不能顺手抹掉用户的改名',
+      );
+      expect(
+        migrated.languageOverride,
+        'ja',
+        reason: '手动指定的内容语言同理（v87 起的既有丢数据路径）',
+      );
+      // 其余字段也不许掉
+      expect(migrated.name, 'JMdict');
+      expect(migrated.formatKey, 'yomitan');
+      expect(migrated.order, 5);
+      expect(migrated.hiddenLanguages, <String>['en']);
+      expect(migrated.collapsedLanguages, <String>['ja']);
+    });
+
     test('fromJson 读旧 JSON（没有 displayName 字段）不炸，退化成没改过名', () {
       final Dictionary old = Dictionary(
         name: 'JMdict',

--- a/fushi/test/dictionary/dictionary_rename_test.dart
+++ b/fushi/test/dictionary/dictionary_rename_test.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi/src/models/dictionary_repository.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
 /// 词典改名（v95）的行为契约。
@@ -190,6 +191,71 @@ void main() {
       final Dictionary back = Dictionary.fromJson(old.toJson());
       expect(back.displayName, isNull);
       expect(back.effectiveDisplayName, 'JMdict');
+    });
+  });
+
+  group('改名投影与归一化（唯一真相源）', () {
+    late FushiDatabase db;
+    late DictionaryRepository repo;
+
+    setUp(() async {
+      db = FushiDatabase.forTesting(NativeDatabase.memory());
+      repo = DictionaryRepository(db);
+      await repo.persistDictionary(Dictionary(
+        name: 'JMdict [2026-05-17]',
+        formatKey: 'yomitan',
+        order: 0,
+      ));
+      await repo.persistDictionary(Dictionary(
+        name: '明鏡',
+        formatKey: 'yomitan',
+        order: 1,
+      ));
+    });
+
+    tearDown(() async => db.close());
+
+    test('没人改过名时投影是空表，不装等值条目', () {
+      expect(
+        repo.displayNameOverrides,
+        isEmpty,
+        reason: '空条目要被序列化进 JS、还要进 memo key——装等值条目既占带宽又'
+            '让指纹无谓地变',
+      );
+    });
+
+    test('只装改过名的那本', () {
+      repo.setDictionaryDisplayName(repo.dictionaries.first, '日汉大辞典');
+      expect(
+        repo.displayNameOverrides,
+        <String, String>{'JMdict [2026-05-17]': '日汉大辞典'},
+      );
+    });
+
+    test('改成与真名相同 → 存 null，投影里不出现', () {
+      final Dictionary d = repo.dictionaries.first;
+      repo.setDictionaryDisplayName(d, d.name);
+      expect(
+        d.displayName,
+        isNull,
+        reason: '等值不该留一行冗余覆盖，否则投影会装进一条永远等于真名的条目',
+      );
+      expect(repo.displayNameOverrides, isEmpty);
+    });
+
+    test('空串 / 纯空白 → 存 null（等于清除改名）', () {
+      final Dictionary d = repo.dictionaries.first;
+      repo.setDictionaryDisplayName(d, '日汉');
+      expect(d.displayName, '日汉');
+
+      repo.setDictionaryDisplayName(d, '   ');
+      expect(d.displayName, isNull);
+      expect(repo.displayNameOverrides, isEmpty);
+    });
+
+    test('投影的值已 trim', () {
+      repo.setDictionaryDisplayName(repo.dictionaries.first, '  日汉  ');
+      expect(repo.displayNameOverrides.values.single, '日汉');
     });
   });
 }

--- a/fushi/test/dictionary/dictionary_rename_test.dart
+++ b/fushi/test/dictionary/dictionary_rename_test.dart
@@ -1,0 +1,151 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+/// 词典改名（v95）的行为契约。
+///
+/// 这套改名的全部风险都压在一句话上：**真名冻结，只加显示层覆盖**。
+/// `dictionary_metadata.name` 同时是主键、磁盘目录名、C++ 引擎装载路径、查词
+/// 结果里的 dictName，还被每词典 CSS map、样式规则、弹窗 `data-dictionary`
+/// 选择器、词典媒体 URL、Anki `{single-glossary-<名>}` token、存储占用条目 id
+/// 和同步资产名当键用。所以这里逐条钉住「改名不改身份」。
+Future<FushiDatabase> _openDb() async {
+  final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+DictionaryMetadataCompanion _meta({
+  String name = 'JMdict [2026-05-17]',
+  String? displayName,
+}) =>
+    DictionaryMetadataCompanion.insert(
+      name: name,
+      formatKey: 'yomitan',
+      order: 0,
+      displayName: Value<String?>(displayName),
+    );
+
+void main() {
+  group('dictionary_metadata.display_name (v95)', () {
+    test('缺省为 null——旧库既有行 = 没改过名', () async {
+      final FushiDatabase db = await _openDb();
+      await db.upsertDictionaryMeta(_meta());
+
+      final List<DictionaryMetaRow> rows = await db.getAllDictionaryMetadata();
+      expect(rows, hasLength(1));
+      expect(rows.single.name, 'JMdict [2026-05-17]');
+      expect(
+        rows.single.displayName,
+        isNull,
+        reason: 'nullable 无 default：不写就是 NULL，等价于改名前的行为',
+      );
+    });
+
+    test('写入后往返一致，且真名一个字节都没动', () async {
+      final FushiDatabase db = await _openDb();
+      await db.upsertDictionaryMeta(_meta(displayName: '日汉大辞典'));
+
+      final DictionaryMetaRow row =
+          (await db.getAllDictionaryMetadata()).single;
+      expect(row.displayName, '日汉大辞典');
+      expect(
+        row.name,
+        'JMdict [2026-05-17]',
+        reason: '改名只写 display_name；name 是主键+目录名+引擎键，必须原样',
+      );
+    });
+
+    test('改名不新增行——按主键 upsert，不会留下孤儿', () async {
+      final FushiDatabase db = await _openDb();
+      await db.upsertDictionaryMeta(_meta());
+      await db.upsertDictionaryMeta(_meta(displayName: '改过的名'));
+
+      final List<DictionaryMetaRow> rows = await db.getAllDictionaryMetadata();
+      expect(
+        rows,
+        hasLength(1),
+        reason: '真名是主键，改显示名走同一行 upsert；若改的是 name 这里会变成 2 行',
+      );
+      expect(rows.single.displayName, '改过的名');
+    });
+  });
+
+  group('Dictionary.effectiveDisplayName', () {
+    Dictionary make({String? displayName}) => Dictionary(
+          name: 'JMdict [2026-05-17]',
+          formatKey: 'yomitan',
+          order: 0,
+          displayName: displayName,
+        );
+
+    test('没改过名 → 显示真名', () {
+      expect(make().effectiveDisplayName, 'JMdict [2026-05-17]');
+    });
+
+    test('改过名 → 显示改的名', () {
+      expect(make(displayName: '日汉大辞典').effectiveDisplayName, '日汉大辞典');
+    });
+
+    test('空串 / 纯空白 → 回落真名，不显示一个空标题', () {
+      expect(make(displayName: '').effectiveDisplayName, 'JMdict [2026-05-17]');
+      expect(
+        make(displayName: '   ').effectiveDisplayName,
+        'JMdict [2026-05-17]',
+      );
+    });
+
+    test('显示名两端空白被裁掉', () {
+      expect(make(displayName: '  日汉  ').effectiveDisplayName, '日汉');
+    });
+  });
+
+  group('改名不改身份', () {
+    test('== / hashCode 仍只看真名', () {
+      final Dictionary a = Dictionary(
+        name: 'JMdict',
+        formatKey: 'yomitan',
+        order: 0,
+      );
+      final Dictionary b = Dictionary(
+        name: 'JMdict',
+        formatKey: 'yomitan',
+        order: 3,
+        displayName: '完全不同的显示名',
+      );
+      expect(
+        a == b,
+        isTrue,
+        reason: '同一本词典改了显示名后必须仍等于自己——一堆集合运算（hidden / '
+            'collapsed / 排序）按 Dictionary 相等性去重',
+      );
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toJson / fromJson 往返保住显示名', () {
+      final Dictionary d = Dictionary(
+        name: 'JMdict',
+        formatKey: 'yomitan',
+        order: 0,
+        displayName: '日汉',
+      );
+      final Dictionary back = Dictionary.fromJson(d.toJson());
+      expect(back.name, 'JMdict');
+      expect(back.displayName, '日汉');
+      expect(back.effectiveDisplayName, '日汉');
+    });
+
+    test('fromJson 读旧 JSON（没有 displayName 字段）不炸，退化成没改过名', () {
+      final Dictionary old = Dictionary(
+        name: 'JMdict',
+        formatKey: 'yomitan',
+        order: 0,
+      );
+      final Dictionary back = Dictionary.fromJson(old.toJson());
+      expect(back.displayName, isNull);
+      expect(back.effectiveDisplayName, 'JMdict');
+    });
+  });
+}

--- a/fushi/test/pages/material_rename_entries_guard_test.dart
+++ b/fushi/test/pages/material_rename_entries_guard_test.dart
@@ -74,18 +74,23 @@ void main() {
         isTrue,
         reason: '书改名必须走 override_title 覆盖层',
       );
-      // bookKey = sanitizeTtuFilename(title)，是跨端身份。任何形态的「改标题列」
-      // 都会换掉主键，十来张子表连坐。
-      for (final String forbidden in <String>[
-        'updateEpubBookTitle(',
-        'updateSrtBookTitle(',
-      ]) {
-        expect(
-          shelf.contains(forbidden),
-          isFalse,
-          reason: '$forbidden 会改主键 bookKey，等于换身份——改名只能走覆盖层',
-        );
-      }
+      // bookKey = sanitizeTtuFilename(title)，是跨端身份，改标题列就是换主键、
+      // 十来张子表连坐。
+      //
+      // 判据钉在**改名方法体**上而不是全文件禁某个方法名：本守卫第一版禁的是
+      // `updateEpubBookTitle(` / `updateSrtBookTitle(`，而那两个方法全仓根本不
+      // 存在（只出现在守卫自己里）——恒真断言，测的是空气。真实的回归形态是在
+      // 这个方法里直接拼一条写 title 的 Drift 更新。
+      // 注意判据不能是裸 `title:`——弹窗标题参数就叫 title，会误伤（实测过）。
+      // 要写列必然经 Companion / update / customStatement 之一，钉这个就够。
+      expect(
+        body.contains('EpubBooksCompanion') ||
+            body.contains('SrtBooksCompanion') ||
+            body.contains('update(') ||
+            body.contains('customStatement('),
+        isFalse,
+        reason: '改名只走覆盖层 API，方法体里不该出现任何直接改表的写法',
+      );
     });
 
     test('改名后让书架重读，而不是只 refreshTab', () {

--- a/fushi/test/pages/material_rename_entries_guard_test.dart
+++ b/fushi/test/pages/material_rename_entries_guard_test.dart
@@ -1,0 +1,244 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 「材料改名」四类入口的结构守卫。
+///
+/// 改名这件事在本仓库有两种落法，选错了就是数据损坏：
+///
+///  * **身份不是名字** 的（视频 `video_books.bookUid` / 扫描根 `media_sources.id`
+///    / 合集 `media_collections.id`）→ 直接改那一列。
+///  * **名字就是身份** 的（书 `epub_books.bookKey` = sanitize(title)、词典
+///    `dictionary_metadata.name` = 主键 + 磁盘目录名 + 引擎装载路径）→ 只能写
+///    覆盖层，真名冻结。改真名等于换身份：书是十来张子表连坐重键，词典是用户
+///    样式失效 + 图音 404 + 制卡字段对不上，且**全都不抛错**。
+///
+/// 所以这里钉的是「哪条路走哪个 API」，外加一条弹窗收敛（别再复制第五份壳）。
+String _read(String path) {
+  final File file = File(path);
+  expect(file.existsSync(), isTrue, reason: '找不到 $path');
+  return maskCommentsAndStrings(file.readAsStringSync());
+}
+
+/// i18n key 在源码里是 `t.xxx` 这种属性访问（代码，不是字符串），掩掉字符串也
+/// 还在——正好避开「把 key 写进注释就骗绿」。
+///
+/// 判「后面不再跟标识符字符」而不是裸 `contains`：`t.book_rename` 会被
+/// `t.book_rename_label` 整段命中，于是「只加了标签 key、没加菜单项」也能骗绿
+/// （同前缀假阳性是这个仓库反复踩过的形状）。
+void _expectUsesKey(String code, String key, {required String reason}) {
+  final String needle = 't.$key';
+  final RegExp identifierChar = RegExp(r'[A-Za-z0-9_]');
+  bool found = false;
+  int at = code.indexOf(needle);
+  while (at >= 0) {
+    final int after = at + needle.length;
+    final String next = after < code.length ? code[after] : ' ';
+    if (!identifierChar.hasMatch(next)) {
+      found = true;
+      break;
+    }
+    at = code.indexOf(needle, at + 1);
+  }
+  expect(found, isTrue, reason: reason);
+}
+
+void main() {
+  group('书（EPUB / 漫画 / PDF / SRT 有声书）', () {
+    test('两类书卡菜单都有一级「重命名」', () {
+      final String shelf =
+          _read('lib/src/pages/implementations/reader_fushi_history_page.dart');
+      _expectUsesKey(
+        shelf,
+        'book_rename',
+        reason: 'EPUB 书卡菜单缺「重命名」——改名又只剩「编辑信息」里那两层',
+      );
+      final String srt =
+          _read('lib/src/pages/implementations/reader_history/books.part.dart');
+      _expectUsesKey(
+        srt,
+        'book_rename',
+        reason: 'SRT / 有声书卡菜单缺「重命名」',
+      );
+    });
+
+    test('落的是显示名覆盖层，绝不写 title 列', () {
+      final String shelf =
+          _read('lib/src/pages/implementations/reader_fushi_history_page.dart');
+      final String body = methodBody(shelf, 'Future<void> _renameBook(');
+
+      expect(
+        body.contains('setOverrideTitleFromMediaItem('),
+        isTrue,
+        reason: '书改名必须走 override_title 覆盖层',
+      );
+      // bookKey = sanitizeTtuFilename(title)，是跨端身份。任何形态的「改标题列」
+      // 都会换掉主键，十来张子表连坐。
+      for (final String forbidden in <String>[
+        'updateEpubBookTitle(',
+        'updateSrtBookTitle(',
+      ]) {
+        expect(
+          shelf.contains(forbidden),
+          isFalse,
+          reason: '$forbidden 会改主键 bookKey，等于换身份——改名只能走覆盖层',
+        );
+      }
+    });
+
+    test('改名后让书架重读，而不是只 refreshTab', () {
+      final String shelf =
+          _read('lib/src/pages/implementations/reader_fushi_history_page.dart');
+      final String body = methodBody(shelf, 'Future<void> _renameBook(');
+      // BUG-1018 同款：书架的响应式源按 key 集合去重，纯覆盖层写入不会重发，
+      // 只 refreshTab 会拿旧缓存 MediaItem 重绘 → 看着像「没保存」。
+      expect(
+        body.contains('invalidate('),
+        isTrue,
+        reason: '改完名必须 invalidate 书籍 provider，否则列表显示旧名',
+      );
+    });
+
+    test('初值取当前显示名，不是原始 title', () {
+      final String shelf =
+          _read('lib/src/pages/implementations/reader_fushi_history_page.dart');
+      final String body = methodBody(shelf, 'Future<void> _renameBook(');
+      // 取 item.title 的话，改过一次名的书再开改名框会闪回原名，用户以为改名丢了。
+      expect(
+        body.contains('displayTitleForBook('),
+        isTrue,
+        reason: '改名框初值必须是当前显示名（走显示名门面）',
+      );
+    });
+  });
+
+  group('扫描根 / 媒体源库', () {
+    test('有改名入口，且落 label 列', () {
+      final String view =
+          _read('lib/src/pages/implementations/media_sources_view.dart');
+      _expectUsesKey(view, 'media_source_rename', reason: '扫描根行缺改名按钮');
+
+      final String body = methodBody(view, 'Future<void> _rename(');
+      expect(
+        body.contains('updateMediaSourceLabel('),
+        isTrue,
+        reason: '扫描根改名走 label 列——身份是自增 id，改名不牵动扫描/凭据/归属',
+      );
+      expect(
+        body.contains('_load()'),
+        isTrue,
+        reason: '改完要重载列表，否则还显示旧名',
+      );
+    });
+  });
+
+  group('词典', () {
+    test('有改名入口，且落 display_name 覆盖列', () {
+      final String page =
+          _read('lib/src/pages/implementations/dictionary_dialog_page.dart');
+      _expectUsesKey(page, 'dict_rename', reason: '词典行缺改名按钮');
+
+      final String body = methodBody(page, 'Future<void> _renameDictionary(');
+      expect(
+        body.contains('setDictionaryDisplayName('),
+        isTrue,
+        reason: '词典改名只能写覆盖列；真名是主键+目录名+引擎装载路径',
+      );
+    });
+
+    test('列表显示走 effectiveDisplayName', () {
+      final String page =
+          _read('lib/src/pages/implementations/dictionary_dialog_page.dart');
+      expect(
+        page.contains('dictionary.effectiveDisplayName'),
+        isTrue,
+        reason: '词典列表标题必须显示用户改的名字',
+      );
+    });
+
+    test('重导 / 在线更新继承显示名', () {
+      final String importer =
+          _read('lib/src/models/dictionary_import_manager.dart');
+      // 两条导入路径（目录导入 / 文件导入+强制覆盖）各有一处 persistDictionary，
+      // 少继承一处就是「在线更新一次名字打回原形」。
+      expect(
+        'preservedSettings?.displayName'.allMatches(importer).length,
+        greaterThanOrEqualTo(2),
+        reason: '两条导入路径都要继承显示名，否则重导后改名丢失',
+      );
+    });
+
+    test('存储占用：翻译 label 但 id 保持真名', () {
+      final String service = _read('lib/src/storage/storage_usage_service.dart');
+      // id 是删除路由主键（settings_schema_storage 按它找磁盘目录），翻译了会
+      // 删不掉 / 删错目录。
+      expect(
+        service.contains('id: dictionaryNames[i]'),
+        isTrue,
+        reason: '存储占用条目 id 必须是真名——删除按它找目录',
+      );
+      expect(
+        service.contains('dictionaryDisplayNames[dictionaryNames[i]]'),
+        isTrue,
+        reason: 'label 该显示用户改的名字',
+      );
+    });
+  });
+
+  group('弹窗收敛', () {
+    test('四个域的改名都走同一个共享原语', () {
+      // 收敛前这里是四份复制品：合集 / 游戏 / 视频（裸 AlertDialog，还过早
+      // dispose 了 controller）/ Profile。再加书、扫描根、词典就是七份。
+      for (final (String what, String path) in <(String, String)>[
+        ('合集', 'lib/src/pages/implementations/collection_name_dialog.dart'),
+        ('视频', 'lib/src/pages/implementations/home_video_page.dart'),
+        ('书', 'lib/src/pages/implementations/reader_fushi_history_page.dart'),
+        ('扫描根', 'lib/src/pages/implementations/media_sources_view.dart'),
+        ('词典', 'lib/src/pages/implementations/dictionary_dialog_page.dart'),
+      ]) {
+        expect(
+          containsIdentifierCall(_read(path), 'showNameInputDialog'),
+          isTrue,
+          reason: '$what 的改名弹窗没走共享原语（$path）',
+        );
+      }
+    });
+
+    test('原语自己管 trim / 空名 / controller 生命周期', () {
+      final String dialog =
+          _read('lib/src/pages/implementations/name_input_dialog.dart');
+      final String submit = methodBody(dialog, 'void _submit()');
+      expect(submit.contains('.trim()'), isTrue, reason: '必须裁空白');
+      expect(
+        submit.contains('isEmpty'),
+        isTrue,
+        reason: '空名不提交——调用方因此不必各自判空',
+      );
+      // 视频那份旧实现在 `await showDialog` 返回后立刻 dispose，那时弹窗还没拆完
+      // （游戏改名踩过同一个坑并留了注释）。原语把 controller 交给 State 持有。
+      expect(
+        methodBody(dialog, 'void dispose()').contains('_controller.dispose()'),
+        isTrue,
+        reason: 'controller 必须由 State 在 dispose 里释放',
+      );
+    });
+
+    test('视频改名不再是裸 AlertDialog', () {
+      final String video =
+          _read('lib/src/pages/implementations/home_video_page.dart');
+      final String body = methodBody(video, 'Future<void> _renameVideo(');
+      expect(
+        body.contains('AlertDialog'),
+        isFalse,
+        reason: '改名弹窗统一走设计系统，不再手搓 AlertDialog',
+      );
+      expect(
+        body.contains('TextEditingController('),
+        isFalse,
+        reason: 'controller 由原语持有，调用方不再自己造（会过早 dispose）',
+      );
+    });
+  });
+}

--- a/fushi/test/pages/material_rename_entries_guard_test.dart
+++ b/fushi/test/pages/material_rename_entries_guard_test.dart
@@ -193,9 +193,13 @@ void main() {
   });
 
   group('弹窗收敛', () {
-    test('四个域的改名都走同一个共享原语', () {
-      // 收敛前这里是四份复制品：合集 / 游戏 / 视频（裸 AlertDialog，还过早
-      // dispose 了 controller）/ Profile。再加书、扫描根、词典就是七份。
+    test('这五处改名都走同一个共享原语', () {
+      // 收敛前是四份复制品：合集 / 游戏 / 视频（裸 AlertDialog，还过早 dispose
+      // 了 controller）/ Profile。再加书、扫描根、词典本会变成七份。
+      //
+      // 下面这五条是**已收编**的。游戏 `_RenameGameDialog` 与 `ProfileNameDialog`
+      // 还没收，所以不在清单里——测试名不写「四个域全收了」，免得读起来像已经
+      // 收干净了（守卫清单说谎比没有守卫更坏）。
       for (final (String what, String path) in <(String, String)>[
         ('合集', 'lib/src/pages/implementations/collection_name_dialog.dart'),
         ('视频', 'lib/src/pages/implementations/home_video_page.dart'),

--- a/fushi/test/pages/name_input_dialog_test.dart
+++ b/fushi/test/pages/name_input_dialog_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/name_input_dialog.dart';
+
+import '../widgets/widget_test_helpers.dart';
+
+/// 共享改名弹窗原语的行为契约。
+///
+/// 这个原语是库内全部改名入口的唯一实现（合集 / 视频 / 书 / 扫描根 / 词典），
+/// 所以它的每一条行为都会同时作用在五个域上——空名怎么处理、trim 在哪一层、
+/// controller 谁释放，只在这里定一次。
+Future<String?> _open(
+  WidgetTester tester, {
+  String initialName = '',
+}) async {
+  String? result;
+  bool returned = false;
+  await tester.pumpWidget(
+    buildTestApp(
+      Builder(
+        builder: (BuildContext context) => TextButton(
+          onPressed: () async {
+            result = await showNameInputDialog(
+              context: context,
+              title: '重命名',
+              labelText: '名称',
+              initialName: initialName,
+            );
+            returned = true;
+          },
+          child: const Text('open'),
+        ),
+      ),
+    ),
+  );
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  addTearDown(() => returned);
+  return result;
+}
+
+/// 取「确认」按钮的 onPressed —— null 即置灰。
+VoidCallback? _okOnPressed(WidgetTester tester) {
+  final Finder ok = find.ancestor(
+    of: find.text('OK'),
+    matching: find.byType(TextButton),
+  );
+  if (ok.evaluate().isEmpty) {
+    // 平台自适应按钮可能不是 TextButton，退回按文本找可点祖先。
+    final Finder any = find.byWidgetPredicate(
+      (Widget w) => w is ButtonStyleButton && w.child is Text,
+    );
+    for (final Element e in any.evaluate()) {
+      final ButtonStyleButton b = e.widget as ButtonStyleButton;
+      if ((b.child as Text).data == 'OK') return b.onPressed;
+    }
+    return null;
+  }
+  return tester.widget<TextButton>(ok).onPressed;
+}
+
+void main() {
+  testWidgets('预填非空时确认键可用', (WidgetTester tester) async {
+    await _open(tester, initialName: '旧名');
+    expect(find.text('重命名'), findsOneWidget);
+    expect(
+      _okOnPressed(tester),
+      isNotNull,
+      reason: '有名字就该能确认',
+    );
+  });
+
+  testWidgets('清空后确认键置灰，而不是可点却毫无反应', (WidgetTester tester) async {
+    await _open(tester, initialName: '旧名');
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+
+    expect(
+      _okOnPressed(tester),
+      isNull,
+      reason: '空名不可提交这件事必须**看得见**。这个原语第一版是让按钮照常可点、'
+          '按下去弹窗不关也无提示——用户只会以为程序卡住了。',
+    );
+  });
+
+  testWidgets('只有空白也算空名', (WidgetTester tester) async {
+    await _open(tester, initialName: '旧名');
+
+    await tester.enterText(find.byType(TextField), '    ');
+    await tester.pumpAndSettle();
+
+    expect(
+      _okOnPressed(tester),
+      isNull,
+      reason: 'trim 在原语这一层做，调用方不必各自判空',
+    );
+  });
+
+  testWidgets('重新输入后确认键恢复可用', (WidgetTester tester) async {
+    await _open(tester, initialName: '旧名');
+
+    await tester.enterText(find.byType(TextField), '');
+    await tester.pumpAndSettle();
+    expect(_okOnPressed(tester), isNull);
+
+    await tester.enterText(find.byType(TextField), '新名');
+    await tester.pumpAndSettle();
+    expect(
+      _okOnPressed(tester),
+      isNotNull,
+      reason: '置灰必须是双向的——只在 initState 算一次就会永久卡住',
+    );
+  });
+
+  testWidgets('初始就为空时确认键一开始就是灰的', (WidgetTester tester) async {
+    await _open(tester);
+    expect(
+      _okOnPressed(tester),
+      isNull,
+      reason: '「组合成合集」那条路径预填就是空串，进来时就该是灰的',
+    );
+  });
+}

--- a/fushi/test/sync/sync_asset_package_service_test.dart
+++ b/fushi/test/sync/sync_asset_package_service_test.dart
@@ -94,6 +94,115 @@ void main() {
       );
     });
 
+    test('重新导入同名词典不吞掉本机的改名与内容语言', () async {
+      // `upsertDictionaryMeta` 是整行覆盖，而 manifest 只带随包走的那几列。
+      // 用户设置列（display_name 改名、language_override 手动指定的内容语言）
+      // 是**本机的**，不属于词典包——导入端必须先捞出来带上，否则从同步重新
+      // 下载一本已有的同名词典，用户的改名和语言指定会被静默清空（表现是
+      // 「同步了一下，词典名字变回那个又长又带日期的原名」）。
+      final Directory temp = await Directory.systemTemp.createTemp(
+        'hibiki-dict-package-preserve-',
+      );
+      addTearDown(() => temp.delete(recursive: true));
+      final FushiDatabase sourceDb = _testDb();
+      final FushiDatabase targetDb = _testDb();
+      addTearDown(sourceDb.close);
+      addTearDown(targetDb.close);
+
+      final Directory sourceResources =
+          Directory(p.join(temp.path, 'source-dictionaries'));
+      final Directory targetResources =
+          Directory(p.join(temp.path, 'target-dictionaries'));
+      await Directory(p.join(sourceResources.path, 'JMdict')).create(
+        recursive: true,
+      );
+      await File(p.join(sourceResources.path, 'JMdict', 'blobs.bin'))
+          .writeAsString('dictionary index');
+
+      // 导出端：一本没改过名的词典。
+      await sourceDb.upsertDictionaryMeta(DictionaryMetadataCompanion.insert(
+        name: 'JMdict',
+        formatKey: 'yomichan',
+        order: 1,
+      ));
+      final File package = await SyncAssetPackageService(db: sourceDb)
+          .exportDictionaryPackage(
+        dictionaryName: 'JMdict',
+        dictionaryResourceRoot: sourceResources,
+        outputFile: File(p.join(temp.path, 'jmdict.hibiki-dictionary.zip')),
+      );
+
+      // 本机：同名词典已经在，且用户改过名、指定过内容语言。
+      await targetDb.upsertDictionaryMeta(DictionaryMetadataCompanion.insert(
+        name: 'JMdict',
+        formatKey: 'yomichan',
+        order: 3,
+        displayName: const Value<String?>('日汉大辞典'),
+        languageOverride: const Value<String?>('ja'),
+      ));
+
+      await SyncAssetPackageService(db: targetDb).importDictionaryPackage(
+        packageFile: package,
+        dictionaryResourceRoot: targetResources,
+      );
+
+      final DictionaryMetaRow row =
+          (await targetDb.getAllDictionaryMetadata()).single;
+      expect(
+        row.displayName,
+        '日汉大辞典',
+        reason: '用户的改名属于本机设置，重新导入不能把它冲掉',
+      );
+      expect(
+        row.languageOverride,
+        'ja',
+        reason: '手动指定的内容语言同理',
+      );
+      // 包里带的那几列照常被更新（这才是导入的意义）。
+      expect(row.order, 1);
+    });
+
+    test('新装词典的用户设置列是 null——没有旧行可继承时不凭空造值', () async {
+      final Directory temp = await Directory.systemTemp.createTemp(
+        'hibiki-dict-package-fresh-',
+      );
+      addTearDown(() => temp.delete(recursive: true));
+      final FushiDatabase sourceDb = _testDb();
+      final FushiDatabase targetDb = _testDb();
+      addTearDown(sourceDb.close);
+      addTearDown(targetDb.close);
+
+      final Directory sourceResources =
+          Directory(p.join(temp.path, 'source-dictionaries'));
+      await Directory(p.join(sourceResources.path, 'JMdict')).create(
+        recursive: true,
+      );
+      await File(p.join(sourceResources.path, 'JMdict', 'blobs.bin'))
+          .writeAsString('x');
+      await sourceDb.upsertDictionaryMeta(DictionaryMetadataCompanion.insert(
+        name: 'JMdict',
+        formatKey: 'yomichan',
+        order: 1,
+      ));
+      final File package = await SyncAssetPackageService(db: sourceDb)
+          .exportDictionaryPackage(
+        dictionaryName: 'JMdict',
+        dictionaryResourceRoot: sourceResources,
+        outputFile: File(p.join(temp.path, 'jmdict.hibiki-dictionary.zip')),
+      );
+
+      await SyncAssetPackageService(db: targetDb).importDictionaryPackage(
+        packageFile: package,
+        dictionaryResourceRoot:
+            Directory(p.join(temp.path, 'target-dictionaries')),
+      );
+
+      final DictionaryMetaRow row =
+          (await targetDb.getAllDictionaryMetadata()).single;
+      expect(row.displayName, isNull);
+      expect(row.languageOverride, isNull);
+    });
+
     test('import rejects dictionary package path traversal', () async {
       final Directory temp = await Directory.systemTemp.createTemp(
         'hibiki-dict-traversal-',

--- a/fushi/test/sync/sync_asset_package_service_test.dart
+++ b/fushi/test/sync/sync_asset_package_service_test.dart
@@ -95,11 +95,14 @@ void main() {
     });
 
     test('重新导入同名词典不吞掉本机的改名与内容语言', () async {
-      // `upsertDictionaryMeta` 是整行覆盖，而 manifest 只带随包走的那几列。
-      // 用户设置列（display_name 改名、language_override 手动指定的内容语言）
-      // 是**本机的**，不属于词典包——导入端必须先捞出来带上，否则从同步重新
-      // 下载一本已有的同名词典，用户的改名和语言指定会被静默清空（表现是
-      // 「同步了一下，词典名字变回那个又长又带日期的原名」）。
+      // 钉的是 `upsertDictionaryMeta` 的 **absent 语义**：它走 drift 的
+      // `insertOnConflictUpdate`，companion 里没列到的列在冲突更新时保持原值。
+      // 导入端因此**只列 manifest 带的列**，用户设置列（display_name 改名、
+      // language_override 内容语言）留 absent 就自动保住了。
+      //
+      // 这条守卫防的是有人把它改成 `InsertMode.replace`、或"顺手"把两列补成
+      // 显式 `Value(null)`——两者都会让「同步一下，词典名字变回那个又长又带
+      // 日期的原名」。
       final Directory temp = await Directory.systemTemp.createTemp(
         'hibiki-dict-package-preserve-',
       );

--- a/packages/fushi_core/lib/src/database/database.dart
+++ b/packages/fushi_core/lib/src/database/database.dart
@@ -723,7 +723,7 @@ class FushiDatabase extends _$FushiDatabase
   final bool _isMainProcess;
 
   @override
-  int get schemaVersion => 94;
+  int get schemaVersion => 95;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2883,6 +2883,22 @@ class FushiDatabase extends _$FushiDatabase
                     'video_download_subscriptions', 'identity_json')) {
               await m.addColumn(videoDownloadSubscriptions,
                   videoDownloadSubscriptions.identityJson);
+            }
+          }
+          if (from < 95) {
+            // v95（词典改名）：dictionary_metadata 加 display_name——用户给词典
+            // 起的显示名。真名 `name` 是主键 + 磁盘目录名 + 引擎装载路径 + 一串
+            // 外键（CSS map key / 样式规则 / data-dictionary 选择器 / 媒体 URL /
+            // Anki token / 同步资产名），冻结不动，只加显示层覆盖（见 tables.dart
+            // 该列的注释）。
+            //
+            // 无损：nullable 无 default → 旧库既有行全 NULL = 没改过名 = 显示真名
+            // = 逐字节保留 v95 前的渲染。守卫幂等（fresh DB 由 onCreate 建好，
+            // 重复升级 _columnExists 短路 no-op）。
+            if (await _tableExists('dictionary_metadata') &&
+                !await _columnExists('dictionary_metadata', 'display_name')) {
+              await m.addColumn(
+                  dictionaryMetadata, dictionaryMetadata.displayName);
             }
           }
         },

--- a/packages/fushi_core/lib/src/database/database.g.dart
+++ b/packages/fushi_core/lib/src/database/database.g.dart
@@ -5748,6 +5748,17 @@ class $DictionaryMetadataTable extends DictionaryMetadata
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _displayNameMeta = const VerificationMeta(
+    'displayName',
+  );
+  @override
+  late final GeneratedColumn<String> displayName = GeneratedColumn<String>(
+    'display_name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     name,
@@ -5758,6 +5769,7 @@ class $DictionaryMetadataTable extends DictionaryMetadata
     hiddenLanguagesJson,
     collapsedLanguagesJson,
     languageOverride,
+    displayName,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -5837,6 +5849,15 @@ class $DictionaryMetadataTable extends DictionaryMetadata
         ),
       );
     }
+    if (data.containsKey('display_name')) {
+      context.handle(
+        _displayNameMeta,
+        displayName.isAcceptableOrUnknown(
+          data['display_name']!,
+          _displayNameMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -5878,6 +5899,10 @@ class $DictionaryMetadataTable extends DictionaryMetadata
         DriftSqlType.string,
         data['${effectivePrefix}language_override'],
       ),
+      displayName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}display_name'],
+      ),
     );
   }
 
@@ -5907,6 +5932,21 @@ class DictionaryMetaRow extends DataClass
   /// 用户的手动指定会随之蒸发。它属于「用户设置」，必须与 hidden/collapsedLanguages
   /// 走同一条继承通道（`preservedSettings`）。
   final String? languageOverride;
+
+  /// v95：用户给词典起的**显示名**（改名）。null / 空 = 没改过，显示 [name]。
+  ///
+  /// 为什么是覆盖列而不是改 [name]：[name] 是本表主键，同时还是**磁盘目录名**
+  /// （`dictionaryResourceDirectory/<name>`）、C++ 引擎的装载路径、查词结果里
+  /// 的 `dictName`，并被一串东西当外键使用——每词典自定义 CSS 的 map key、
+  /// 样式规则的 `dictionaryName`、弹窗的 `data-dictionary` 选择器、词典媒体
+  /// URL 的 `dictionary=` 参数、Anki 的 `{single-glossary-<名>}` token、
+  /// 存储占用条目 id、同步资产名。改 [name] 会让上述全部静默失配（用户样式
+  /// 丢失、图/音 404、已配置的制卡字段失效），所以真名冻结，只加显示层覆盖。
+  ///
+  /// 为什么不塞进 [metadataJson]：同 [languageOverride] 的理由——重导/在线更新
+  /// 时 metadata 被包内 index.json 整体重建，用户设置会蒸发。它属于「用户设置」，
+  /// 走 `preservedSettings` 继承通道。
+  final String? displayName;
   const DictionaryMetaRow({
     required this.name,
     required this.formatKey,
@@ -5916,6 +5956,7 @@ class DictionaryMetaRow extends DataClass
     required this.hiddenLanguagesJson,
     required this.collapsedLanguagesJson,
     this.languageOverride,
+    this.displayName,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -5929,6 +5970,9 @@ class DictionaryMetaRow extends DataClass
     map['collapsed_languages_json'] = Variable<String>(collapsedLanguagesJson);
     if (!nullToAbsent || languageOverride != null) {
       map['language_override'] = Variable<String>(languageOverride);
+    }
+    if (!nullToAbsent || displayName != null) {
+      map['display_name'] = Variable<String>(displayName);
     }
     return map;
   }
@@ -5945,6 +5989,9 @@ class DictionaryMetaRow extends DataClass
       languageOverride: languageOverride == null && nullToAbsent
           ? const Value.absent()
           : Value(languageOverride),
+      displayName: displayName == null && nullToAbsent
+          ? const Value.absent()
+          : Value(displayName),
     );
   }
 
@@ -5966,6 +6013,7 @@ class DictionaryMetaRow extends DataClass
         json['collapsedLanguagesJson'],
       ),
       languageOverride: serializer.fromJson<String?>(json['languageOverride']),
+      displayName: serializer.fromJson<String?>(json['displayName']),
     );
   }
   @override
@@ -5982,6 +6030,7 @@ class DictionaryMetaRow extends DataClass
         collapsedLanguagesJson,
       ),
       'languageOverride': serializer.toJson<String?>(languageOverride),
+      'displayName': serializer.toJson<String?>(displayName),
     };
   }
 
@@ -5994,6 +6043,7 @@ class DictionaryMetaRow extends DataClass
     String? hiddenLanguagesJson,
     String? collapsedLanguagesJson,
     Value<String?> languageOverride = const Value.absent(),
+    Value<String?> displayName = const Value.absent(),
   }) => DictionaryMetaRow(
     name: name ?? this.name,
     formatKey: formatKey ?? this.formatKey,
@@ -6006,6 +6056,7 @@ class DictionaryMetaRow extends DataClass
     languageOverride: languageOverride.present
         ? languageOverride.value
         : this.languageOverride,
+    displayName: displayName.present ? displayName.value : this.displayName,
   );
   DictionaryMetaRow copyWithCompanion(DictionaryMetadataCompanion data) {
     return DictionaryMetaRow(
@@ -6025,6 +6076,9 @@ class DictionaryMetaRow extends DataClass
       languageOverride: data.languageOverride.present
           ? data.languageOverride.value
           : this.languageOverride,
+      displayName: data.displayName.present
+          ? data.displayName.value
+          : this.displayName,
     );
   }
 
@@ -6038,7 +6092,8 @@ class DictionaryMetaRow extends DataClass
           ..write('metadataJson: $metadataJson, ')
           ..write('hiddenLanguagesJson: $hiddenLanguagesJson, ')
           ..write('collapsedLanguagesJson: $collapsedLanguagesJson, ')
-          ..write('languageOverride: $languageOverride')
+          ..write('languageOverride: $languageOverride, ')
+          ..write('displayName: $displayName')
           ..write(')'))
         .toString();
   }
@@ -6053,6 +6108,7 @@ class DictionaryMetaRow extends DataClass
     hiddenLanguagesJson,
     collapsedLanguagesJson,
     languageOverride,
+    displayName,
   );
   @override
   bool operator ==(Object other) =>
@@ -6065,7 +6121,8 @@ class DictionaryMetaRow extends DataClass
           other.metadataJson == this.metadataJson &&
           other.hiddenLanguagesJson == this.hiddenLanguagesJson &&
           other.collapsedLanguagesJson == this.collapsedLanguagesJson &&
-          other.languageOverride == this.languageOverride);
+          other.languageOverride == this.languageOverride &&
+          other.displayName == this.displayName);
 }
 
 class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
@@ -6077,6 +6134,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
   final Value<String> hiddenLanguagesJson;
   final Value<String> collapsedLanguagesJson;
   final Value<String?> languageOverride;
+  final Value<String?> displayName;
   final Value<int> rowid;
   const DictionaryMetadataCompanion({
     this.name = const Value.absent(),
@@ -6087,6 +6145,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
     this.hiddenLanguagesJson = const Value.absent(),
     this.collapsedLanguagesJson = const Value.absent(),
     this.languageOverride = const Value.absent(),
+    this.displayName = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   DictionaryMetadataCompanion.insert({
@@ -6098,6 +6157,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
     this.hiddenLanguagesJson = const Value.absent(),
     this.collapsedLanguagesJson = const Value.absent(),
     this.languageOverride = const Value.absent(),
+    this.displayName = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : name = Value(name),
        formatKey = Value(formatKey),
@@ -6111,6 +6171,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
     Expression<String>? hiddenLanguagesJson,
     Expression<String>? collapsedLanguagesJson,
     Expression<String>? languageOverride,
+    Expression<String>? displayName,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -6124,6 +6185,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
       if (collapsedLanguagesJson != null)
         'collapsed_languages_json': collapsedLanguagesJson,
       if (languageOverride != null) 'language_override': languageOverride,
+      if (displayName != null) 'display_name': displayName,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -6137,6 +6199,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
     Value<String>? hiddenLanguagesJson,
     Value<String>? collapsedLanguagesJson,
     Value<String?>? languageOverride,
+    Value<String?>? displayName,
     Value<int>? rowid,
   }) {
     return DictionaryMetadataCompanion(
@@ -6149,6 +6212,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
       collapsedLanguagesJson:
           collapsedLanguagesJson ?? this.collapsedLanguagesJson,
       languageOverride: languageOverride ?? this.languageOverride,
+      displayName: displayName ?? this.displayName,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -6184,6 +6248,9 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
     if (languageOverride.present) {
       map['language_override'] = Variable<String>(languageOverride.value);
     }
+    if (displayName.present) {
+      map['display_name'] = Variable<String>(displayName.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -6201,6 +6268,7 @@ class DictionaryMetadataCompanion extends UpdateCompanion<DictionaryMetaRow> {
           ..write('hiddenLanguagesJson: $hiddenLanguagesJson, ')
           ..write('collapsedLanguagesJson: $collapsedLanguagesJson, ')
           ..write('languageOverride: $languageOverride, ')
+          ..write('displayName: $displayName, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -52494,6 +52562,7 @@ typedef $$DictionaryMetadataTableCreateCompanionBuilder =
       Value<String> hiddenLanguagesJson,
       Value<String> collapsedLanguagesJson,
       Value<String?> languageOverride,
+      Value<String?> displayName,
       Value<int> rowid,
     });
 typedef $$DictionaryMetadataTableUpdateCompanionBuilder =
@@ -52506,6 +52575,7 @@ typedef $$DictionaryMetadataTableUpdateCompanionBuilder =
       Value<String> hiddenLanguagesJson,
       Value<String> collapsedLanguagesJson,
       Value<String?> languageOverride,
+      Value<String?> displayName,
       Value<int> rowid,
     });
 
@@ -52555,6 +52625,11 @@ class $$DictionaryMetadataTableFilterComposer
 
   ColumnFilters<String> get languageOverride => $composableBuilder(
     column: $table.languageOverride,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get displayName => $composableBuilder(
+    column: $table.displayName,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -52607,6 +52682,11 @@ class $$DictionaryMetadataTableOrderingComposer
     column: $table.languageOverride,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get displayName => $composableBuilder(
+    column: $table.displayName,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$DictionaryMetadataTableAnnotationComposer
@@ -52647,6 +52727,11 @@ class $$DictionaryMetadataTableAnnotationComposer
 
   GeneratedColumn<String> get languageOverride => $composableBuilder(
     column: $table.languageOverride,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get displayName => $composableBuilder(
+    column: $table.displayName,
     builder: (column) => column,
   );
 }
@@ -52699,6 +52784,7 @@ class $$DictionaryMetadataTableTableManager
                 Value<String> hiddenLanguagesJson = const Value.absent(),
                 Value<String> collapsedLanguagesJson = const Value.absent(),
                 Value<String?> languageOverride = const Value.absent(),
+                Value<String?> displayName = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DictionaryMetadataCompanion(
                 name: name,
@@ -52709,6 +52795,7 @@ class $$DictionaryMetadataTableTableManager
                 hiddenLanguagesJson: hiddenLanguagesJson,
                 collapsedLanguagesJson: collapsedLanguagesJson,
                 languageOverride: languageOverride,
+                displayName: displayName,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -52721,6 +52808,7 @@ class $$DictionaryMetadataTableTableManager
                 Value<String> hiddenLanguagesJson = const Value.absent(),
                 Value<String> collapsedLanguagesJson = const Value.absent(),
                 Value<String?> languageOverride = const Value.absent(),
+                Value<String?> displayName = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DictionaryMetadataCompanion.insert(
                 name: name,
@@ -52731,6 +52819,7 @@ class $$DictionaryMetadataTableTableManager
                 hiddenLanguagesJson: hiddenLanguagesJson,
                 collapsedLanguagesJson: collapsedLanguagesJson,
                 languageOverride: languageOverride,
+                displayName: displayName,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/packages/fushi_core/lib/src/database/tables.dart
+++ b/packages/fushi_core/lib/src/database/tables.dart
@@ -325,6 +325,21 @@ class DictionaryMetadata extends Table {
   /// 走同一条继承通道（`preservedSettings`）。
   TextColumn get languageOverride => text().nullable()();
 
+  /// v95：用户给词典起的**显示名**（改名）。null / 空 = 没改过，显示 [name]。
+  ///
+  /// 为什么是覆盖列而不是改 [name]：[name] 是本表主键，同时还是**磁盘目录名**
+  /// （`dictionaryResourceDirectory/<name>`）、C++ 引擎的装载路径、查词结果里
+  /// 的 `dictName`，并被一串东西当外键使用——每词典自定义 CSS 的 map key、
+  /// 样式规则的 `dictionaryName`、弹窗的 `data-dictionary` 选择器、词典媒体
+  /// URL 的 `dictionary=` 参数、Anki 的 `{single-glossary-<名>}` token、
+  /// 存储占用条目 id、同步资产名。改 [name] 会让上述全部静默失配（用户样式
+  /// 丢失、图/音 404、已配置的制卡字段失效），所以真名冻结，只加显示层覆盖。
+  ///
+  /// 为什么不塞进 [metadataJson]：同 [languageOverride] 的理由——重导/在线更新
+  /// 时 metadata 被包内 index.json 整体重建，用户设置会蒸发。它属于「用户设置」，
+  /// 走 `preservedSettings` 继承通道。
+  TextColumn get displayName => text().nullable()();
+
   @override
   Set<Column> get primaryKey => {name};
 }

--- a/packages/fushi_dictionary/lib/src/engine/dictionary.dart
+++ b/packages/fushi_dictionary/lib/src/engine/dictionary.dart
@@ -4,6 +4,29 @@ import '../language/language.dart';
 
 enum DictionaryType { term, frequency, pitch, kanji }
 
+/// 改名投影：**真名 -> 显示名**，只含真正改过名的词典。
+///
+/// 全库唯一的推导处。消费方有五个（弹窗注入、悬浮窗、扩展下发、存储占用、
+/// 以及浏览器扩展 CSS 载体的缓存判定），它们要的是同一张表——散开各写一遍就是
+/// 五份逐字相同的推导，其中任何一份漏掉 trim 或漏掉空串判断，都会让某一个宿主
+/// 的改名行为跟别处不一样。
+///
+/// 只装改过名的：消费方都要把它序列化进 JS 或存进 memo key，等值条目既占带宽
+/// 又让指纹无谓地变。
+///
+/// 写成作用于 [Iterable] 的纯函数而不是挂在某个仓库上，是因为调用方拿到的词典
+/// 列表来路不同（AppModel 的 getter 可被测试替身覆盖），绑死数据源会绕过那些
+/// 覆盖点。
+Map<String, String> dictionaryDisplayNameOverridesOf(
+  Iterable<Dictionary> dictionaries,
+) {
+  return <String, String>{
+    for (final Dictionary d in dictionaries)
+      if (d.displayName != null && d.displayName!.trim().isNotEmpty)
+        d.name: d.displayName!.trim(),
+  };
+}
+
 class Dictionary {
   factory Dictionary.fromJson(String json) {
     final map = Map<String, dynamic>.from(jsonDecode(json));

--- a/packages/fushi_dictionary/lib/src/engine/dictionary.dart
+++ b/packages/fushi_dictionary/lib/src/engine/dictionary.dart
@@ -97,6 +97,35 @@ class Dictionary {
     return null;
   }
 
+  /// 在**已有词典对象**上换掉几个字段，其余原样带过。
+  ///
+  /// 存在的理由是防一类静默数据丢失：[Dictionary] 的构造器把用户设置列
+  /// （[languageOverride] / [displayName]）设成可选默认 null，而
+  /// `DictionaryRepository._dictionaryToCompanion` 对**每一列**都写
+  /// `Value(...)`（不是 absent）——于是「new 一个 Dictionary 再 persist」的写法
+  /// 只要漏填一个参数，就是往 DB 里显式写 NULL 把用户设置抹掉，且不报错。
+  ///
+  /// 类型自愈迁移就这么丢过（`AppModel._migrateDictionaryTypes` 两处只想换
+  /// `type`，却把用户手动指定的内容语言和改名一起清了）。补参数治不了本——下一
+  /// 列加进来时照样漏，所以那种写法一律改成 [copyWith]。
+  Dictionary copyWith({
+    DictionaryType? type,
+    Map<String, String>? metadata,
+    int? order,
+  }) {
+    return Dictionary(
+      name: name,
+      formatKey: formatKey,
+      order: order ?? this.order,
+      type: type ?? this.type,
+      metadata: metadata ?? this.metadata,
+      hiddenLanguages: hiddenLanguages,
+      collapsedLanguages: collapsedLanguages,
+      languageOverride: languageOverride,
+      displayName: displayName,
+    );
+  }
+
   bool isHidden(Language language) {
     return hiddenLanguages.contains(language.languageCode);
   }

--- a/packages/fushi_dictionary/lib/src/engine/dictionary.dart
+++ b/packages/fushi_dictionary/lib/src/engine/dictionary.dart
@@ -21,6 +21,7 @@ class Dictionary {
       hiddenLanguages: List<String>.from(map['hiddenLanguages'] ?? []),
       collapsedLanguages: List<String>.from(map['collapsedLanguages'] ?? []),
       languageOverride: map['languageOverride'] as String?,
+      displayName: map['displayName'] as String?,
     );
   }
   Dictionary({
@@ -32,6 +33,7 @@ class Dictionary {
     this.hiddenLanguages = const [],
     this.collapsedLanguages = const [],
     this.languageOverride,
+    this.displayName,
   });
 
   final String name;
@@ -48,6 +50,17 @@ class Dictionary {
   /// 词典时由 `preservedSettings` 继承，不会被包内 index.json 冲掉。这与
   /// [sourceLanguage]（自动、随包刷新）是两个字段，不要合并。
   String? languageOverride;
+
+  /// 用户给这本词典起的**显示名**（改名）。null / 空 = 没改过。
+  ///
+  /// 只影响给人看的地方。[name] 是真名，同时是主键、磁盘目录名、引擎装载
+  /// 路径，以及 CSS map key / 样式规则 / `data-dictionary` 选择器 / 媒体 URL /
+  /// Anki `{single-glossary-<名>}` token / 同步资产名的键——那些一律继续用
+  /// [name]，改名不得波及（详见 `tables.dart` 该列注释）。
+  ///
+  /// 与 [languageOverride] 同属「用户设置」，重导/在线更新时走 `preservedSettings`
+  /// 继承，不会被包内 index.json 冲掉。
+  String? displayName;
 
   /// yomitan `index.json` 声明的**词头语言**（词典在解释哪种语言）。
   /// 导入时由 `readSourceMetadataFromIndex` 落进 [metadata]；旧词典/本地包缺则空串。
@@ -70,6 +83,11 @@ class Dictionary {
   String? get effectiveTargetLanguage => _firstNonEmpty(
         <String?>[languageOverride, targetLanguage],
       );
+
+  /// 该显示给用户看的名字：改过名用改的，否则用真名。**所有面向用户的词典名
+  /// 渲染点都必须走这里**，而不是直接读 [name]。
+  String get effectiveDisplayName =>
+      _firstNonEmpty(<String?>[displayName]) ?? name;
 
   static String? _firstNonEmpty(List<String?> candidates) {
     for (final String? candidate in candidates) {
@@ -115,6 +133,7 @@ class Dictionary {
       'hiddenLanguages': hiddenLanguages,
       'collapsedLanguages': collapsedLanguages,
       'languageOverride': languageOverride,
+      'displayName': displayName,
     });
   }
 

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -198,7 +198,7 @@ async function diagnoseConnectionCapped(base, timeoutMs = 750) {
 // 响应拿。但它体量大（实测整库 285 KB，单本 OALDPE 就 210 KB），不能每次 hover 查词都传，
 // 故走 revision 门控：请求里带上已缓存的 revision，server 只在指纹变了（用户导入/删词典、
 // 改自定义 CSS）时才回全量，其余时候只回指纹。SW 被回收后缓存清空，下次查词自动重取一次。
-let fushiPopupCss = { revision: null, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {} };
+let fushiPopupCss = { revision: null, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {}, dictionaryDisplayNames: {} };
 
 // 把服务端这次查词响应里的 CSS 尾段并进缓存，并把**完整**尾段回填进 data，
 // 让 content.js / side-panel.js 无论命中缓存与否都能拿到同一份可直接赋给 window.* 的值。
@@ -214,14 +214,20 @@ function fushiMergePopupCss(data) {
       globalDictCSS: typeof data.globalDictCSS === 'string' ? data.globalDictCSS : '',
       customDictCSS: (data.customDictCSS && typeof data.customDictCSS === 'object')
         ? data.customDictCSS : {},
+      // 词典改名（v95）：真名 -> 显示名。与 CSS 同一条 revision 门控，改名会改
+      // 指纹 → 下次查词全量重取一次。
+      dictionaryDisplayNames:
+        (data.dictionaryDisplayNames && typeof data.dictionaryDisplayNames === 'object')
+          ? data.dictionaryDisplayNames : {},
     };
   } else if (fushiPopupCss.revision !== revision) {
     // 指纹变了但这次响应没带正文（不该发生；真发生时宁可清空也不能用陈旧样式）。
-    fushiPopupCss = { revision, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {} };
+    fushiPopupCss = { revision, dictionaryStyles: {}, globalDictCSS: '', customDictCSS: {}, dictionaryDisplayNames: {} };
   }
   data.dictionaryStyles = fushiPopupCss.dictionaryStyles;
   data.globalDictCSS = fushiPopupCss.globalDictCSS;
   data.customDictCSS = fushiPopupCss.customDictCSS;
+  data.dictionaryDisplayNames = fushiPopupCss.dictionaryDisplayNames;
   return data;
 }
 

--- a/tools/browser-extension/vendor/dict-media.js
+++ b/tools/browser-extension/vendor/dict-media.js
@@ -272,4 +272,9 @@ function applyFushiPopupCss(data) {
     window.customDictCSS =
         (data.customDictCSS && typeof data.customDictCSS === 'object')
             ? data.customDictCSS : {};
+    // 词典改名（v95）：popup.js 的 __fushiDictDisplayName 读这张表。缺了不会崩
+    // （回落真名），但改名在扩展里就不生效。
+    window.dictionaryDisplayNames =
+        (data.dictionaryDisplayNames && typeof data.dictionaryDisplayNames === 'object')
+            ? data.dictionaryDisplayNames : {};
 }

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -1155,6 +1155,13 @@ function constructSingleGlossaryHtml(entryIndex) {
         rewriteExportedGlossaryAnchors(tempDiv);
         const content = applyTableStyles(tempDiv.innerHTML);
         let listIdentifier = '';
+        /* 词典改名（v95）刻意**不**翻这里：本行进的是导出到 Anki 的卡片正文。
+           卡片是历史存档，改名不回溯——翻了之后同一个牌组里旧卡显示真名、新卡
+           显示新名，比统一显示真名更难认。同一段 HTML 里的 data-dictionary
+           属性也必须是真名（Lapis 模板 CSS 靠它命中），文本与属性不一致会让
+           排查变难。
+           上游 Yomitan 同位置放的是 dictionaryAlias，所以「跟着改名走」是个
+           合理的反向选择；要改就只翻这一行的 label 文本，别碰下面的属性。 */
         if (dictChanged) {
             label = tags ? `(${tags}, ${dictName})` : `(${dictName})`;
         } else {

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -18,6 +18,22 @@ function __fushiRootNode(){ return window.__fushiRoot || document; }
 function __fushiContainer(){ var r = window.__fushiRoot; return r ? r.querySelector('#entries-container') : document.getElementById('entries-container'); }
 function __fushiViewportWidth(){ var w = Number(window.__fushiPopupViewportWidth); return (isFinite(w) && w > 0) ? w : (window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth || 0); }
 function __fushiOverlayParent(){ return window.__fushiRoot || document.body; }
+/* 词典改名（v95）：把**真名**翻成用户起的显示名，只用于渲染给人看的文本。
+   宿主在 popup_settings_injection 注入 window.dictionaryDisplayNames = {真名: 显示名}，
+   只含真正改过名的条目；没改过 / 表不存在 → 原样返回真名。
+
+   ⚠️ 绝不能拿它去替换 dictName 变量本身。同一个真名在本文件里还承担 6 种非显示
+   职责：`data-dictionary` CSS 作用域属性、window.dictionaryStyles 查表、隐藏/折叠
+   过滤、释义语言查表、词典媒体 URL 的 dictionary= 参数（要对上磁盘目录名）、
+   glossaries 分组 key（Anki `{single-glossary-<名>}` token 靠它对齐）。翻译了那些
+   就是：用户样式静默失效、词典图/音 404、已配置的制卡字段对不上。
+   只在 textContent 处调用本函数。 */
+function __fushiDictDisplayName(name){
+    var map = window.dictionaryDisplayNames;
+    if (!map || typeof name !== 'string') return name;
+    var shown = map[name];
+    return (typeof shown === 'string' && shown.length > 0) ? shown : name;
+}
 // 注意：scrollHeight 是**未乘 CSS zoom 的 layout px**。要和宿主几何（host CSS px）同单位，
 // 用下面的 __fushiReportedContentHeight()（BUG-1651 ②）。
 function __fushiScrollHeight(){ var c = __fushiContainer(); return c ? c.scrollHeight : document.body.scrollHeight; }
@@ -2327,7 +2343,7 @@ function createDeinflectionTag(tag) {
 function createFrequencyGroup(freqGroup) {
     const values = freqGroup.frequencies.map(f => f.displayValue || f.value).join(', ');
     return el('span', { className: 'frequency-group', 'data-details': freqGroup.dictionary }, [
-        el('span', { className: 'frequency-dict-label', textContent: freqGroup.dictionary }),
+        el('span', { className: 'frequency-dict-label', textContent: __fushiDictDisplayName(freqGroup.dictionary) }),
         el('span', { className: 'frequency-values', textContent: values })
     ]);
 }
@@ -2429,7 +2445,7 @@ function createTranscriptionsHtml(transcriptions) {
 
 function createPitchGroup(pitchData, reading) {
     const container = el('div', { className: 'pitch-group', 'data-details': pitchData.dictionary });
-    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: pitchData.dictionary }));
+    container.appendChild(el('span', { className: 'pitch-dict-label', textContent: __fushiDictDisplayName(pitchData.dictionary) }));
 
     const list = el('ul', { className: 'pitch-entries' });
     (pitchData.pitchPositions || []).forEach((pitch) => {
@@ -3649,7 +3665,7 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
     }
 
     const summary = el('summary', { className: 'dict-label' });
-    summary.appendChild(el('span', { className: 'dict-name', textContent: dictName }));
+    summary.appendChild(el('span', { className: 'dict-name', textContent: __fushiDictDisplayName(dictName) }));
     details.appendChild(summary);
 
     let longPressTimer = null;
@@ -4191,7 +4207,7 @@ function createKanjiCard(kanji) {
     }
 
     if (kanji.dictName) {
-        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: kanji.dictName }));
+        card.appendChild(el('div', { className: 'kanji-card-dict', textContent: __fushiDictDisplayName(kanji.dictName) }));
     }
 
     return card;


### PR DESCRIPTION
本分支早已完成但从未开过 PR，现补开以便审查/合并。

提交：
- docs(dict): 写下「制卡字段冻结真名」的决策（审查 #4）
- refactor(dict): 改名投影收成单点（审查 G5）
- fix(rename): 空名置灰 + 词典页文案跟着改名走
- fix(dict): 修代码审查查出的三个真问题
- test(db): schema bump 到 v95 的连带——迁移测试的版本号断言
- fix(dict): 悬浮弹窗的显示名改成入参，不在渲染路径读全局
- fix(sync): 重新导入词典不再吞掉本机的改名与内容语言 + v95 迁移测试
- i18n(zh-HK): 补改名六个 key 的繁体译文
- test(rename): 改名三类入口 + 词典显示名的行为与边界守卫
- feat(dict): 词典改名——加显示名覆盖列，真名冻结
- feat(library): 书卡与扫描根补改名入口，改名弹窗收成一个原语

改动规模： 83 files changed, 2481 insertions(+), 252 deletions(-)
分支基点：18b2f4aaae（2026-09-02）

与当前 develop 的冲突块数：55 —— **需要先解冲突，PR 处于 CONFLICTING 时不会启动任何 CI check**。
注意：schema bump 到 v95，合并前需按 schema bump 连带清单复核（schemaVersion 断言、PRAGMA user_version、migration 全表清单、packages/*/test）。

https://claude.ai/code/session_01M3Uvn1LeRdu8J2mU4mZvAb