### PR TITLE
fix(stats): 时段汇总卡在手机上自适应两列（BUG-2396）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,7 +29,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2215 条。点号进各自文件。
+> 共 2216 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -38,6 +38,7 @@
 | [BUG-2399](bugs/BUG-2399-reader-chapter-stale-progress.md) | ✅ | ✅ | 小说跨章节晚到进度污染阅读字数和速度 |
 | [BUG-2398](bugs/BUG-2398-anime-season-search.md) | ✅ | ✅ | 搜索在AniList故障时缺少动画续季 |
 | [BUG-2397](bugs/BUG-2397-pitch-dedup-ignores-patterns-and-ipa.md) | ✅ | ✅ | 音调去重对 pattern 式音调与 IPA 完全不生效 |
+| [BUG-2396](bugs/BUG-2396-stat-period-grid-phone-single-column.md) | ✅ | ✅ | 统计中心时段汇总卡在手机上只显示一列 |
 | [BUG-2395](bugs/BUG-2395-mobile-nav-bar-too-tall.md) | ✅ | ✅ | 移动端底部导航栏过高未贴近底部 |
 | [BUG-2393](bugs/BUG-2393-reader-audio-chapter-anchor.md) | ✅ | ✅ | 有声书恢复只定位章节却当作句子恢复成功 |
 | [BUG-2392](bugs/BUG-2392-reader-audio-resume-priority.md) | ✅ | ✅ | 阅读进度异步快照在导航后仍写入位置与统计 |

--- a/docs/bugs/BUG-2396-stat-period-grid-phone-single-column.md
+++ b/docs/bugs/BUG-2396-stat-period-grid-phone-single-column.md
@@ -1,0 +1,20 @@
+## BUG-2396 · 统计中心时段汇总卡在手机上只显示一列
+- **报告**：2026-09-10（用户：手机统计中心「今日 / 本周 / 本月 / 全部」只显示一列，希望自适应显示两列）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/pages/implementations/stat_shared.dart:254`（修前）——
+  `buildStatPeriodSummaryGrid` 用 `constraints.maxWidth >= 380` 判两列，但 `LayoutBuilder`
+  外面就套着 `EdgeInsets.all(tokens.spacing.card)`（20dp），到 `maxWidth` 时左右各已扣掉 20dp：
+  360dp 手机只剩 320dp、412dp 大屏手机只剩 372dp，**阈值结构上高于任何手机宽度**，
+  两列分支在手机端永远走不到（`statistics_center_page.dart` 的 `ListView` 无额外横向内边距；
+  reading / video / game 三个统计页共用同一 helper，症状一致）。
+- **[x] ① 已修复** — 判据从「屏幕宽度阈值」改成「实际算出的列宽」：抽纯函数
+  `resolveStatPeriodSummaryLayout`，先按 wideGap(12) 试两列，差几 dp 时改 compactGap(8) 再试，
+  列宽 ≥ `kStatPeriodSummaryMinColumnWidth`(144) 就排两列，否则退单列；列宽 <
+  `kStatPeriodSummaryCompactColumnWidth`(200) 时卡片内边距由 20dp 收到 16dp，避免手机两列下
+  主值被 `FittedBox` 压到读不出来。360 / 375 / 412dp 手机现在都是 2×2，320dp 小屏机仍单列。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/stat_period_summary_grid_columns_test.dart`：
+  纯函数层钉住 320 / 335 / 372dp 判两列、280dp 退单列、紧凑间距救窄带、无界宽度退单列，
+  以及「两列宽度和 + 间距永不超出可用宽度」的扫宽不变式；widget 层在 360×800 真实渲染四张卡，
+  按 `getTopLeft` 断言 2 列 × 2 行。另在 360dp × dpr3 下渲染真实像素人工复核过四个值均完整可读
+  （含最长的「1234 小时 56 分钟」）。
+- **备注**：`FushiSpacingTokens.card = 20 / gap = 8 / rowHorizontal = 16`。380..412dp 这一窄带
+  （小平板分屏）此前是两列 + 20dp 内边距，现在改为两列 + 16dp 内边距，属阈值统一的附带变化。

--- a/fushi/lib/src/pages/implementations/stat_shared.dart
+++ b/fushi/lib/src/pages/implementations/stat_shared.dart
@@ -235,43 +235,59 @@ Widget buildEmbeddedStatTab(
   );
 }
 
-/// 统计页共用的四周期汇总卡网格：宽屏 2×2，窄屏单列。
+/// 汇总卡两列布局的最小列宽（dp）。低于此宽度时「1234 小时 56 分钟」这类长主值
+/// 会被 [FittedBox] 压到读不出来，不如退回单列。
+const double kStatPeriodSummaryMinColumnWidth = 144;
+
+/// 列宽低于此值时卡片切紧凑内边距。手机两列每列只有 ~155dp，[FushiCard] 默认的
+/// 20dp 四边内边距会吃掉四成可用宽度，主值被压得比单列还小。
+const double kStatPeriodSummaryCompactColumnWidth = 200;
+
+/// 统计页共用的四周期汇总卡网格：能放下两列就 2×2，放不下才单列。
+///
+/// BUG：旧实现按「可用宽度 ≥ 380」判两列。这层外面还有 [FushiSpacingTokens.card]
+/// （20dp）的左右内边距，360dp 宽的手机到这里只剩 320dp，连 412dp 的大屏手机也只
+/// 有 372dp——阈值结构上高于任何手机，所以手机端永远单列。改成按**实际算出的列宽**
+/// 判：列宽够放一张卡就两列，跟屏幕宽度阈值脱钩。
 Widget buildStatPeriodSummaryGrid(
   BuildContext context,
   List<StatPeriodSummary> summaries,
 ) {
   final FushiDesignTokens tokens = FushiDesignTokens.of(context);
-  final double gap = tokens.spacing.gap + tokens.spacing.gap / 2;
-  final List<Widget> panels = summaries
-      .map((StatPeriodSummary summary) =>
-          _StatPeriodSummaryCard(summary: summary))
-      .toList();
+  final double wideGap = tokens.spacing.gap + tokens.spacing.gap / 2;
+  final double compactGap = tokens.spacing.gap;
 
   return Padding(
     padding: EdgeInsets.all(tokens.spacing.card),
     child: LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
-        final bool twoColumns =
-            constraints.maxWidth.isFinite && constraints.maxWidth >= 380;
-        if (!twoColumns) {
+        final StatPeriodSummaryLayout layout = resolveStatPeriodSummaryLayout(
+          maxWidth: constraints.maxWidth,
+          wideGap: wideGap,
+          compactGap: compactGap,
+        );
+        final List<Widget> panels = summaries
+            .map((StatPeriodSummary summary) => _StatPeriodSummaryCard(
+                  summary: summary,
+                  compact: layout.compact,
+                ))
+            .toList();
+        if (layout.columnWidth == null) {
           return Column(
             children: <Widget>[
               for (int i = 0; i < panels.length; i++) ...<Widget>[
-                if (i > 0) SizedBox(height: gap),
+                if (i > 0) SizedBox(height: layout.gap),
                 panels[i],
               ],
             ],
           );
         }
         return Wrap(
-          spacing: gap,
-          runSpacing: gap,
+          spacing: layout.gap,
+          runSpacing: layout.gap,
           children: <Widget>[
             for (final Widget panel in panels)
-              SizedBox(
-                width: (constraints.maxWidth - gap) / 2,
-                child: panel,
-              ),
+              SizedBox(width: layout.columnWidth, child: panel),
           ],
         );
       },
@@ -279,10 +295,70 @@ Widget buildStatPeriodSummaryGrid(
   );
 }
 
+/// [buildStatPeriodSummaryGrid] 解出的布局：列宽为 null 表示单列。
+class StatPeriodSummaryLayout {
+  const StatPeriodSummaryLayout({
+    required this.columnWidth,
+    required this.gap,
+    required this.compact,
+  });
+
+  /// 两列时每列的宽度；null = 放不下两列，走单列。
+  final double? columnWidth;
+
+  /// 卡片之间的间距（两列时同时用于横纵）。
+  final double gap;
+
+  /// 列窄到需要卡片用紧凑内边距。
+  final bool compact;
+}
+
+/// 纯函数：按可用宽度解出汇总卡网格布局，方便直接测宽度→列数的判据。
+///
+/// 先按 [wideGap] 试两列；差一点点放不下时改用 [compactGap] 再试一次（挤出的
+/// 几 dp 常常正好够 360dp 手机排下两列），仍不够才退单列。单列时间距一律用
+/// [wideGap]，纵向不缺空间。
+StatPeriodSummaryLayout resolveStatPeriodSummaryLayout({
+  required double maxWidth,
+  required double wideGap,
+  required double compactGap,
+}) {
+  // 无界宽度（横向滚动容器里）算不出列宽，只能单列。
+  if (!maxWidth.isFinite) {
+    return StatPeriodSummaryLayout(
+      columnWidth: null,
+      gap: wideGap,
+      compact: false,
+    );
+  }
+  for (final double gap in <double>[wideGap, compactGap]) {
+    final double columnWidth = (maxWidth - gap) / 2;
+    if (columnWidth >= kStatPeriodSummaryMinColumnWidth) {
+      return StatPeriodSummaryLayout(
+        columnWidth: columnWidth,
+        gap: gap,
+        compact: columnWidth < kStatPeriodSummaryCompactColumnWidth,
+      );
+    }
+  }
+  return StatPeriodSummaryLayout(
+    columnWidth: null,
+    gap: wideGap,
+    compact: false,
+  );
+}
+
 class _StatPeriodSummaryCard extends StatelessWidget {
-  const _StatPeriodSummaryCard({required this.summary});
+  const _StatPeriodSummaryCard({
+    required this.summary,
+    this.compact = false,
+  });
 
   final StatPeriodSummary summary;
+
+  /// 手机两列下每列只有 ~155dp，卡片默认 20dp 内边距会把主值挤到读不出来；
+  /// 紧凑态改用 [FushiSpacingTokens.rowHorizontal]（16dp），多让出 8dp 正文宽。
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -292,6 +368,9 @@ class _StatPeriodSummaryCard extends StatelessWidget {
           color: colorScheme.onSurfaceVariant,
         );
     final Widget card = FushiCard(
+      padding: compact
+          ? EdgeInsets.all(tokens.spacing.rowHorizontal)
+          : EdgeInsets.all(tokens.spacing.card),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/fushi/test/pages/stat_period_summary_grid_columns_test.dart
+++ b/fushi/test/pages/stat_period_summary_grid_columns_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/pages/implementations/stat_shared.dart';
+
+/// 统计中心「今日 / 本周 / 本月 / 全部」在手机上只显示一列的回归测试。
+///
+/// 根因：[buildStatPeriodSummaryGrid] 旧实现按「可用宽度 ≥ 380」判两列，但这层
+/// 外面还有 20dp 的左右内边距，360dp 手机到这里只剩 320dp、412dp 大屏手机也只有
+/// 372dp——阈值结构上高于任何手机宽度，两列分支在手机上永远走不到。修复：改按
+/// 实际算出的**列宽**判（[resolveStatPeriodSummaryLayout]）。
+void main() {
+  // 生产实参：wideGap = gap * 1.5 = 12，compactGap = gap = 8。
+  const double wideGap = 12;
+  const double compactGap = 8;
+
+  StatPeriodSummaryLayout layoutAt(double maxWidth) =>
+      resolveStatPeriodSummaryLayout(
+        maxWidth: maxWidth,
+        wideGap: wideGap,
+        compactGap: compactGap,
+      );
+
+  group('resolveStatPeriodSummaryLayout', () {
+    test('phone widths get two columns', () {
+      // 360dp 手机 − 2×20dp 内边距 = 320dp；旧阈值 380 在这里判单列。
+      expect(layoutAt(320).columnWidth, isNotNull);
+      // 412dp 大屏手机 − 40 = 372dp，同样低于旧阈值 380。
+      expect(layoutAt(372).columnWidth, isNotNull);
+      // 375dp iPhone − 40 = 335dp。
+      expect(layoutAt(335).columnWidth, isNotNull);
+    });
+
+    test('narrow columns switch the card to compact padding', () {
+      expect(layoutAt(320).compact, isTrue);
+      // 平板宽度列宽充裕，保持原内边距。
+      final StatPeriodSummaryLayout tablet = layoutAt(728);
+      expect(tablet.compact, isFalse);
+      expect(tablet.columnWidth, (728 - wideGap) / 2);
+    });
+
+    test('very narrow widths fall back to a single column', () {
+      // 320dp 小屏机 − 40 = 280dp：两种间距下列宽都 < 144，退单列。
+      final StatPeriodSummaryLayout tiny = layoutAt(280);
+      expect(tiny.columnWidth, isNull);
+      expect(tiny.gap, wideGap);
+      expect(tiny.compact, isFalse);
+    });
+
+    test('compact gap rescues widths that just miss with the wide gap', () {
+      // (maxWidth − 12) / 2 < 144 <= (maxWidth − 8) / 2 的窄带：296..299。
+      final StatPeriodSummaryLayout squeezed = layoutAt(296);
+      expect(squeezed.columnWidth, isNotNull);
+      expect(squeezed.gap, compactGap);
+    });
+
+    test('unbounded width falls back to a single column', () {
+      expect(layoutAt(double.infinity).columnWidth, isNull);
+    });
+
+    test('two columns never overflow the available width', () {
+      for (double w = 144; w <= 900; w += 1) {
+        final StatPeriodSummaryLayout l = layoutAt(w);
+        final double? column = l.columnWidth;
+        if (column == null) continue;
+        expect(column * 2 + l.gap, lessThanOrEqualTo(w + 0.001),
+            reason: 'maxWidth=$w');
+        expect(column, greaterThanOrEqualTo(kStatPeriodSummaryMinColumnWidth),
+            reason: 'maxWidth=$w');
+      }
+    });
+  });
+
+  testWidgets('four period cards lay out 2x2 at phone width',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) => buildStatPeriodSummaryGrid(
+            context,
+            const <StatPeriodSummary>[
+              StatPeriodSummary(label: 'Today', primaryValue: '12 min'),
+              StatPeriodSummary(label: 'Week', primaryValue: '3 hr 20 min'),
+              StatPeriodSummary(label: 'Month', primaryValue: '18 hr 5 min'),
+              StatPeriodSummary(label: 'All', primaryValue: '412 hr 9 min'),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final List<double> lefts = <double>[];
+    final List<double> tops = <double>[];
+    for (final String label in <String>['Today', 'Week', 'Month', 'All']) {
+      final Offset o = tester.getTopLeft(find.text(label));
+      lefts.add(o.dx);
+      tops.add(o.dy);
+    }
+    // 两列：1/3 同列左对齐、2/4 同列左对齐，且第二列明显靠右。
+    expect(lefts[0], lefts[2]);
+    expect(lefts[1], lefts[3]);
+    expect(lefts[1], greaterThan(lefts[0] + 100));
+    // 两行：1/2 同行、3/4 同行，第二行在下。
+    expect(tops[0], tops[1]);
+    expect(tops[2], tops[3]);
+    expect(tops[2], greaterThan(tops[0]));
+  });
+}


### PR DESCRIPTION
## 问题

手机上进统计中心，「今日 / 本周 / 本月 / 全部」四张时段汇总卡永远只排一列，右边整片空白。

## 根因

`buildStatPeriodSummaryGrid`（`fushi/lib/src/pages/implementations/stat_shared.dart`）按
「可用宽度 ≥ 380」判两列：

```dart
final bool twoColumns =
    constraints.maxWidth.isFinite && constraints.maxWidth >= 380;
```

但 `LayoutBuilder` 外面就套着 `EdgeInsets.all(tokens.spacing.card)`（20dp），传进来的
`maxWidth` 左右各已经扣掉 20dp：

| 手机 | 屏宽 | 到 `maxWidth` 时 | ≥ 380？ |
|---|---|---|---|
| 常规 Android | 360dp | 320dp | ❌ |
| iPhone | 375dp | 335dp | ❌ |
| 大屏 Android（Pixel Pro 等） | 412dp | 372dp | ❌ |

阈值结构上高于**任何**手机宽度，所以两列分支在手机端永远走不到。统计中心、阅读统计、
视频统计、游戏统计四个页面共用这个 helper，症状一致。

## 修复

判据从「屏幕宽度阈值」改成「实际算出的列宽」，抽成纯函数 `resolveStatPeriodSummaryLayout`：

- 先按 `wideGap`(12) 试两列；差几 dp 放不下时改 `compactGap`(8) 再试一次
- 列宽 ≥ `kStatPeriodSummaryMinColumnWidth`(144) 就排两列，否则才退单列
- 列宽 < `kStatPeriodSummaryCompactColumnWidth`(200) 时，卡片内边距由 20dp 收到 16dp
  （手机两列每列只有 ~155dp，20dp 四边内边距会吃掉四成可用宽度，主值被 `FittedBox`
  压得比单列还小）

结果：360 / 375 / 412dp 手机都变成 2×2；320dp 小屏机仍单列（列宽不够，压下去不如不排）。

## 验证

- 新增 `fushi/test/pages/stat_period_summary_grid_columns_test.dart`
  - 纯函数层：钉住 320 / 335 / 372dp 判两列、280dp 退单列、紧凑间距救窄带、无界宽度退单列
  - 扫宽不变式：144..900dp 逐 dp 检查「两列宽度和 + 间距 ≤ 可用宽度」且列宽不低于下限
  - widget 层：360×800 真实渲染四张卡，按 `getTopLeft` 断言 2 列 × 2 行
- `flutter analyze`：No issues found
- 相邻统计测试（`stat_*` / `statistics_center_static` / `game_statistics_page_guard` /
  `reading_statistics_*` 等）+ `bugs_per_file_guard`：全绿
- 另在 360dp × dpr3 下渲染真实像素人工复核，四个值均完整可读（含最长的
  「1234 小时 56 分钟」，仅被 `FittedBox` 轻微缩放）

## 注

380..412dp 这一窄带（小平板分屏）此前是两列 + 20dp 内边距，现在是两列 + 16dp 内边距，
属阈值统一后的附带变化。

BUG-2396

https://claude.ai/code/session_01CYNBTKwZxvqqK8qJ7yPNSU
