### PR TITLE
refactor(settings): 听书并入阅读，一级分类分四块，副标题纳入搜索命中面

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -2172,6 +2172,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_destination_tracking => 'Media tracking';
   String get settings_destination_video => 'Video';
   String get settings_experimental_suffix => ' (experimental)';
+  String get settings_group_content => 'Content';
+  String get settings_group_data => 'Data & device';
+  String get settings_group_tools => 'Tools';
   String get settings_search_hint => 'Search settings';
   String get settings_search_no_results => 'No matching settings';
   String get settings_secret_hide => 'Hide value';
@@ -8676,6 +8679,12 @@ class _StringsAr extends _StringsEn {
   String get settings_destination_video => 'فيديو';
   @override
   String get settings_experimental_suffix => ' (تجريبي، قد يكون غير مستقر)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -17408,6 +17417,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimentell, kann instabil sein)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -26179,6 +26194,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimental, puede ser inestable)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -34968,6 +34989,12 @@ class _StringsFr extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (expérimental, peut être instable)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -43717,6 +43744,12 @@ class _StringsId extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (eksperimental, mungkin tidak stabil)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -52464,6 +52497,12 @@ class _StringsIt extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (sperimentale, potrebbe essere instabile)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -61142,6 +61181,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get settings_experimental_suffix => '（実験的機能、不安定な場合があります）';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -69724,6 +69769,12 @@ class _StringsKo extends _StringsEn {
   String get settings_destination_video => '비디오';
   @override
   String get settings_experimental_suffix => ' (실험적, 불안정할 수 있음)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -78387,6 +78438,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimenteel, mogelijk instabiel)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -87144,6 +87201,12 @@ class _StringsPtBr extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (experimental, pode ser instável)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -95893,6 +95956,12 @@ class _StringsRu extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (экспериментально, возможна нестабильность)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -104604,6 +104673,12 @@ class _StringsTh extends _StringsEn {
   String get settings_destination_video => 'วิดีโอ';
   @override
   String get settings_experimental_suffix => ' (ทดลอง, อาจไม่เสถียร)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -113317,6 +113392,12 @@ class _StringsTr extends _StringsEn {
   String get settings_destination_video => 'Video';
   @override
   String get settings_experimental_suffix => ' (deneysel, kararsız olabilir)';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -122035,6 +122116,12 @@ class _StringsVi extends _StringsEn {
   String get settings_experimental_suffix =>
       ' (thử nghiệm, có thể chưa ổn định)';
   @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_data => 'Data & device';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
   String get settings_search_hint => 'Search settings';
   @override
   String get settings_search_no_results => 'No matching settings';
@@ -130504,6 +130591,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get settings_experimental_suffix => '（实验性）';
   @override
+  String get settings_group_content => '内容';
+  @override
+  String get settings_group_data => '数据与设备';
+  @override
+  String get settings_group_tools => '工具';
+  @override
   String get settings_search_hint => '搜索设置';
   @override
   String get settings_search_no_results => '没有匹配的设置项';
@@ -138698,6 +138791,12 @@ class _StringsZhHk extends _StringsEn {
   String get settings_destination_video => '影片';
   @override
   String get settings_experimental_suffix => '（實驗性）';
+  @override
+  String get settings_group_content => '內容';
+  @override
+  String get settings_group_data => '資料與裝置';
+  @override
+  String get settings_group_tools => '工具';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -146922,6 +147021,12 @@ extension on _StringsEn {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimental)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -154616,6 +154721,12 @@ extension on _StringsAr {
         return 'فيديو';
       case 'settings_experimental_suffix':
         return ' (تجريبي، قد يكون غير مستقر)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -162320,6 +162431,12 @@ extension on _StringsDe {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimentell, kann instabil sein)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -170035,6 +170152,12 @@ extension on _StringsEs {
         return 'Vídeo';
       case 'settings_experimental_suffix':
         return ' (experimental, puede ser inestable)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -177752,6 +177875,12 @@ extension on _StringsFr {
         return 'Vidéo';
       case 'settings_experimental_suffix':
         return ' (expérimental, peut être instable)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -185460,6 +185589,12 @@ extension on _StringsId {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (eksperimental, mungkin tidak stabil)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -193165,6 +193300,12 @@ extension on _StringsIt {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (sperimentale, potrebbe essere instabile)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -200862,6 +201003,12 @@ extension on _StringsJa {
         return '動画';
       case 'settings_experimental_suffix':
         return '（実験的機能、不安定な場合があります）';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -208541,6 +208688,12 @@ extension on _StringsKo {
         return '비디오';
       case 'settings_experimental_suffix':
         return ' (실험적, 불안정할 수 있음)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -216238,6 +216391,12 @@ extension on _StringsNl {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimenteel, mogelijk instabiel)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -223947,6 +224106,12 @@ extension on _StringsPtBr {
         return 'Vídeo';
       case 'settings_experimental_suffix':
         return ' (experimental, pode ser instável)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -231656,6 +231821,12 @@ extension on _StringsRu {
         return 'Видео';
       case 'settings_experimental_suffix':
         return ' (экспериментально, возможна нестабильность)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -239354,6 +239525,12 @@ extension on _StringsTh {
         return 'วิดีโอ';
       case 'settings_experimental_suffix':
         return ' (ทดลอง, อาจไม่เสถียร)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -247054,6 +247231,12 @@ extension on _StringsTr {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (deneysel, kararsız olabilir)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -254755,6 +254938,12 @@ extension on _StringsVi {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (thử nghiệm, có thể chưa ổn định)';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_data':
+        return 'Data & device';
+      case 'settings_group_tools':
+        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -262430,6 +262619,12 @@ extension on _StringsZhCn {
         return '视频';
       case 'settings_experimental_suffix':
         return '（实验性）';
+      case 'settings_group_content':
+        return '内容';
+      case 'settings_group_data':
+        return '数据与设备';
+      case 'settings_group_tools':
+        return '工具';
       case 'settings_search_hint':
         return '搜索设置';
       case 'settings_search_no_results':
@@ -270083,6 +270278,12 @@ extension on _StringsZhHk {
         return '影片';
       case 'settings_experimental_suffix':
         return '（實驗性）';
+      case 'settings_group_content':
+        return '內容';
+      case 'settings_group_data':
+        return '資料與裝置';
+      case 'settings_group_tools':
+        return '工具';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -2172,9 +2172,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_destination_tracking => 'Media tracking';
   String get settings_destination_video => 'Video';
   String get settings_experimental_suffix => ' (experimental)';
-  String get settings_group_content => 'Content';
-  String get settings_group_data => 'Data & device';
-  String get settings_group_tools => 'Tools';
   String get settings_search_hint => 'Search settings';
   String get settings_search_no_results => 'No matching settings';
   String get settings_secret_hide => 'Hide value';
@@ -5098,6 +5095,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Install failed: ${message}';
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  String get settings_group_content => 'Content';
+  String get settings_group_tools => 'Tools';
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -8679,12 +8679,6 @@ class _StringsAr extends _StringsEn {
   String get settings_destination_video => 'فيديو';
   @override
   String get settings_experimental_suffix => ' (تجريبي، قد يكون غير مستقر)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -13802,6 +13796,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -17417,12 +17417,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimentell, kann instabil sein)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -22571,6 +22565,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -26194,12 +26194,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimental, puede ser inestable)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -31356,6 +31350,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -34988,12 +34988,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (expérimental, peut être instable)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -40153,6 +40147,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -43743,12 +43743,6 @@ class _StringsId extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (eksperimental, mungkin tidak stabil)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -48880,6 +48874,12 @@ class _StringsId extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -52496,12 +52496,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (sperimentale, potrebbe essere instabile)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -57651,6 +57645,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -61180,12 +61180,6 @@ class _StringsJa extends _StringsEn {
   String get settings_destination_video => '動画';
   @override
   String get settings_experimental_suffix => '（実験的機能、不安定な場合があります）';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -66239,6 +66233,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -69769,12 +69769,6 @@ class _StringsKo extends _StringsEn {
   String get settings_destination_video => '비디오';
   @override
   String get settings_experimental_suffix => ' (실험적, 불안정할 수 있음)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -74835,6 +74829,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -78438,12 +78438,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimenteel, mogelijk instabiel)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -83586,6 +83580,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -87200,12 +87200,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (experimental, pode ser instável)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -92349,6 +92343,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -95955,12 +95955,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (экспериментально, возможна нестабильность)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -101099,6 +101093,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -104673,12 +104673,6 @@ class _StringsTh extends _StringsEn {
   String get settings_destination_video => 'วิดีโอ';
   @override
   String get settings_experimental_suffix => ' (ทดลอง, อาจไม่เสถียร)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -109797,6 +109791,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -113392,12 +113392,6 @@ class _StringsTr extends _StringsEn {
   String get settings_destination_video => 'Video';
   @override
   String get settings_experimental_suffix => ' (deneysel, kararsız olabilir)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -118526,6 +118520,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -122115,12 +122115,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get settings_experimental_suffix =>
       ' (thử nghiệm, có thể chưa ổn định)';
-  @override
-  String get settings_group_content => 'Content';
-  @override
-  String get settings_group_data => 'Data & device';
-  @override
-  String get settings_group_tools => 'Tools';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -127241,6 +127235,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => 'Content';
+  @override
+  String get settings_group_tools => 'Tools';
+  @override
+  String get settings_group_data => 'Data & device';
 }
 
 // Path: <root>
@@ -130590,12 +130590,6 @@ class _StringsZhCn extends _StringsEn {
   String get settings_destination_video => '视频';
   @override
   String get settings_experimental_suffix => '（实验性）';
-  @override
-  String get settings_group_content => '内容';
-  @override
-  String get settings_group_data => '数据与设备';
-  @override
-  String get settings_group_tools => '工具';
   @override
   String get settings_search_hint => '搜索设置';
   @override
@@ -135302,6 +135296,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
+  @override
+  String get settings_group_content => '内容';
+  @override
+  String get settings_group_tools => '工具';
+  @override
+  String get settings_group_data => '数据与设备';
 }
 
 // Path: <root>
@@ -138791,12 +138791,6 @@ class _StringsZhHk extends _StringsEn {
   String get settings_destination_video => '影片';
   @override
   String get settings_experimental_suffix => '（實驗性）';
-  @override
-  String get settings_group_content => '內容';
-  @override
-  String get settings_group_data => '資料與裝置';
-  @override
-  String get settings_group_tools => '工具';
   @override
   String get settings_search_hint => 'Search settings';
   @override
@@ -143815,6 +143809,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_hook_reason_capability_probe_failed =>
       'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+  @override
+  String get settings_group_content => '內容';
+  @override
+  String get settings_group_tools => '工具';
+  @override
+  String get settings_group_data => '資料與裝置';
 }
 
 /// Flat map(s) containing all translations.
@@ -147021,12 +147021,6 @@ extension on _StringsEn {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimental)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -151515,6 +151509,12 @@ extension on _StringsEn {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -154721,12 +154721,6 @@ extension on _StringsAr {
         return 'فيديو';
       case 'settings_experimental_suffix':
         return ' (تجريبي، قد يكون غير مستقر)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -159213,6 +159207,12 @@ extension on _StringsAr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -162431,12 +162431,6 @@ extension on _StringsDe {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimentell, kann instabil sein)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -166933,6 +166927,12 @@ extension on _StringsDe {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -170152,12 +170152,6 @@ extension on _StringsEs {
         return 'Vídeo';
       case 'settings_experimental_suffix':
         return ' (experimental, puede ser inestable)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -174652,6 +174646,12 @@ extension on _StringsEs {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -177875,12 +177875,6 @@ extension on _StringsFr {
         return 'Vidéo';
       case 'settings_experimental_suffix':
         return ' (expérimental, peut être instable)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -182377,6 +182371,12 @@ extension on _StringsFr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -185589,12 +185589,6 @@ extension on _StringsId {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (eksperimental, mungkin tidak stabil)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -190084,6 +190078,12 @@ extension on _StringsId {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -193300,12 +193300,6 @@ extension on _StringsIt {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (sperimentale, potrebbe essere instabile)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -197805,6 +197799,12 @@ extension on _StringsIt {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -201003,12 +201003,6 @@ extension on _StringsJa {
         return '動画';
       case 'settings_experimental_suffix':
         return '（実験的機能、不安定な場合があります）';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -205488,6 +205482,12 @@ extension on _StringsJa {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -208688,12 +208688,6 @@ extension on _StringsKo {
         return '비디오';
       case 'settings_experimental_suffix':
         return ' (실험적, 불안정할 수 있음)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -213175,6 +213169,12 @@ extension on _StringsKo {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -216391,12 +216391,6 @@ extension on _StringsNl {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (experimenteel, mogelijk instabiel)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -220890,6 +220884,12 @@ extension on _StringsNl {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -224106,12 +224106,6 @@ extension on _StringsPtBr {
         return 'Vídeo';
       case 'settings_experimental_suffix':
         return ' (experimental, pode ser instável)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -228602,6 +228596,12 @@ extension on _StringsPtBr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -231821,12 +231821,6 @@ extension on _StringsRu {
         return 'Видео';
       case 'settings_experimental_suffix':
         return ' (экспериментально, возможна нестабильность)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -236319,6 +236313,12 @@ extension on _StringsRu {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -239525,12 +239525,6 @@ extension on _StringsTh {
         return 'วิดีโอ';
       case 'settings_experimental_suffix':
         return ' (ทดลอง, อาจไม่เสถียร)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -244019,6 +244013,12 @@ extension on _StringsTh {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -247231,12 +247231,6 @@ extension on _StringsTr {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (deneysel, kararsız olabilir)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -251728,6 +251722,12 @@ extension on _StringsTr {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -254938,12 +254938,6 @@ extension on _StringsVi {
         return 'Video';
       case 'settings_experimental_suffix':
         return ' (thử nghiệm, có thể chưa ổn định)';
-      case 'settings_group_content':
-        return 'Content';
-      case 'settings_group_data':
-        return 'Data & device';
-      case 'settings_group_tools':
-        return 'Tools';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -259433,6 +259427,12 @@ extension on _StringsVi {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return 'Content';
+      case 'settings_group_tools':
+        return 'Tools';
+      case 'settings_group_data':
+        return 'Data & device';
       default:
         return null;
     }
@@ -262619,12 +262619,6 @@ extension on _StringsZhCn {
         return '视频';
       case 'settings_experimental_suffix':
         return '（实验性）';
-      case 'settings_group_content':
-        return '内容';
-      case 'settings_group_data':
-        return '数据与设备';
-      case 'settings_group_tools':
-        return '工具';
       case 'settings_search_hint':
         return '搜索设置';
       case 'settings_search_no_results':
@@ -267081,6 +267075,12 @@ extension on _StringsZhCn {
         return ({required Object message}) => '安装失败：${message}';
       case 'game_hook_reason_capability_probe_failed':
         return '捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。';
+      case 'settings_group_content':
+        return '内容';
+      case 'settings_group_tools':
+        return '工具';
+      case 'settings_group_data':
+        return '数据与设备';
       default:
         return null;
     }
@@ -270278,12 +270278,6 @@ extension on _StringsZhHk {
         return '影片';
       case 'settings_experimental_suffix':
         return '（實驗性）';
-      case 'settings_group_content':
-        return '內容';
-      case 'settings_group_data':
-        return '資料與裝置';
-      case 'settings_group_tools':
-        return '工具';
       case 'settings_search_hint':
         return 'Search settings';
       case 'settings_search_no_results':
@@ -274759,6 +274753,12 @@ extension on _StringsZhHk {
         return ({required Object message}) => 'Install failed: ${message}';
       case 'game_hook_reason_capability_probe_failed':
         return 'The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.';
+      case 'settings_group_content':
+        return '內容';
+      case 'settings_group_tools':
+        return '工具';
+      case 'settings_group_data':
+        return '資料與裝置';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "Content",
+  "settings_group_tools": "Tools",
+  "settings_group_data": "Data & device"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "已装好 AnkiConnect：启动或重启 Anki，然后点「测试连接」。",
   "onboarding_anki_addon_no_anki": "没找到 Anki 数据目录：请先安装 Anki 并打开一次，再回来重试。",
   "onboarding_anki_addon_failed": "安装失败：$message",
-  "game_hook_reason_capability_probe_failed": "捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。"
+  "game_hook_reason_capability_probe_failed": "捕获组件没有回应能力探测：文件在，但跑不起来或没在时限内回应。多为杀毒软件拦截、权限不足，或上一局残留的 helper 进程挂住了。请关闭所有游戏、检查杀软隔离区后重试。",
+  "settings_group_content": "内容",
+  "settings_group_tools": "工具",
+  "settings_group_data": "数据与设备"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -3750,5 +3750,8 @@
   "onboarding_anki_addon_installed": "AnkiConnect is installed. Start (or restart) Anki, then tap Test connection.",
   "onboarding_anki_addon_no_anki": "Anki data folder not found. Install Anki and open it once, then try again.",
   "onboarding_anki_addon_failed": "Install failed: $message",
-  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again."
+  "game_hook_reason_capability_probe_failed": "The capture component did not answer the capability check. It was found on disk but could not run or did not respond in time - antivirus may be blocking it, Fushi may lack permission to launch it, or a leftover helper process may be stuck. Close every game, check your antivirus quarantine, then try again.",
+  "settings_group_content": "內容",
+  "settings_group_tools": "工具",
+  "settings_group_data": "資料與裝置"
 }

--- a/fushi/lib/src/settings/cupertino_settings_renderer.dart
+++ b/fushi/lib/src/settings/cupertino_settings_renderer.dart
@@ -31,7 +31,12 @@ class CupertinoSettingsRenderer implements SettingsRenderer {
           CupertinoSliverNavigationBar(
             largeTitle: Text(settingsContext.context.t.settings),
           ),
-          SliverFillRemaining(child: list),
+          // buildDestinationList 返回的是不可滚动的 section 列表，高度随分类数
+          // 增长（分块后又多了几个组标题头）。SliverFillRemaining 会把它钉死在
+          // 「剩余视口高度」里、内容超出即 RenderFlex 溢出；SliverToBoxAdapter 让
+          // 它按自身高度参与外层 CustomScrollView 的滚动（宽屏那条路径已由主页的
+          // SingleChildScrollView 兜住，见 settings_home_page）。
+          SliverToBoxAdapter(child: list),
         ],
       ),
     );
@@ -47,28 +52,46 @@ class CupertinoSettingsRenderer implements SettingsRenderer {
   }) {
     final Color primaryColor =
         CupertinoTheme.of(settingsContext.context).primaryColor;
-    return CupertinoListSection.insetGrouped(
-      backgroundColor: CupertinoColors.systemGroupedBackground.resolveFrom(
-        settingsContext.context,
-      ),
-      children: destinations.map((SettingsDestination destination) {
-        return CupertinoListTile(
-          leading: Icon(destination.icon, color: primaryColor),
-          title: Text(destination.title),
-          subtitle:
-              destination.summary != null ? Text(destination.summary!) : null,
-          trailing: const CupertinoListTileChevron(),
-          onTap: () {
-            onDestinationSelected(destination.id);
-            if (!pushRoutes) return;
-            Navigator.of(settingsContext.context).push(
-              CupertinoPageRoute<void>(
-                builder: (_) => SettingsDetailPage(destination: destination),
-              ),
-            );
-          },
-        );
-      }).toList(growable: false),
+    final Color background = CupertinoColors.systemGroupedBackground.resolveFrom(
+      settingsContext.context,
+    );
+    CupertinoListTile tileFor(SettingsDestination destination) {
+      return CupertinoListTile(
+        leading: Icon(destination.icon, color: primaryColor),
+        title: Text(destination.title),
+        subtitle:
+            destination.summary != null ? Text(destination.summary!) : null,
+        trailing: const CupertinoListTileChevron(),
+        onTap: () {
+          onDestinationSelected(destination.id);
+          if (!pushRoutes) return;
+          Navigator.of(settingsContext.context).push(
+            CupertinoPageRoute<void>(
+              builder: (_) => SettingsDetailPage(destination: destination),
+            ),
+          );
+        },
+      );
+    }
+
+    // 与 Material 侧同款分块（groupSettingsDestinations 是共享真相源）：每批一个
+    // inset-grouped section，组标题落在 header。列表整体不再是单个 section，故这里
+    // 自带 Column——buildHomePage 的 SliverFillRemaining 与主页窄布局都给了滚动。
+    final List<SettingsDestinationBatch> batches =
+        groupSettingsDestinations(destinations);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        for (final SettingsDestinationBatch batch in batches)
+          CupertinoListSection.insetGrouped(
+            backgroundColor: background,
+            header: batch.title != null ? Text(batch.title!) : null,
+            children: batch.destinations
+                .map(tileFor)
+                .toList(growable: false),
+          ),
+      ],
     );
   }
 

--- a/fushi/lib/src/settings/material_settings_renderer.dart
+++ b/fushi/lib/src/settings/material_settings_renderer.dart
@@ -55,8 +55,8 @@ class MaterialSettingsRenderer implements SettingsRenderer {
     final BuildContext context = settingsContext.context;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     final EdgeInsets mediaPadding = MediaQuery.of(context).padding;
-    final List<Widget> rows = <Widget>[
-      for (final SettingsDestination destination in destinations)
+    List<Widget> rowsFor(List<SettingsDestination> group) => <Widget>[
+      for (final SettingsDestination destination in group)
         FushiListItem(
           selected: destination.id == selectedDestinationId,
           // Master-detail (pushRoutes:false) keeps selection in-pane, so use the
@@ -87,6 +87,9 @@ class MaterialSettingsRenderer implements SettingsRenderer {
         ),
     ];
 
+    // 一级分类按四块渲染成带组标题的多张卡片（外观那块单成员，标题为 null 即无题
+    // 卡）。分组本身是数据层的事，两个渲染器共用 groupSettingsDestinations——这里
+    // 只负责把批次画成卡片，不重排顺序。
     return ListView(
       padding: EdgeInsets.fromLTRB(
         tokens.spacing.page,
@@ -95,10 +98,13 @@ class MaterialSettingsRenderer implements SettingsRenderer {
         tokens.spacing.page + mediaPadding.bottom,
       ),
       children: <Widget>[
-        AdaptiveSettingsSection(
-          surfaceColor: tokens.surfaces.card,
-          children: rows,
-        ),
+        for (final SettingsDestinationBatch batch
+            in groupSettingsDestinations(destinations))
+          AdaptiveSettingsSection(
+            title: batch.title,
+            surfaceColor: tokens.surfaces.card,
+            children: rowsFor(batch.destinations),
+          ),
       ],
     );
   }

--- a/fushi/lib/src/settings/settings_destination.dart
+++ b/fushi/lib/src/settings/settings_destination.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 
 enum SettingsDestinationId {
@@ -14,7 +15,9 @@ enum SettingsDestinationId {
   lookup,
   cardCreation,
   video,
-  listening,
+  // 注：曾有 `listening`（听书）一级分类，2026-08-24 并入 `reading`——两个分类装
+  // 的是同一本 EPUB 的读与听。它没有任何持久化用途（只做内存态选中项身份），故
+  // 直接删除而非保留兼容值；分区本身在 settings_schema_listening.dart 存活。
   mediaTracking,
   // 「下载」一级分类：torrent / qBittorrent 后端配置从下载页齿轮抬进设置主页
   // （可达 + 可搜）。位置紧随视频/听，在同步备份之前。
@@ -46,6 +49,85 @@ enum SettingsDestinationId {
   // (ShortcutSettingsPage)；own id so the shell no longer borrows `system` for
   // content that isn't the system destination（与 appIcon 同款约定）。
   shortcuts,
+}
+
+/// 设置主页一级分类的分块。原先这四块只活在 `_buildDestinations()` 的注释里——
+/// 顺序确实按块排，但 UI 上是 13 个分类平铺进同一张卡片，用户看不出块界，也就没法
+/// 「先定位到块、再在块内找」。本枚举把那份注释变成数据，主页据此渲染成四张带组
+/// 标题的卡片（真相源仍是 `_buildDestinations()` 的调用顺序，见
+/// [groupSettingsDestinations]）。
+///
+/// 声明顺序无意义：组的先后由 destination 在 schema 里的出现顺序决定，本枚举只负
+/// 责给块起名。
+enum SettingsDestinationGroup {
+  /// 全局界面（当前只有「外观」）。单成员组不渲染标题头——一个标题带一行是噪音，
+  /// 见 [settingsDestinationGroupTitle]。
+  interface,
+
+  /// 内容：阅读（含听书）/ 漫画 / 视频 / 下载 / 游戏。
+  content,
+
+  /// 横切工具：查词 / 制卡（各内容域共用）。
+  tools,
+
+  /// 数据与设备：配置方案 / 同步备份 / 互联 / 存储 / 系统。
+  data,
+}
+
+/// 组标题；null = 该组只渲染成一张无标题卡片。
+String? settingsDestinationGroupTitle(SettingsDestinationGroup group) {
+  switch (group) {
+    // 「外观」独占一块，标题只会重复它自己。
+    case SettingsDestinationGroup.interface:
+      return null;
+    case SettingsDestinationGroup.content:
+      return t.settings_group_content;
+    case SettingsDestinationGroup.tools:
+      return t.settings_group_tools;
+    case SettingsDestinationGroup.data:
+      return t.settings_group_data;
+  }
+}
+
+/// 主页分类列表的一批：一个组标题 + 该组的分类（组内顺序 = schema 顺序）。
+class SettingsDestinationBatch {
+  const SettingsDestinationBatch({
+    required this.title,
+    required this.destinations,
+  });
+
+  /// null = 不渲染组标题头。
+  final String? title;
+  final List<SettingsDestination> destinations;
+}
+
+/// 把一级分类按 [SettingsDestination.group] 切成有序批次，两个渲染器共用。
+///
+/// **组的先后不是第二处真相源**：这里按「各组在 [destinations] 里首次出现的次序」
+/// 排批次，所以块顺序仍完全由 `_buildDestinations()` 决定（它有顺序守卫）。同组的
+/// 分类必须在 schema 里相邻——否则后面那段会被并回前面那批，UI 顺序与 schema 顺序
+/// 脱节；`settings_destination_group_guard_test` 钉住这条不变式。
+///
+/// [SettingsDestination.group] 为 null 的（阅读器/视频快捷面板等 synthetic
+/// destination）落进一批无标题卡片，行为与分组前一致。
+List<SettingsDestinationBatch> groupSettingsDestinations(
+  List<SettingsDestination> destinations,
+) {
+  // Dart 的 Map 字面量是插入序的 LinkedHashMap，故首次出现次序即批次次序。
+  final Map<SettingsDestinationGroup?, List<SettingsDestination>> buckets =
+      <SettingsDestinationGroup?, List<SettingsDestination>>{};
+  for (final SettingsDestination destination in destinations) {
+    buckets
+        .putIfAbsent(destination.group, () => <SettingsDestination>[])
+        .add(destination);
+  }
+  return buckets.entries
+      .map((MapEntry<SettingsDestinationGroup?, List<SettingsDestination>> e) =>
+          SettingsDestinationBatch(
+            title: e.key == null ? null : settingsDestinationGroupTitle(e.key!),
+            destinations: List<SettingsDestination>.unmodifiable(e.value),
+          ))
+      .toList(growable: false);
 }
 
 /// 书内快捷面板的分组维度，与全局 [SettingsDestinationId] 正交。
@@ -112,6 +194,7 @@ class SettingsDestination {
     required this.title,
     required this.icon,
     required this.sections,
+    this.group,
     this.summary,
     this.visible,
     this.body,
@@ -121,6 +204,12 @@ class SettingsDestination {
   final SettingsDestinationId id;
   final String title;
   final IconData icon;
+
+  /// 主页分块归属；null = 不参与分组（synthetic destination：阅读器/视频快捷面板、
+  /// 推入式子页）。真实一级分类必须声明——由 `settings_destination_group_guard_test`
+  /// 钉住，新增分类漏填会红。
+  final SettingsDestinationGroup? group;
+
   final String? summary;
   final SettingsVisibility? visible;
   final List<SettingsSection> sections;

--- a/fushi/lib/src/settings/settings_home_page.dart
+++ b/fushi/lib/src/settings/settings_home_page.dart
@@ -29,10 +29,11 @@ class SettingsHomePage extends BasePage {
 
 class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     with SettingsContextHost<SettingsHomePage> {
-  // 默认选中 schema 首个可见分类（当前重排后是「阅读」），与宽屏导航列表的
+  // 默认选中 schema 首个可见分类（当前是「外观」块的首项），与宽屏导航列表的
   // 视觉首项一致：不再硬编码某个 id——分类顺序的唯一真相源是 buildSettingsSchema
   // （有顺序守卫），这里在 build 里首次解析时取 destinations.first.id，顺序调整
-  // 时默认项自动跟随，不会再脱节。
+  // 时默认项自动跟随，不会再脱节。分块渲染同样不改顺序（groupSettingsDestinations
+  // 只切段），故首项仍是视觉首项。
   SettingsDestinationId? _selectedDestinationId;
 
   // 设置搜索：跨全部分类按标题/副标题/分区/分类名过滤配置项，点结果跳转到

--- a/fushi/lib/src/settings/settings_schema.dart
+++ b/fushi/lib/src/settings/settings_schema.dart
@@ -6,7 +6,6 @@ import 'package:fushi/src/settings/settings_schema_appearance.dart';
 import 'package:fushi/src/settings/settings_schema_card_creation.dart';
 import 'package:fushi/src/settings/settings_schema_downloads.dart';
 import 'package:fushi/src/settings/settings_schema_game.dart';
-import 'package:fushi/src/settings/settings_schema_listening.dart';
 import 'package:fushi/src/settings/settings_schema_lookup.dart';
 import 'package:fushi/src/settings/settings_schema_manga.dart';
 import 'package:fushi/src/media/tracking/media_tracking_service.dart'
@@ -83,17 +82,20 @@ List<SettingsDestination> buildSettingsSchema(SettingsContext context) =>
 List<SettingsDestination> _buildDestinations() {
   // 四块分层排序（用户拍板，取代阶段 G 的纯任务优先排序）——块内相关项相邻：
   // ① 外观：全局界面，装完 app 第一批要调的，置顶。
-  // ② 内容：阅读 → 听书（同一本书的两面）→ 视频 → 下载（torrent/番剧，喂视频库）
-  //   → 游戏（galgame 库/捕获，仅 Windows 可见）。
+  // ② 内容：阅读（含听书——同一本书的两面，2026-08-24 合并）→ 漫画 → 视频 →
+  //   下载（torrent/番剧，喂视频库）→ 游戏（galgame 库/捕获，仅 Windows 可见）。
   // ③ 横切工具：查词 → 制卡（阅读/视频/galgame/扩展共用一套查词弹窗；制卡依赖查词）。
   // ④ 数据与设备：Profile（上述设置的快照）→ 同步备份 → 互联；「系统」惯例殿后。
+  //
+  // 这四块不再只是注释：每个 destination 声明 [SettingsDestinationGroup]，主页据
+  // 此渲染成带组标题的四张卡（见 groupSettingsDestinations）。块的先后仍只由本
+  // 列表的顺序决定，故同块的分类必须在这里连续——有守卫钉住。
   // unmodifiable：这棵树被所有设置宿主共享，任何就地改动都会污染其它面板。
   return List<SettingsDestination>.unmodifiable(<SettingsDestination>[
     buildAppearanceDestination(),
     buildReadingDestination(),
     // 「漫画」大类：从阅读分类拆出（观看偏好 + OCR，详见 buildMangaDestination）。
     buildMangaDestination(),
-    buildListeningDestination(),
     buildVideoDestination(),
     // Bangumi 同步临时下线（编译期常量开关，不破坏 schema 缓存的纯度前提；
     // 见 media_tracking_service.dart 的 kMediaTrackingEnabled）。

--- a/fushi/lib/src/settings/settings_schema_appearance.dart
+++ b/fushi/lib/src/settings/settings_schema_appearance.dart
@@ -10,6 +10,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildAppearanceDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.appearance,
+    group: SettingsDestinationGroup.interface,
     title: t.settings_destination_appearance,
     summary: t.design_system_hint,
     icon: Icons.palette_outlined,

--- a/fushi/lib/src/settings/settings_schema_card_creation.dart
+++ b/fushi/lib/src/settings/settings_schema_card_creation.dart
@@ -9,6 +9,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildCardCreationDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.cardCreation,
+    group: SettingsDestinationGroup.tools,
     title: t.settings_destination_card_creation,
     summary: t.anki_settings_label,
     icon: Icons.style_outlined,

--- a/fushi/lib/src/settings/settings_schema_downloads.dart
+++ b/fushi/lib/src/settings/settings_schema_downloads.dart
@@ -25,6 +25,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildDownloadsDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.downloads,
+    group: SettingsDestinationGroup.content,
     title: t.nav_downloads,
     summary: t.download_settings,
     icon: Icons.download_outlined,

--- a/fushi/lib/src/settings/settings_schema_game.dart
+++ b/fushi/lib/src/settings/settings_schema_game.dart
@@ -33,6 +33,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildGameDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.game,
+    group: SettingsDestinationGroup.content,
     title: t.nav_game,
     summary: t.game_home_subtitle,
     icon: Icons.sports_esports_outlined,

--- a/fushi/lib/src/settings/settings_schema_listening.dart
+++ b/fushi/lib/src/settings/settings_schema_listening.dart
@@ -6,259 +6,266 @@ import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/utils.dart';
 
-SettingsDestination buildListeningDestination() {
-  return SettingsDestination(
-    id: SettingsDestinationId.listening,
-    title: t.settings_destination_listening,
-    summary: t.floating_lyric_hint,
-    icon: Icons.headphones_outlined,
-    sections: <SettingsSection>[
-      SettingsSection(
-        title: t.section_audiobook,
-        items: <SettingsItem>[
-          // TODO-702：有声书退出即停（默认 OFF）/ 后台续播（开启）。默认关 = 退出
-          // 阅读页就停止有声书播放；开启后退书后会话继续在后台播。
-          SettingsSwitchItem(
-            id: 'listening.audiobook_background_play',
-            title: t.audiobook_background_play,
-            subtitle: t.audiobook_background_play_hint,
-            icon: Icons.play_circle_outline,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.audiobookBackgroundPlay,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel
-                  .setAudiobookBackgroundPlay(value: value);
-              settingsContext.refresh();
-            },
+/// 「听书」的两个设置分区（有声书 + 悬浮歌词）。
+///
+/// 2026-08-24 用户决策：不再作为独立一级分类，由 [buildReadingDestination] 展开
+/// 进「阅读」末尾。理由是同一本 EPUB 的「读」与「听」被拆在两个一级分类里，用户
+/// 得在两处找同一本书的设置；而听书总共只有 12 项、其中 9 项还是悬浮歌词一个子
+/// 功能，撑不起一个一级分类。
+///
+/// 合并只动**归属**：item id（`listening.*`）、持久化 key、[ReaderPlacement]
+/// （书内快捷面板分组）与各项的 visible 门控全部原样保留——`SettingsDestinationId
+/// .listening` 随之删除，它没有任何持久化用途（只做内存态选中项身份）。
+///
+/// 保持独立 library 而不是把这 200 行搬进已 850 行的 settings_schema_reading.dart：
+/// 领域文件边界不变，settings_redesign_static_test 的「一域一文件」契约照旧成立。
+List<SettingsSection> buildListeningSections() {
+  return <SettingsSection>[
+    SettingsSection(
+      title: t.section_audiobook,
+      items: <SettingsItem>[
+        // TODO-702：有声书退出即停（默认 OFF）/ 后台续播（开启）。默认关 = 退出
+        // 阅读页就停止有声书播放；开启后退书后会话继续在后台播。
+        SettingsSwitchItem(
+          id: 'listening.audiobook_background_play',
+          title: t.audiobook_background_play,
+          subtitle: t.audiobook_background_play_hint,
+          icon: Icons.play_circle_outline,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.audiobookBackgroundPlay,
+          onChanged: (SettingsContext settingsContext, bool value) async {
+            await settingsContext.appModel
+                .setAudiobookBackgroundPlay(value: value);
+            settingsContext.refresh();
+          },
+        ),
+        SettingsSwitchItem(
+          id: 'listening.media_notification',
+          title: t.show_media_notification,
+          icon: Icons.notifications_outlined,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.showMediaNotification,
+          onChanged: (SettingsContext settingsContext, bool value) async {
+            await settingsContext.appModel.setShowMediaNotification(value);
+            settingsContext.refresh();
+          },
+        ),
+        SettingsSwitchItem(
+          id: 'listening.volume_key_sentence_nav',
+          title: t.volume_key_sentence_nav,
+          icon: Icons.skip_next_outlined,
+          // VolumeKeyChannel 仅 Android 实现，桌面隐藏此项（TODO-1155）。
+          visible: (_) => Platform.isAndroid,
+          reader: const ReaderPlacement(
+            group: ReaderGroup.behavior,
+            order: 10,
           ),
-          SettingsSwitchItem(
-            id: 'listening.media_notification',
-            title: t.show_media_notification,
-            icon: Icons.notifications_outlined,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.showMediaNotification,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setShowMediaNotification(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'listening.volume_key_sentence_nav',
-            title: t.volume_key_sentence_nav,
-            icon: Icons.skip_next_outlined,
-            // VolumeKeyChannel 仅 Android 实现，桌面隐藏此项（TODO-1155）。
-            visible: (_) => Platform.isAndroid,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.behavior,
-              order: 10,
-            ),
-            value: (SettingsContext settingsContext) =>
-                settingsContext.readerSource.volumeKeySentenceNavEnabled,
-            onChanged: (SettingsContext settingsContext, bool value) {
-              settingsContext.readerSource.toggleVolumeKeySentenceNavEnabled();
-              notifyReaderSettingsChanged(settingsContext);
-            },
-          ),
-        ],
-      ),
-      // 悬浮歌词全家桶（总开关 + 7 个样式/行为子项）独立成组：原先与后台播放/
-      // 媒体通知平铺同级，一个子功能占了「有声书」分区 2/3 的行数。
-      SettingsSection(
-        title: t.section_floating_lyric,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsSwitchItem(
-            id: 'listening.floating_lyric',
-            title: t.show_floating_lyric,
-            subtitle: t.floating_lyric_hint,
-            icon: Icons.subtitles_outlined,
-            // The strip is the desktop counterpart of the Android overlay
-            // (windows/runner/floating_lyric_window.cpp), so Windows must see
-            // this switch too — gating it to Android hid it from desktop users
-            // and was the "floating subtitle setting missing/permission"
-            // complaint (TODO-038). The Dart channel's isSupported already
-            // allows Android + Windows.
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.showFloatingLyric,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              // TODO-1069/1070：走语义意图入口，置位（非翻转）+ 有会话时原子拉/隐
-              // 原生悬浮窗 + 写意图 pref。旧实现只裸写 setShowFloatingLyric 旁路，
-              // 不真正显隐窗，导致开关不即时、与书内翻转显隐反相。
-              await settingsContext.appModel.setFloatingLyricEnabled(value);
-              settingsContext.refresh();
-            },
-          ),
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_font_size',
-            title: t.floating_lyric_font_size,
-            icon: Icons.format_size,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 8,
-            max: 64,
-            step: 1,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricFontSize,
-            format: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel.setFloatingLyricFontSize(value);
-              // TODO-1069：改字号后把整支 style（含 fontSize）经 FloatingLyricChannel
-              // .updateStyle 即时推给原生悬浮窗——与透明度三项对齐。漏掉这一步时字号
-              // 只写了 pref，原生窗不刷新，得等改透明度才顺带把字号推过去。
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-370: 悬浮字幕「文字透明度」+「按钮底色透明度」自定义（0..100%，
-          // 100=保持现观感）。与字号一样仅 Android/Windows 可见（有原生悬浮窗后端）。
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_text_opacity',
-            title: t.floating_lyric_text_opacity,
-            icon: Icons.opacity_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 100,
-            step: 5,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricTextOpacity.toDouble(),
-            format: (double value) => '${value.round()}%',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel
-                  .setFloatingLyricTextOpacity(value.round());
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_button_bg_opacity',
-            title: t.floating_lyric_button_bg_opacity,
-            icon: Icons.smart_button_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 100,
-            step: 5,
-            value: (SettingsContext settingsContext) => settingsContext
-                .appModel.floatingLyricButtonBgOpacity
-                .toDouble(),
-            format: (double value) => '${value.round()}%',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel
-                  .setFloatingLyricButtonBgOpacity(value.round());
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-576: 悬浮字幕/歌词条「背景透明度」自定义（0..100%，默认 70=更不挡
-          // 视野）。同样仅 Android/Windows 可见（有原生悬浮窗后端）。
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_bg_opacity',
-            title: t.floating_lyric_bg_opacity,
-            icon: Icons.gradient_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 100,
-            step: 5,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricBgOpacity.toDouble(),
-            format: (double value) => '${value.round()}%',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel
-                  .setFloatingLyricBgOpacity(value.round());
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-708 P2: 悬浮字幕/歌词条「圆角半径」自定义（dp，0=平台原生观感）。同样仅
-          // Android/Windows 可见（有原生悬浮窗后端）。镜像透明度那条 apply 链路。
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_corner_radius',
-            title: t.floating_lyric_corner_radius,
-            subtitle: t.floating_lyric_corner_radius_hint,
-            icon: Icons.rounded_corner_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 48,
-            step: 2,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricCornerRadius.toDouble(),
-            format: (double value) =>
-                value.round() == 0 ? t.audio_panel_auto : '${value.round()}',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel
-                  .setFloatingLyricCornerRadius(value.round());
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-708 P2: 悬浮字幕/歌词条「宽度」自定义（dp，0=平台默认宽）。0 显示为「自动」，
-          // 其余 200..1200 逐 40 dp 步进。
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_width',
-            title: t.floating_lyric_width,
-            subtitle: t.floating_lyric_width_hint,
-            icon: Icons.width_normal_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 1200,
-            step: 40,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricWidth.toDouble(),
-            format: (double value) =>
-                value.round() == 0 ? t.audio_panel_auto : '${value.round()}',
-            onChanged: (SettingsContext settingsContext, double value) async {
-              // 0=自动；其余夹到 [200,1200]（<200 的步进值向上取到 200，保持哨兵语义只在 0）。
-              final int rounded = value.round();
-              final int width =
-                  rounded <= 0 ? 0 : (rounded < 200 ? 200 : rounded);
-              await settingsContext.appModel.setFloatingLyricWidth(width);
-              await settingsContext.appModel.audiobookSession
-                  .applyFloatingLyricStyle();
-              settingsContext.refresh();
-            },
-          ),
-          // TODO-708 P4: 悬浮字幕/歌词条「上下文行数」（对称单值，0=只当前行=今天单行
-          // 观感）。0 显示为「自动」/单行语义，1..3 在当前行上下各显示 N 行。改值后调
-          // resyncFloatingLyricText 即时重推（对称透明度那条的 applyFloatingLyricStyle）。
-          SettingsStepperItem(
-            id: 'listening.floating_lyric_context_lines',
-            title: t.floating_lyric_context_lines,
-            subtitle: t.floating_lyric_context_lines_hint,
-            icon: Icons.format_line_spacing_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            min: 0,
-            max: 3,
-            step: 1,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricContextLines.toDouble(),
-            format: (double value) => value.round().toString(),
-            onChanged: (SettingsContext settingsContext, double value) async {
-              await settingsContext.appModel
-                  .setFloatingLyricContextLines(value.round());
-              await settingsContext.appModel.audiobookSession
-                  .resyncFloatingLyricText();
-              settingsContext.refresh();
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'listening.floating_lyric_click_lookup',
-            title: t.floating_lyric_click_lookup,
-            subtitle: t.floating_lyric_click_lookup_hint,
-            icon: Icons.touch_app_outlined,
-            visible: (_) => Platform.isAndroid || Platform.isWindows,
-            value: (SettingsContext settingsContext) =>
-                settingsContext.appModel.floatingLyricClickLookup,
-            onChanged: (SettingsContext settingsContext, bool value) async {
-              await settingsContext.appModel.setFloatingLyricClickLookup(value);
-              settingsContext.refresh();
-            },
-          ),
-        ],
-      ),
-    ],
-  );
+          value: (SettingsContext settingsContext) =>
+              settingsContext.readerSource.volumeKeySentenceNavEnabled,
+          onChanged: (SettingsContext settingsContext, bool value) {
+            settingsContext.readerSource.toggleVolumeKeySentenceNavEnabled();
+            notifyReaderSettingsChanged(settingsContext);
+          },
+        ),
+      ],
+    ),
+    // 悬浮歌词全家桶（总开关 + 7 个样式/行为子项）独立成组：原先与后台播放/
+    // 媒体通知平铺同级，一个子功能占了「有声书」分区 2/3 的行数。
+    SettingsSection(
+      title: t.section_floating_lyric,
+      collapsedByDefault: true,
+      items: <SettingsItem>[
+        SettingsSwitchItem(
+          id: 'listening.floating_lyric',
+          title: t.show_floating_lyric,
+          subtitle: t.floating_lyric_hint,
+          icon: Icons.subtitles_outlined,
+          // The strip is the desktop counterpart of the Android overlay
+          // (windows/runner/floating_lyric_window.cpp), so Windows must see
+          // this switch too — gating it to Android hid it from desktop users
+          // and was the "floating subtitle setting missing/permission"
+          // complaint (TODO-038). The Dart channel's isSupported already
+          // allows Android + Windows.
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.showFloatingLyric,
+          onChanged: (SettingsContext settingsContext, bool value) async {
+            // TODO-1069/1070：走语义意图入口，置位（非翻转）+ 有会话时原子拉/隐
+            // 原生悬浮窗 + 写意图 pref。旧实现只裸写 setShowFloatingLyric 旁路，
+            // 不真正显隐窗，导致开关不即时、与书内翻转显隐反相。
+            await settingsContext.appModel.setFloatingLyricEnabled(value);
+            settingsContext.refresh();
+          },
+        ),
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_font_size',
+          title: t.floating_lyric_font_size,
+          icon: Icons.format_size,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 8,
+          max: 64,
+          step: 1,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricFontSize,
+          format: (double value) => value.round().toString(),
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel.setFloatingLyricFontSize(value);
+            // TODO-1069：改字号后把整支 style（含 fontSize）经 FloatingLyricChannel
+            // .updateStyle 即时推给原生悬浮窗——与透明度三项对齐。漏掉这一步时字号
+            // 只写了 pref，原生窗不刷新，得等改透明度才顺带把字号推过去。
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        // TODO-370: 悬浮字幕「文字透明度」+「按钮底色透明度」自定义（0..100%，
+        // 100=保持现观感）。与字号一样仅 Android/Windows 可见（有原生悬浮窗后端）。
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_text_opacity',
+          title: t.floating_lyric_text_opacity,
+          icon: Icons.opacity_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 100,
+          step: 5,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricTextOpacity.toDouble(),
+          format: (double value) => '${value.round()}%',
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel
+                .setFloatingLyricTextOpacity(value.round());
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_button_bg_opacity',
+          title: t.floating_lyric_button_bg_opacity,
+          icon: Icons.smart_button_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 100,
+          step: 5,
+          value: (SettingsContext settingsContext) => settingsContext
+              .appModel.floatingLyricButtonBgOpacity
+              .toDouble(),
+          format: (double value) => '${value.round()}%',
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel
+                .setFloatingLyricButtonBgOpacity(value.round());
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        // TODO-576: 悬浮字幕/歌词条「背景透明度」自定义（0..100%，默认 70=更不挡
+        // 视野）。同样仅 Android/Windows 可见（有原生悬浮窗后端）。
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_bg_opacity',
+          title: t.floating_lyric_bg_opacity,
+          icon: Icons.gradient_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 100,
+          step: 5,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricBgOpacity.toDouble(),
+          format: (double value) => '${value.round()}%',
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel
+                .setFloatingLyricBgOpacity(value.round());
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        // TODO-708 P2: 悬浮字幕/歌词条「圆角半径」自定义（dp，0=平台原生观感）。同样仅
+        // Android/Windows 可见（有原生悬浮窗后端）。镜像透明度那条 apply 链路。
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_corner_radius',
+          title: t.floating_lyric_corner_radius,
+          subtitle: t.floating_lyric_corner_radius_hint,
+          icon: Icons.rounded_corner_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 48,
+          step: 2,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricCornerRadius.toDouble(),
+          format: (double value) =>
+              value.round() == 0 ? t.audio_panel_auto : '${value.round()}',
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel
+                .setFloatingLyricCornerRadius(value.round());
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        // TODO-708 P2: 悬浮字幕/歌词条「宽度」自定义（dp，0=平台默认宽）。0 显示为「自动」，
+        // 其余 200..1200 逐 40 dp 步进。
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_width',
+          title: t.floating_lyric_width,
+          subtitle: t.floating_lyric_width_hint,
+          icon: Icons.width_normal_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 1200,
+          step: 40,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricWidth.toDouble(),
+          format: (double value) =>
+              value.round() == 0 ? t.audio_panel_auto : '${value.round()}',
+          onChanged: (SettingsContext settingsContext, double value) async {
+            // 0=自动；其余夹到 [200,1200]（<200 的步进值向上取到 200，保持哨兵语义只在 0）。
+            final int rounded = value.round();
+            final int width =
+                rounded <= 0 ? 0 : (rounded < 200 ? 200 : rounded);
+            await settingsContext.appModel.setFloatingLyricWidth(width);
+            await settingsContext.appModel.audiobookSession
+                .applyFloatingLyricStyle();
+            settingsContext.refresh();
+          },
+        ),
+        // TODO-708 P4: 悬浮字幕/歌词条「上下文行数」（对称单值，0=只当前行=今天单行
+        // 观感）。0 显示为「自动」/单行语义，1..3 在当前行上下各显示 N 行。改值后调
+        // resyncFloatingLyricText 即时重推（对称透明度那条的 applyFloatingLyricStyle）。
+        SettingsStepperItem(
+          id: 'listening.floating_lyric_context_lines',
+          title: t.floating_lyric_context_lines,
+          subtitle: t.floating_lyric_context_lines_hint,
+          icon: Icons.format_line_spacing_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          min: 0,
+          max: 3,
+          step: 1,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricContextLines.toDouble(),
+          format: (double value) => value.round().toString(),
+          onChanged: (SettingsContext settingsContext, double value) async {
+            await settingsContext.appModel
+                .setFloatingLyricContextLines(value.round());
+            await settingsContext.appModel.audiobookSession
+                .resyncFloatingLyricText();
+            settingsContext.refresh();
+          },
+        ),
+        SettingsSwitchItem(
+          id: 'listening.floating_lyric_click_lookup',
+          title: t.floating_lyric_click_lookup,
+          subtitle: t.floating_lyric_click_lookup_hint,
+          icon: Icons.touch_app_outlined,
+          visible: (_) => Platform.isAndroid || Platform.isWindows,
+          value: (SettingsContext settingsContext) =>
+              settingsContext.appModel.floatingLyricClickLookup,
+          onChanged: (SettingsContext settingsContext, bool value) async {
+            await settingsContext.appModel.setFloatingLyricClickLookup(value);
+            settingsContext.refresh();
+          },
+        ),
+      ],
+    ),
+  ];
 }

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -124,6 +124,7 @@ Future<void> _terminatePortOwnerAndRetry(
 SettingsDestination buildLookupDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.lookup,
+    group: SettingsDestinationGroup.tools,
     title: t.settings_destination_lookup,
     summary: t.dictionary_settings,
     icon: Icons.manage_search_outlined,

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -415,7 +415,10 @@ SettingsDestination buildLookupDestination() {
       ),
       // 朗读与反馈：查中词后的语音朗读与播放暂停联动。
       SettingsSection(
+        // 发音 / 触感反馈：装完调一次的偏好，默认折叠（与阅读、视频同一条规则：
+        // 一个分类只默认展开最常调的一两组）。
         title: t.settings_section_lookup_audio,
+        collapsedByDefault: true,
         items: <SettingsItem>[
           SettingsSwitchItem(
             id: 'lookup.auto_read_on_lookup',
@@ -955,7 +958,9 @@ SettingsDestination buildLookupDestination() {
       // 外部集成：远程查词 / Yomitan API / texthooker——都是「让别的程序或设备
       // 参与查词」的接线项，与本机查词触发行为分开。
       SettingsSection(
+        // 外部集成（浏览器扩展 / 外部工具）：一次性接线，默认折叠。
         title: t.settings_section_lookup_integrations,
+        collapsedByDefault: true,
         items: <SettingsItem>[
           // 远端词典查询抽成共享 builder：查词分类与 Hibiki 互联分类都引用（它直连
           // 互联对端的词典，逻辑上属互联，故互联分类也提供入口）。

--- a/fushi/lib/src/settings/settings_schema_manga.dart
+++ b/fushi/lib/src/settings/settings_schema_manga.dart
@@ -21,6 +21,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildMangaDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.manga,
+    group: SettingsDestinationGroup.content,
     title: t.manga_library,
     summary: t.settings_destination_manga_summary,
     icon: Icons.auto_stories_outlined,

--- a/fushi/lib/src/settings/settings_schema_profiles.dart
+++ b/fushi/lib/src/settings/settings_schema_profiles.dart
@@ -7,6 +7,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildProfilesDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.profiles,
+    group: SettingsDestinationGroup.data,
     title: t.settings_destination_profiles,
     summary: t.profile_management,
     icon: Icons.manage_accounts_outlined,

--- a/fushi/lib/src/settings/settings_schema_reading.dart
+++ b/fushi/lib/src/settings/settings_schema_reading.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:fushi/src/settings/settings_actions.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_schema_listening.dart';
 import 'package:fushi/utils.dart';
 
 SettingsDestination buildReadingDestination() {
@@ -17,8 +18,11 @@ SettingsDestination buildReadingDestination() {
       c.readerSource.readerViewMode == 'paginated';
   return SettingsDestination(
     id: SettingsDestinationId.reading,
+    group: SettingsDestinationGroup.content,
     title: t.settings_destination_reading,
-    summary: t.section_layout,
+    // 副标题带上「有声书」：听书并入本分类后，一级列表上「阅读」是听书设置的
+    // 唯一入口，标题本身看不出这一点。用既有分区名拼，不新增 i18n key。
+    summary: '${t.section_layout} · ${t.section_audiobook}',
     icon: Icons.auto_stories_outlined,
     sections: <SettingsSection>[
       // 「模式与排版方向」：阅读呈现的模式与方向选择（翻页/滚动、竖排、跨页展开、
@@ -407,12 +411,120 @@ SettingsDestination buildReadingDestination() {
           ),
         ],
       ),
+      // 「高级选项」紧跟「排版」（同一件事的粗调/细调两半，读者调完字号行高就地
+      // 往下找字距/两端对齐，不必翻过翻页与听书四组）：文字两端对齐、竖排字距/
+      // VPAL、优先阅读器样式、图片防剧透模糊、合并插图页。默认折叠，与各项
+      // id/持久化 key/ReaderPlacement 全不变，仅调 section 相对位置。
+      SettingsSection(
+        title: t.section_advanced_typography,
+        collapsedByDefault: true,
+        items: <SettingsItem>[
+          SettingsSwitchItem(
+            id: 'reading_display.text_justify',
+            title: t.reader_text_justify,
+            icon: Icons.format_align_justify,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 14,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.readerEnableTextJustification,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderEnableTextJustification(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.vert_kerning',
+            title: t.reader_vert_kerning,
+            icon: Icons.space_bar,
+            visible: isVertical,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 15,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.readerEnableVerticalFontKerning,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderEnableVerticalFontKerning(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.font_vpal',
+            title: t.reader_font_vpal,
+            icon: Icons.format_shapes,
+            visible: isVertical,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 16,
+            ),
+            value: (SettingsContext c) => c.readerSource.readerEnableFontVPAL,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderEnableFontVPAL(value);
+              notifyReaderSettingsChanged(c);
+            },
+          ),
+          SettingsSwitchItem(
+            id: 'reading_display.prioritize_reader_styles',
+            title: t.reader_reader_styles,
+            icon: Icons.style_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 17,
+            ),
+            value: (SettingsContext c) =>
+                c.readerSource.readerPrioritizeReaderStyles,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderPrioritizeReaderStyles(value);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          // TODO-861④（移植 Hoshi `f286108`）：图片防剧透模糊。加 `blurred` 类需重跑
+          // 分页脚本（非纯 CSS），故走结构 reload（notifyReaderLayoutChanged）。
+          SettingsSwitchItem(
+            id: 'reading_display.blur_images',
+            title: t.reader_blur_images,
+            icon: Icons.blur_on_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 19,
+            ),
+            value: (SettingsContext c) => c.readerSource.readerBlurImages,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderBlurImages(value);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+          // TODO-1128（受限方案 A）：把 0 字符单图 spine 章并入相邻正文章连续显示，
+          // 不再各占一页/一条目录。结构性布局键（改虚拟页映射 + 注入章 DOM），故走
+          // notifyReaderLayoutChanged（重建 spread map + 重排）。**默认开**
+          // （ReaderSettings.mergeImagePages 的 `_get` 真值就是 true）——旧注释写
+          // 「默认关」已过期。
+          SettingsSwitchItem(
+            id: 'reading_display.merge_image_pages',
+            title: t.reader_merge_image_pages,
+            subtitle: t.reader_merge_image_pages_subtitle,
+            icon: Icons.collections_bookmark_outlined,
+            reader: const ReaderPlacement(
+              group: ReaderGroup.layout,
+              order: 20,
+            ),
+            value: (SettingsContext c) => c.readerSource.readerMergeImagePages,
+            onChanged: (SettingsContext c, bool value) {
+              c.readerSource.setReaderMergeImagePages(value);
+              notifyReaderLayoutChanged(c);
+            },
+          ),
+        ],
+      ),
       // 原「导航」13 项混杂平铺，拆两组：阅读界面（进度条/悬浮 chrome/底栏提示/
       // 常亮 + 从「底栏布局」并入的「反转阅读器底栏」）与翻页与交互（点击高亮/音量
       // 翻页/滚轮/滑动灵敏度）。纯展示重组：item id、持久化 key、ReaderPlacement
       // 全部不变（快捷面板分组不动）。
       SettingsSection(
         title: t.settings_section_reader_chrome,
+        collapsedByDefault: true,
         items: <SettingsItem>[
           SettingsSwitchItem(
             id: 'reading_controls.show_top_progress_bar',
@@ -585,6 +697,7 @@ SettingsDestination buildReadingDestination() {
       ),
       SettingsSection(
         title: t.settings_section_page_turn_input,
+        collapsedByDefault: true,
         items: <SettingsItem>[
           SettingsSwitchItem(
             id: 'reading_controls.highlight_on_tap',
@@ -738,112 +851,10 @@ SettingsDestination buildReadingDestination() {
           ),
         ],
       ),
-      // 「高级选项」现移到最后（低频排版微调）：文字两端对齐、竖排字距/VPAL、
-      // 优先阅读器样式、图片防剧透模糊、合并插图页。collapsedByDefault 与各项
-      // id/持久化 key/ReaderPlacement 全不变，仅调 section 相对位置。
-      SettingsSection(
-        title: t.section_advanced_typography,
-        collapsedByDefault: true,
-        items: <SettingsItem>[
-          SettingsSwitchItem(
-            id: 'reading_display.text_justify',
-            title: t.reader_text_justify,
-            icon: Icons.format_align_justify,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 14,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.readerEnableTextJustification,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderEnableTextJustification(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.vert_kerning',
-            title: t.reader_vert_kerning,
-            icon: Icons.space_bar,
-            visible: isVertical,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 15,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.readerEnableVerticalFontKerning,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderEnableVerticalFontKerning(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.font_vpal',
-            title: t.reader_font_vpal,
-            icon: Icons.format_shapes,
-            visible: isVertical,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 16,
-            ),
-            value: (SettingsContext c) => c.readerSource.readerEnableFontVPAL,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderEnableFontVPAL(value);
-              notifyReaderSettingsChanged(c);
-            },
-          ),
-          SettingsSwitchItem(
-            id: 'reading_display.prioritize_reader_styles',
-            title: t.reader_reader_styles,
-            icon: Icons.style_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 17,
-            ),
-            value: (SettingsContext c) =>
-                c.readerSource.readerPrioritizeReaderStyles,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderPrioritizeReaderStyles(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          // TODO-861④（移植 Hoshi `f286108`）：图片防剧透模糊。加 `blurred` 类需重跑
-          // 分页脚本（非纯 CSS），故走结构 reload（notifyReaderLayoutChanged）。
-          SettingsSwitchItem(
-            id: 'reading_display.blur_images',
-            title: t.reader_blur_images,
-            icon: Icons.blur_on_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 19,
-            ),
-            value: (SettingsContext c) => c.readerSource.readerBlurImages,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderBlurImages(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-          // TODO-1128（受限方案 A）：把 0 字符单图 spine 章并入相邻正文章连续显示，
-          // 不再各占一页/一条目录。结构性布局键（改虚拟页映射 + 注入章 DOM），故走
-          // notifyReaderLayoutChanged（重建 spread map + 重排）。**默认开**
-          // （ReaderSettings.mergeImagePages 的 `_get` 真值就是 true）——旧注释写
-          // 「默认关」已过期。
-          SettingsSwitchItem(
-            id: 'reading_display.merge_image_pages',
-            title: t.reader_merge_image_pages,
-            subtitle: t.reader_merge_image_pages_subtitle,
-            icon: Icons.collections_bookmark_outlined,
-            reader: const ReaderPlacement(
-              group: ReaderGroup.layout,
-              order: 20,
-            ),
-            value: (SettingsContext c) => c.readerSource.readerMergeImagePages,
-            onChanged: (SettingsContext c, bool value) {
-              c.readerSource.setReaderMergeImagePages(value);
-              notifyReaderLayoutChanged(c);
-            },
-          ),
-        ],
-      ),
+      // 「听书」原为独立一级分类，现并入本分类末尾（有声书 + 悬浮歌词两组）——
+      // 见 buildListeningSections 的合并说明。放在阅读六组之后：同一本 EPUB 的
+      // 「读」与「听」是一件事的两面，但绝大多数会话只读不听，故排最后。
+      ...buildListeningSections(),
     ],
   );
 }

--- a/fushi/lib/src/settings/settings_schema_reading.dart
+++ b/fushi/lib/src/settings/settings_schema_reading.dart
@@ -20,9 +20,10 @@ SettingsDestination buildReadingDestination() {
     id: SettingsDestinationId.reading,
     group: SettingsDestinationGroup.content,
     title: t.settings_destination_reading,
-    // 副标题带上「有声书」：听书并入本分类后，一级列表上「阅读」是听书设置的
-    // 唯一入口，标题本身看不出这一点。用既有分区名拼，不新增 i18n key。
-    summary: '${t.section_layout} · ${t.section_audiobook}',
+    // 副标题带上「听书」：并入后本分类是听书设置的唯一入口，标题本身看不出这
+    // 一点；且 summary 参与设置搜索的命中面（settings_search 的 haystack），
+    // 用户搜「听书」才还能落到这里。复用原一级分类名，不新增 i18n key。
+    summary: '${t.section_layout} · ${t.settings_destination_listening}',
     icon: Icons.auto_stories_outlined,
     sections: <SettingsSection>[
       // 「模式与排版方向」：阅读呈现的模式与方向选择（翻页/滚动、竖排、跨页展开、

--- a/fushi/lib/src/settings/settings_schema_storage.dart
+++ b/fushi/lib/src/settings/settings_schema_storage.dart
@@ -27,6 +27,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildStorageDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.storage,
+    group: SettingsDestinationGroup.data,
     title: t.settings_destination_storage,
     summary: t.settings_destination_storage_summary,
     icon: Icons.sd_storage_outlined,

--- a/fushi/lib/src/settings/settings_schema_system.dart
+++ b/fushi/lib/src/settings/settings_schema_system.dart
@@ -16,6 +16,7 @@ import 'package:url_launcher/url_launcher.dart';
 SettingsDestination buildSystemDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.system,
+    group: SettingsDestinationGroup.data,
     title: t.settings_destination_system,
     summary: t.settings_destination_system_summary,
     icon: Icons.settings_suggest_outlined,

--- a/fushi/lib/src/settings/settings_schema_tracking.dart
+++ b/fushi/lib/src/settings/settings_schema_tracking.dart
@@ -7,6 +7,7 @@ import 'package:fushi/utils.dart';
 SettingsDestination buildMediaTrackingDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.mediaTracking,
+    group: SettingsDestinationGroup.content,
     title: t.settings_destination_tracking,
     summary: t.media_tracking_summary,
     icon: Icons.auto_awesome_motion_outlined,

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -316,7 +316,10 @@ SettingsDestination buildVideoDestination() {
         ],
       ),
       SettingsSection(
+        // 刮削凭据 / 语言 / 清库：装完配一次就不再碰，默认折叠（与阅读、查词
+        // 同一条规则：一个分类只默认展开最常调的一两组）。
         title: t.section_video_library,
+        collapsedByDefault: true,
         items: <SettingsItem>[
           SettingsTextItem(
             id: 'video.library.metadata_anidb_client',

--- a/fushi/lib/src/settings/settings_schema_video.dart
+++ b/fushi/lib/src/settings/settings_schema_video.dart
@@ -40,6 +40,7 @@ Future<void> _commitVideoMetadataRuntimePreference(
 SettingsDestination buildVideoDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.video,
+    group: SettingsDestinationGroup.content,
     title: t.settings_destination_video,
     summary: t.video_settings_title,
     icon: Icons.movie_outlined,

--- a/fushi/lib/src/settings/settings_search.dart
+++ b/fushi/lib/src/settings/settings_search.dart
@@ -125,6 +125,10 @@ List<SettingsSearchEntry> filterSettingsEntries(
       e.item.subtitle,
       e.sectionTitle,
       e.destination.title,
+      // 分类副标题也算命中面：它就印在一级列表上、是用户看得见的分类描述，
+      // 搜不到它才是意外。合并类分类尤其依赖这条——「听书」并入「阅读」后，
+      // 「听书」只剩在阅读的 summary 里出现（见 buildReadingDestination）。
+      e.destination.summary,
     ].whereType<String>().join('\n').toLowerCase();
     if (haystack.contains(q)) return 2;
     return -1;

--- a/fushi/lib/src/sync/sync_settings_schema.dart
+++ b/fushi/lib/src/sync/sync_settings_schema.dart
@@ -77,6 +77,7 @@ part 'sync_settings_schema/data_root.part.dart';
 SettingsDestination buildSyncBackupDestination() {
   return SettingsDestination(
     id: SettingsDestinationId.syncBackup,
+    group: SettingsDestinationGroup.data,
     title: t.settings_destination_sync_backup,
     summary: t.sync_summary,
     icon: Icons.sync,
@@ -442,6 +443,7 @@ SettingsDestination buildInterconnectDestination() {
       _syncSettings(ctx).interconnectEnabled;
   return SettingsDestination(
     id: SettingsDestinationId.interconnect,
+    group: SettingsDestinationGroup.data,
     title: t.settings_destination_interconnect,
     summary: t.interconnect_summary,
     icon: Icons.devices_outlined,

--- a/fushi/test/settings/reader_settings_reorg_guard_test.dart
+++ b/fushi/test/settings/reader_settings_reorg_guard_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
-import 'package:fushi/src/settings/settings_schema_listening.dart';
 import 'package:fushi/src/settings/settings_schema_reading.dart';
 
 /// TODO-725 守卫：阅读器设置面板重新归类/排序。
@@ -39,11 +38,10 @@ void main() {
     return grouped;
   }
 
+  // 听书 2026-08-24 并入阅读，其分区由 buildReadingDestination 展开，故这里只需
+  // 一个 destination 就能覆盖到 `listening.volume_key_sentence_nav` 的 placement。
   Map<ReaderGroup, List<SettingsItem>> collected() => collectFrom(
-        <SettingsDestination>[
-          buildReadingDestination(),
-          buildListeningDestination(),
-        ],
+        <SettingsDestination>[buildReadingDestination()],
       );
 
   test('view_mode（翻页/滚动）归 layout 组且为该组首项（TODO-725）', () {

--- a/fushi/test/settings/settings_collapse_policy_test.dart
+++ b/fushi/test/settings/settings_collapse_policy_test.dart
@@ -1,0 +1,138 @@
+// 长分类的默认折叠策略守卫（2026-08-24）。
+//
+// 用户诉求「调整自动展开、非自动展开的配置项」落成一条规则：**一个分类只默认展开
+// 最常调的一两组，其余带标题的分区默认折叠**。理由是详情页一屏能容纳的是「分区标题
+// 的清单」而不是「几十行配置」——阅读并入听书后 8 组 49 项、视频 11 组 81 项、查词
+// 7 组 44 项，全平铺的话用户要滚三四屏才知道这个分类里有什么。
+//
+// 守卫只钉可维护的上界，不钉「具体哪一组展开」（那是产品判断，会随功能重心变）：
+// 分区数 >= 7 的分类，默认展开的带标题分区不超过 3 个。
+//
+// 阈值取 7 而不是「所有分类」：6 组以内的详情页一屏就能扫完分区标题，全平铺不构成
+// 问题（互联那种「配一次就不再碰」的流程页反而更适合平铺）。这条守卫防的是超长分类
+// 退回全平铺，不是要求人人折叠。
+//
+// 注意 collapsedByDefault 只对带 title 的分区生效（无题分区没有可点的头，恒平铺，
+// 见 SettingsSection.collapsedByDefault），所以计数只看带标题的。
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/settings/settings_context.dart';
+import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_schema.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// 触发本规则的分区数下限。
+const int kLongDestinationSectionCount = 7;
+
+/// 长分类允许的默认展开分区上限。
+const int kMaxExpandedSections = 3;
+
+void main() {
+  Future<SettingsContext> makeContext(WidgetTester tester) async {
+    final FushiDatabase db =
+        FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_collapse_policy_');
+    addTearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+    final AppModel appModel = AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+        prefsRepo: prefsRepo,
+        databaseDirectory: tempDir,
+      )
+      ..wireDatabaseForTesting(db);
+
+    late SettingsContext sctx;
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (BuildContext ctx, WidgetRef ref, Widget? _) {
+            sctx = SettingsContext(
+              context: ctx,
+              appModel: ref.read(appProvider),
+              ref: ref,
+              readerSource: ReaderFushiSource.instance,
+              refresh: () {},
+            );
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ));
+    return sctx;
+  }
+
+  /// 带标题的分区（无题分区不可折叠，不计入）。
+  List<SettingsSection> titledSections(SettingsDestination d) =>
+      d.sections
+          .where((SettingsSection s) => (s.title ?? '').isNotEmpty)
+          .toList(growable: false);
+
+  testWidgets('分区多的分类不得全平铺（默认展开 <= $kMaxExpandedSections 组）',
+      (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final Map<String, int> offenders = <String, int>{};
+    int longDestinations = 0;
+    for (final SettingsDestination d in buildSettingsSchema(sctx)) {
+      final List<SettingsSection> titled = titledSections(d);
+      if (titled.length < kLongDestinationSectionCount) continue;
+      longDestinations += 1;
+      final int expanded = titled
+          .where((SettingsSection s) => !s.collapsedByDefault)
+          .length;
+      if (expanded > kMaxExpandedSections) offenders[d.id.name] = expanded;
+    }
+    // 规则本身要有作用对象——阈值以上一个分类都没有，说明这条守卫已经空转
+    // （分类被拆小了就该重新定阈值，而不是留一条恒真断言）。
+    expect(longDestinations, greaterThan(0),
+        reason: '没有分区数 >= $kLongDestinationSectionCount 的分类了，本守卫需要重新定阈值');
+    expect(
+      offenders,
+      isEmpty,
+      reason: '这些分类默认展开的分区过多，进详情页要滚几屏才知道里面有什么：$offenders',
+    );
+  });
+
+  testWidgets('阅读：默认展开的正是三组核心（模式 / 排版 / 有声书）',
+      (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final SettingsDestination reading = buildSettingsSchema(sctx).firstWhere(
+      (SettingsDestination d) => d.id == SettingsDestinationId.reading,
+    );
+    final List<String> expanded = titledSections(reading)
+        .where((SettingsSection s) => !s.collapsedByDefault)
+        .map((SettingsSection s) => s.title!)
+        .toList(growable: false);
+    expect(expanded, hasLength(3));
+    expect(
+      expanded,
+      containsAll(<String>[t.reading_section_mode, t.section_typography]),
+      reason: '模式与排版是进阅读设置最先要调的两组',
+    );
+    // 「有声书」这组必须还在默认展开里：听书并进来后不能被折叠一起藏掉——那等于
+    // 把一个原本的一级分类降级成了两次点击才够得着。
+    expect(expanded, contains(t.section_audiobook));
+    final List<String> collapsed = titledSections(reading)
+        .where((SettingsSection s) => s.collapsedByDefault)
+        .map((SettingsSection s) => s.title!)
+        .toList(growable: false);
+    expect(collapsed, isNotEmpty);
+    expect(expanded.length + collapsed.length, titledSections(reading).length);
+  });
+}

--- a/fushi/test/settings/settings_destination_group_guard_test.dart
+++ b/fushi/test/settings/settings_destination_group_guard_test.dart
@@ -22,6 +22,7 @@ import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/settings/settings_context.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
 import 'package:fushi/src/settings/settings_schema.dart';
+import 'package:fushi/src/settings/settings_search.dart';
 import 'package:fushi_core/fushi_core.dart';
 
 import '../helpers/test_platform_services.dart';
@@ -145,5 +146,28 @@ void main() {
             .any((SettingsItem i) => i.id == 'listening.floating_lyric'))
         .length;
     expect(owners, 1, reason: '听书分区只应挂在「阅读」一处');
+  });
+
+  testWidgets('搜「听书」仍落到阅读分类（合并后它只活在 summary 里）',
+      (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final List<SettingsSearchEntry> hits = filterSettingsEntries(
+      flattenVisibleSettings(buildSettingsSchema(sctx), sctx),
+      // 默认 locale 是 en，对应 settings_destination_listening 的英文值。
+      'listening',
+    );
+    expect(hits, isNotEmpty, reason: '听书并入阅读后，这个词必须仍能搜到');
+    expect(
+      hits.map((SettingsSearchEntry e) => e.destination.id).toSet(),
+      contains(SettingsDestinationId.reading),
+    );
+    // 命中面确实来自分类 summary，而不是碰巧撞上了某条 item 标题。
+    final SettingsSearchEntry viaSummary = hits.firstWhere(
+      (SettingsSearchEntry e) =>
+          e.destination.id == SettingsDestinationId.reading,
+    );
+    expect(viaSummary.title.toLowerCase(), isNot(contains('listening')));
+    expect(viaSummary.destination.summary?.toLowerCase(),
+        contains('listening'));
   });
 }

--- a/fushi/test/settings/settings_destination_group_guard_test.dart
+++ b/fushi/test/settings/settings_destination_group_guard_test.dart
@@ -1,0 +1,149 @@
+// 设置主页分块守卫（2026-08-24）。
+//
+// 主页原先把全部一级分类平铺进一张卡片，四块分层只活在 `_buildDestinations()` 的
+// 注释里；现在每个 destination 声明 SettingsDestinationGroup，渲染器据此切成带组
+// 标题的多张卡（groupSettingsDestinations）。两条不变式一旦破，症状都不是崩溃而是
+// 「主页顺序悄悄变了 / 某分类掉进别的块」，肉眼很难发现：
+//
+// ① 每个真实一级分类都声明了 group——漏填会静默落进无标题首批（外观那块），
+//    新增分类时最容易踩；
+// ② 同一块的分类在 schema 里连续——批次顺序按「组首次出现」定，交错声明会把后半段
+//    并回前面那批，UI 顺序与 schema 顺序脱节。
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/media.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/settings/settings_context.dart';
+import 'package:fushi/src/settings/settings_destination.dart';
+import 'package:fushi/src/settings/settings_schema.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+import '../helpers/test_platform_services.dart';
+
+void main() {
+  // 与 settings_schema_cache_test 同款轻量宿主：schema 树本身是纯的（分类构建函数
+  // 零参），但 buildSettingsSchema 收 SettingsContext，故仍给它一个真的。
+  Future<SettingsContext> makeContext(WidgetTester tester) async {
+    final FushiDatabase db =
+        FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_dest_group_');
+    addTearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+    final AppModel appModel = AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+        prefsRepo: prefsRepo,
+        databaseDirectory: tempDir,
+      )
+      ..wireDatabaseForTesting(db);
+
+    late SettingsContext sctx;
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (BuildContext ctx, WidgetRef ref, Widget? _) {
+            sctx = SettingsContext(
+              context: ctx,
+              appModel: ref.read(appProvider),
+              ref: ref,
+              readerSource: ReaderFushiSource.instance,
+              refresh: () {},
+            );
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ));
+    return sctx;
+  }
+
+  testWidgets('每个一级分类都声明了主页分块 group', (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final List<String> missing = buildSettingsSchema(sctx)
+        .where((SettingsDestination d) => d.group == null)
+        .map((SettingsDestination d) => d.id.name)
+        .toList(growable: false);
+    expect(
+      missing,
+      isEmpty,
+      reason: '这些一级分类没声明 SettingsDestinationGroup，会掉进主页的无标题首批：$missing',
+    );
+  });
+
+  testWidgets('同一分块的分类在 schema 里连续（批次顺序 = schema 顺序）',
+      (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final List<SettingsDestinationGroup?> sequence = buildSettingsSchema(sctx)
+        .map((SettingsDestination d) => d.group)
+        .toList(growable: false);
+    final Set<SettingsDestinationGroup?> seen = <SettingsDestinationGroup?>{};
+    SettingsDestinationGroup? previous;
+    bool first = true;
+    for (final SettingsDestinationGroup? group in sequence) {
+      if (!first && group == previous) continue;
+      first = false;
+      expect(
+        seen.contains(group),
+        isFalse,
+        reason: '分块 ${group?.name} 在 schema 里被切成了不相邻的两段：'
+            '${sequence.map((SettingsDestinationGroup? g) => g?.name).toList()}',
+      );
+      seen.add(group);
+      previous = group;
+    }
+  });
+
+  testWidgets('分块批次覆盖全部分类且不重排组内顺序', (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final List<SettingsDestination> destinations = buildSettingsSchema(sctx);
+    final List<SettingsDestinationBatch> batches =
+        groupSettingsDestinations(destinations);
+    expect(
+      batches.expand((SettingsDestinationBatch b) => b.destinations).toList(),
+      destinations,
+      reason: '分批只应切段，不应增删或重排任何分类',
+    );
+    // 外观独占一块且不渲染标题；其余各块都必须有标题，否则主页会出现两张无题卡
+    // 而用户看不出块界。
+    expect(batches.first.title, isNull);
+    expect(
+      batches.skip(1).map((SettingsDestinationBatch b) => b.title).toList(),
+      everyElement(isNotNull),
+    );
+    expect(batches.length, greaterThan(1), reason: '分块没生效就退化成了一张大卡');
+  });
+
+  testWidgets('听书并入阅读：不再是一级分类，两个分区落在阅读里',
+      (WidgetTester tester) async {
+    final SettingsContext sctx = await makeContext(tester);
+    final List<SettingsDestination> destinations = buildSettingsSchema(sctx);
+    final SettingsDestination reading = destinations.firstWhere(
+      (SettingsDestination d) => d.id == SettingsDestinationId.reading,
+    );
+    final List<String> ids = reading.sections
+        .expand((SettingsSection s) => s.items)
+        .map((SettingsItem i) => i.id)
+        .toList(growable: false);
+    // 有声书 + 悬浮歌词两组的代表项，都必须能在「阅读」里找到。
+    expect(ids, contains('listening.audiobook_background_play'));
+    expect(ids, contains('listening.floating_lyric'));
+    // 反向：不能有第二个 destination 也装着这些项（合并而非复制）。
+    final int owners = destinations
+        .where((SettingsDestination d) => d.sections
+            .expand((SettingsSection s) => s.items)
+            .any((SettingsItem i) => i.id == 'listening.floating_lyric'))
+        .length;
+    expect(owners, 1, reason: '听书分区只应挂在「阅读」一处');
+  });
+}

--- a/fushi/test/settings/settings_destination_order_guard_test.dart
+++ b/fushi/test/settings/settings_destination_order_guard_test.dart
@@ -5,15 +5,15 @@ import 'package:flutter_test/flutter_test.dart';
 /// 顶层大类顺序守卫：设置 schema 四块分层（外观 → 内容 → 横切工具 →
 /// 数据与设备/系统）。
 ///
-/// 这是「用户决策过的位置」（2026-07-26 用户拍板，取代阶段 G 纯任务优先排序）：
-/// 外观置顶；内容块内相关项相邻（阅读→听书、视频→下载→游戏）；查词/制卡是跨媒体
-/// 横切工具排内容之后；Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移
-/// 必须是有意为之（改分类顺序时同步改本守卫）。用源码顺序断言
-/// （零 harness 依赖：无需构造 SettingsContext + AppModel 即可校验列表次序）。
+/// 这是「用户决策过的位置」（2026-07-26 用户拍板，取代阶段 G 纯任务优先排序；
+/// 2026-08-24 听书并入阅读）：外观置顶；内容块内相关项相邻（阅读→漫画→视频→
+/// 下载→游戏）；查词/制卡是跨媒体横切工具排内容之后；Profile / 同步备份 / 互联 /
+/// 系统殿后。锁死顺序让未来漂移必须是有意为之（改分类顺序时同步改本守卫）。用源码
+/// 顺序断言（零 harness 依赖：无需构造 SettingsContext + AppModel 即可校验次序）。
 ///
 /// 顺序真相源是 `_buildDestinations()`——`buildSettingsSchema()` 自 schema 缓存
-/// （见 settings_schema_cache_test.dart）起只是读快照的薄入口，13 个分类调用留在
-/// 前者体内。
+/// （见 settings_schema_cache_test.dart）起只是读快照的薄入口，分类调用留在前者
+/// 体内。主页的分块渲染也读同一份顺序（见 settings_destination_group_guard_test）。
 void main() {
   test('_buildDestinations keeps the four-block top-level destination order',
       () {
@@ -31,7 +31,8 @@ void main() {
       'buildAppearanceDestination()',
       'buildReadingDestination()',
       'buildMangaDestination()',
-      'buildListeningDestination()',
+      // 「听书」2026-08-24 并入「阅读」，不再是一级分类（分区在
+      // settings_schema_listening.dart 由 buildReadingDestination 展开）。
       'buildVideoDestination()',
       'buildDownloadsDestination()',
       'buildGameDestination()',

--- a/fushi/test/settings/settings_redesign_static_test.dart
+++ b/fushi/test/settings/settings_redesign_static_test.dart
@@ -69,7 +69,6 @@ void main() {
       'buildLookupDestination()',
       'buildCardCreationDestination()',
       'buildVideoDestination()',
-      'buildListeningDestination()',
       'buildSyncBackupDestination()',
       'buildSystemDestination()',
     ],
@@ -97,9 +96,11 @@ void main() {
       'SettingsDestination buildVideoDestination()',
       'SettingsDestinationId.video',
     ],
+    // 听书 2026-08-24 并入阅读：不再是 destination，但仍是自己的领域 library
+    // （返回分区，由 buildReadingDestination 展开）——「一域一文件」契约不变。
     'lib/src/settings/settings_schema_listening.dart': <String>[
-      'SettingsDestination buildListeningDestination()',
-      'SettingsDestinationId.listening',
+      'List<SettingsSection> buildListeningSections()',
+      "id: 'listening.audiobook_background_play'",
     ],
     'lib/src/settings/settings_schema_system.dart': <String>[
       'SettingsDestination buildSystemDestination()',
@@ -290,7 +291,6 @@ void main() {
       'SettingsDestinationId.reading',
       'SettingsDestinationId.lookup',
       'SettingsDestinationId.cardCreation',
-      'SettingsDestinationId.listening',
       'SettingsDestinationId.syncBackup',
       'SettingsDestinationId.system',
     ]) {
@@ -300,6 +300,9 @@ void main() {
     expect(
         combined, isNot(contains('SettingsDestinationId.dictionaryAndCards')));
     expect(combined, isNot(contains('SettingsDestinationId.audiobook')));
+    // 听书并入阅读后该 id 被删（无持久化用途）；留着会让「听书是独立一级分类」
+    // 的假设悄悄复活。
+    expect(combined, isNot(contains('SettingsDestinationId.listening')));
     expect(schemaSource, isNot(contains('DictionarySettingsDialogPage')));
   });
 

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -527,44 +527,48 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'test/pages/popup_auto_expand_dictionaries_test.js (popup.js node behaviour guard) + test/pages/popup_auto_expand_dictionaries_test.dart',
   'lookup/Show expression tags': 'DEVICE: popup.js expression tags',
   'lookup/Deduplicate pitch accents': 'DEVICE: popup.js pitch dedup',
+  // 下面这批「有声书 / 悬浮字幕」项的 key 前缀在 2026-08-24 从 `listening/` 变成
+  // `reading/`：听书并入阅读一级分类，本表的 key 是「destination/标题」，归属换了
+  // key 就得跟着换（item id 仍是 `listening.*`，没动）。
+  //
   // TODO-702: 有声书退出即停（默认）/ 后台续播（可选）。pref-only（门控阅读器
   // dispose 时是否 stop 会话，无渲染树效果）；schema coverage 证 focus/change/
   // persist/restore 经 DB，运行时分流由偏好默认 + dispose 源码守卫覆盖。
-  'listening/Keep playing after exit':
+  'reading/Keep playing after exit':
       'test/models/preferences_repository_test.dart + test/media/audiobook/audiobook_exit_stop_policy_static_test.dart',
-  'listening/Show media notification':
+  'reading/Show media notification':
       'DEVICE: native AudioHandler notification',
   // TODO-038: now visible on Windows desktop too (no longer Android-only). The
   // strip is a runner-owned Win32 window, so the real overlay needs a desktop;
   // covered by source guards + device backlog.
-  'listening/Floating lyric overlay':
+  'reading/Floating lyric overlay':
       'test/media/audiobook/floating_lyric_click_through_guard_test.dart + test/settings/floating_lyric_settings_visibility_guard_test.dart + DEVICE: native always-on-top strip',
-  'listening/Floating subtitle font size':
+  'reading/Floating subtitle font size':
       'test/media/audiobook/desktop_floating_lyric_test.dart + DEVICE: native strip font size',
   // TODO-370: 文字 / 按钮底色透明度作用于 ARGB alpha 通道，效果由 scaleAlpha 纯函数测试
   // 覆盖；落到原生悬浮窗的实际像素需真机。
-  'listening/Floating subtitle text opacity':
+  'reading/Floating subtitle text opacity':
       'test/media/audiobook/floating_lyric_opacity_test.dart (scaleAlpha) + DEVICE: native strip text alpha',
-  'listening/Floating subtitle button background opacity':
+  'reading/Floating subtitle button background opacity':
       'test/media/audiobook/floating_lyric_opacity_test.dart (scaleAlpha) + DEVICE: native strip button alpha',
   // TODO-576: 条背景透明度（默认 70=更不挡视野）作用于条背景 ARGB alpha；缩放由
   // scaleAlpha 纯函数测试覆盖，落到原生悬浮窗的实际像素需真机。
-  'listening/Floating subtitle background opacity':
+  'reading/Floating subtitle background opacity':
       'test/media/audiobook/floating_lyric_opacity_test.dart (scaleAlpha) + test/settings/floating_lyric_bg_opacity_test.dart + DEVICE: native strip bg alpha',
   // TODO-708 P2: 圆角半径 / 宽度（dp，0=平台原生观感）。偏好往返 + 默认哨兵 + 两个样式
   // 构造点喂入由专项测试覆盖；落到原生悬浮窗的实际圆角/窗宽像素需真机点验。
-  'listening/Floating subtitle corner radius':
+  'reading/Floating subtitle corner radius':
       'test/media/audiobook/floating_lyric_style_dimensions_test.dart + DEVICE: native strip corner radius (Android GradientDrawable / Windows D2D)',
-  'listening/Floating subtitle width':
+  'reading/Floating subtitle width':
       'test/media/audiobook/floating_lyric_style_dimensions_test.dart + DEVICE: native strip window width (Android LayoutParams / Windows SetWindowPos)',
   // TODO-708 P4: 悬浮字幕前后 N 行上下文块（N=0 单行）。偏好往返 + 上下文行区间
   // 构建（当前行 start/length 高亮）由专项测试覆盖；落到原生悬浮窗的多行渲染 +
   // 当前行明暗需真机点验。
-  'listening/Floating subtitle context lines':
+  'reading/Floating subtitle context lines':
       'test/media/audiobook/floating_lyric_context_pref_test.dart + test/media/audiobook/floating_lyric_context_test.dart + DEVICE: native strip multi-line context + current-line highlight (Android FloatingLyricService / Windows floating_lyric_window)',
-  'listening/Tap floating subtitle to look up':
+  'reading/Tap floating subtitle to look up':
       'test/media/audiobook/floating_lyric_click_through_guard_test.dart + DEVICE: native strip tap lookup',
-  'listening/Volume key sentence navigation':
+  'reading/Volume key sentence navigation':
       'DEVICE: native volume-key cue nav',
   'system/Update channel': 'DEVICE: Android-only UpdateChecker (beta/stable)',
   "system/Don't remind me about updates": 'DEVICE: Android-only UpdateChecker',

--- a/fushi/test/settings/volume_key_desktop_gate_test.dart
+++ b/fushi/test/settings/volume_key_desktop_gate_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/settings/settings_destination.dart';
-import 'package:fushi/src/settings/settings_schema_listening.dart';
 import 'package:fushi/src/settings/settings_schema_manga.dart';
 import 'package:fushi/src/settings/settings_schema_reading.dart';
 
@@ -33,7 +32,9 @@ void main() {
     });
 
     test('listening：音量键句子导航项带 visible 门控（非总是显示）', () {
-      final SettingsDestination listening = buildListeningDestination();
+      // 听书 2026-08-24 并入阅读；该项仍是 `listening.*` id，只是归属换成了
+      // 阅读 destination 里的「有声书」分区。
+      final SettingsDestination listening = buildReadingDestination();
       expect(
         itemById(listening, 'listening.volume_key_sentence_nav').visible,
         isNotNull,


### PR DESCRIPTION
本分支早已完成但从未开过 PR，现补开以便审查/合并。

提交：
- chore(i18n): strings.g.dart 里三个新 key 挪到 slang 实际输出的位置
- fix(settings): 分类副标题纳入搜索命中面；折叠规则推广到视频/查词
- refactor(settings): 听书并入阅读，主页一级分类分四块，阅读详情重排折叠

改动规模： 45 files changed, 1180 insertions(+), 445 deletions(-)
分支基点：c299d259ff（2026-08-24）

与当前 develop 的冲突块数：36 —— **需要先解冲突，PR 处于 CONFLICTING 时不会启动任何 CI check**。
内容级复核：新增行有约 38% 已经以别的形状进了 develop，解冲突时须按「哪边新增」判定，别整块取一侧（会吞掉后来先落地的改动）。

https://claude.ai/code/session_01M3Uvn1LeRdu8J2mU4mZvAb