### PR TITLE
fix(lookup): 墨水屏瞬时滚动接上触摸拖动，不再走原生惯性（BUG-2403）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2215 条。点号进各自文件。
+> 共 2216 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2403](bugs/BUG-2403-eink-popup-touch-instant-scroll.md) | ✅ | ✅ | 墨水屏瞬时滚动只接了滚轮，触摸拖动仍走原生惯性滚动 |
 | [BUG-2402](bugs/BUG-2402-mobile-library-layout.md) | ✅ | ✅ | 手机标签页头留白与筛选工具堆叠 |
 | [BUG-2400](bugs/BUG-2400-remote-manga-empty-content.md) | ✅ | ✅ | 远端空漫画合集被标记为可下载内容 |
 | [BUG-2399](bugs/BUG-2399-reader-chapter-stale-progress.md) | ✅ | ✅ | 小说跨章节晚到进度污染阅读字数和速度 |

--- a/docs/bugs/BUG-2403-eink-popup-touch-instant-scroll.md
+++ b/docs/bugs/BUG-2403-eink-popup-touch-instant-scroll.md
@@ -1,0 +1,57 @@
+## BUG-2403 · 墨水屏瞬时滚动只接了滚轮，触摸拖动仍走原生惯性滚动
+- **报告**：2026-09-10（用户：墨水屏的查词弹窗上下瞬时滑动还没做吗）
+- **真实性**：✅ 真 bug —— 根因 `fushi/assets/popup/popup.js:5818`（BUG-2284 把
+  `window.__fushiPopupInstantScroll` 只接进了 `__fushiPopupWheelListener`，全文件没有第二个
+  消费点）。设置项 `lookup.popup_instant_scroll` 的文案写的是「Jump the lookup popup by fixed
+  distances without animated scrolling **for e-ink screens**」（`strings.i18n.json:2710`），
+  没有任何「仅限滚轮」的限定；可墨水屏设备是 Android e-ink 阅读器，**根本没有滚轮**，用户是用
+  手指上下滑弹窗的。那条路径此前 100% 走 WebView 原生滚动：逐帧连续位移 + 松手后的惯性 fling，
+  正是文案承诺要消掉的「animated scrolling」。于是在唯一真正的墨水屏输入方式上，这个开关等于
+  没接线——与 BUG-2284 ① 认定的「三元两个分支等价 = 空开关」同一类，只是换了输入设备。
+  弹窗的其余 eink 动效此前都已归零（入场淡入 `dictionary_popup_layer.dart:500`、侧滑关闭补间
+  同文件 `:1348`、顶栏 swipe `swipe_dismiss_wrapper.dart:79`、CSS 通配 `popup.css:1987` 关掉
+  全部 transition/animation），唯独触摸滚动这条漏网。
+- **[x] ① 已修复** —— `popup.js` 新增触摸半边（三镜像逐字节同步：`assets/popup/`、
+  `assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`）。与滚轮同源但不同形：
+  滚轮是离散 notch，可以「一格跳半屏」；手指是连续位移，同样按固定距离跳，但量化的是**手指行程**
+  ——每滑够一步（视口 × `POPUP_EINK_TOUCH_VIEWPORT_FRACTION` 0.25，夹在 `[MIN_STEP 24, 一屏]`）
+  就 `scrollBy` 一步、锚点同步推进一步，即「量化的 1:1 跟手」。保留方向反馈（与
+  `_BodySwipeDismissDetector` 跟手期刻意保留 `Transform.translate` 同理，见 BUG-2283 备注），
+  同时把整段滑动的重绘从每帧一次压成每步一次，`preventDefault` 再把松手惯性彻底掐掉——墨水屏上
+  「松手后还要糊几秒」正是惯性拖出来的。偏好仍读 BUG-2284 已铺好的同一个
+  `window.__fushiPopupInstantScroll`，不新增下发通道。
+  - **接管判定放在 `touchstart` 一次定死，`touchmove` 里不再判轴**：Chromium 只在某帧 touchmove
+    未被 `preventDefault` 时才启动原生滚动，一旦启动，后续帧 `cancelable` 变 false、再
+    `preventDefault` 也没用。若留一段「判轴死区」不拦截，Android ~8dp 的 touch slop 恰好落在死区
+    里，原生滚动会抢先起步 → 变成原生滚动与瞬跳**同时**位移（双倍）。所以要么从第一帧就拿下整轮
+    手势，要么整轮不碰。
+  - 整轮不碰的三条豁免（都在 `touchstart` 判）：多指（缩放/系统手势）、已有选区（选区手柄拖动也是
+    touchmove，拦了就拖不动手柄，嵌套查词要靠它选词）、手指落在**真正横向溢出**的祖先上
+    （`.expression-scroll` / `.gloss-image-scroll` / `.gloss-sc-table-container`）——判据是
+    `scrollWidth > clientWidth` 的实际溢出 + `overflowX` 为 auto/scroll，不是只看 CSS 声明，
+    所以短词头那种没溢出的 `.expression-scroll` 不会误触发豁免。
+  - 只在 in-app 弹窗挂载：扩展镜像里 popup.js 与宿主页共用 document，非 passive 的 touchmove 会
+    掐掉宿主页整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow host，见 BUG-1078），而
+    墨水屏场景是 app 内弹窗。三镜像仍逐字节一致，差别只在运行期分支。
+- **[x] ② 已加自动化测试** —— `fushi/test/dictionary/popup_touch_instant_scroll_guard_test.dart`
+  共 23 条（7 条 × 3 镜像 + 2 条跨镜像）。单测里没有真 WebView，滚动本身无法直接断言（与既有
+  `popup_instant_scroll_guard_test.dart` 同处境），所以钉死的是「开关 → 触摸行为」这条线上每一段
+  **载荷位**的存在性：偏好真被触摸入口消费、touchmove 是 `passive:false` 且真的 `preventDefault`
+  （少任一条则惯性照旧且**无任何报错**）、步长来自视口比例而非 travel 的函数、锚点按步长推进
+  （少了它一次 touchmove 就跳到底）、补步循环有防御性上限、三条豁免都在 touchstart 判、横向判据
+  看实际溢出、扩展分支不得挂 document 级触摸监听、三镜像的触摸块逐字节一致。
+  判别力验证：把 `{ passive: false }` 临时改成 `true`，passive 守卫 + 三镜像一致性 2 条立刻红
+  （退出码 1）；恢复后 23/23 绿。相邻既有守卫（`popup_instant_scroll_guard` /
+  `browser_extension_popup_parity_guard` / `popup_css_eink_guard` /
+  `browser_extension_popup_wheel_surface_guard` / `popup_wheel_native_residual_guard`）40/40 绿。
+- **备注**：
+  - **真机未验**：本机没有 Android 墨水屏设备，「手指滑动不再有惯性、按步跳」这条只在源码与守卫层
+    验过，属 `implemented_unverified`。要落实需在真机开「查词 › 瞬时滚动」后滑弹窗对比。
+  - 盘点时另发现三条**本次未修**的相邻缺口，都不在「触摸滑动」这条路径上，留作独立条目：
+    ① `popupInstantScroll` 与 `einkMode` 完全解耦（`preferences_repository.dart:721-726` 有明确
+    注释说这是刻意的 opt-in），所以开了墨水屏主题**不会**自动获得瞬时滚动，得再手动开一个开关；
+    是否让 eink 隐含开启是产品决定，不在本 bug 内改。
+    ② 滚动条 thumb 的「滚动时浮现 / 900ms 后消失」（`popup.js:6041` + `popup.css:234`）在
+    `html.eink` 下无覆盖，等于每次滚完额外一次延迟局部刷新，且 thumb 是半透明灰。
+    ③ 扩展侧从来没人挂 `eink` class（只有 `popup_settings_injection.dart:112` 一处），
+    `vendor/content.css` 里整块 eink 覆盖是死码。

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -5858,6 +5858,137 @@ if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
     document.addEventListener('wheel', __fushiPopupWheelListener, { passive: false });
 }
 
+/* BUG-2403: 墨水屏「瞬时滚动」（app 设置 lookup.popup_instant_scroll）的**触摸**半边。
+   BUG-2284 把 window.__fushiPopupInstantScroll 接进了 wheel 监听，但墨水屏设备
+   （Android e-ink 阅读器）上根本没有滚轮——用户是用手指上下**滑**弹窗的，而那条路径
+   此前 100% 走 WebView 原生滚动：逐帧连续位移 + 松手后的惯性 fling。设置文案承诺的正是
+   「按固定距离瞬时跳动、无动画滚动（for e-ink screens）」，触摸路径不认这个开关 =
+   在唯一真正的墨水屏输入方式上开关等于没接线（与 BUG-2284 ① 同一类空开关）。
+
+   与滚轮同源但不同形：滚轮是离散 notch，可以「一格跳半屏」；手指是连续位移，同样按
+   固定距离跳，但量化的是**手指行程**——每滑够一步就跳一步，即「量化的 1:1 跟手」。
+   这样既保留方向反馈（与 _BodySwipeDismissDetector 跟手期刻意保留 Transform.translate
+   同理，见 BUG-2283 备注），又把整段滑动的重绘从每帧一次压成每步一次，preventDefault
+   再把松手惯性彻底掐掉——墨水屏上「松手后还要糊几秒」正是惯性拖出来的。
+
+   接管判定放在 touchstart 一次定死，touchmove 里不再判轴：Chromium 只在某一帧
+   touchmove 未被 preventDefault 时才会启动原生滚动，一旦启动，后续帧的 cancelable
+   就变 false、再 preventDefault 也没用。若留一段「判轴死区」不拦截，Android 的
+   ~8dp touch slop 恰好落在死区里，原生滚动会抢先起步 → 变成原生滚动与瞬跳同时位移。
+   所以要么从第一帧就拿下整轮手势，要么整轮不碰。
+
+   整轮不碰的三个豁免（都在 touchstart 判）：多指（缩放/系统手势）、已有选区（选区手柄
+   拖动也是 touchmove，拦了就拖不动手柄，嵌套查词要靠它选词）、以及手指落在**真正横向
+   溢出**的祖先上（.expression-scroll / .gloss-image-scroll / .gloss-sc-table-container，
+   见 popup.css）——拿下整轮会连它们的横滚一起掐掉。判据是实际溢出而非 CSS 声明，所以
+   短词头那种没溢出的 .expression-scroll 不会误触发豁免。
+
+   只在 in-app 弹窗挂载：扩展镜像里 popup.js 与宿主页共用 document，非 passive 的
+   touchmove 会掐掉宿主页整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow
+   host，见 BUG-1078），而墨水屏场景是 app 内弹窗，扩展侧没有这个需求。三镜像仍逐字节
+   一致（TODO-1267 parity guard），差别只在运行期分支。 */
+const POPUP_EINK_TOUCH_VIEWPORT_FRACTION = 0.25; // 一步跳 1/4 屏
+const POPUP_EINK_TOUCH_MIN_STEP = 24;            // 视口异常小时的下限（布局 px）
+// 防御性上限：一帧内最多补几步。正常一帧手指走不了几步，这个上限只为杜绝异常输入
+// （极端 zoom / 视口塌成 0）下的死循环。
+const POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE = 20;
+let _popupEinkTouchId = null;
+let _popupEinkTouchScroller = null;
+let _popupEinkTouchAnchorY = 0;
+
+function __fushiPopupEinkTouchReset() {
+    _popupEinkTouchId = null;
+    _popupEinkTouchScroller = null;
+}
+
+// 一步的距离：被滚表面视口高度 × FRACTION，夹在 [MIN_STEP, 一屏] 内（永不一步跳过整屏
+// 内容）。复用滚轮那条的 extent 解析——zoom → 布局 px 的换算已经在里面。
+function popupEinkTouchStep(scroller) {
+    const extent = popupEinkWheelExtent(scroller);
+    return Math.max(
+        POPUP_EINK_TOUCH_MIN_STEP,
+        Math.min(extent, extent * POPUP_EINK_TOUCH_VIEWPORT_FRACTION));
+}
+
+// 从触点向上找**真正横向溢出**的祖先（不是只看 CSS 声明）。找到 → 本轮不接管。
+function __fushiPopupEinkTouchHasHorizontalScroll(node) {
+    let el = node;
+    let hops = 0;
+    while (el && el.nodeType === 1 && hops < 32) {
+        if (el.scrollWidth > el.clientWidth + 1) {
+            let overflowX = '';
+            try {
+                overflowX = (window.getComputedStyle(el) || {}).overflowX || '';
+            } catch (_) { overflowX = ''; }
+            if (overflowX === 'auto' || overflowX === 'scroll') return true;
+        }
+        el = el.parentElement || (el.parentNode && el.parentNode.host) || null;
+        hops++;
+    }
+    return false;
+}
+
+function __fushiPopupEinkTouchStart(e) {
+    __fushiPopupEinkTouchReset();
+    if (!window.__fushiPopupInstantScroll) return;
+    if (!__fushiEventInsidePopup(e)) return;
+    if (!e.touches || e.touches.length !== 1) return;
+    try {
+        const sel = __fushiSel();
+        if (sel && !sel.isCollapsed) return;
+    } catch (_) { /* 读不到选区就按「无选区」走，最坏是拦了一次手柄拖动 */ }
+    if (__fushiPopupEinkTouchHasHorizontalScroll(__fushiEventTarget(e))) return;
+    const t = e.touches[0];
+    _popupEinkTouchId = t.identifier;
+    _popupEinkTouchScroller = __fushiWheelScroller(e);
+    _popupEinkTouchAnchorY = t.clientY;
+}
+
+function __fushiPopupEinkTouchMove(e) {
+    if (_popupEinkTouchId === null) return;
+    if (!window.__fushiPopupInstantScroll) { __fushiPopupEinkTouchReset(); return; }
+    // 中途落下第二根指针：本轮永久失效（不能把剩余指针重新解释成新的一次纵滑，
+    // 与 _BodySwipeDismissDetector 的 BUG-1242 同一条纪律）。
+    if (!e.touches || e.touches.length !== 1) { __fushiPopupEinkTouchReset(); return; }
+    const t = e.touches[0];
+    if (t.identifier !== _popupEinkTouchId) { __fushiPopupEinkTouchReset(); return; }
+    // 已经不可取消 = 原生滚动已起步（理论上进不来，touchstart 已拿下整轮）。此时再跳
+    // 会和原生一起双倍位移，直接弃掉本轮。
+    if (e.cancelable === false) { __fushiPopupEinkTouchReset(); return; }
+    e.preventDefault();
+    const step = popupEinkTouchStep(_popupEinkTouchScroller);
+    if (!(step > 0)) return;
+    // 手指上滑（clientY 变小）→ 正 → 内容下滚，与原生方向一致。
+    let travel = _popupEinkTouchAnchorY - t.clientY;
+    let guard = 0;
+    while (Math.abs(travel) >= step && guard < POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE) {
+        const dir = travel > 0 ? 1 : -1;
+        const jump = Math.trunc(dir * step);
+        if (jump === 0) break;
+        if (_popupEinkTouchScroller) {
+            _popupEinkTouchScroller.scrollBy({ top: jump, behavior: 'auto' });
+        } else {
+            window.scrollBy({ top: jump, behavior: 'auto' });
+        }
+        // 锚点跟着走一步：手指要再滑满一步才触发下一跳（这就是 1:1 量化）。
+        _popupEinkTouchAnchorY -= dir * step;
+        travel -= dir * step;
+        guard++;
+    }
+}
+
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // 扩展镜像：不挂（理由见上方块注释）。留空分支是为了让三镜像逐字节一致时，
+    // 「扩展侧刻意不挂」这条决定在代码里看得见，而不是靠读注释推断。
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗。touchmove 必须 passive:false，否则
+    // preventDefault 无效、惯性照旧（这正是 BUG-2403 要掐的东西）。
+    document.addEventListener('touchstart', __fushiPopupEinkTouchStart, { passive: true });
+    document.addEventListener('touchmove', __fushiPopupEinkTouchMove, { passive: false });
+    document.addEventListener('touchend', __fushiPopupEinkTouchReset, { passive: true });
+    document.addEventListener('touchcancel', __fushiPopupEinkTouchReset, { passive: true });
+}
+
 
 let _popupMouseDownPos = null;
 function __fushiPopupMouseDown(e) {

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -5858,6 +5858,137 @@ if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
     document.addEventListener('wheel', __fushiPopupWheelListener, { passive: false });
 }
 
+/* BUG-2403: 墨水屏「瞬时滚动」（app 设置 lookup.popup_instant_scroll）的**触摸**半边。
+   BUG-2284 把 window.__fushiPopupInstantScroll 接进了 wheel 监听，但墨水屏设备
+   （Android e-ink 阅读器）上根本没有滚轮——用户是用手指上下**滑**弹窗的，而那条路径
+   此前 100% 走 WebView 原生滚动：逐帧连续位移 + 松手后的惯性 fling。设置文案承诺的正是
+   「按固定距离瞬时跳动、无动画滚动（for e-ink screens）」，触摸路径不认这个开关 =
+   在唯一真正的墨水屏输入方式上开关等于没接线（与 BUG-2284 ① 同一类空开关）。
+
+   与滚轮同源但不同形：滚轮是离散 notch，可以「一格跳半屏」；手指是连续位移，同样按
+   固定距离跳，但量化的是**手指行程**——每滑够一步就跳一步，即「量化的 1:1 跟手」。
+   这样既保留方向反馈（与 _BodySwipeDismissDetector 跟手期刻意保留 Transform.translate
+   同理，见 BUG-2283 备注），又把整段滑动的重绘从每帧一次压成每步一次，preventDefault
+   再把松手惯性彻底掐掉——墨水屏上「松手后还要糊几秒」正是惯性拖出来的。
+
+   接管判定放在 touchstart 一次定死，touchmove 里不再判轴：Chromium 只在某一帧
+   touchmove 未被 preventDefault 时才会启动原生滚动，一旦启动，后续帧的 cancelable
+   就变 false、再 preventDefault 也没用。若留一段「判轴死区」不拦截，Android 的
+   ~8dp touch slop 恰好落在死区里，原生滚动会抢先起步 → 变成原生滚动与瞬跳同时位移。
+   所以要么从第一帧就拿下整轮手势，要么整轮不碰。
+
+   整轮不碰的三个豁免（都在 touchstart 判）：多指（缩放/系统手势）、已有选区（选区手柄
+   拖动也是 touchmove，拦了就拖不动手柄，嵌套查词要靠它选词）、以及手指落在**真正横向
+   溢出**的祖先上（.expression-scroll / .gloss-image-scroll / .gloss-sc-table-container，
+   见 popup.css）——拿下整轮会连它们的横滚一起掐掉。判据是实际溢出而非 CSS 声明，所以
+   短词头那种没溢出的 .expression-scroll 不会误触发豁免。
+
+   只在 in-app 弹窗挂载：扩展镜像里 popup.js 与宿主页共用 document，非 passive 的
+   touchmove 会掐掉宿主页整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow
+   host，见 BUG-1078），而墨水屏场景是 app 内弹窗，扩展侧没有这个需求。三镜像仍逐字节
+   一致（TODO-1267 parity guard），差别只在运行期分支。 */
+const POPUP_EINK_TOUCH_VIEWPORT_FRACTION = 0.25; // 一步跳 1/4 屏
+const POPUP_EINK_TOUCH_MIN_STEP = 24;            // 视口异常小时的下限（布局 px）
+// 防御性上限：一帧内最多补几步。正常一帧手指走不了几步，这个上限只为杜绝异常输入
+// （极端 zoom / 视口塌成 0）下的死循环。
+const POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE = 20;
+let _popupEinkTouchId = null;
+let _popupEinkTouchScroller = null;
+let _popupEinkTouchAnchorY = 0;
+
+function __fushiPopupEinkTouchReset() {
+    _popupEinkTouchId = null;
+    _popupEinkTouchScroller = null;
+}
+
+// 一步的距离：被滚表面视口高度 × FRACTION，夹在 [MIN_STEP, 一屏] 内（永不一步跳过整屏
+// 内容）。复用滚轮那条的 extent 解析——zoom → 布局 px 的换算已经在里面。
+function popupEinkTouchStep(scroller) {
+    const extent = popupEinkWheelExtent(scroller);
+    return Math.max(
+        POPUP_EINK_TOUCH_MIN_STEP,
+        Math.min(extent, extent * POPUP_EINK_TOUCH_VIEWPORT_FRACTION));
+}
+
+// 从触点向上找**真正横向溢出**的祖先（不是只看 CSS 声明）。找到 → 本轮不接管。
+function __fushiPopupEinkTouchHasHorizontalScroll(node) {
+    let el = node;
+    let hops = 0;
+    while (el && el.nodeType === 1 && hops < 32) {
+        if (el.scrollWidth > el.clientWidth + 1) {
+            let overflowX = '';
+            try {
+                overflowX = (window.getComputedStyle(el) || {}).overflowX || '';
+            } catch (_) { overflowX = ''; }
+            if (overflowX === 'auto' || overflowX === 'scroll') return true;
+        }
+        el = el.parentElement || (el.parentNode && el.parentNode.host) || null;
+        hops++;
+    }
+    return false;
+}
+
+function __fushiPopupEinkTouchStart(e) {
+    __fushiPopupEinkTouchReset();
+    if (!window.__fushiPopupInstantScroll) return;
+    if (!__fushiEventInsidePopup(e)) return;
+    if (!e.touches || e.touches.length !== 1) return;
+    try {
+        const sel = __fushiSel();
+        if (sel && !sel.isCollapsed) return;
+    } catch (_) { /* 读不到选区就按「无选区」走，最坏是拦了一次手柄拖动 */ }
+    if (__fushiPopupEinkTouchHasHorizontalScroll(__fushiEventTarget(e))) return;
+    const t = e.touches[0];
+    _popupEinkTouchId = t.identifier;
+    _popupEinkTouchScroller = __fushiWheelScroller(e);
+    _popupEinkTouchAnchorY = t.clientY;
+}
+
+function __fushiPopupEinkTouchMove(e) {
+    if (_popupEinkTouchId === null) return;
+    if (!window.__fushiPopupInstantScroll) { __fushiPopupEinkTouchReset(); return; }
+    // 中途落下第二根指针：本轮永久失效（不能把剩余指针重新解释成新的一次纵滑，
+    // 与 _BodySwipeDismissDetector 的 BUG-1242 同一条纪律）。
+    if (!e.touches || e.touches.length !== 1) { __fushiPopupEinkTouchReset(); return; }
+    const t = e.touches[0];
+    if (t.identifier !== _popupEinkTouchId) { __fushiPopupEinkTouchReset(); return; }
+    // 已经不可取消 = 原生滚动已起步（理论上进不来，touchstart 已拿下整轮）。此时再跳
+    // 会和原生一起双倍位移，直接弃掉本轮。
+    if (e.cancelable === false) { __fushiPopupEinkTouchReset(); return; }
+    e.preventDefault();
+    const step = popupEinkTouchStep(_popupEinkTouchScroller);
+    if (!(step > 0)) return;
+    // 手指上滑（clientY 变小）→ 正 → 内容下滚，与原生方向一致。
+    let travel = _popupEinkTouchAnchorY - t.clientY;
+    let guard = 0;
+    while (Math.abs(travel) >= step && guard < POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE) {
+        const dir = travel > 0 ? 1 : -1;
+        const jump = Math.trunc(dir * step);
+        if (jump === 0) break;
+        if (_popupEinkTouchScroller) {
+            _popupEinkTouchScroller.scrollBy({ top: jump, behavior: 'auto' });
+        } else {
+            window.scrollBy({ top: jump, behavior: 'auto' });
+        }
+        // 锚点跟着走一步：手指要再滑满一步才触发下一跳（这就是 1:1 量化）。
+        _popupEinkTouchAnchorY -= dir * step;
+        travel -= dir * step;
+        guard++;
+    }
+}
+
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // 扩展镜像：不挂（理由见上方块注释）。留空分支是为了让三镜像逐字节一致时，
+    // 「扩展侧刻意不挂」这条决定在代码里看得见，而不是靠读注释推断。
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗。touchmove 必须 passive:false，否则
+    // preventDefault 无效、惯性照旧（这正是 BUG-2403 要掐的东西）。
+    document.addEventListener('touchstart', __fushiPopupEinkTouchStart, { passive: true });
+    document.addEventListener('touchmove', __fushiPopupEinkTouchMove, { passive: false });
+    document.addEventListener('touchend', __fushiPopupEinkTouchReset, { passive: true });
+    document.addEventListener('touchcancel', __fushiPopupEinkTouchReset, { passive: true });
+}
+
 
 let _popupMouseDownPos = null;
 function __fushiPopupMouseDown(e) {

--- a/fushi/test/dictionary/popup_touch_instant_scroll_guard_test.dart
+++ b/fushi/test/dictionary/popup_touch_instant_scroll_guard_test.dart
@@ -1,0 +1,239 @@
+// BUG-2403 回归守卫：查词弹窗「瞬时滚动」（lookup.popup_instant_scroll）的**触摸**半边。
+//
+// 原始 bug：BUG-2284 只把 window.__fushiPopupInstantScroll 接进了 wheel 监听，可墨水屏
+// 设备（Android e-ink 阅读器）上没有滚轮——用户是用手指上下滑弹窗的。那条路径此前
+// 100% 走 WebView 原生滚动：逐帧连续位移 + 松手惯性 fling，正是设置文案（"Jump the
+// lookup popup by fixed distances without animated scrolling for e-ink screens."）
+// 承诺要消掉的东西。于是在唯一真正的墨水屏输入方式上，这个开关等于没接线。
+//
+// 单测里没有真 WebView，滚动本身无法直接断言（与 popup_instant_scroll_guard_test 同
+// 处境），所以本守卫钉死的是「开关 → 触摸行为」这条线上每一段**载荷位**的存在性：
+// 任何一段被摘掉，触摸路径都会静默退回原生惯性滚动，而 UI 上看不出任何差别。
+//
+// flutter test cwd 是 fushi 包根。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const List<String> popupCopies = <String>[
+    'assets/popup/popup.js', // in-app 渲染器（真源）
+    'assets/browser_extension/vendor/popup.js', // 扩展 bundle 镜像
+    '../tools/browser-extension/vendor/popup.js', // 扩展 tools 镜像
+  ];
+
+  group('BUG-2403 popup touch instant-scroll guard', () {
+    for (final String path in popupCopies) {
+      late String src;
+
+      setUp(() => src = File(path).readAsStringSync());
+
+      test('[$path] 触摸路径真的消费 __fushiPopupInstantScroll', () {
+        // 触摸接管的入口必须读这个偏好——否则开关对手指无效（原始 bug）。
+        final int startAt = src.indexOf('function __fushiPopupEinkTouchStart(');
+        expect(
+          startAt,
+          greaterThanOrEqualTo(0),
+          reason: '触摸接管必须有独立入口 __fushiPopupEinkTouchStart',
+        );
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        expect(moveAt, greaterThan(startAt));
+        final String startBody = src.substring(startAt, moveAt);
+        expect(
+          startBody,
+          contains('window.__fushiPopupInstantScroll'),
+          reason: 'touchstart 必须按偏好决定是否接管，否则开关对触摸无效',
+        );
+      });
+
+      test('[$path] touchmove 是 passive:false 且真的 preventDefault', () {
+        // 这两条是「掐掉原生惯性」的全部载荷：passive 默认为 true 时
+        // preventDefault 静默失效，惯性照旧，bug 完全复发且无任何报错。
+        expect(
+          src,
+          contains(
+            "document.addEventListener('touchmove', __fushiPopupEinkTouchMove, "
+            '{ passive: false });',
+          ),
+          reason: 'touchmove 必须非 passive，否则 preventDefault 无效、惯性照旧',
+        );
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        final int tailAt = src.indexOf(
+          "if (typeof chrome !== 'undefined'",
+          moveAt,
+        );
+        expect(tailAt, greaterThan(moveAt));
+        final String moveBody = src.substring(moveAt, tailAt);
+        expect(
+          moveBody,
+          contains('e.preventDefault();'),
+          reason: '不 preventDefault 就掐不掉原生滚动与松手惯性',
+        );
+      });
+
+      test('[$path] 跳跃是固定步长，不按手指位移比例缩放', () {
+        // 设置文案承诺的是「按固定距离瞬时跳动」。步长必须来自视口比例，而不是
+        // travel 的函数——后者就退化回连续滚动了（只是换了个实现）。
+        expect(src, contains('POPUP_EINK_TOUCH_VIEWPORT_FRACTION'));
+        expect(src, contains('POPUP_EINK_TOUCH_MIN_STEP'));
+        expect(src, contains('function popupEinkTouchStep('));
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        final int tailAt = src.indexOf(
+          "if (typeof chrome !== 'undefined'",
+          moveAt,
+        );
+        final String moveBody = src.substring(moveAt, tailAt);
+        expect(
+          moveBody.contains('travel *'),
+          isFalse,
+          reason: '步长不得按手指位移比例缩放——那就不是「固定距离跳动」了',
+        );
+        expect(
+          moveBody,
+          contains('popupEinkTouchStep('),
+          reason: '每帧的步长必须实时解析（视口会随 zoom/旋转变）',
+        );
+      });
+
+      test('[$path] 锚点按步长推进 = 量化的 1:1 跟手', () {
+        // 跳完一步后锚点必须跟着走一步，手指要再滑满一步才触发下一跳。少了这行，
+        // travel 永远 >= step，一次 touchmove 就会把内容一路跳到底。
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        final int tailAt = src.indexOf(
+          "if (typeof chrome !== 'undefined'",
+          moveAt,
+        );
+        final String moveBody = src.substring(moveAt, tailAt);
+        expect(
+          moveBody,
+          contains('_popupEinkTouchAnchorY -= dir * step;'),
+          reason: '锚点不推进 → 一次 touchmove 跳到底',
+        );
+        expect(
+          moveBody,
+          contains('POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE'),
+          reason: '补步循环必须有防御性上限，杜绝异常视口下的死循环',
+        );
+      });
+
+      test('[$path] 三条整轮豁免都在 touchstart 判', () {
+        // 接管必须在 touchstart 一次定死：Chromium 只在某帧 touchmove 未被
+        // preventDefault 时才启动原生滚动，一旦启动后续帧 cancelable 就变 false。
+        // 留「判轴死区」不拦截，Android ~8dp touch slop 恰好落在死区里 → 原生滚动
+        // 抢先起步，变成原生与瞬跳同时位移。所以豁免只能在 touchstart 判。
+        final int startAt = src.indexOf('function __fushiPopupEinkTouchStart(');
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        final String startBody = src.substring(startAt, moveAt);
+
+        expect(
+          startBody,
+          contains('e.touches.length !== 1'),
+          reason: '多指（缩放/系统手势）必须整轮不接管',
+        );
+        expect(
+          startBody,
+          contains('sel.isCollapsed'),
+          reason: '已有选区时不接管——选区手柄拖动也是 touchmove，拦了就拖不动手柄',
+        );
+        expect(
+          startBody,
+          contains('__fushiPopupEinkTouchHasHorizontalScroll('),
+          reason: '手指落在真正横向溢出的祖先上时必须整轮交还，否则横滚被一起掐掉',
+        );
+        expect(
+          startBody,
+          contains('__fushiEventInsidePopup(e)'),
+          reason: '扩展镜像与宿主页共用 document，必须只消费弹窗内的事件',
+        );
+      });
+
+      test('[$path] 横向溢出判据看实际溢出，不是只看 CSS 声明', () {
+        // popup.css 里 .expression-scroll 常驻 overflow-x:auto，但短词头根本没溢出。
+        // 只看声明会让绝大多数条目都命中豁免，开关等于又没接线。
+        final int fnAt = src.indexOf(
+          'function __fushiPopupEinkTouchHasHorizontalScroll(',
+        );
+        expect(fnAt, greaterThanOrEqualTo(0));
+        final int endAt = src.indexOf(
+          'function __fushiPopupEinkTouchStart(',
+          fnAt,
+        );
+        final String body = src.substring(fnAt, endAt);
+        expect(
+          body,
+          contains('el.scrollWidth > el.clientWidth'),
+          reason: '必须以实际溢出为判据',
+        );
+        expect(
+          body,
+          allOf(contains("'auto'"), contains("'scroll'")),
+          reason: '还要确认该祖先真的可横滚（overflowX auto/scroll）',
+        );
+      });
+
+      test('[$path] 扩展镜像刻意不挂 document 级触摸监听', () {
+        // 扩展里 popup.js 与宿主页共用 document，非 passive 的 touchmove 会掐掉宿主页
+        // 整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow host，BUG-1078）。
+        // 三镜像逐字节一致，差别只能在运行期分支上。
+        final int tailAt = src.indexOf(
+          "if (typeof chrome !== 'undefined' && !!(chrome.runtime && "
+          'chrome.runtime.id)) {',
+          src.indexOf('function __fushiPopupEinkTouchMove('),
+        );
+        expect(
+          tailAt,
+          greaterThanOrEqualTo(0),
+          reason: '触摸监听的挂载必须按 in-app / 扩展分支',
+        );
+        final String tail = src.substring(tailAt);
+        final int elseAt = tail.indexOf('} else {');
+        expect(elseAt, greaterThan(0));
+        expect(
+          tail.substring(0, elseAt).contains('addEventListener'),
+          isFalse,
+          reason: '扩展分支不得挂任何 document 级触摸监听',
+        );
+      });
+    }
+
+    test('三镜像的触摸块逐字节一致（TODO-1267 parity 的子集自检）', () {
+      final List<String> blocks = popupCopies.map((String path) {
+        final String src = File(path).readAsStringSync();
+        final int from = src.indexOf('/* BUG-2403:');
+        expect(from, greaterThanOrEqualTo(0), reason: '$path 缺少 BUG-2403 触摸块');
+        final int to = src.indexOf(
+          'let _popupMouseDownPos = null;',
+          from,
+        );
+        expect(to, greaterThan(from));
+        return src.substring(from, to);
+      }).toList();
+      expect(blocks[1], blocks[0]);
+      expect(blocks[2], blocks[0]);
+    });
+
+    test('偏好本身仍经既有通道下发（触摸半边不新增下发通道）', () {
+      // 触摸路径读的是 BUG-2284 已经铺好的同一个全局。这条钉死「没有另起炉灶」，
+      // 否则两个半边会各读各的、设置只对其中一半生效。
+      final String injection = File(
+        'lib/src/pages/implementations/popup_settings_injection.dart',
+      ).readAsStringSync();
+      expect(
+        injection,
+        contains(
+          r'window.__fushiPopupInstantScroll = ${appModel.popupInstantScroll};',
+        ),
+      );
+      for (final String path in popupCopies) {
+        final String src = File(path).readAsStringSync();
+        final int startAt = src.indexOf('function __fushiPopupEinkTouchStart(');
+        final int moveAt = src.indexOf('function __fushiPopupEinkTouchMove(');
+        expect(
+          src.substring(startAt, moveAt),
+          isNot(contains('__fushiPopupInstantTouchScroll')),
+          reason: '$path 触摸半边不得另起一个偏好全局',
+        );
+      }
+    });
+  });
+}

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -5858,6 +5858,137 @@ if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
     document.addEventListener('wheel', __fushiPopupWheelListener, { passive: false });
 }
 
+/* BUG-2403: 墨水屏「瞬时滚动」（app 设置 lookup.popup_instant_scroll）的**触摸**半边。
+   BUG-2284 把 window.__fushiPopupInstantScroll 接进了 wheel 监听，但墨水屏设备
+   （Android e-ink 阅读器）上根本没有滚轮——用户是用手指上下**滑**弹窗的，而那条路径
+   此前 100% 走 WebView 原生滚动：逐帧连续位移 + 松手后的惯性 fling。设置文案承诺的正是
+   「按固定距离瞬时跳动、无动画滚动（for e-ink screens）」，触摸路径不认这个开关 =
+   在唯一真正的墨水屏输入方式上开关等于没接线（与 BUG-2284 ① 同一类空开关）。
+
+   与滚轮同源但不同形：滚轮是离散 notch，可以「一格跳半屏」；手指是连续位移，同样按
+   固定距离跳，但量化的是**手指行程**——每滑够一步就跳一步，即「量化的 1:1 跟手」。
+   这样既保留方向反馈（与 _BodySwipeDismissDetector 跟手期刻意保留 Transform.translate
+   同理，见 BUG-2283 备注），又把整段滑动的重绘从每帧一次压成每步一次，preventDefault
+   再把松手惯性彻底掐掉——墨水屏上「松手后还要糊几秒」正是惯性拖出来的。
+
+   接管判定放在 touchstart 一次定死，touchmove 里不再判轴：Chromium 只在某一帧
+   touchmove 未被 preventDefault 时才会启动原生滚动，一旦启动，后续帧的 cancelable
+   就变 false、再 preventDefault 也没用。若留一段「判轴死区」不拦截，Android 的
+   ~8dp touch slop 恰好落在死区里，原生滚动会抢先起步 → 变成原生滚动与瞬跳同时位移。
+   所以要么从第一帧就拿下整轮手势，要么整轮不碰。
+
+   整轮不碰的三个豁免（都在 touchstart 判）：多指（缩放/系统手势）、已有选区（选区手柄
+   拖动也是 touchmove，拦了就拖不动手柄，嵌套查词要靠它选词）、以及手指落在**真正横向
+   溢出**的祖先上（.expression-scroll / .gloss-image-scroll / .gloss-sc-table-container，
+   见 popup.css）——拿下整轮会连它们的横滚一起掐掉。判据是实际溢出而非 CSS 声明，所以
+   短词头那种没溢出的 .expression-scroll 不会误触发豁免。
+
+   只在 in-app 弹窗挂载：扩展镜像里 popup.js 与宿主页共用 document，非 passive 的
+   touchmove 会掐掉宿主页整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow
+   host，见 BUG-1078），而墨水屏场景是 app 内弹窗，扩展侧没有这个需求。三镜像仍逐字节
+   一致（TODO-1267 parity guard），差别只在运行期分支。 */
+const POPUP_EINK_TOUCH_VIEWPORT_FRACTION = 0.25; // 一步跳 1/4 屏
+const POPUP_EINK_TOUCH_MIN_STEP = 24;            // 视口异常小时的下限（布局 px）
+// 防御性上限：一帧内最多补几步。正常一帧手指走不了几步，这个上限只为杜绝异常输入
+// （极端 zoom / 视口塌成 0）下的死循环。
+const POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE = 20;
+let _popupEinkTouchId = null;
+let _popupEinkTouchScroller = null;
+let _popupEinkTouchAnchorY = 0;
+
+function __fushiPopupEinkTouchReset() {
+    _popupEinkTouchId = null;
+    _popupEinkTouchScroller = null;
+}
+
+// 一步的距离：被滚表面视口高度 × FRACTION，夹在 [MIN_STEP, 一屏] 内（永不一步跳过整屏
+// 内容）。复用滚轮那条的 extent 解析——zoom → 布局 px 的换算已经在里面。
+function popupEinkTouchStep(scroller) {
+    const extent = popupEinkWheelExtent(scroller);
+    return Math.max(
+        POPUP_EINK_TOUCH_MIN_STEP,
+        Math.min(extent, extent * POPUP_EINK_TOUCH_VIEWPORT_FRACTION));
+}
+
+// 从触点向上找**真正横向溢出**的祖先（不是只看 CSS 声明）。找到 → 本轮不接管。
+function __fushiPopupEinkTouchHasHorizontalScroll(node) {
+    let el = node;
+    let hops = 0;
+    while (el && el.nodeType === 1 && hops < 32) {
+        if (el.scrollWidth > el.clientWidth + 1) {
+            let overflowX = '';
+            try {
+                overflowX = (window.getComputedStyle(el) || {}).overflowX || '';
+            } catch (_) { overflowX = ''; }
+            if (overflowX === 'auto' || overflowX === 'scroll') return true;
+        }
+        el = el.parentElement || (el.parentNode && el.parentNode.host) || null;
+        hops++;
+    }
+    return false;
+}
+
+function __fushiPopupEinkTouchStart(e) {
+    __fushiPopupEinkTouchReset();
+    if (!window.__fushiPopupInstantScroll) return;
+    if (!__fushiEventInsidePopup(e)) return;
+    if (!e.touches || e.touches.length !== 1) return;
+    try {
+        const sel = __fushiSel();
+        if (sel && !sel.isCollapsed) return;
+    } catch (_) { /* 读不到选区就按「无选区」走，最坏是拦了一次手柄拖动 */ }
+    if (__fushiPopupEinkTouchHasHorizontalScroll(__fushiEventTarget(e))) return;
+    const t = e.touches[0];
+    _popupEinkTouchId = t.identifier;
+    _popupEinkTouchScroller = __fushiWheelScroller(e);
+    _popupEinkTouchAnchorY = t.clientY;
+}
+
+function __fushiPopupEinkTouchMove(e) {
+    if (_popupEinkTouchId === null) return;
+    if (!window.__fushiPopupInstantScroll) { __fushiPopupEinkTouchReset(); return; }
+    // 中途落下第二根指针：本轮永久失效（不能把剩余指针重新解释成新的一次纵滑，
+    // 与 _BodySwipeDismissDetector 的 BUG-1242 同一条纪律）。
+    if (!e.touches || e.touches.length !== 1) { __fushiPopupEinkTouchReset(); return; }
+    const t = e.touches[0];
+    if (t.identifier !== _popupEinkTouchId) { __fushiPopupEinkTouchReset(); return; }
+    // 已经不可取消 = 原生滚动已起步（理论上进不来，touchstart 已拿下整轮）。此时再跳
+    // 会和原生一起双倍位移，直接弃掉本轮。
+    if (e.cancelable === false) { __fushiPopupEinkTouchReset(); return; }
+    e.preventDefault();
+    const step = popupEinkTouchStep(_popupEinkTouchScroller);
+    if (!(step > 0)) return;
+    // 手指上滑（clientY 变小）→ 正 → 内容下滚，与原生方向一致。
+    let travel = _popupEinkTouchAnchorY - t.clientY;
+    let guard = 0;
+    while (Math.abs(travel) >= step && guard < POPUP_EINK_TOUCH_MAX_STEPS_PER_MOVE) {
+        const dir = travel > 0 ? 1 : -1;
+        const jump = Math.trunc(dir * step);
+        if (jump === 0) break;
+        if (_popupEinkTouchScroller) {
+            _popupEinkTouchScroller.scrollBy({ top: jump, behavior: 'auto' });
+        } else {
+            window.scrollBy({ top: jump, behavior: 'auto' });
+        }
+        // 锚点跟着走一步：手指要再滑满一步才触发下一跳（这就是 1:1 量化）。
+        _popupEinkTouchAnchorY -= dir * step;
+        travel -= dir * step;
+        guard++;
+    }
+}
+
+if (typeof chrome !== 'undefined' && !!(chrome.runtime && chrome.runtime.id)) {
+    // 扩展镜像：不挂（理由见上方块注释）。留空分支是为了让三镜像逐字节一致时，
+    // 「扩展侧刻意不挂」这条决定在代码里看得见，而不是靠读注释推断。
+} else {
+    // in-app 弹窗 WebView：整份文档就是弹窗。touchmove 必须 passive:false，否则
+    // preventDefault 无效、惯性照旧（这正是 BUG-2403 要掐的东西）。
+    document.addEventListener('touchstart', __fushiPopupEinkTouchStart, { passive: true });
+    document.addEventListener('touchmove', __fushiPopupEinkTouchMove, { passive: false });
+    document.addEventListener('touchend', __fushiPopupEinkTouchReset, { passive: true });
+    document.addEventListener('touchcancel', __fushiPopupEinkTouchReset, { passive: true });
+}
+
 
 let _popupMouseDownPos = null;
 function __fushiPopupMouseDown(e) {


### PR DESCRIPTION
## 问题

`lookup.popup_instant_scroll` 的文案是「Jump the lookup popup by fixed distances without animated scrolling **for e-ink screens**」，没有任何「仅限滚轮」的限定。但 BUG-2284 只把 `window.__fushiPopupInstantScroll` 接进了 `__fushiPopupWheelListener`，**全文件没有第二个消费点**（`fushi/assets/popup/popup.js:5818`）。

而墨水屏设备是 Android e-ink 阅读器，**根本没有滚轮**——用户是用手指上下滑弹窗的。那条路径此前 100% 走 WebView 原生滚动：逐帧连续位移 + 松手后的惯性 fling，正是文案承诺要消掉的「animated scrolling」。于是在唯一真正的墨水屏输入方式上，这个开关等于没接线（与 BUG-2284 ① 认定的「三元两个分支等价 = 空开关」同一类，只是换了输入设备）。

弹窗的其余 eink 动效此前都已归零（入场淡入 `dictionary_popup_layer.dart:500`、侧滑关闭补间同文件 `:1348`、顶栏 swipe `swipe_dismiss_wrapper.dart:79`、CSS 通配 `popup.css:1987` 关掉全部 transition/animation），唯独触摸滚动这条漏网。

## 修法

与滚轮同源但不同形：滚轮是离散 notch，可以「一格跳半屏」；手指是连续位移，同样按固定距离跳，但量化的是**手指行程**——每滑够一步（视口 × `0.25`，夹在 `[24, 一屏]`）就 `scrollBy` 一步、锚点同步推进一步，即「量化的 1:1 跟手」。

保留方向反馈（与 `_BodySwipeDismissDetector` 跟手期刻意保留 `Transform.translate` 同理，见 BUG-2283 备注），同时把整段滑动的重绘从每帧一次压成每步一次，`preventDefault` 再把松手惯性彻底掐掉——墨水屏上「松手后还要糊几秒」正是惯性拖出来的。偏好仍读 BUG-2284 已铺好的同一个全局，**不新增下发通道**。

### 为什么接管判定必须在 touchstart 一次定死

Chromium 只在某帧 touchmove 未被 `preventDefault` 时才启动原生滚动，一旦启动，后续帧 `cancelable` 变 false、再 `preventDefault` 也没用。若留一段「判轴死区」不拦截，Android ~8dp 的 touch slop 恰好落在死区里，原生滚动会抢先起步 → 变成原生滚动与瞬跳**同时**位移（双倍）。所以要么从第一帧就拿下整轮手势，要么整轮不碰。

整轮不碰的三条豁免（都在 `touchstart` 判）：

- 多指（缩放/系统手势）
- 已有选区（选区手柄拖动也是 touchmove，拦了就拖不动手柄，嵌套查词要靠它选词）
- 手指落在**真正横向溢出**的祖先上（`.expression-scroll` / `.gloss-image-scroll` / `.gloss-sc-table-container`）——判据是 `scrollWidth > clientWidth` 的实际溢出 + `overflowX` 为 auto/scroll，不是只看 CSS 声明，所以短词头那种没溢出的 `.expression-scroll` 不会误触发豁免

### 只在 in-app 弹窗挂载

扩展镜像里 popup.js 与宿主页共用 document，非 passive 的 touchmove 会掐掉宿主页整页的合成器快速滚动路径（wheel 那条为此专门只挂 shadow host，见 BUG-1078），而墨水屏场景是 app 内弹窗。三镜像仍逐字节一致，差别只在运行期分支。

## 测试

新增 `fushi/test/dictionary/popup_touch_instant_scroll_guard_test.dart` 共 23 条（7 条 × 3 镜像 + 2 条跨镜像）。单测里没有真 WebView，滚动本身无法直接断言（与既有 `popup_instant_scroll_guard_test.dart` 同处境），所以钉死的是「开关 → 触摸行为」这条线上每一段**载荷位**的存在性：偏好真被触摸入口消费、touchmove 是 `passive:false` 且真的 `preventDefault`（少任一条则惯性照旧且**无任何报错**）、步长来自视口比例而非 travel 的函数、锚点按步长推进（少了它一次 touchmove 就跳到底）、补步循环有防御性上限、三条豁免都在 touchstart 判、横向判据看实际溢出、扩展分支不得挂 document 级触摸监听、三镜像的触摸块逐字节一致。

- **判别力验证**：把 `{ passive: false }` 临时改成 `true`，passive 守卫 + 三镜像一致性 2 条立刻红（退出码 1）；恢复后 23/23 绿。
- 相邻既有守卫 40/40 绿：`popup_instant_scroll_guard` / `browser_extension_popup_parity_guard`（含 TODO-1267 三镜像 parity）/ `popup_css_eink_guard` / `browser_extension_popup_wheel_surface_guard` / `popup_wheel_native_residual_guard`。
- `flutter analyze` 零问题。

## 已知限制

**真机未验**：提交者本机没有 Android 墨水屏设备，「手指滑动不再有惯性、按步跳」这条只在源码与守卫层验过，属 `implemented_unverified`。要落实需在真机开「查词 › 瞬时滚动」后滑弹窗对比。

## 盘点时另发现三条本次未修的相邻缺口

都不在「触摸滑动」这条路径上，留作独立条目，未在本 PR 内改：

1. `popupInstantScroll` 与 `einkMode` **完全解耦**（`preferences_repository.dart:721-726` 有明确注释说这是刻意的 opt-in），所以开了墨水屏主题**不会**自动获得瞬时滚动，得再手动开一个开关。是否让 eink 隐含开启是产品决定。
2. 滚动条 thumb 的「滚动时浮现 / 900ms 后消失」（`popup.js:6041` + `popup.css:234`）在 `html.eink` 下无覆盖，等于每次滚完额外一次延迟局部刷新，且 thumb 是半透明灰。
3. 扩展侧从来没人挂 `eink` class（只有 `popup_settings_injection.dart:112` 一处），`vendor/content.css` 里整块 eink 覆盖是死码。

https://claude.ai/code/session_01PcCxyhsuiU7TUHQPBtRfAd
