### PR TITLE
feat(anki): 制卡后自动按词频重排新卡

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77979 (4587 per locale)
+/// Strings: 77996 (4588 per locale)
 ///
-/// Built on 2026-09-09 at 22:49 UTC
+/// Built on 2026-09-09 at 23:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6361,6 +6361,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_reposition_auto_title => 'Auto-reposition after mining';
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -17136,6 +17138,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -28139,6 +28144,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -39196,6 +39204,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -50287,6 +50298,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -61180,6 +61194,9 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -72166,6 +72183,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -82528,6 +82548,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -92901,6 +92924,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -103843,6 +103869,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -114839,6 +114868,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -125812,6 +125844,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -136584,6 +136619,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -147472,6 +147510,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -158331,6 +158372,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 // Path: <root>
@@ -168305,6 +168349,9 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       '最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      '「${deck}」自动重排失败';
 }
 
 // Path: <root>
@@ -178351,6 +178398,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_reposition_auto_hint =>
       'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+  @override
+  String anki_reposition_auto_failed({required Object deck}) =>
+      'Auto reposition failed for ${deck}';
 }
 
 /// Flat map(s) containing all translations.
@@ -187786,6 +187836,8 @@ extension on _StringsEn {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -197216,6 +197268,8 @@ extension on _StringsAr {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -206691,6 +206745,8 @@ extension on _StringsDe {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -216157,6 +216213,8 @@ extension on _StringsEs {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -225632,6 +225690,8 @@ extension on _StringsFr {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -235078,6 +235138,8 @@ extension on _StringsId {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -244546,6 +244608,8 @@ extension on _StringsIt {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -253941,6 +254005,8 @@ extension on _StringsJa {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -263340,6 +263406,8 @@ extension on _StringsKo {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -272801,6 +272869,8 @@ extension on _StringsNl {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -282257,6 +282327,8 @@ extension on _StringsPtBr {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -291720,6 +291792,8 @@ extension on _StringsRu {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -301155,6 +301229,8 @@ extension on _StringsTh {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -310605,6 +310681,8 @@ extension on _StringsTr {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -320049,6 +320127,8 @@ extension on _StringsVi {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }
@@ -329411,6 +329491,8 @@ extension on _StringsZhCn {
         return '制卡后自动重排';
       case 'anki_reposition_auto_hint':
         return '最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => '「${deck}」自动重排失败';
       default:
         return null;
     }
@@ -338784,6 +338866,8 @@ extension on _StringsZhHk {
         return 'Auto-reposition after mining';
       case 'anki_reposition_auto_hint':
         return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
+      case 'anki_reposition_auto_failed':
+        return ({required Object deck}) => 'Auto reposition failed for ${deck}';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77945 (4585 per locale)
+/// Strings: 77979 (4587 per locale)
 ///
-/// Built on 2026-09-09 at 20:23 UTC
+/// Built on 2026-09-09 at 22:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6358,6 +6358,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Path mapping and target video source';
   String get settings_downloads_encryption_title => 'Peer encryption';
   String get settings_service_disabled => 'Disabled';
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -17128,6 +17131,11 @@ class _StringsAr extends _StringsEn {
   String get settings_downloads_encryption_title => 'تشفير الاتصال بالأقران';
   @override
   String get settings_service_disabled => 'معطّل';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -28126,6 +28134,11 @@ class _StringsDe extends _StringsEn {
   String get settings_downloads_encryption_title => 'Peer-Verschlüsselung';
   @override
   String get settings_service_disabled => 'Deaktiviert';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -39178,6 +39191,11 @@ class _StringsEs extends _StringsEn {
   String get settings_downloads_encryption_title => 'Cifrado entre pares';
   @override
   String get settings_service_disabled => 'Desactivado';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -50264,6 +50282,11 @@ class _StringsFr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Chiffrement entre pairs';
   @override
   String get settings_service_disabled => 'Désactivé';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -61152,6 +61175,11 @@ class _StringsId extends _StringsEn {
   String get settings_downloads_encryption_title => 'Enkripsi peer';
   @override
   String get settings_service_disabled => 'Dinonaktifkan';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -72133,6 +72161,11 @@ class _StringsIt extends _StringsEn {
   String get settings_downloads_encryption_title => 'Crittografia dei peer';
   @override
   String get settings_service_disabled => 'Disattivato';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -82490,6 +82523,11 @@ class _StringsJa extends _StringsEn {
   String get settings_downloads_encryption_title => 'ピア通信の暗号化';
   @override
   String get settings_service_disabled => '無効';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -92858,6 +92896,11 @@ class _StringsKo extends _StringsEn {
   String get settings_downloads_encryption_title => '피어 암호화';
   @override
   String get settings_service_disabled => '사용 안 함';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -103795,6 +103838,11 @@ class _StringsNl extends _StringsEn {
   String get settings_downloads_encryption_title => 'Peer-versleuteling';
   @override
   String get settings_service_disabled => 'Uitgeschakeld';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -114786,6 +114834,11 @@ class _StringsPtBr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Criptografia entre pares';
   @override
   String get settings_service_disabled => 'Desativado';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -125754,6 +125807,11 @@ class _StringsRu extends _StringsEn {
       'Шифрование соединений с пирами';
   @override
   String get settings_service_disabled => 'Отключено';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -136521,6 +136579,11 @@ class _StringsTh extends _StringsEn {
   String get settings_downloads_encryption_title => 'การเข้ารหัสระหว่างเพียร์';
   @override
   String get settings_service_disabled => 'ปิดใช้งาน';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -147404,6 +147467,11 @@ class _StringsTr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Eş şifrelemesi';
   @override
   String get settings_service_disabled => 'Devre dışı';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -158258,6 +158326,11 @@ class _StringsVi extends _StringsEn {
   String get settings_downloads_encryption_title => 'Mã hóa kết nối peer';
   @override
   String get settings_service_disabled => 'Đã tắt';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 // Path: <root>
@@ -168227,6 +168300,11 @@ class _StringsZhCn extends _StringsEn {
   String get settings_downloads_encryption_title => '节点加密';
   @override
   String get settings_service_disabled => '已停用';
+  @override
+  String get anki_reposition_auto_title => '制卡后自动重排';
+  @override
+  String get anki_reposition_auto_hint =>
+      '最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。';
 }
 
 // Path: <root>
@@ -178268,6 +178346,11 @@ class _StringsZhHk extends _StringsEn {
   String get settings_downloads_encryption_title => '節點通訊加密';
   @override
   String get settings_service_disabled => '已停用';
+  @override
+  String get anki_reposition_auto_title => 'Auto-reposition after mining';
+  @override
+  String get anki_reposition_auto_hint =>
+      'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
 }
 
 /// Flat map(s) containing all translations.
@@ -187699,6 +187782,10 @@ extension on _StringsEn {
         return 'Peer encryption';
       case 'settings_service_disabled':
         return 'Disabled';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -197125,6 +197212,10 @@ extension on _StringsAr {
         return 'تشفير الاتصال بالأقران';
       case 'settings_service_disabled':
         return 'معطّل';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -206596,6 +206687,10 @@ extension on _StringsDe {
         return 'Peer-Verschlüsselung';
       case 'settings_service_disabled':
         return 'Deaktiviert';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -216058,6 +216153,10 @@ extension on _StringsEs {
         return 'Cifrado entre pares';
       case 'settings_service_disabled':
         return 'Desactivado';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -225529,6 +225628,10 @@ extension on _StringsFr {
         return 'Chiffrement entre pairs';
       case 'settings_service_disabled':
         return 'Désactivé';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -234971,6 +235074,10 @@ extension on _StringsId {
         return 'Enkripsi peer';
       case 'settings_service_disabled':
         return 'Dinonaktifkan';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -244435,6 +244542,10 @@ extension on _StringsIt {
         return 'Crittografia dei peer';
       case 'settings_service_disabled':
         return 'Disattivato';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -253826,6 +253937,10 @@ extension on _StringsJa {
         return 'ピア通信の暗号化';
       case 'settings_service_disabled':
         return '無効';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -263221,6 +263336,10 @@ extension on _StringsKo {
         return '피어 암호화';
       case 'settings_service_disabled':
         return '사용 안 함';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -272678,6 +272797,10 @@ extension on _StringsNl {
         return 'Peer-versleuteling';
       case 'settings_service_disabled':
         return 'Uitgeschakeld';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -282130,6 +282253,10 @@ extension on _StringsPtBr {
         return 'Criptografia entre pares';
       case 'settings_service_disabled':
         return 'Desativado';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -291589,6 +291716,10 @@ extension on _StringsRu {
         return 'Шифрование соединений с пирами';
       case 'settings_service_disabled':
         return 'Отключено';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -301020,6 +301151,10 @@ extension on _StringsTh {
         return 'การเข้ารหัสระหว่างเพียร์';
       case 'settings_service_disabled':
         return 'ปิดใช้งาน';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -310466,6 +310601,10 @@ extension on _StringsTr {
         return 'Eş şifrelemesi';
       case 'settings_service_disabled':
         return 'Devre dışı';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -319906,6 +320045,10 @@ extension on _StringsVi {
         return 'Mã hóa kết nối peer';
       case 'settings_service_disabled':
         return 'Đã tắt';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }
@@ -329264,6 +329407,10 @@ extension on _StringsZhCn {
         return '节点加密';
       case 'settings_service_disabled':
         return '已停用';
+      case 'anki_reposition_auto_title':
+        return '制卡后自动重排';
+      case 'anki_reposition_auto_hint':
+        return '最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。';
       default:
         return null;
     }
@@ -338633,6 +338780,10 @@ extension on _StringsZhHk {
         return '節點通訊加密';
       case 'settings_service_disabled':
         return '已停用';
+      case 'anki_reposition_auto_title':
+        return 'Auto-reposition after mining';
+      case 'anki_reposition_auto_hint':
+        return 'Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Peer encryption",
   "settings_service_disabled": "Disabled",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Completed downloads",
   "settings_downloads_routing_hint": "Path mapping and target video source",
   "settings_downloads_encryption_title": "Peer encryption",
-  "settings_service_disabled": "Disabled"
+  "settings_service_disabled": "Disabled",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "تشفير الاتصال بالأقران",
   "settings_service_disabled": "معطّل",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "التنزيلات المكتملة",
   "settings_downloads_routing_hint": "تعيين المسارات ومصدر الفيديو المستهدف",
   "settings_downloads_encryption_title": "تشفير الاتصال بالأقران",
-  "settings_service_disabled": "معطّل"
+  "settings_service_disabled": "معطّل",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Abgeschlossene Downloads",
   "settings_downloads_routing_hint": "Pfadzuordnung und Ziel-Videoquelle",
   "settings_downloads_encryption_title": "Peer-Verschlüsselung",
-  "settings_service_disabled": "Deaktiviert"
+  "settings_service_disabled": "Deaktiviert",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Peer-Verschlüsselung",
   "settings_service_disabled": "Deaktiviert",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Cifrado entre pares",
   "settings_service_disabled": "Desactivado",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Descargas completadas",
   "settings_downloads_routing_hint": "Asignación de rutas y fuente de vídeo de destino",
   "settings_downloads_encryption_title": "Cifrado entre pares",
-  "settings_service_disabled": "Desactivado"
+  "settings_service_disabled": "Desactivado",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Téléchargements terminés",
   "settings_downloads_routing_hint": "Correspondance des chemins et source vidéo cible",
   "settings_downloads_encryption_title": "Chiffrement entre pairs",
-  "settings_service_disabled": "Désactivé"
+  "settings_service_disabled": "Désactivé",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Chiffrement entre pairs",
   "settings_service_disabled": "Désactivé",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Unduhan selesai",
   "settings_downloads_routing_hint": "Pemetaan jalur dan sumber video tujuan",
   "settings_downloads_encryption_title": "Enkripsi peer",
-  "settings_service_disabled": "Dinonaktifkan"
+  "settings_service_disabled": "Dinonaktifkan",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Enkripsi peer",
   "settings_service_disabled": "Dinonaktifkan",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Crittografia dei peer",
   "settings_service_disabled": "Disattivato",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Download completati",
   "settings_downloads_routing_hint": "Mappatura dei percorsi e sorgente video di destinazione",
   "settings_downloads_encryption_title": "Crittografia dei peer",
-  "settings_service_disabled": "Disattivato"
+  "settings_service_disabled": "Disattivato",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "完了したダウンロード",
   "settings_downloads_routing_hint": "パスの対応付けと保存先の動画ソース",
   "settings_downloads_encryption_title": "ピア通信の暗号化",
-  "settings_service_disabled": "無効"
+  "settings_service_disabled": "無効",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "ピア通信の暗号化",
   "settings_service_disabled": "無効",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "완료된 다운로드",
   "settings_downloads_routing_hint": "경로 매핑 및 대상 동영상 소스",
   "settings_downloads_encryption_title": "피어 암호화",
-  "settings_service_disabled": "사용 안 함"
+  "settings_service_disabled": "사용 안 함",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "피어 암호화",
   "settings_service_disabled": "사용 안 함",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Voltooide downloads",
   "settings_downloads_routing_hint": "Padkoppeling en doelvideobron",
   "settings_downloads_encryption_title": "Peer-versleuteling",
-  "settings_service_disabled": "Uitgeschakeld"
+  "settings_service_disabled": "Uitgeschakeld",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Peer-versleuteling",
   "settings_service_disabled": "Uitgeschakeld",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Criptografia entre pares",
   "settings_service_disabled": "Desativado",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Downloads concluídos",
   "settings_downloads_routing_hint": "Mapeamento de caminhos e fonte de vídeo de destino",
   "settings_downloads_encryption_title": "Criptografia entre pares",
-  "settings_service_disabled": "Desativado"
+  "settings_service_disabled": "Desativado",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Шифрование соединений с пирами",
   "settings_service_disabled": "Отключено",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Завершённые загрузки",
   "settings_downloads_routing_hint": "Сопоставление путей и целевой источник видео",
   "settings_downloads_encryption_title": "Шифрование соединений с пирами",
-  "settings_service_disabled": "Отключено"
+  "settings_service_disabled": "Отключено",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "การเข้ารหัสระหว่างเพียร์",
   "settings_service_disabled": "ปิดใช้งาน",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "การดาวน์โหลดที่เสร็จสิ้น",
   "settings_downloads_routing_hint": "การแมปเส้นทางและแหล่งวิดีโอปลายทาง",
   "settings_downloads_encryption_title": "การเข้ารหัสระหว่างเพียร์",
-  "settings_service_disabled": "ปิดใช้งาน"
+  "settings_service_disabled": "ปิดใช้งาน",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Tamamlanan indirmeler",
   "settings_downloads_routing_hint": "Yol eşleme ve hedef video kaynağı",
   "settings_downloads_encryption_title": "Eş şifrelemesi",
-  "settings_service_disabled": "Devre dışı"
+  "settings_service_disabled": "Devre dışı",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Eş şifrelemesi",
   "settings_service_disabled": "Devre dışı",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "Mã hóa kết nối peer",
   "settings_service_disabled": "Đã tắt",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Tải xuống đã hoàn tất",
   "settings_downloads_routing_hint": "Ánh xạ đường dẫn và nguồn video đích",
   "settings_downloads_encryption_title": "Mã hóa kết nối peer",
-  "settings_service_disabled": "Đã tắt"
+  "settings_service_disabled": "Đã tắt",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "节点加密",
   "settings_service_disabled": "已停用",
   "anki_reposition_auto_title": "制卡后自动重排",
-  "anki_reposition_auto_hint": "最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。"
+  "anki_reposition_auto_hint": "最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。",
+  "anki_reposition_auto_failed": "「$deck」自动重排失败"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "下载完成后",
   "settings_downloads_routing_hint": "路径映射与目标视频来源",
   "settings_downloads_encryption_title": "节点加密",
-  "settings_service_disabled": "已停用"
+  "settings_service_disabled": "已停用",
+  "anki_reposition_auto_title": "制卡后自动重排",
+  "anki_reposition_auto_hint": "最后一张卡制好约 30 秒后，自动按词频重排该牌组的新卡。仅 AnkiConnect 可用。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4585,5 +4585,6 @@
   "settings_downloads_encryption_title": "節點通訊加密",
   "settings_service_disabled": "已停用",
   "anki_reposition_auto_title": "Auto-reposition after mining",
-  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only.",
+  "anki_reposition_auto_failed": "Auto reposition failed for $deck"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "已完成的下載",
   "settings_downloads_routing_hint": "路徑對應與目標影片來源",
   "settings_downloads_encryption_title": "節點通訊加密",
-  "settings_service_disabled": "已停用"
+  "settings_service_disabled": "已停用",
+  "anki_reposition_auto_title": "Auto-reposition after mining",
+  "anki_reposition_auto_hint": "Reposition new cards by frequency about 30 seconds after the last card is mined. AnkiConnect only."
 }

--- a/fushi/lib/src/anki/anki_auto_reposition.dart
+++ b/fushi/lib/src/anki/anki_auto_reposition.dart
@@ -17,11 +17,15 @@ import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi/src/anki/anki_deck_reposition.dart';
 import 'package:fushi/src/anki/anki_deck_reposition_runner.dart';
 
-/// 自动重排失败时报给用户的通道（生产实现是 toast）。
+/// 自动重排失败时报给用户的通道，入参是**出问题的牌组名**（生产实现是 toast）。
 ///
-/// 注入而不是直接调 UI，是为了让本类保持无 Flutter widget 依赖、可纯 Dart 单测。
+/// 传牌组名而不是现成的句子：本类要保持无 Flutter 依赖、可纯 Dart 单测，够不到
+/// `t.*`；文案在注入点（`anki_view_model.dart`）用 i18n 渲染，否则 17 种语言的
+/// 用户都会看到一句英文字面量。
+///
 /// 只在**失败**时调用：成功是静默的——用户没点任何按钮，不该为此收到通知。
-typedef AnkiAutoRepositionFailureReporter = void Function(String message);
+/// 「部分卡没移动」与「整轮抛异常」共用这一条通道，因为用户能做的动作一样。
+typedef AnkiAutoRepositionFailureReporter = void Function(String deckName);
 
 /// 一次自动重排跑完的结果，仅供测试与诊断断言（生产路径不消费）。
 @immutable
@@ -54,12 +58,12 @@ class AnkiAutoRepositionScheduler {
     required Future<AnkiSettings> Function() loadSettings,
     AnkiAutoRepositionFailureReporter? onFailure,
     Duration debounce = kDefaultDebounce,
-    int snapshotsPerDeck = AnkiDeckRepositionRunner.kDefaultSnapshotsPerDeck,
+    int keepSnapshots = AnkiDeckRepositionRunner.kDefaultAutoSnapshots,
   })  : _runner = runner,
         _loadSettings = loadSettings,
         _onFailure = onFailure,
         _debounce = debounce,
-        _snapshotsPerDeck = snapshotsPerDeck;
+        _keepSnapshots = keepSnapshots;
 
   /// 默认防抖窗口。够长到把「连着挖十个词」合成一批，又短到用户切回 Anki
   /// 时位置已经排好。
@@ -69,7 +73,7 @@ class AnkiAutoRepositionScheduler {
   final Future<AnkiSettings> Function() _loadSettings;
   final AnkiAutoRepositionFailureReporter? _onFailure;
   final Duration _debounce;
-  final int _snapshotsPerDeck;
+  final int _keepSnapshots;
 
   final Set<String> _pending = <String>{};
   Timer? _timer;
@@ -80,7 +84,7 @@ class AnkiAutoRepositionScheduler {
   @visibleForTesting
   void Function(AnkiAutoRepositionRun run)? onRunForTesting;
 
-  /// 正在等防抖或正在跑（测试与诊断用）。
+  /// 既没在等防抖也没在跑、且没有待办（测试与诊断用）。
   bool get isIdle => _timer == null && !_running && _pending.isEmpty;
 
   /// 制卡成功后调用。[deckName] 是**后端实际落卡**的牌组名。
@@ -98,7 +102,10 @@ class AnkiAutoRepositionScheduler {
     });
   }
 
-  /// 立刻跑掉待办（跳过剩余防抖）。设置页关掉开关前的收尾、测试用。
+  /// 跳过剩余防抖，立刻处理待办。
+  ///
+  /// **已经有一轮在跑时立即返回、不等它跑完**（单飞由 [_flush] 保证）——待办
+  /// 不会丢，正在跑的那轮收尾时会捡走。目前只有测试调它。
   Future<void> flushNow() {
     _timer?.cancel();
     _timer = null;
@@ -141,11 +148,34 @@ class AnkiAutoRepositionScheduler {
         deckName: deckName,
         settings: settings,
         options: options,
+        shouldCancel: () => _disposed,
       );
       // plan == null：后端不支持（已在 _flush 里挡过，这里是兜底）。
-      // updates 为空：位置本来就是对的，不写、也不留快照。
-      if (plan == null || plan.updates.isEmpty) return;
-      final AnkiRepositionOutcome outcome = await _runner.apply(plan);
+      if (plan == null) return;
+
+      // 🔴 判据是 `changed`，**不是** `updates.isEmpty`：`planCardPositions` 给
+      // 每张新卡都发一条 update（位置 = 1..N），所以只要牌组里有新卡，
+      // `updates` 就永远非空。用它当判据等于「每批制卡都把整个牌组的位置重写
+      // 一遍、并写一份全量快照」——挖一个词就给 2000 张卡发 2000 条
+      // setSpecificValueOfCard，哪怕排完与原来一模一样。
+      if (plan.changed == 0) return;
+
+      // 词典来源下一张都没查到词频 = 这次重排没有任何排序依据，`planCardPositions`
+      // 会保持原有相对顺序但把位置重编成 1..N——一次没有信息量的全牌组重写。
+      // 成因是真实的：用户在弹窗里选过的词频词典后来被删/被隐藏（弹窗自己会把
+      // 选择与已装载求交，`fromSettings` 不会），或这个 entry point 的词典引擎
+      // 没初始化（`defaultAnkiFrequencyLookup` 返回空）。手动路径有预览给用户
+      // 看，自动路径没有，只能在这里挡掉。
+      if (options.source == AnkiRepositionSource.dictionaries &&
+          plan.ranked == 0) {
+        return;
+      }
+
+      // apply 一旦开始就让它跑完，即使中途 dispose：它是一批位置写入，
+      // 半途停下留下的是「排了一半」的队列，比写完更糟。
+      if (_disposed) return;
+      final AnkiRepositionOutcome outcome =
+          await _runner.apply(plan, auto: true);
       onRunForTesting?.call(
         AnkiAutoRepositionRun(
           deckName: deckName,
@@ -154,19 +184,14 @@ class AnkiAutoRepositionScheduler {
           failed: outcome.failures.length,
         ),
       );
-      if (outcome.failures.isNotEmpty) {
-        _onFailure?.call(
-          'Auto reposition: ${outcome.failures.length} of '
-          '${plan.updates.length} cards in "$deckName" could not be moved.',
-        );
-      }
-      await _runner.pruneSnapshots(keep: _snapshotsPerDeck);
+      if (outcome.failures.isNotEmpty) _onFailure?.call(deckName);
+      await _runner.pruneSnapshots(keep: _keepSnapshots);
     } on AnkiRepositionCancelled {
       // 自动路径没有取消按钮，走到这里只可能是 runner 内部的兜底；不打扰用户。
       return;
     } catch (e, stack) {
       debugPrint('AnkiAutoRepositionScheduler: $deckName failed: $e\n$stack');
-      _onFailure?.call('Auto reposition failed for "$deckName": $e');
+      _onFailure?.call(deckName);
     }
   }
 

--- a/fushi/lib/src/anki/anki_auto_reposition.dart
+++ b/fushi/lib/src/anki/anki_auto_reposition.dart
@@ -1,0 +1,179 @@
+/// 制卡后自动按词频重排新卡——**调度层**（防抖 + 单飞，无 UI 依赖）。
+///
+/// 数据流：制卡成功 → [AnkiAutoRepositionScheduler.notifyMined] 收下**后端实际
+/// 落卡的牌组名**（`MineOutcome.deckName`）→ 防抖窗口内的多次制卡合并成一批 →
+/// 一次 `plan` + `apply` 把这批新卡排到正确位置 → 清理过期快照。
+///
+/// 触发点接在 `AutoRepositionAnkiRepository`（`auto_reposition_anki_repository.dart`）
+/// 上，它包在 `ankiRepositoryProvider` 最外层，因此查词/阅读器/视频/漫画所有制卡
+/// 入口都自动经过，无需逐个调用点改动。
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+
+import 'package:fushi/src/anki/anki_deck_reposition.dart';
+import 'package:fushi/src/anki/anki_deck_reposition_runner.dart';
+
+/// 自动重排失败时报给用户的通道（生产实现是 toast）。
+///
+/// 注入而不是直接调 UI，是为了让本类保持无 Flutter widget 依赖、可纯 Dart 单测。
+/// 只在**失败**时调用：成功是静默的——用户没点任何按钮，不该为此收到通知。
+typedef AnkiAutoRepositionFailureReporter = void Function(String message);
+
+/// 一次自动重排跑完的结果，仅供测试与诊断断言（生产路径不消费）。
+@immutable
+class AnkiAutoRepositionRun {
+  const AnkiAutoRepositionRun({
+    required this.deckName,
+    required this.written,
+    required this.skipped,
+    required this.failed,
+  });
+
+  final String deckName;
+  final int written;
+  final int skipped;
+  final int failed;
+}
+
+/// 制卡后自动重排的防抖调度器。
+///
+/// 三条不变式：
+/// * **防抖**：窗口内的多次制卡只触发一次重排。一张卡一次全牌组重写既没必要
+///   （位置是按整组算的），又会把 AnkiConnect 打满。
+/// * **单飞**：同一时刻只有一次重排在跑。重排期间新来的牌组进 [_pending]，由
+///   正在跑的那一轮的循环捡走，不并发——两次 `apply` 并发写同一牌组的位置，
+///   后写的那份会基于过期的 `plan`。
+/// * **静默**：只有失败才经 [_onFailure] 出声。
+class AnkiAutoRepositionScheduler {
+  AnkiAutoRepositionScheduler({
+    required AnkiDeckRepositionRunner runner,
+    required Future<AnkiSettings> Function() loadSettings,
+    AnkiAutoRepositionFailureReporter? onFailure,
+    Duration debounce = kDefaultDebounce,
+    int snapshotsPerDeck = AnkiDeckRepositionRunner.kDefaultSnapshotsPerDeck,
+  })  : _runner = runner,
+        _loadSettings = loadSettings,
+        _onFailure = onFailure,
+        _debounce = debounce,
+        _snapshotsPerDeck = snapshotsPerDeck;
+
+  /// 默认防抖窗口。够长到把「连着挖十个词」合成一批，又短到用户切回 Anki
+  /// 时位置已经排好。
+  static const Duration kDefaultDebounce = Duration(seconds: 30);
+
+  final AnkiDeckRepositionRunner _runner;
+  final Future<AnkiSettings> Function() _loadSettings;
+  final AnkiAutoRepositionFailureReporter? _onFailure;
+  final Duration _debounce;
+  final int _snapshotsPerDeck;
+
+  final Set<String> _pending = <String>{};
+  Timer? _timer;
+  bool _running = false;
+  bool _disposed = false;
+
+  /// 每跑完一个牌组回调一次，供测试观测。生产不接。
+  @visibleForTesting
+  void Function(AnkiAutoRepositionRun run)? onRunForTesting;
+
+  /// 正在等防抖或正在跑（测试与诊断用）。
+  bool get isIdle => _timer == null && !_running && _pending.isEmpty;
+
+  /// 制卡成功后调用。[deckName] 是**后端实际落卡**的牌组名。
+  ///
+  /// 这里不查开关也不查后端支持：那两项要读设置（异步），而本方法在制卡的
+  /// 返回路径上，必须是同步且极廉价的。真正的判据在 [_flush] 里、防抖窗口
+  /// 到期后统一查一次——顺带让「制卡途中把开关关掉」立即生效。
+  void notifyMined(String deckName) {
+    if (_disposed || deckName.isEmpty) return;
+    _pending.add(deckName);
+    _timer?.cancel();
+    _timer = Timer(_debounce, () {
+      _timer = null;
+      unawaited(_flush());
+    });
+  }
+
+  /// 立刻跑掉待办（跳过剩余防抖）。设置页关掉开关前的收尾、测试用。
+  Future<void> flushNow() {
+    _timer?.cancel();
+    _timer = null;
+    return _flush();
+  }
+
+  Future<void> _flush() async {
+    // 单飞：已经在跑就直接返回。待办已经进了 [_pending]，正在跑的那轮的
+    // while 会捡走——`_pending` 的读取与清空之间没有 await，不会漏。
+    if (_disposed || _running) return;
+    _running = true;
+    try {
+      while (_pending.isNotEmpty) {
+        final List<String> decks = _pending.toList()..sort();
+        _pending.clear();
+        final AnkiSettings settings = await _loadSettings();
+        // 开关与后端支持每轮都重新判：用户可能在防抖窗口里关掉开关，或者
+        // 「制卡到已配对设备」把仓库换成了没有卡片级读写的那种。
+        if (!settings.autoRepositionEnabled) return;
+        if (!_runner.isSupported) return;
+        final AnkiRepositionRankOptions options =
+            AnkiRepositionRankOptions.fromSettings(settings);
+        for (final String deck in decks) {
+          if (_disposed) return;
+          await _runDeck(deck, settings, options);
+        }
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _runDeck(
+    String deckName,
+    AnkiSettings settings,
+    AnkiRepositionRankOptions options,
+  ) async {
+    try {
+      final AnkiRepositionPlan? plan = await _runner.plan(
+        deckName: deckName,
+        settings: settings,
+        options: options,
+      );
+      // plan == null：后端不支持（已在 _flush 里挡过，这里是兜底）。
+      // updates 为空：位置本来就是对的，不写、也不留快照。
+      if (plan == null || plan.updates.isEmpty) return;
+      final AnkiRepositionOutcome outcome = await _runner.apply(plan);
+      onRunForTesting?.call(
+        AnkiAutoRepositionRun(
+          deckName: deckName,
+          written: outcome.written,
+          skipped: outcome.skipped,
+          failed: outcome.failures.length,
+        ),
+      );
+      if (outcome.failures.isNotEmpty) {
+        _onFailure?.call(
+          'Auto reposition: ${outcome.failures.length} of '
+          '${plan.updates.length} cards in "$deckName" could not be moved.',
+        );
+      }
+      await _runner.pruneSnapshots(keep: _snapshotsPerDeck);
+    } on AnkiRepositionCancelled {
+      // 自动路径没有取消按钮，走到这里只可能是 runner 内部的兜底；不打扰用户。
+      return;
+    } catch (e, stack) {
+      debugPrint('AnkiAutoRepositionScheduler: $deckName failed: $e\n$stack');
+      _onFailure?.call('Auto reposition failed for "$deckName": $e');
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _timer?.cancel();
+    _timer = null;
+    _pending.clear();
+  }
+}

--- a/fushi/lib/src/anki/anki_deck_reposition.dart
+++ b/fushi/lib/src/anki/anki_deck_reposition.dart
@@ -27,6 +27,7 @@ class AnkiRepositionRankOptions {
         source: settings.repositionSource,
         dictionaries: settings.repositionDictionaries.toSet(),
         aggregate: FrequencyAggregate.fromName(settings.repositionAggregate),
+        rareFirst: settings.repositionRareFirst,
       );
 
   final AnkiRepositionSource source;

--- a/fushi/lib/src/anki/anki_deck_reposition_dialogs.dart
+++ b/fushi/lib/src/anki/anki_deck_reposition_dialogs.dart
@@ -51,7 +51,7 @@ class _RepositionDialogState extends State<_RepositionDialog> {
   late AnkiRepositionSource _source;
   late Set<String> _dictionaries;
   late FrequencyAggregate _aggregate;
-  bool _rareFirst = false;
+  late bool _rareFirst;
   bool _busy = false;
   AnkiRepositionSnapshot? _snapshot;
 
@@ -71,6 +71,7 @@ class _RepositionDialogState extends State<_RepositionDialog> {
         .where(widget.loadedDictionaries.contains)
         .toSet();
     _aggregate = FrequencyAggregate.fromName(_settings.repositionAggregate);
+    _rareFirst = _settings.repositionRareFirst;
     unawaited(_refreshSnapshot());
   }
 
@@ -102,6 +103,7 @@ class _RepositionDialogState extends State<_RepositionDialog> {
         source: _source,
         dictionaries: _dictionaries.toList()..sort(),
         aggregate: _aggregate.name,
+        rareFirst: _rareFirst,
       );
 
   @override

--- a/fushi/lib/src/anki/anki_deck_reposition_runner.dart
+++ b/fushi/lib/src/anki/anki_deck_reposition_runner.dart
@@ -256,6 +256,7 @@ class AnkiDeckRepositionRunner {
   Future<AnkiRepositionOutcome> apply(
     AnkiRepositionPlan plan, {
     AnkiRepositionOnProgress? onProgress,
+    bool auto = false,
   }) async {
     onProgress?.call(AnkiRepositionProgress(
       stage: AnkiRepositionStage.fetch,
@@ -281,7 +282,7 @@ class AnkiDeckRepositionRunner {
       stage: AnkiRepositionStage.write,
       total: updates.length,
     ));
-    final File snapshot = await _writeSnapshot(plan, previous);
+    final File snapshot = await _writeSnapshot(plan, previous, auto: auto);
     final AnkiCardDueWriteResult result =
         await _repository.setNewCardPositions(updates);
     return AnkiRepositionOutcome(
@@ -294,12 +295,14 @@ class AnkiDeckRepositionRunner {
 
   Future<File> _writeSnapshot(
     AnkiRepositionPlan plan,
-    List<AnkiCardDueUpdate> previous,
-  ) async {
+    List<AnkiCardDueUpdate> previous, {
+    required bool auto,
+  }) async {
     final Directory dir = await _snapshotDirectory();
     final DateTime now = DateTime.now();
     final String stamp = now.toUtc().toIso8601String().replaceAll(':', '-');
-    final File file = File(p.join(dir.path, 'reposition-$stamp.json'));
+    final String prefix = auto ? kAutoPrefix : kManualPrefix;
+    final File file = File(p.join(dir.path, '$prefix$stamp.json'));
     final AnkiRepositionSnapshot snapshot = AnkiRepositionSnapshot(
       file: file,
       deckName: plan.deckName,
@@ -312,12 +315,18 @@ class AnkiDeckRepositionRunner {
     return file;
   }
 
-  /// [deckName] 最近一次重排的快照；没有返回 null。坏文件跳过。
+  /// [deckName] 最近一次**手动**重排的快照；没有返回 null。坏文件跳过。
+  ///
+  /// **不看自动重排写的快照**：撤销按钮的语义是「撤销我刚才点的那次重排」。
+  /// 自动重排每批新卡就写一份，若一并参与挑选，用户手动重排后随便挖一个词，
+  /// 30 秒后撤销按钮指向的就变成「自动那次之前」＝手动重排的结果本身，于是
+  /// 那次手动重排**永远撤不回去了**，而按钮看起来一切正常。
   Future<AnkiRepositionSnapshot?> latestSnapshot(String deckName) async {
     final Directory dir = await _snapshotDirectory();
     AnkiRepositionSnapshot? best;
     for (final FileSystemEntity entity in dir.listSync()) {
       if (entity is! File || !entity.path.endsWith('.json')) continue;
+      if (_isAutoSnapshot(entity.path)) continue;
       AnkiRepositionSnapshot? parsed;
       try {
         parsed = AnkiRepositionSnapshot.fromJson(
@@ -336,53 +345,51 @@ class AnkiDeckRepositionRunner {
     return best;
   }
 
-  /// 每个牌组最多保留几份快照（[pruneSnapshots] 的默认值）。
-  static const int kDefaultSnapshotsPerDeck = 10;
+  /// 最多保留几份**自动**快照（[pruneSnapshots] 的默认值）。
+  static const int kDefaultAutoSnapshots = 20;
 
-  /// 按**牌组**各保留最近 [keep] 份快照，其余删除；返回删掉的份数。
+  /// 自动重排写的快照文件名前缀。**来源编进文件名而不是文件内容**：
+  /// [latestSnapshot] 与 [pruneSnapshots] 都只需要按来源筛，编进文件名就能
+  /// 零解析地筛掉——否则每次都要把每份快照的整个 `positions` 数组读进来
+  /// 反序列化一遍，只为看一眼它是谁写的。
+  static const String kAutoPrefix = 'reposition-auto-';
+
+  /// 手动重排写的快照文件名前缀（沿用历史文件名，旧快照照常认）。
+  static const String kManualPrefix = 'reposition-';
+
+  static bool _isAutoSnapshot(String path) =>
+      p.basename(path).startsWith(kAutoPrefix);
+
+  /// 只保留最近 [keep] 份**自动**快照，其余删除；返回删掉的份数。
   ///
-  /// 手动重排一次写一份快照，用户点一次撤销就消耗掉；自动重排则是每批新卡
-  /// 写一份、没人消费，目录会无界增长——而 [latestSnapshot] 每次都要读完整个
-  /// 目录才能挑出最新的一份，于是「撤销」会随使用越来越慢。
-  ///
-  /// 为什么按牌组分组而不是全局留最近 N 份：全局策略下，在牌组 B 上自动重排
-  /// N 次就会把牌组 A 手动重排的快照挤掉，用户在 A 上的撤销按钮**静默失效**。
-  /// 解析失败的坏文件一律不删（宁可留着占位，也不让一次解析 bug 变成删数据）。
-  Future<int> pruneSnapshots({int keep = kDefaultSnapshotsPerDeck}) async {
+  /// 三条都是有意的：
+  /// * **只删自动的**。手动快照是用户点「重排」时留下的撤销点，一份都不能被
+  ///   自动路径的产物挤掉——那会让撤销按钮静默失效。
+  /// * **不按牌组分组**。自动快照不参与 [latestSnapshot]（撤销只认手动的），
+  ///   它们只是诊断兜底，全局留最近若干份就够；分组反而要读文件内容。
+  /// * **零解析**。来源与时刻都在文件名里（`reposition-auto-<ISO 时刻>.json`，
+  ///   冒号换成 `-`，字典序 == 时间序），按名字排序即可，不必把每份快照的整个
+  ///   `positions` 数组反序列化一遍——自动路径无人值守地跑，那笔开销会随牌组
+  ///   变大而变成每轮几 MB 的 JSON 解析。
+  Future<int> pruneSnapshots({int keep = kDefaultAutoSnapshots}) async {
     if (keep < 0) return 0;
     final Directory dir = await _snapshotDirectory();
-    final Map<String, List<AnkiRepositionSnapshot>> byDeck =
-        <String, List<AnkiRepositionSnapshot>>{};
-    for (final FileSystemEntity entity in dir.listSync()) {
-      if (entity is! File || !entity.path.endsWith('.json')) continue;
-      AnkiRepositionSnapshot? parsed;
-      try {
-        parsed = AnkiRepositionSnapshot.fromJson(
-          entity,
-          jsonDecode(await entity.readAsString()),
-        );
-      } catch (e) {
-        debugPrint('AnkiDeckRepositionRunner: bad snapshot ${entity.path}: $e');
-        continue;
-      }
-      if (parsed == null) continue;
-      byDeck
-          .putIfAbsent(parsed.deckName, () => <AnkiRepositionSnapshot>[])
-          .add(parsed);
-    }
+    final List<String> autoSnapshots = <String>[
+      for (final FileSystemEntity e in dir.listSync())
+        if (e is File && e.path.endsWith('.json') && _isAutoSnapshot(e.path))
+          e.path,
+    ];
+    if (autoSnapshots.length <= keep) return 0;
+    // 文件名里的 ISO 时刻字典序即时间序，新的在后。
+    autoSnapshots.sort();
     int deleted = 0;
-    for (final List<AnkiRepositionSnapshot> snaps in byDeck.values) {
-      if (snaps.length <= keep) continue;
-      snaps.sort((AnkiRepositionSnapshot a, AnkiRepositionSnapshot b) =>
-          b.createdAt.compareTo(a.createdAt));
-      for (final AnkiRepositionSnapshot old in snaps.sublist(keep)) {
-        try {
-          await old.file.delete();
-          deleted++;
-        } catch (e) {
-          debugPrint(
-              'AnkiDeckRepositionRunner: cannot delete ${old.file.path}: $e');
-        }
+    for (final String path
+        in autoSnapshots.sublist(0, autoSnapshots.length - keep)) {
+      try {
+        await File(path).delete();
+        deleted++;
+      } catch (e) {
+        debugPrint('AnkiDeckRepositionRunner: cannot delete $path: $e');
       }
     }
     return deleted;

--- a/fushi/lib/src/anki/anki_deck_reposition_runner.dart
+++ b/fushi/lib/src/anki/anki_deck_reposition_runner.dart
@@ -336,6 +336,58 @@ class AnkiDeckRepositionRunner {
     return best;
   }
 
+  /// 每个牌组最多保留几份快照（[pruneSnapshots] 的默认值）。
+  static const int kDefaultSnapshotsPerDeck = 10;
+
+  /// 按**牌组**各保留最近 [keep] 份快照，其余删除；返回删掉的份数。
+  ///
+  /// 手动重排一次写一份快照，用户点一次撤销就消耗掉；自动重排则是每批新卡
+  /// 写一份、没人消费，目录会无界增长——而 [latestSnapshot] 每次都要读完整个
+  /// 目录才能挑出最新的一份，于是「撤销」会随使用越来越慢。
+  ///
+  /// 为什么按牌组分组而不是全局留最近 N 份：全局策略下，在牌组 B 上自动重排
+  /// N 次就会把牌组 A 手动重排的快照挤掉，用户在 A 上的撤销按钮**静默失效**。
+  /// 解析失败的坏文件一律不删（宁可留着占位，也不让一次解析 bug 变成删数据）。
+  Future<int> pruneSnapshots({int keep = kDefaultSnapshotsPerDeck}) async {
+    if (keep < 0) return 0;
+    final Directory dir = await _snapshotDirectory();
+    final Map<String, List<AnkiRepositionSnapshot>> byDeck =
+        <String, List<AnkiRepositionSnapshot>>{};
+    for (final FileSystemEntity entity in dir.listSync()) {
+      if (entity is! File || !entity.path.endsWith('.json')) continue;
+      AnkiRepositionSnapshot? parsed;
+      try {
+        parsed = AnkiRepositionSnapshot.fromJson(
+          entity,
+          jsonDecode(await entity.readAsString()),
+        );
+      } catch (e) {
+        debugPrint('AnkiDeckRepositionRunner: bad snapshot ${entity.path}: $e');
+        continue;
+      }
+      if (parsed == null) continue;
+      byDeck
+          .putIfAbsent(parsed.deckName, () => <AnkiRepositionSnapshot>[])
+          .add(parsed);
+    }
+    int deleted = 0;
+    for (final List<AnkiRepositionSnapshot> snaps in byDeck.values) {
+      if (snaps.length <= keep) continue;
+      snaps.sort((AnkiRepositionSnapshot a, AnkiRepositionSnapshot b) =>
+          b.createdAt.compareTo(a.createdAt));
+      for (final AnkiRepositionSnapshot old in snaps.sublist(keep)) {
+        try {
+          await old.file.delete();
+          deleted++;
+        } catch (e) {
+          debugPrint(
+              'AnkiDeckRepositionRunner: cannot delete ${old.file.path}: $e');
+        }
+      }
+    }
+    return deleted;
+  }
+
   /// 把 [snapshot] 里的旧位置写回去——**只恢复此刻仍是新卡的那些**（快照之后
   /// 学过的卡 `due` 已经是日期，写位置进去就是毁进度）。成功后删掉快照文件。
   Future<AnkiRepositionUndoOutcome> undo(

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -606,8 +606,10 @@ BaseAnkiRepository _withAutoReposition(Ref ref, BaseAnkiRepository repo) {
   final AnkiAutoRepositionScheduler scheduler = AnkiAutoRepositionScheduler(
     runner: AnkiDeckRepositionRunner(repo),
     loadSettings: repo.loadSettings,
-    onFailure: (String message) => FushiToast.showMine(
-      msg: message,
+    // 文案在这一层渲染：调度器本身够不到 `t.*`（它要保持无 Flutter 依赖），
+    // 在那边拼字面量等于让 17 种语言的用户都看英文。
+    onFailure: (String deckName) => FushiToast.showMine(
+      msg: t.anki_reposition_auto_failed(deck: deckName),
       status: MineToastStatus.failed,
     ),
   );

--- a/fushi/lib/src/anki/anki_view_model.dart
+++ b/fushi/lib/src/anki/anki_view_model.dart
@@ -4,7 +4,9 @@ import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fushi_anki/fushi_anki.dart';
+import 'package:fushi/src/anki/anki_auto_reposition.dart';
 import 'package:fushi/src/anki/anki_deck_reposition_runner.dart';
+import 'package:fushi/src/anki/auto_reposition_anki_repository.dart';
 import 'package:fushi/src/anki/anki_media_dedup_runner.dart';
 import 'package:fushi/src/anki/lapis_template_service.dart';
 import 'package:fushi/src/anki/remote_mining_anki_repository.dart';
@@ -458,12 +460,24 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
     required AnkiRepositionSource source,
     required List<String> dictionaries,
     required String aggregate,
+    required bool rareFirst,
   }) async {
     final updated = await _repository.updateSettings((s) => s.copyWith(
           repositionSource: source,
           repositionDictionaries: dictionaries,
           repositionAggregate: aggregate,
+          repositionRareFirst: rareFirst,
         ));
+    state = state.copyWith(settings: updated);
+  }
+
+  /// 打开/关闭「制卡后自动重排新卡」。默认关。
+  ///
+  /// 只写设置，不碰调度器：调度器每轮跑之前重新读这个值，所以关掉是立即生效的
+  /// （连正在等防抖的那一批也会在到期时被挡下），不需要在这里去把它叫醒。
+  Future<void> setAutoRepositionEnabled(bool enabled) async {
+    final updated = await _repository
+        .updateSettings((s) => s.copyWith(autoRepositionEnabled: enabled));
     state = state.copyWith(settings: updated);
   }
 
@@ -559,9 +573,9 @@ final ankiRepositoryProvider = Provider<BaseAnkiRepository>((ref) {
       ref.watch(platformServicesProvider).createAnkiRepository();
   final bool mineToServer =
       ref.watch(appProvider.select((AppModel m) => m.mineToServerEnabled));
-  if (!mineToServer) return local;
+  if (!mineToServer) return _withAutoReposition(ref, local);
   final AppModel appModel = ref.read(appProvider);
-  return RemoteMiningAnkiRepository(
+  final RemoteMiningAnkiRepository remote = RemoteMiningAnkiRepository(
     local: local,
     client: appModel.createRemoteMiningClient(),
     // BUG-1185：主机拒绝互联 token 时查重根本没跑成。bool 契约表达不了「不知道」，
@@ -571,7 +585,35 @@ final ankiRepositoryProvider = Provider<BaseAnkiRepository>((ref) {
       status: MineToastStatus.failed,
     ),
   );
+  // 远端制卡的仓库 `supportsDeckReposition` 为 false，装饰器里的判据会跳过——
+  // 包上只是让两条返回路径形状一致，将来主机端支持了不必再改这里。
+  return _withAutoReposition(ref, remote);
 });
+
+/// 给 [repo] 套上「制卡后自动重排新卡」。
+///
+/// 调度器随 provider 生命周期走：provider 被 invalidate（切 Profile、改 Anki 连接
+/// 设置）时旧的必须 [AnkiAutoRepositionScheduler.dispose]，否则它手里的防抖 Timer
+/// 会在一个已经废弃的仓库上触发一次重排。
+///
+/// runner 与 loadSettings 都绑**被包装的 [repo]** 而不是包装后的自己：重排只读写
+/// 卡片位置、不制卡，绑自己不会递归，但多绕一层没有意义。
+///
+/// 这里**不**看 `autoRepositionEnabled`：开关由调度器每轮重新读。若在此处按开关
+/// 决定包不包，provider 就得 watch 它，而它存在 Anki 仓库的 SharedPreferences 里
+/// （不是 Riverpod 状态）watch 不到，那样改开关得重启 app 才生效。
+BaseAnkiRepository _withAutoReposition(Ref ref, BaseAnkiRepository repo) {
+  final AnkiAutoRepositionScheduler scheduler = AnkiAutoRepositionScheduler(
+    runner: AnkiDeckRepositionRunner(repo),
+    loadSettings: repo.loadSettings,
+    onFailure: (String message) => FushiToast.showMine(
+      msg: message,
+      status: MineToastStatus.failed,
+    ),
+  );
+  ref.onDispose(scheduler.dispose);
+  return AutoRepositionAnkiRepository(inner: repo, scheduler: scheduler);
+}
 
 final ankiViewModelProvider =
     StateNotifierProvider<AnkiViewModel, AnkiUiState>((ref) {

--- a/fushi/lib/src/anki/auto_reposition_anki_repository.dart
+++ b/fushi/lib/src/anki/auto_reposition_anki_repository.dart
@@ -1,0 +1,194 @@
+/// 制卡后自动按词频重排的**接线层**：一个纯委派的 Anki 仓库包装，只在
+/// [mineEntry] 成功后多做一件事——把落卡牌组喂给 [AnkiAutoRepositionScheduler]。
+///
+/// 为什么包在仓库层而不是在制卡调用点加钩子：制卡入口有 12 处（查词弹窗、
+/// 阅读器、视频、漫画、PDF、悬浮词典、浏览器扩展桥、互联转发……），它们都读同一个
+/// `ankiRepositoryProvider`。包一层等于零调用点改动，也不会有人新加第 13 个入口
+/// 时忘了接钩子。同样的手法见 `RemoteMiningAnkiRepository`。
+///
+/// **与 RemoteMining 的关键区别**：那一层是**有意**只改道一部分方法（配置类仍走
+/// 本地）；本层的语义是「行为与 [inner] 完全一致，只是多一个副作用」，所以凡是
+/// 后端会覆盖的成员都必须逐个委派。漏掉一个就会掉回 [BaseAnkiRepository] 的降级
+/// 默认（例如 `supportsNoteTypeEditing` 变 false、`noteFields` 恒返回 null），而且
+/// **不会报错**——只会表现为「开了自动重排以后某个功能莫名其妙不工作了」。
+/// 守卫测试 `fushi/test/anki/auto_reposition_repository_delegation_test.dart` 钉死
+/// 这份清单：基类里新增或被任一后端覆盖的成员，没在本文件委派就会红。
+library;
+
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fushi/src/anki/anki_auto_reposition.dart';
+
+/// 包装 [inner]，制卡成功后触发自动重排。
+class AutoRepositionAnkiRepository extends BaseAnkiRepository {
+  AutoRepositionAnkiRepository({
+    required BaseAnkiRepository inner,
+    required AnkiAutoRepositionScheduler scheduler,
+  })  : _inner = inner,
+        _scheduler = scheduler;
+
+  final BaseAnkiRepository _inner;
+  final AnkiAutoRepositionScheduler _scheduler;
+
+  /// 被包装的仓库（测试与诊断用）。
+  BaseAnkiRepository get inner => _inner;
+
+  // --- 唯一一处有额外行为的方法 ---------------------------------------------
+
+  /// 制卡成功后把**后端实际落卡**的牌组名喂给调度器。
+  ///
+  /// 三个前置判据都在这里挡掉，让调度器不必知道仓库：
+  /// * 结果必须是成功——失败/重复/未配置都没有新卡产生。
+  /// * [MineOutcome.deckName] 必须非空——它才是真正落卡的牌组（BUG-1549）；
+  ///   拿设置里的 `selectedDeckName` 猜会在旧存档上猜空。
+  /// * [_inner] 必须支持卡片级读写——AnkiDroid / AnkiMobile / 「制卡到已配对
+  ///   设备」都没有，喂进去只会让调度器空跑一轮。
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async {
+    final MineOutcome outcome = await _inner.mineEntry(
+      rawPayloadJson: rawPayloadJson,
+      context: context,
+    );
+    final String? deck = outcome.deckName;
+    if (outcome.result == MineResult.success &&
+        deck != null &&
+        deck.isNotEmpty &&
+        _inner.supportsDeckReposition) {
+      _scheduler.notifyMined(deck);
+    }
+    return outcome;
+  }
+
+  // --- 以下全部是纯委派 -----------------------------------------------------
+
+  @override
+  Future<String?> readSettingsJson(SharedPreferences prefs) =>
+      _inner.readSettingsJson(prefs);
+
+  @override
+  Future<AnkiSettings> loadSettings() => _inner.loadSettings();
+
+  @override
+  Future<void> saveSettings(AnkiSettings settings) =>
+      _inner.saveSettings(settings);
+
+  @override
+  Future<AnkiSettings> updateSettings(
+    AnkiSettings Function(AnkiSettings) transform,
+  ) =>
+      _inner.updateSettings(transform);
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() => _inner.fetchConfiguration();
+
+  @override
+  Future<MineOutcome> updateMinedNote({
+    required int noteId,
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) =>
+      _inner.updateMinedNote(
+        noteId: noteId,
+        rawPayloadJson: rawPayloadJson,
+        context: context,
+      );
+
+  @override
+  Future<int?> findOverwriteTargetNoteId(String expression, String reading) =>
+      _inner.findOverwriteTargetNoteId(expression, reading);
+
+  @override
+  Future<List<MinedNoteRef>> findMatchingNotes(
+    String expression,
+    String reading,
+  ) =>
+      _inner.findMatchingNotes(expression, reading);
+
+  @override
+  Future<Map<String, String>?> noteFields(int noteId) =>
+      _inner.noteFields(noteId);
+
+  @override
+  Future<bool> openNoteInAnki(int noteId) => _inner.openNoteInAnki(noteId);
+
+  @override
+  Future<AnkiOpenWordOutcome> openWordInAnki(
+    String expression,
+    String reading,
+  ) =>
+      _inner.openWordInAnki(expression, reading);
+
+  @override
+  Future<Set<int>> findDeletedNotes(Set<int> noteIds) =>
+      _inner.findDeletedNotes(noteIds);
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) =>
+      _inner.isDuplicate(expression, reading);
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) =>
+      _inner.createNoteType(template);
+
+  @override
+  Future<bool> createDeck(String name) => _inner.createDeck(name);
+
+  @override
+  bool get supportsNoteTypeEditing => _inner.supportsNoteTypeEditing;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(String modelName) =>
+      _inner.readNoteTypeDefinition(modelName);
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) =>
+      _inner.updateNoteTypeStyling(modelName, css);
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+    String modelName,
+    List<AnkiCardTemplate> templates,
+  ) =>
+      _inner.updateNoteTypeTemplates(modelName, templates);
+
+  @override
+  bool get supportsMediaMaintenance => _inner.supportsMediaMaintenance;
+
+  @override
+  Future<bool> probeMediaMaintenance() => _inner.probeMediaMaintenance();
+
+  @override
+  bool get supportsMediaMaintenanceProgress =>
+      _inner.supportsMediaMaintenanceProgress;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+    AnkiMediaDedupOnProgress? onProgress,
+    bool Function()? shouldCancel,
+  }) =>
+      _inner.runMediaDedup(
+        dryRun: dryRun,
+        onJournal: onJournal,
+        onProgress: onProgress,
+        shouldCancel: shouldCancel,
+      );
+
+  @override
+  bool get supportsDeckReposition => _inner.supportsDeckReposition;
+
+  @override
+  Future<List<AnkiCardInfo>> listNewCards(String deckName) =>
+      _inner.listNewCards(deckName);
+
+  @override
+  Future<AnkiCardDueWriteResult> setNewCardPositions(
+    List<AnkiCardDueUpdate> updates,
+  ) =>
+      _inner.setNewCardPositions(updates);
+}

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -204,6 +204,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 id: 'card_creation.anki.reposition',
                 child: _buildDeckRepositionRow(vm),
               ),
+              SettingsSearchTarget(
+                id: 'card_creation.anki.reposition_auto',
+                child: _buildAutoRepositionRow(settings, vm),
+              ),
             ],
           ),
           AdaptiveSettingsSection(
@@ -1439,6 +1443,23 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           : t.anki_reposition_unsupported,
       subtitleMaxLines: 3,
       onTap: supported ? () => _openDeckReposition(vm) : null,
+    );
+  }
+
+  /// 「制卡后自动重排」开关。与上面那行同样的支持判据：不支持的后端置灰而
+  /// 不隐藏，否则用户会以为这功能不存在。
+  Widget _buildAutoRepositionRow(AnkiSettings settings, AnkiViewModel vm) {
+    final bool supported = vm.supportsDeckReposition;
+    return AdaptiveSettingsSwitchRow(
+      icon: Icons.autorenew_outlined,
+      showIcon: true,
+      title: t.anki_reposition_auto_title,
+      subtitle: supported
+          ? t.anki_reposition_auto_hint
+          : t.anki_reposition_unsupported,
+      value: supported && settings.autoRepositionEnabled,
+      onChanged:
+          supported ? (bool v) => vm.setAutoRepositionEnabled(v) : null,
     );
   }
 

--- a/fushi/lib/src/settings/settings_schema_card_creation.dart
+++ b/fushi/lib/src/settings/settings_schema_card_creation.dart
@@ -107,6 +107,13 @@ SettingsDestination buildCardCreationDestination() {
             c.ref.watch(ankiViewModelProvider).isConfigured,
       ),
       SettingsBodySearchEntry(
+        id: 'card_creation.anki.reposition_auto',
+        title: t.anki_reposition_auto_title,
+        hasRevealTarget: true,
+        visible: (SettingsContext c) =>
+            c.ref.watch(ankiViewModelProvider).isConfigured,
+      ),
+      SettingsBodySearchEntry(
         id: 'card_creation.anki.profile',
         hasRevealTarget: true,
         title: t.profile_label,

--- a/fushi/test/anki/anki_auto_reposition_test.dart
+++ b/fushi/test/anki/anki_auto_reposition_test.dart
@@ -1,0 +1,307 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/anki/anki_auto_reposition.dart';
+import 'package:fushi/src/anki/anki_deck_reposition_runner.dart';
+import 'package:fushi/src/anki/auto_reposition_anki_repository.dart';
+import 'package:fushi_anki/fushi_anki.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+// 「制卡后自动重排」调度器的行为守卫。用**真** runner + 假仓库跑，所以
+// plan/apply/pruneSnapshots 三段真实代码都在测试路径上（只有 AnkiConnect 的
+// HTTP 与词典 FFI 被替掉）。
+//
+// 钉四条不变式：
+//   - 防抖：窗口内多次制卡只触发一次写回；
+//   - 开关关着一次都不跑（默认关，老用户升级不会凭空多出自动写 Anki 的路径）；
+//   - 后端不支持（AnkiDroid / AnkiMobile / 远端制卡）一次都不跑；
+//   - 单飞：上一轮还在跑时进来的牌组不并发写，由那一轮收尾时捡走。
+
+class _FakeRepo extends BaseAnkiRepository {
+  _FakeRepo({required this.supported, required AnkiSettings settings})
+      : _settings = settings;
+
+  final bool supported;
+  AnkiSettings _settings;
+
+  /// 牌组 → 新卡。默认给一组「位置与词频相反」的卡，保证 plan 必产生改动。
+  final Map<String, List<AnkiCardInfo>> cards = <String, List<AnkiCardInfo>>{};
+
+  /// 每次 setNewCardPositions 的入参，用来数「写了几轮」。
+  final List<List<AnkiCardDueUpdate>> writes = <List<AnkiCardDueUpdate>>[];
+
+  /// 写回时先等这个 completer，用来把一轮重排按住做单飞测试。
+  Completer<void>? gate;
+
+  @override
+  bool get supportsDeckReposition => supported;
+
+  @override
+  Future<List<AnkiCardInfo>> listNewCards(String deckName) async =>
+      cards[deckName] ?? const <AnkiCardInfo>[];
+
+  @override
+  Future<AnkiCardDueWriteResult> setNewCardPositions(
+    List<AnkiCardDueUpdate> updates,
+  ) async {
+    if (gate != null) await gate!.future;
+    writes.add(updates);
+    return AnkiCardDueWriteResult(
+      written: updates.length,
+      failures: const <int, String>{},
+    );
+  }
+
+  @override
+  Future<AnkiSettings> loadSettings() async => _settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => _settings = s;
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  /// 下一次 mineEntry 返回什么（装饰器测试用）。
+  MineOutcome mineResult = MineOutcome.failure('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      mineResult;
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+AnkiCardInfo _card(int id, int due, String expression) => AnkiCardInfo(
+      cardId: id,
+      noteId: id,
+      ord: 0,
+      due: due,
+      type: 0,
+      queue: 0,
+      modelName: 'Basic',
+      deckName: 'Mining',
+      fields: <String, String>{'Expression': expression, 'Meaning': ''},
+    );
+
+/// 假词频表：`common` 排名 1、`rare` 排名 9999。
+List<FushiTermResult> _lookup(String expression) {
+  final int rank = expression == 'common' ? 1 : 9999;
+  return <FushiTermResult>[
+    FushiTermResult(
+      expression: expression,
+      reading: '',
+      rules: '',
+      glossaries: const <FushiGlossaryEntry>[],
+      pitches: const <FushiPitchEntry>[],
+      frequencies: <FushiFrequencyEntry>[
+        FushiFrequencyEntry(
+          dictName: 'JPDB',
+          frequencies: <FushiFrequency>[
+            FushiFrequency(value: rank, displayValue: ''),
+          ],
+        ),
+      ],
+    ),
+  ];
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('auto_reposition_test');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  ({_FakeRepo repo, AnkiAutoRepositionScheduler scheduler}) build({
+    bool enabled = true,
+    bool supported = true,
+    Duration debounce = const Duration(milliseconds: 20),
+  }) {
+    final AnkiSettings settings = AnkiSettings(
+      selectedDeckId: 1,
+      availableDecks: const <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
+      autoRepositionEnabled: enabled,
+    );
+    final _FakeRepo repo = _FakeRepo(supported: supported, settings: settings);
+    // 位置与词频相反：rare 在前(due 1)、common 在后(due 2)，重排必然要动。
+    repo.cards['Mining'] = <AnkiCardInfo>[
+      _card(1, 1, 'rare'),
+      _card(2, 2, 'common'),
+    ];
+    final AnkiAutoRepositionScheduler scheduler = AnkiAutoRepositionScheduler(
+      runner: AnkiDeckRepositionRunner(
+        repo,
+        lookup: _lookup,
+        snapshotDirectory: () async => tempDir,
+      ),
+      loadSettings: repo.loadSettings,
+      debounce: debounce,
+    );
+    return (repo: repo, scheduler: scheduler);
+  }
+
+  test('防抖：窗口内多次制卡只触发一轮写回', () async {
+    final r = build();
+    for (int i = 0; i < 5; i++) {
+      r.scheduler.notifyMined('Mining');
+    }
+    await r.scheduler.flushNow();
+
+    expect(r.repo.writes, hasLength(1),
+        reason: '五次制卡应合并成一次写回，而不是一张卡刷一次 AnkiConnect');
+    expect(r.repo.writes.single, hasLength(2));
+    // common(cardId 2) 应被排到第一个位置。
+    final AnkiCardDueUpdate first = r.repo.writes.single
+        .reduce((AnkiCardDueUpdate a, AnkiCardDueUpdate b) =>
+            a.due <= b.due ? a : b);
+    expect(first.cardId, 2, reason: '词频最高的卡应排到队首');
+    r.scheduler.dispose();
+  });
+
+  test('开关关着一次都不跑', () async {
+    final r = build(enabled: false);
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+    expect(r.repo.writes, isEmpty);
+    r.scheduler.dispose();
+  });
+
+  test('后端不支持卡片级读写时一次都不跑', () async {
+    final r = build(supported: false);
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+    expect(r.repo.writes, isEmpty);
+    r.scheduler.dispose();
+  });
+
+  test('单飞：上一轮在跑时进来的制卡不并发写，收尾时补跑', () async {
+    final r = build();
+    final Completer<void> gate = Completer<void>();
+    r.repo.gate = gate;
+
+    r.scheduler.notifyMined('Mining');
+    final Future<void> firstRun = r.scheduler.flushNow();
+    await Future<void>.delayed(Duration.zero);
+
+    // 第一轮卡在写回上，此时又制了一张卡并立刻催它跑。
+    r.scheduler.notifyMined('Mining');
+    final Future<void> secondCall = r.scheduler.flushNow();
+    await Future<void>.delayed(Duration.zero);
+    expect(r.repo.writes, isEmpty, reason: '第一轮还没写完，不该有任何写回落地');
+
+    r.repo.gate = null;
+    gate.complete();
+    await Future.wait(<Future<void>>[firstRun, secondCall]);
+
+    expect(r.repo.writes, hasLength(2),
+        reason: '第二次制卡不能被丢掉，应由第一轮收尾时捡走再跑一轮');
+    r.scheduler.dispose();
+  });
+
+  test('dispose 之后的制卡不再触发', () async {
+    final r = build();
+    r.scheduler.dispose();
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+    expect(r.repo.writes, isEmpty);
+  });
+
+  group('装饰器只在真的制出新卡时才通知调度器', () {
+    ({_FakeRepo repo, AutoRepositionAnkiRepository decorated}) wrap({
+      bool supported = true,
+    }) {
+      final r = build(supported: supported);
+      // 直接观测 notifyMined 的入参：把调度器换成一个只记账的探针不现实
+      // （它是具体类），改用真调度器 + 记 pending 的间接观测反而更脆。
+      // 这里用 onRunForTesting 之外的最短路径：跑完 flushNow 后看写回次数。
+      final AutoRepositionAnkiRepository decorated =
+          AutoRepositionAnkiRepository(
+        inner: r.repo,
+        scheduler: r.scheduler,
+      );
+      return (repo: r.repo, decorated: decorated);
+    }
+
+    Future<int> minesThenFlush(
+      ({_FakeRepo repo, AutoRepositionAnkiRepository decorated}) w,
+    ) async {
+      await w.decorated.mineEntry(
+        rawPayloadJson: '{}',
+        context: const AnkiMiningContext(sentence: ''),
+      );
+      // 装饰器是否通知了调度器，只能由「有没有真的跑出一轮写回」体现。
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      return w.repo.writes.length;
+    }
+
+    test('制卡成功且带落卡牌组 → 触发', () async {
+      final w = wrap();
+      w.repo.mineResult = const MineOutcome.success(deckName: 'Mining');
+      expect(await minesThenFlush(w), 1);
+    });
+
+    test('制卡失败 → 不触发', () async {
+      final w = wrap();
+      w.repo.mineResult = MineOutcome.failure('nope');
+      expect(await minesThenFlush(w), 0);
+    });
+
+    test('成功但没有落卡牌组名 → 不触发', () async {
+      final w = wrap();
+      w.repo.mineResult = const MineOutcome.success();
+      expect(await minesThenFlush(w), 0,
+          reason: '牌组名是唯一的重排目标，猜一个比不做更危险');
+    });
+
+    test('后端不支持卡片级读写 → 不触发', () async {
+      final w = wrap(supported: false);
+      w.repo.mineResult = const MineOutcome.success(deckName: 'Mining');
+      expect(await minesThenFlush(w), 0);
+    });
+  });
+
+  test('快照按牌组各留最近 N 份，不会互相挤掉', () async {
+    final r = build();
+    final AnkiDeckRepositionRunner runner = AnkiDeckRepositionRunner(
+      r.repo,
+      lookup: _lookup,
+      snapshotDirectory: () async => tempDir,
+    );
+    // 牌组 A 一份（模拟手动重排留下的撤销点）、牌组 B 五份。
+    void writeSnapshot(String deck, int seq) {
+      File('${tempDir.path}/reposition-$deck-$seq.json').writeAsStringSync(
+        '{"deckName":"$deck","createdAt":'
+        '"2026-09-0${seq}T00:00:00.000Z","positions":[]}',
+      );
+    }
+
+    writeSnapshot('A', 1);
+    for (int i = 1; i <= 5; i++) {
+      writeSnapshot('B', i);
+    }
+
+    final int deleted = await runner.pruneSnapshots(keep: 2);
+
+    expect(deleted, 3, reason: 'B 的 5 份只留 2 份');
+    final AnkiRepositionSnapshot? a = await runner.latestSnapshot('A');
+    expect(a, isNotNull,
+        reason: '在 B 上反复自动重排，不能把 A 的撤销点静默挤掉');
+    r.scheduler.dispose();
+  });
+}

--- a/fushi/test/anki/anki_auto_reposition_test.dart
+++ b/fushi/test/anki/anki_auto_reposition_test.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:fushi/src/anki/anki_auto_reposition.dart';
+import 'package:fushi/src/anki/anki_deck_reposition.dart';
 import 'package:fushi/src/anki/anki_deck_reposition_runner.dart';
 import 'package:fushi/src/anki/auto_reposition_anki_repository.dart';
 import 'package:fushi_anki/fushi_anki.dart';
@@ -131,23 +133,27 @@ void main() {
   ({_FakeRepo repo, AnkiAutoRepositionScheduler scheduler}) build({
     bool enabled = true,
     bool supported = true,
+    bool alreadySorted = false,
+    bool noFrequencies = false,
+    AnkiRepositionSource source = AnkiRepositionSource.dictionaries,
     Duration debounce = const Duration(milliseconds: 20),
   }) {
     final AnkiSettings settings = AnkiSettings(
       selectedDeckId: 1,
       availableDecks: const <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
       autoRepositionEnabled: enabled,
+      repositionSource: source,
     );
     final _FakeRepo repo = _FakeRepo(supported: supported, settings: settings);
     // 位置与词频相反：rare 在前(due 1)、common 在后(due 2)，重排必然要动。
-    repo.cards['Mining'] = <AnkiCardInfo>[
-      _card(1, 1, 'rare'),
-      _card(2, 2, 'common'),
-    ];
+    repo.cards['Mining'] = alreadySorted
+        ? <AnkiCardInfo>[_card(1, 1, 'common'), _card(2, 2, 'rare')]
+        : <AnkiCardInfo>[_card(1, 1, 'rare'), _card(2, 2, 'common')];
     final AnkiAutoRepositionScheduler scheduler = AnkiAutoRepositionScheduler(
       runner: AnkiDeckRepositionRunner(
         repo,
-        lookup: _lookup,
+        lookup:
+            noFrequencies ? (String e) => const <FushiTermResult>[] : _lookup,
         snapshotDirectory: () async => tempDir,
       ),
       loadSettings: repo.loadSettings,
@@ -167,9 +173,8 @@ void main() {
         reason: '五次制卡应合并成一次写回，而不是一张卡刷一次 AnkiConnect');
     expect(r.repo.writes.single, hasLength(2));
     // common(cardId 2) 应被排到第一个位置。
-    final AnkiCardDueUpdate first = r.repo.writes.single
-        .reduce((AnkiCardDueUpdate a, AnkiCardDueUpdate b) =>
-            a.due <= b.due ? a : b);
+    final AnkiCardDueUpdate first = r.repo.writes.single.reduce(
+        (AnkiCardDueUpdate a, AnkiCardDueUpdate b) => a.due <= b.due ? a : b);
     expect(first.cardId, 2, reason: '词频最高的卡应排到队首');
     r.scheduler.dispose();
   });
@@ -209,8 +214,7 @@ void main() {
     gate.complete();
     await Future.wait(<Future<void>>[firstRun, secondCall]);
 
-    expect(r.repo.writes, hasLength(2),
-        reason: '第二次制卡不能被丢掉，应由第一轮收尾时捡走再跑一轮');
+    expect(r.repo.writes, hasLength(2), reason: '第二次制卡不能被丢掉，应由第一轮收尾时捡走再跑一轮');
     r.scheduler.dispose();
   });
 
@@ -265,8 +269,7 @@ void main() {
     test('成功但没有落卡牌组名 → 不触发', () async {
       final w = wrap();
       w.repo.mineResult = const MineOutcome.success();
-      expect(await minesThenFlush(w), 0,
-          reason: '牌组名是唯一的重排目标，猜一个比不做更危险');
+      expect(await minesThenFlush(w), 0, reason: '牌组名是唯一的重排目标，猜一个比不做更危险');
     });
 
     test('后端不支持卡片级读写 → 不触发', () async {
@@ -276,32 +279,95 @@ void main() {
     });
   });
 
-  test('快照按牌组各留最近 N 份，不会互相挤掉', () async {
+  test('位置本来就对时一张卡都不写、也不留快照', () async {
+    final r = build(alreadySorted: true);
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+
+    expect(r.repo.writes, isEmpty,
+        reason: '判据必须是 plan.changed，不是 plan.updates.isEmpty——'
+            'planCardPositions 给每张新卡都发一条 update，用 updates 判等于'
+            '每批制卡都把整个牌组重写一遍');
+    expect(tempDir.listSync(), isEmpty, reason: '没写回就不该留快照');
+    r.scheduler.dispose();
+  });
+
+  test('词典来源下一张都没查到词频时不重排', () async {
+    final r = build(noFrequencies: true);
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+
+    expect(r.repo.writes, isEmpty,
+        reason: '没有任何排序依据的「重排」只是一次无信息量的全牌组位置重写'
+            '（选中的词频词典被删/被隐藏时就是这个状态）');
+    r.scheduler.dispose();
+  });
+
+  test('自动重排的快照不会劫持手动重排的撤销点', () async {
     final r = build();
     final AnkiDeckRepositionRunner runner = AnkiDeckRepositionRunner(
       r.repo,
       lookup: _lookup,
       snapshotDirectory: () async => tempDir,
     );
-    // 牌组 A 一份（模拟手动重排留下的撤销点）、牌组 B 五份。
-    void writeSnapshot(String deck, int seq) {
-      File('${tempDir.path}/reposition-$deck-$seq.json').writeAsStringSync(
-        '{"deckName":"$deck","createdAt":'
-        '"2026-09-0${seq}T00:00:00.000Z","positions":[]}',
-      );
-    }
 
-    writeSnapshot('A', 1);
+    // 手动重排一次（auto 默认 false）。
+    final AnkiRepositionPlan? manual = await runner.plan(
+      deckName: 'Mining',
+      settings: await r.repo.loadSettings(),
+      options: const AnkiRepositionRankOptions(),
+    );
+    await runner.apply(manual!);
+    final AnkiRepositionSnapshot? afterManual =
+        await runner.latestSnapshot('Mining');
+    expect(afterManual, isNotNull);
+
+    // 再让自动路径跑一轮（卡的位置已被手动那次改过，这里重新造成待排状态）。
+    r.repo.cards['Mining'] = <AnkiCardInfo>[
+      _card(1, 1, 'rare'),
+      _card(2, 2, 'common'),
+    ];
+    r.scheduler.notifyMined('Mining');
+    await r.scheduler.flushNow();
+    expect(r.repo.writes, isNotEmpty, reason: '自动那轮应该真的写了');
+
+    final AnkiRepositionSnapshot? afterAuto =
+        await runner.latestSnapshot('Mining');
+    expect(afterAuto!.file.path, afterManual!.file.path,
+        reason: '撤销按钮必须仍指向手动那次之前的状态；被自动快照顶掉的话，'
+            '那次手动重排就永远撤不回去了，而按钮看起来一切正常');
+    r.scheduler.dispose();
+  });
+
+  test('pruneSnapshots 只削自动快照，手动的一份不动', () async {
+    final r = build();
+    final AnkiDeckRepositionRunner runner = AnkiDeckRepositionRunner(
+      r.repo,
+      lookup: _lookup,
+      snapshotDirectory: () async => tempDir,
+    );
+    File snap(String name) =>
+        File('${tempDir.path}/$name')..writeAsStringSync('{}');
+
+    snap(
+        '${AnkiDeckRepositionRunner.kManualPrefix}2026-09-01T00-00-00.000Z.json');
     for (int i = 1; i <= 5; i++) {
-      writeSnapshot('B', i);
+      snap('${AnkiDeckRepositionRunner.kAutoPrefix}2026-09-0${i}T00-00-00.000Z'
+          '.json');
     }
 
     final int deleted = await runner.pruneSnapshots(keep: 2);
 
-    expect(deleted, 3, reason: 'B 的 5 份只留 2 份');
-    final AnkiRepositionSnapshot? a = await runner.latestSnapshot('A');
-    expect(a, isNotNull,
-        reason: '在 B 上反复自动重排，不能把 A 的撤销点静默挤掉');
+    expect(deleted, 3, reason: '5 份自动快照只留 2 份');
+    final List<String> left = tempDir
+        .listSync()
+        .map((FileSystemEntity e) => p.basename(e.path))
+        .toList()
+      ..sort();
+    expect(
+        left.where((String n) => !n.startsWith('reposition-auto-')).length, 1,
+        reason: '手动快照是用户的撤销点，一份都不能被自动路径的产物挤掉');
+    expect(left.length, 3);
     r.scheduler.dispose();
   });
 }

--- a/fushi/test/anki/anki_deck_reposition_dialog_test.dart
+++ b/fushi/test/anki/anki_deck_reposition_dialog_test.dart
@@ -70,6 +70,7 @@ Future<AnkiViewModel> _pumpDialog(
     source: AnkiRepositionSource.dictionaries,
     dictionaries: const <String>['JPDB'],
     aggregate: 'harmonic',
+    rareFirst: false,
   );
   late BuildContext hostContext;
   await tester.pumpWidget(TranslationProvider(

--- a/fushi/test/anki/auto_reposition_repository_delegation_test.dart
+++ b/fushi/test/anki/auto_reposition_repository_delegation_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+// `AutoRepositionAnkiRepository` 的委派完整性守卫。
+//
+// 那个类的语义是「行为与被包装的仓库完全一致，只在 mineEntry 成功后多一个副作用」。
+// 它靠**逐个方法手写委派**做到这点——而 Dart 没有自动转发，漏掉一个方法不会报错：
+// 调用会静默掉回 `BaseAnkiRepository` 的降级默认（`supportsNoteTypeEditing` 变
+// false、`noteFields` 恒返回 null、`listNewCards` 恒返回空……）。表现出来就是
+// 「打开自动重排以后某个不相干的功能坏了」，而且不可能有人一眼看出关联。
+//
+// 所以这里把不变式钉死：**基类里凡是被任一后端实现覆盖过的实例成员，装饰器
+// 都必须覆盖**。以后给基类加方法、或某个后端新覆盖一个方法，忘了同步装饰器
+// 就会在这里红。
+//
+// 后端清单是**磁盘枚举**出来的（扫 `extends BaseAnkiRepository`），不是写死的
+// 文件名——将来新增一个后端实现，它的 override 面自动纳入本守卫的扫描范围。
+
+/// 从一份 Dart 源码里抓出所有 `@override` 紧跟着声明的成员名。
+Set<String> _overriddenMembers(String source) {
+  final Set<String> names = <String>{};
+  final RegExp re = RegExp(
+    r'@override\s*\n\s*([^\n;{]*?)\b([a-zA-Z_]\w*)\s*[({=]',
+  );
+  for (final RegExpMatch m in re.allMatches(source)) {
+    final String name = m.group(2)!;
+    names.add(name);
+  }
+  return names;
+}
+
+/// 递归找出 [root] 下所有源码文件。
+List<File> _dartFiles(Directory root) => root
+    .listSync(recursive: true)
+    .whereType<File>()
+    .where((File f) => f.path.endsWith('.dart'))
+    .toList();
+
+void main() {
+  // 测试的工作目录是 `fushi/`。
+  final Directory appLib = Directory('lib');
+  final Directory packagesDir = Directory(p.join('..', 'packages'));
+  final File decoratorFile =
+      File(p.join('lib', 'src', 'anki', 'auto_reposition_anki_repository.dart'));
+  final File baseFile = File(p.join(
+    '..',
+    'packages',
+    'fushi_anki',
+    'lib',
+    'src',
+    'base_anki_repository.dart',
+  ));
+
+  test('装饰器覆盖了所有被后端实现覆盖过的基类成员', () {
+    expect(decoratorFile.existsSync(), isTrue,
+        reason: '找不到装饰器源码，本守卫失去意义');
+    expect(baseFile.existsSync(), isTrue, reason: '找不到 BaseAnkiRepository');
+
+    final String decoratorSource = decoratorFile.readAsStringSync();
+    final Set<String> delegated = _overriddenMembers(decoratorSource);
+    // 空壳自检：装饰器至少得覆盖十几个成员，否则说明正则没匹配上，
+    // 下面的差集会恒为空、守卫恒绿。
+    expect(delegated.length, greaterThan(15),
+        reason: '只解析出 ${delegated.length} 个委派，正则大概率没匹配上');
+
+    // 枚举所有后端实现（含 app 侧的 AnkiMobile / RemoteMining）。
+    final List<File> candidates = <File>[
+      ..._dartFiles(appLib),
+      if (packagesDir.existsSync()) ..._dartFiles(packagesDir),
+    ];
+    final Set<String> backendOverrides = <String>{};
+    int backendCount = 0;
+    for (final File f in candidates) {
+      if (p.equals(f.path, decoratorFile.path)) continue;
+      final String src = f.readAsStringSync();
+      if (!src.contains('extends BaseAnkiRepository')) continue;
+      backendCount++;
+      backendOverrides.addAll(_overriddenMembers(src));
+    }
+    // 哨兵：本仓至少有 AnkiConnect / AnkiDroid / AnkiMobile / RemoteMining 四个
+    // 实现。扫到的数量掉下来，多半是扫描根写错了、而不是真的删了后端。
+    expect(backendCount, greaterThanOrEqualTo(4),
+        reason: '只扫到 $backendCount 个后端实现，扫描根可能不对');
+
+    // 只关心基类里真实存在的成员：后端自己的私有辅助方法不算。
+    final String baseSource = baseFile.readAsStringSync();
+    final Set<String> required = backendOverrides
+        .where((String n) => RegExp('\\b$n\\s*[({=;]').hasMatch(baseSource))
+        .toSet();
+
+    final Set<String> missing = required.difference(delegated);
+    expect(
+      missing,
+      isEmpty,
+      reason: '这些成员被某个后端覆盖过，但 AutoRepositionAnkiRepository 没有委派：'
+          '$missing\n'
+          '漏委派不会报错，只会让调用静默掉回基类降级默认。'
+          '请在 auto_reposition_anki_repository.dart 里补上纯委派实现。',
+    );
+  });
+}

--- a/fushi/test/pages/open_in_anki_wiring_static_test.dart
+++ b/fushi/test/pages/open_in_anki_wiring_static_test.dart
@@ -204,6 +204,12 @@ void main() {
       'lib/src/pages/implementations/dictionary_page_mixin.dart',
       'lib/src/pages/base_source_page.dart',
       'lib/src/lookup/overlay_bridge_handlers.dart',
+      // 不是第四条车道，是**纯委派层**：`AutoRepositionAnkiRepository` 包在
+      // `ankiRepositoryProvider` 最外层给制卡加自动重排副作用，语义要求它把
+      // 基类每个被后端覆盖的成员逐个转发（漏一个就静默掉回基类降级默认，
+      // 见 auto_reposition_repository_delegation_test）。这里的
+      // `_inner.openWordInAnki(...)` 是转发上面三条车道的调用，不是新起一处。
+      'lib/src/anki/auto_reposition_anki_repository.dart',
     };
     expect(
       filesWhere('lib', (String code) => code.contains('.openWordInAnki(')),
@@ -219,6 +225,9 @@ void main() {
     const Set<String> idLanes = <String>{
       'lib/src/anki/anki_mined_card_action_sheet.dart',
       'lib/src/lookup/overlay_bridge_handlers.dart',
+      // 同上：纯委派层两个方法都要转发，凑巧落进「既反查又打开」的形状，
+      // 但它自己不拼装任何链路——两处都只是 `=> _inner.xxx(...)` 一行。
+      'lib/src/anki/auto_reposition_anki_repository.dart',
     };
     expect(
       filesWhere(

--- a/packages/fushi_anki/lib/src/anki_models.dart
+++ b/packages/fushi_anki/lib/src/anki_models.dart
@@ -218,6 +218,8 @@ class AnkiSettings {
     this.repositionSource = AnkiRepositionSource.dictionaries,
     this.repositionDictionaries = const <String>[],
     this.repositionAggregate = 'harmonic',
+    this.repositionRareFirst = false,
+    this.autoRepositionEnabled = false,
   });
 
   factory AnkiSettings.fromJson(Map<String, dynamic> json) => AnkiSettings(
@@ -278,6 +280,11 @@ class AnkiSettings {
             const <String>[],
         repositionAggregate:
             json['repositionAggregate'] as String? ?? 'harmonic',
+        repositionRareFirst: json['repositionRareFirst'] as bool? ?? false,
+        // 缺键 = 老装置升级上来：自动重排默认关，升级不会凭空获得
+        // 一条会动 Anki 新卡队列位置的自动路径。
+        autoRepositionEnabled:
+            json['autoRepositionEnabled'] as bool? ?? false,
       );
   final int? selectedDeckId;
   final String? selectedDeckName;
@@ -397,6 +404,16 @@ class AnkiSettings {
   /// fushi_anki 不依赖 fushi_dictionary）。
   final String repositionAggregate;
 
+  /// 重排时罕见词优先（默认常见词优先）。此前只活在对话框的临时
+  /// 状态里；自动重排没有对话框，必须能从设置里读到它。
+  final bool repositionRareFirst;
+
+  /// 制卡成功后自动按词频重排该牌组的新卡（防抖批量、静默）。
+  /// 默认关：它会在用户没有点任何按钮的情况下写 Anki 的新卡位置，
+  /// 必须是显式选择而不是升级送的。仅 AnkiConnect 后端真正生效
+  /// （[BaseAnkiRepository.supportsDeckReposition]）。
+  final bool autoRepositionEnabled;
+
   bool get isConfigured => selectedDeckId != null && selectedNoteTypeId != null;
 
   /// BUG-2380：不需要真卡内容就能下的结论——当前选中的牌组 + 笔记类型 + 字段映射，
@@ -475,6 +492,8 @@ class AnkiSettings {
     AnkiRepositionSource? repositionSource,
     List<String>? repositionDictionaries,
     String? repositionAggregate,
+    bool? repositionRareFirst,
+    bool? autoRepositionEnabled,
   }) =>
       AnkiSettings(
         selectedDeckId:
@@ -529,6 +548,9 @@ class AnkiSettings {
         repositionDictionaries:
             repositionDictionaries ?? this.repositionDictionaries,
         repositionAggregate: repositionAggregate ?? this.repositionAggregate,
+        repositionRareFirst: repositionRareFirst ?? this.repositionRareFirst,
+        autoRepositionEnabled:
+            autoRepositionEnabled ?? this.autoRepositionEnabled,
       );
 
   Map<String, dynamic> toJson() => {
@@ -568,6 +590,8 @@ class AnkiSettings {
         'repositionSource': repositionSource.name,
         'repositionDictionaries': repositionDictionaries,
         'repositionAggregate': repositionAggregate,
+        'repositionRareFirst': repositionRareFirst,
+        'autoRepositionEnabled': autoRepositionEnabled,
       };
 }
 


### PR DESCRIPTION
## 为什么

「按词频重排新卡」此前只有 Anki 设置页里的手动对话框一个入口，每挖一批词都要
自己去点一次。本 PR 让它可以在制卡后自动跑。

**默认关**，且只有 AnkiConnect 后端会真正触发（AnkiDroid / AnkiMobile /
「制卡到已配对设备」都没有卡片级读写）——升级不会凭空多出一条自动写 Anki 的路径。

## 怎么做

- `AnkiAutoRepositionScheduler`：30 秒防抖把一批制卡合成一轮，单飞锁避免并发写
  同一牌组（两次 `apply` 并发会让后写的那份基于过期 plan），成功静默、失败才 toast。
- `AutoRepositionAnkiRepository`：包在 `ankiRepositoryProvider` 最外层，`mineEntry`
  成功后把**后端实际落卡的牌组名**（`MineOutcome.deckName`，BUG-1549）喂给调度器。
  **12 处制卡调用点零改动**，手法同既有的 `RemoteMiningAnkiRepository`。
- 设置项 `autoRepositionEnabled` + 设置页开关 + 搜索登记。
- 顺带修好对话框「罕见词优先」选项不被记住（此前只活在弹窗临时状态里）。

## 自动化引入的新问题，一并处理了

手动路径每次重排写一份快照，用户点一次撤销就消耗掉；自动路径每批新卡写一份、
没人消费。三个后果都在本 PR 里解决：

- **快照会无界增长**，且 `latestSnapshot` 读全目录，撤销会越用越慢 → `pruneSnapshots`。
- **自动快照会劫持手动撤销点**：`latestSnapshot` 按牌组挑最新、不分来源，用户手动
  重排后随便挖一个词，30 秒后撤销按钮就指向「自动那次之前」＝手动重排的结果本身，
  那次手动重排永远撤不回去，而按钮看起来一切正常 → 来源编进文件名
  （`reposition-auto-` 前缀），撤销只认手动快照，prune 只削自动快照。
- **prune 逐份全量 `jsonDecode`**（含整个 `positions` 数组）只为读两个字段 → 来源与
  时刻都进文件名后改成纯文件名排序，零解析。

## 审查发现的三个真 bug（已修）

1. **判据用错，每批制卡都全牌组重写**。`planCardPositions` 给每张新卡都发一条
   update，所以 `plan.updates.isEmpty` 只在牌组零新卡时成立。挖一个词就给 2000 张卡
   发 2000 条 `setSpecificValueOfCard`，哪怕排完与原来逐字节相同。改用 `plan.changed`。
2. 上面的快照劫持。
3. **选中的词频词典失效后静默全牌组重写**：弹窗会把持久化选择与已装载词典求交，
   `fromSettings` 不会；词典被删/被隐藏后 rank 全 null，重排退化成一次没有信息量的
   位置重编。词典来源下 `plan.ranked == 0` 时跳过。

## 验证

- `test/anki` + `test/settings` **843 绿**；新写的调度器/装饰器测试 **13 绿**
- `packages/fushi_anki` **551 绿**（改了 `AnkiSettings`，该包测试不在主 analyze 面里）
- `fushi` 全量 `flutter analyze` **无 issue**
- 51 条目录枚举型守卫整批 **368 绿**（与文档记录的当前基线一致）
- **变异实测两次**：删掉一个委派 → 委派守卫报出精确成员名变红；判据改回
  `updates.isEmpty` → 对应回归测试立刻红。都不是空壳。

`AutoRepositionAnkiRepository` 是纯委派层，语义要求逐个转发基类每个被后端覆盖的
成员——漏一个不会报错，只会静默掉回基类降级默认。
`auto_reposition_repository_delegation_test` 用磁盘枚举扫出所有后端的 override 面
钉死这条。它也因此撞上 BUG-2051 两条守卫的形状判据（同文件里既反查又打开），按
那两条守卫自己预留的出口登记并写明理由。

## 没做

没做真机验证（真开着 Anki + AnkiConnect 制卡再看牌组顺序）。逻辑链路由单测覆盖，
但「装上去真跑一遍」这一步没做。

https://claude.ai/code/session_01W9X86o26WmnVsiUV6nwK7S
