### PR TITLE
fix(mihon): 修复代理、图片生命周期及筛选器类型兼容

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2181 条。点号进各自文件。
+> 共 2182 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2404](bugs/BUG-2404-mihon-proxy-socket-uri.md) | ✅ | ✅ | Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |
 | [BUG-2362](bugs/BUG-2362-ios-exit-affordances.md) | ✅ | ✅ | iOS 多处页面/模态没有出口，进去就得重启 app |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2184 条。点号进各自文件。
+> 共 2186 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2408](bugs/BUG-2408-mihon-filter-wire-codec.md) | ✅ | ✅ | Mihon 裸 FilterList 绕过类型化序列化导致选项对象报错 |
+| [BUG-2407](bugs/BUG-2407-mihon-concrete-allocation-type.md) | ✅ | ✅ | Comic Days 筛选选项类型被转成 Object 导致 ArrayStoreException |
 | [BUG-2406](bugs/BUG-2406-mihon-inlined-filter-constructor.md) | ✅ | ✅ | SchaleNetwork 内联筛选组构造器导致抽象类实例化失败 |
 | [BUG-2405](bugs/BUG-2405-mihon-image-response-lifetime.md) | ✅ | ✅ | Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket |
 | [BUG-2404](bugs/BUG-2404-mihon-proxy-socket-uri.md) | ✅ | ✅ | Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2186 条。点号进各自文件。
+> 共 2187 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2409](bugs/BUG-2409-mihon-source-http-error.md) | ✅ | ✅ | Mihon 保留源站HTTP错误状态并区分桥接失败 |
 | [BUG-2408](bugs/BUG-2408-mihon-filter-wire-codec.md) | ✅ | ✅ | Mihon 裸 FilterList 绕过类型化序列化导致选项对象报错 |
 | [BUG-2407](bugs/BUG-2407-mihon-concrete-allocation-type.md) | ✅ | ✅ | Comic Days 筛选选项类型被转成 Object 导致 ArrayStoreException |
 | [BUG-2406](bugs/BUG-2406-mihon-inlined-filter-constructor.md) | ✅ | ✅ | SchaleNetwork 内联筛选组构造器导致抽象类实例化失败 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2183 条。点号进各自文件。
+> 共 2184 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2406](bugs/BUG-2406-mihon-inlined-filter-constructor.md) | ✅ | ✅ | SchaleNetwork 内联筛选组构造器导致抽象类实例化失败 |
 | [BUG-2405](bugs/BUG-2405-mihon-image-response-lifetime.md) | ✅ | ✅ | Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket |
 | [BUG-2404](bugs/BUG-2404-mihon-proxy-socket-uri.md) | ✅ | ✅ | Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-2405](bugs/BUG-2405-mihon-image-response-lifetime.md) | 🚧 | 🚧 | Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket |
+| [BUG-2405](bugs/BUG-2405-mihon-image-response-lifetime.md) | ✅ | ✅ | Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket |
 | [BUG-2404](bugs/BUG-2404-mihon-proxy-socket-uri.md) | ✅ | ✅ | Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2182 条。点号进各自文件。
+> 共 2183 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2405](bugs/BUG-2405-mihon-image-response-lifetime.md) | 🚧 | 🚧 | Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket |
 | [BUG-2404](bugs/BUG-2404-mihon-proxy-socket-uri.md) | ✅ | ✅ | Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点 |
 | [BUG-2364](bugs/BUG-2364-vn-mouse-wheel.md) | ✅ | ✅ | VN模式鼠标滚轮被分页器能力门误拦截 |
 | [BUG-2363](bugs/BUG-2363-reader-longpress-stationary-selection.md) | ✅ | ✅ | 小说长按必须额外拖动才进入文本选择 |

--- a/docs/bugs/BUG-2404-mihon-proxy-socket-uri.md
+++ b/docs/bugs/BUG-2404-mihon-proxy-socket-uri.md
@@ -1,0 +1,10 @@
+## BUG-2404 · Mihon 全局代理选择器误将 TCP socket URI 发送至 HTTP 策略端点
+- **报告**：2026-09-10（用户：在 Windows Fushi 下载《週に一度クラスメイトを買う話》测试，不使用 Mokuro；Rawkuma / WeLoveManga 均报代理策略不可用。）
+- **真实性**：✅ 真 bug。`third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/impl/HostProxyPolicy.kt:92` 的全局 `ProxySelector.select` 无条件把所有 URI 发送到宿主；JDK `SocksSocketImpl.connect` 会为 OkHttp 已选路的底层 TCP socket 再调用它，URI scheme 为 `socket`。`fushi/lib/src/media/manga/mihon/mihon_proxy_policy_server.dart:41` 仅接受 HTTP(S)，返回 400；Kotlin lookup 抛出通用 IOException，被外层包装成 BRIDGE_HTTP_500。
+- **[x] ① 已修复** — `HostProxyPolicy.select` 区分底层 socket 传输与原始 HTTP 选路；非 200 错误保留纯数字状态码。修复提交见本文件同批 Git 提交。
+- **[x] ② 已加自动化测试** — `HostProxyPolicyTest.kt` 新增全局真实选择器下 Socket 字节往返、OkHttp 已选 HTTP 代理的真实请求测试。移除修复：7 项执行/2 项失败；恢复修复：7 项通过/0 跳过（Gradle exit 0）。
+- **证据**：用户安装版 `D:/APP/Hibiki/fushi.exe` 的 Mihon 日志（2026-09-10 07:12:56 Rawkuma / 07:13:09 WeLoveManga）含完整 `HostProxyPolicy.lookup → select → SocksSocketImpl.connect → Socket.connect → okhttp3.internal.platform.Platform.connectSocket` 栈。使用安装版 Java 21 加全局选择器及真实 Socket 可复现 `socket://127.0.0.1:<port>` 回调；策略查询自身的 `openConnection(Proxy.NO_PROXY)` 不触发该回调。
+- **边界**：HTTP(S) 仍由宿主决定 auto/manual/direct、认证与本地绕过，策略接口不可用仍报错；仅底层 `socket` 传输不重复做 HTTP 代理选路。不能通过放宽宿主 URL 校验、HTTP 失败自动直连或重启重试掩盖错误。
+- **验收**：Windows `build_desktop_runtime.ps1` 完整 `:server:test` + `:server:shadowJar` 和 `verify_desktop_runtime.ps1` 均 exit 0。Dart 宿主策略、vendored server、出站纪律三个 suite 共 35 项通过（首次 PDFium 下载超时，补构建进程代理后通过）。已备份安装版 JAR/checksums 并替换 JAR，只停止已核身份的 Mihon 子进程让主应用重新拉起。原始 Rawkuma UI 列表、封面与搜索均恢复，日志确认公网 HTTP 200，原代理错误消失。指定漫画下载验收另记。
+- **安全复核**：宿主 token、URL 验证、HTTP 策略失败关闭和代理凭据作用域不变；仅 `socket` 分支不再重复路由。verify-security 脚本未支持 Kotlin（扫描 0 文件），不计作安全通过；以上边界以人工 diff 和实际代理回归测试复核。
+- **指定作品复测**：用户安装版通过 Rawkuma 搜索 `shuu ni` 找到 `Shuu ni Ichido Classmate wo Kau Hanashi`，详情显示作者 HANEDA Usa、匹配封面及 15 个章节。随后用户物理 Escape 停止 Computer Use，加入书架操作未执行，下载/离线阅读未验证。

--- a/docs/bugs/BUG-2405-mihon-image-response-lifetime.md
+++ b/docs/bugs/BUG-2405-mihon-image-response-lifetime.md
@@ -1,0 +1,8 @@
+## BUG-2405 · Mihon 图片响应在读取正文前因 Rx 退订关闭 Socket
+- **报告**：2026-09-10（用户：日语漫画《週に一度クラスメイトを買う話》章节图片加载不出来。）
+- **真实性**：✅ 真 bug。安装版 Chapter 15.1 阅读器停在 1/12 黑屏破图；Mihon 日志显示原站返回 200 和图片 Content-Length，随后 `Socket closed`，栈为 `ResponseBody.bytes → MihonImageProxy.fetch:92`。`upstream_src/server/src/main/kotlin/mextensionserver/impl/MihonImageProxy.kt:89` 在 `fetchImage(...).toBlocking().single()` 结束后才读取正文；`upstream_src/server/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt:111` 的退订会 `call.cancel()`，因此网络 Response 已失效。旧测试都用内存 ResponseBody，无法暴露该错误。
+- **[x] ① 已修复** — overlay `MihonImageProxy.fetch` 在 Rx map 内读取并关闭 Response，然后才返回已脱离网络生命周期的 ImageData。修复哈希见本文件同批提交。
+- **[x] ② 已加自动化测试** — overlay `MihonImageProxyTest` 增加真实回环 HTTP 256 KiB 图片逐字节校验。旧代码执行 4 项/1 项失败（Socket closed），修复后图片与代理测试通过；全 JVM 29 项/0 失败/0 跳过。
+- **修复边界**：通过 overlay 修正响应消费生命周期，不改 pristine upstream、不绕过扩展 fetchImage/client/interceptor、不重试或延长超时。公网图片已开始返回正文，不能把这个错误归因于原站没资源。
+- **等价路径**：扫描桌面 bridge 的 blocking/await 消费点，唯一把 live Response 移出订阅再读取正文的位置是 MihonImageProxy.fetch；封面独立请求路径不受此生命周期问题影响。
+- **验收**：`:server:test :server:shadowJar` exit 0，`verify_desktop_runtime.ps1` exit 0；本地 `.codex-test/jvm-policy-validation/image-{red,green,full}.log` 和 XML 保存证据。备份本机旧 JAR/checksums 后应用修复，重启精确识别的 Mihon Java 子进程。用户安装版重开同一 Chapter 15.1：1/12 封面正常，向左翻页后人物介绍及黑白日语对白均真实渲染；2026-09-10 07:35 图片请求返回 200，未重现 Socket closed。整书离线下载未验证。

--- a/docs/bugs/BUG-2406-mihon-inlined-filter-constructor.md
+++ b/docs/bugs/BUG-2406-mihon-inlined-filter-constructor.md
@@ -1,0 +1,9 @@
+## BUG-2406 · SchaleNetwork 内联筛选组构造器导致抽象类实例化失败
+- **报告**：2026-09-10（用户：SchaleNetwork ALL / JA 搜索显示 BRIDGE_HTTP_500 和 Filter$Group。）
+- **真实性**：✅ 真 bug。用户安装版 koharu APK 的 `Lp0;` 是具体 final `Filter$Group` 子类，原始 DEX 中无方法或字段；`Lp;.getFilterList` 的 `new-instance v3, Lp0;` 与 `invoke-direct {v3,v4,v6}, Filter$Group.<init>(String,List)` 分离，其间包含构造参数的循环。转换后 NEW 被改成抽象 Group，现有 `DexAllocationRepair.kt:233` 因子类无匹配构造器而拒绝恢复，导致 InstantiationError。
+- **[x] ① 已修复** — `DexAllocationRepair` 从原始 DEX 证明具体分配类型及直接父类构造调用；验证接收寄存器不变、无外部跳转/异常入口后，补缺失的转发构造器并恢复具体 NEW。提交见本文件同批 Git 历史。
+- **[x] ② 已加自动化测试** — `DexInlinedConstructorTest` 使用真实 DexFileWriter → 完整 PackageTools.dex2jar 转换 → JVM 类加载与调用，校验循环、筛选组类型/name/state、幂等；负向覆盖寄存器覆盖、别名逸出、外部 branch 和异常入口。原有 DexAllocationRepairTest 继续覆盖歧义和缺失证据时不修复。
+- **真实证据**：安装版日志 2026-09-10 07:47:54 显示 `Skipping abstract allocation in p.getFilterList: p0 has no constructor matching ...`，随后 InstantiationError；独立 bridge 使用同一 APK 实测 all/en/ja/zh 四个 source 的 sourcesManga 正常而 filtersManga 全部 HTTP 500。证据留在本地 `.codex-test/schale/{dex.txt,before-results.json,before.log}`。
+- **修复约束**：以原始 DEX 分配/构造接收者及控制流为证据，保留具体筛选组类型和父类构造语义；不把抽象宿主类改为具体类、不按 SchaleNetwork/混淆类名硬编码、不跳过筛选器。原始 upstream_src 不修改。
+- **真实 APK 验收**：修复版独立 bridge 对用户原 APK（SHA256 `e7ff9e5d70b3fd5bf47a1fc2f846da118937c5bbe3ba5dca104a31d8faa51486`）all/en/ja/zh 四语言 filtersManga 全部返回 HTTP 200，保留排序及筛选组内容；修复前四个均为 500。证据 `.codex-test/schale/after-fixed-results.json`。
+- **最终验收**：全 JVM 35 项/0 失败/0 跳过、format/lint/shadowJar、Windows runtime smoke 均通过。备份本机旧 JAR/checksums 后替换最终产物（SHA256 `b2c52d2c2db80eadf7cdb704192e04767afcd36f41e2b03279158c912240899f`），重启已核身份的 Mihon 子进程；本机 Fushi 使用原始完整日文书名重搜，SchaleNetwork ALL/JA 均正常结束并显示“没有找到漫画”，原 InstantiationError 消失，Rawkuma 仍能找到目标作品。该搜索的空结果不等同于源站没有本书。其它平台和 SchaleNetwork 整书下载未验证。

--- a/docs/bugs/BUG-2407-mihon-concrete-allocation-type.md
+++ b/docs/bugs/BUG-2407-mihon-concrete-allocation-type.md
@@ -1,0 +1,8 @@
+## BUG-2407 · Comic Days 筛选选项类型被转成 Object 导致 ArrayStoreException
+- **报告**：2026-09-10（用户：Comic Days 搜索报 BRIDGE_HTTP_500: java.lang.Object。）
+- **真实性**：✅ 真 bug。安装版日志为 `ArrayStoreException: java.lang.Object → AbstractCollection.toArray → g.<init> → Generated.getFilterList`。原 APK 的 `Lf;` 是 Object 的 final 子类，仅有 toString、无构造器；getFilterList 原始指令为 `new-instance v3,Lf; → invoke-direct Object.<init>() → listOf(v3)`，随后 g 的构造器将集合写入 f[]。转换后具体 f 被丢成 Object，数组写入失败。现有 DexAllocationRepair 仅检查抽象类分配，漏掉具体父类泛化。
+- **[x] ① 已修复** — 将转换后的具体父类分配纳入原始 DEX 恢复，但额外要求每个被替换接收者的构造证据匹配；不将“计数缺额”单独作为修改合法 concrete NEW 的授权。提交见同批 Git 历史。
+- **[x] ② 已加自动化测试** — DexConcreteAllocationTest 真实 DEX 转换先复现 ArrayStoreException，再校验修复后的 typed toArray、toString、幂等，以及无证据、合法 Object、多候选歧义不改写。
+- **证据**：本机 Comic Days APK 在独立 bridge 中 sourcesManga 返回 200、filtersManga 返回 500，错误栈与 UI 一致；原始 DEX 与响应保存于 `.codex-test/schale/comicdays-{types.txt,before-results.json,before.log}`。
+- **边界**：具体父类分配不能仅靠类型缺额判定，须另有原始 DEX 构造接收者证明；合法 Object、歧义候选、未知数据流均不改写。保留类型特有的 toString/筛选选项行为，不跳过筛选器。
+- **验收**：首轮全 JVM39项通过；真实 APK复测已越过ArrayStoreException，暴露后续过滤器JSON编码问题，单独跟踪BUG-2408；最终联合验收见BUG-2408。

--- a/docs/bugs/BUG-2408-mihon-filter-wire-codec.md
+++ b/docs/bugs/BUG-2408-mihon-filter-wire-codec.md
@@ -1,0 +1,9 @@
+## BUG-2408 · Mihon 裸 FilterList 绕过类型化序列化导致选项对象报错
+- **报告**：2026-09-10（用户：Comic Days筛选器不可用，沿原始路径修复BUG-2407后继续复测发现。）
+- **真实性**：✅ 真 bug。MihonInvoker.invokeFiltersManga返回裸FilterList，但overlay DalvikHandler.kt:87只为FiltersResponse包装类型调用既有toBridgeMap；裸列表直接交给Jackson，将Filter.Select的自定义无字段选项f当Java Bean序列化，抛FAIL_ON_EMPTY_BEANS。既有codec已正确按toString输出显示标签，实际路径却未接入。
+- **[x] ① 已修复** — filterResponseForBridge同时处理裸FilterList和包装FiltersResponse，复用既有显式codec，保持各自wire形状。提交见同批Git历史。
+- **[x] ② 已加自动化测试** — 新增Jackson真实序列化测试覆盖无字段自定义选项、日文显示标签、嵌套Group、TriState/Sort及两种响应形状；联合完整JVM41项通过、0跳过，lint/shadowJar和Windows运行时smoke通过。
+- **边界**：同时支持实际裸FilterList数组与历史FiltersResponse包装形状，复用现有显式filter codec，保留type/state/values/children及顺序；不关闭Jackson序列化错误，不为具体扩展对象加特例。
+- **证据**：`.codex-test/schale/comicdays-after-results.json`含真实APK的`No serializer found for class f ... FilterList[0]->g[values]->f[0]`错误。
+- **真实APK验收**：Comic Days的filtersManga由500恢复200，返回`コレクション`、`連載作品一覧`；SchaleNetwork四语言同样200，type/state/values/children均经统一codec。证据`.codex-test/schale/comicdays-final-results.json`、`schale-after-codec-results.json`。最终JAR SHA256为`90d60e9cf6e0fc33a9c2b82974a729f57143930f80422973c4e203efd3986c22`，已备份并应用本机。其他平台未验证。
+- **用户UI验收**：本机Fushi重新提交原始完整日文书名，Comic Days正常结束并显示“没有找到漫画”，原Object错误消失；该查询空结果不代表站点不存在作品。

--- a/docs/bugs/BUG-2409-mihon-source-http-error.md
+++ b/docs/bugs/BUG-2409-mihon-source-http-error.md
@@ -1,0 +1,7 @@
+## BUG-2409 · Mihon 保留源站HTTP错误状态并区分桥接失败
+- **报告**：2026-09-10（用户：源站502不应被包装成BRIDGE_HTTP_500。）
+- **真实性**：✅ 真 bug。DalvikHandler.errorResponse只保留少数4xx，HttpException(502)被降为桥接500；DesktopMihonRuntime._postJson又仅按transport状态生成BRIDGE_HTTP，忽略响应里的源站类型/状态。真实カドコミ日志含源站502→UI桥接500。
+- **[x] ① 已修复** — JVM保留类型化源站HTTP400..599原状态并附errorKind/sourceStatusCode；Dart按结构化来源生成SOURCE_HTTP_n，兼容旧版HttpException类型+code，桥接内部失败仍用BRIDGE_HTTP_n。非JSON失败响应保留HTTP分类，完整栈保留在details。
+- **[x] ② 已加自动化测试** — DalvikErrorResponseTest覆盖来源403/429/500/502/503/599、内部异常和非法状态；desktop_mihon_error_response_test覆盖新版/旧版协议、伪HTTP文本、非法字段、非JSON；运行时集成通过真实子进程+HTTP响应fixture验证分类及失败后进程不变。
+- **验证**：Dart定向7项（含3项实际启动Java运行时的测试）通过、0跳过；Kotlin完整JVM44项、0失败/0跳过，lint与shadowJar通过；`flutter analyze --no-pub`通过（No issues found）。
+- **范围**：本修复针对桌面漫画元数据/搜索桥接错误归因，不修复外部站点502/403本身；不从异常消息字符串猜测来源。主应用需包含Dart改动的新构建才显示SOURCE_HTTP分类，本轮未替换用户主程序。

--- a/fushi/lib/src/media/manga/mihon/desktop_mihon_runtime.dart
+++ b/fushi/lib/src/media/manga/mihon/desktop_mihon_runtime.dart
@@ -525,6 +525,40 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
     return '$type\n$stack';
   }
 
+  /// Decode the bridge envelope without confusing source HTTP failures with
+  /// transport failures. Older sidecars expose the source code via HttpException.
+  static MihonRuntimeException decodeErrorResponse(http.Response response) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on FormatException {
+      // Non-JSON gateway responses still have a meaningful transport status.
+    }
+    final Map<Object?, Object?> error = decoded is Map<Object?, Object?>
+        ? decoded
+        : const <Object?, Object?>{};
+    final Object? kind = error['errorKind'];
+    final Object? sourceCode = kind == 'sourceHttp'
+        ? error['sourceStatusCode']
+        : kind == null &&
+              error['errorType'] == 'eu.kanade.tachiyomi.network.HttpException'
+        ? error['code']
+        : null;
+    final int? sourceStatus =
+        sourceCode is int && sourceCode >= 400 && sourceCode <= 599
+        ? sourceCode
+        : null;
+    return MihonRuntimeException(
+      sourceStatus == null
+          ? 'BRIDGE_HTTP_${response.statusCode}'
+          : 'SOURCE_HTTP_$sourceStatus',
+      sourceStatus == null
+          ? error['error']?.toString() ?? 'Mihon bridge request failed'
+          : 'Manga source returned HTTP $sourceStatus',
+      details: _errorDetails(error),
+    );
+  }
+
   Future<MihonCapabilities> _readCapabilities() async {
     final http.Response response = await _http
         .get(_uri('/capabilities'), headers: _headers)
@@ -567,23 +601,10 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
       final http.Response response = await _http
           .post(_uri(path), headers: _headers, body: jsonEncode(body))
           .timeout(const Duration(seconds: 45));
-      final Object? decoded = response.body.isEmpty
-          ? null
-          : jsonDecode(response.body);
       if (response.statusCode < 200 || response.statusCode >= 300) {
-        final Map<Object?, Object?>? error = decoded is Map<Object?, Object?>
-            ? decoded
-            : null;
-        throw MihonRuntimeException(
-          'BRIDGE_HTTP_${response.statusCode}',
-          error?['error']?.toString() ?? 'Mihon bridge request failed',
-          // 桌面路径此前从不填 details，于是「查看详情」对话框在桌面端恒为空，
-          // 用户只能看到一行没有出处的错误文本。sidecar 现在回传异常类型与 Java
-          // 栈（DalvikHandler.errorResponse），把它们接上，与 Android 路径对齐。
-          details: _errorDetails(error),
-        );
+        throw decodeErrorResponse(response);
       }
-      return decoded;
+      return response.body.isEmpty ? null : jsonDecode(response.body);
     } on MihonRuntimeException {
       rethrow;
     } on TimeoutException catch (error) {

--- a/fushi/test/media/manga/desktop_mihon_error_response_test.dart
+++ b/fushi/test/media/manga/desktop_mihon_error_response_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/mihon/desktop_mihon_runtime.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  MihonRuntimeException decode(int status, Object? body) =>
+      DesktopMihonRuntime.decodeErrorResponse(
+        http.Response(jsonEncode(body), status),
+      );
+
+  test('source HTTP failures retain source status and diagnostic stack', () {
+    for (final int status in <int>[403, 429, 500, 502, 503, 599]) {
+      final MihonRuntimeException error = decode(status, <String, Object>{
+        'errorKind': 'sourceHttp',
+        'sourceStatusCode': status,
+        'error': 'HTTP error $status',
+        'errorType': 'eu.kanade.tachiyomi.network.HttpException',
+        'stackTrace': 'source fixture stack',
+      });
+      expect(error.code, 'SOURCE_HTTP_$status');
+      expect(error.message, 'Manga source returned HTTP $status');
+      expect(error.details, contains('source fixture stack'));
+    }
+  });
+
+  test(
+    'older typed sidecar envelopes recover source 502 from transport 500',
+    () {
+      final MihonRuntimeException error = decode(500, <String, Object>{
+        'errorType': 'eu.kanade.tachiyomi.network.HttpException',
+        'code': 502,
+        'error': 'HTTP error 502',
+      });
+      expect(error.code, 'SOURCE_HTTP_502');
+    },
+  );
+
+  test(
+    'internal failure text and untyped code cannot impersonate a source',
+    () {
+      for (final Map<String, Object> envelope in <Map<String, Object>>[
+        <String, Object>{'error': 'HTTP error 502', 'code': 502},
+        <String, Object>{
+          'errorKind': 'bridge',
+          'sourceStatusCode': 502,
+          'errorType': 'eu.kanade.tachiyomi.network.HttpException',
+          'code': 502,
+        },
+        <String, Object>{'errorKind': 'sourceHttp', 'sourceStatusCode': '502'},
+        <String, Object>{'errorKind': 'sourceHttp', 'sourceStatusCode': 200},
+        <String, Object>{'errorKind': 'sourceHttp', 'sourceStatusCode': 600},
+      ]) {
+        expect(decode(500, envelope).code, 'BRIDGE_HTTP_500');
+      }
+    },
+  );
+
+  test(
+    'non-JSON gateway response retains transport error instead of IO error',
+    () {
+      for (final String body in <String>[
+        '',
+        '<html>Bad Gateway</html>',
+        'null',
+      ]) {
+        final MihonRuntimeException error =
+            DesktopMihonRuntime.decodeErrorResponse(http.Response(body, 502));
+        expect(error.code, 'BRIDGE_HTTP_502');
+        expect(error.message, 'Mihon bridge request failed');
+      }
+    },
+  );
+}

--- a/fushi/test/media/manga/desktop_mihon_runtime_integration_test.dart
+++ b/fushi/test/media/manga/desktop_mihon_runtime_integration_test.dart
@@ -19,6 +19,92 @@ void main() {
       File('${resourceDirectory.path}/m-extension-server.jar').existsSync();
 
   test(
+    'source errors cross the real runtime boundary without restarting it',
+    () async {
+      final Directory data = await Directory.systemTemp.createTemp(
+        'mihon-http-error-',
+      );
+      final File apk = File('${data.path}/fixture.apk')
+        ..writeAsBytesSync(<int>[0]);
+      final http.Client realClient = http.Client();
+      final DesktopMihonRuntime runtime = DesktopMihonRuntime(
+        dataDirectory: data,
+        resourceDirectory: resourceDirectory,
+        httpClient: MockClient((http.Request request) async {
+          if (request.url.path != '/dalvik') {
+            final http.Request forwarded =
+                http.Request(request.method, request.url)
+                  ..headers.addAll(request.headers)
+                  ..bodyBytes = request.bodyBytes;
+            return http.Response.fromStream(await realClient.send(forwarded));
+          }
+          final Map<String, dynamic> payload =
+              jsonDecode(request.body) as Map<String, dynamic>;
+          if (payload['method'] == 'external') {
+            return http.Response(
+              jsonEncode(<String, Object>{
+                'errorKind': 'sourceHttp',
+                'sourceStatusCode': 502,
+                'error': 'HTTP error 502',
+                'stackTrace': 'source trace',
+              }),
+              502,
+            );
+          }
+          if (payload['method'] == 'gateway') {
+            return http.Response('<html>502</html>', 502);
+          }
+          return http.Response('{"ok":true}', 200);
+        }),
+      );
+      final MihonExtensionRef extension = MihonExtensionRef(
+        packageName: 'fixture',
+        apkPath: apk.path,
+      );
+      try {
+        await runtime.getCapabilities();
+        final int? pid = runtime.processId;
+        await expectLater(
+          runtime.invokeBridge(extension, 'external', <String, Object?>{}),
+          throwsA(
+            isA<MihonRuntimeException>()
+                .having(
+                  (MihonRuntimeException e) => e.code,
+                  'code',
+                  'SOURCE_HTTP_502',
+                )
+                .having(
+                  (MihonRuntimeException e) => e.details,
+                  'details',
+                  'source trace',
+                ),
+          ),
+        );
+        await expectLater(
+          runtime.invokeBridge(extension, 'gateway', <String, Object?>{}),
+          throwsA(
+            isA<MihonRuntimeException>().having(
+              (MihonRuntimeException e) => e.code,
+              'code',
+              'BRIDGE_HTTP_502',
+            ),
+          ),
+        );
+        expect(
+          await runtime.invokeBridge(extension, 'healthy', <String, Object?>{}),
+          <String, Object>{'ok': true},
+        );
+        expect(runtime.processId, pid);
+      } finally {
+        await runtime.dispose();
+        realClient.close();
+        await data.delete(recursive: true);
+      }
+    },
+    skip: !bridgeAvailable,
+  );
+
+  test(
     'bundled Java bridge is stopped without a residual process',
     () async {
       final Directory dataDirectory = await Directory.systemTemp.createTemp(

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -63,6 +63,12 @@ and manifest point straight at the commit recorded above.
 
 Hibiki modifications
 --------------------
+overlay/.../DalvikHandler.kt:
+  Route both bare FilterList results and legacy FiltersResponse wrappers through
+  the explicit filter wire codec. Select options use their display toString,
+  never arbitrary extension-object bean serialization; array/wrapper shapes,
+  filter kinds, states and nested groups remain stable.
+
 overlay/.../DexAllocationRepair.kt:
   Original DEX may allocate a concrete subtype whose constructor was inlined,
   then invoke the direct superclass constructor on that same register. Recover
@@ -70,6 +76,10 @@ overlay/.../DexAllocationRepair.kt:
   proof and unambiguous allocation counts. A synthetic forwarding constructor
   preserves the verified superclass call when the subtype no longer declares
   it. Unknown/ambiguous flows remain unchanged; no source names are special-cased.
+  Concrete ancestors (including Object) require the same original-DEX receiver
+  proof even if a matching constructor exists; allocation counts alone cannot
+  authorize changing an otherwise valid concrete NEW. This preserves typed
+  filter options instead of allowing Object values to fail later in typed arrays.
 
 overlay/.../MihonImageProxy.kt:
   Consume and close the extension's network response inside the Rx emission,

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -63,6 +63,13 @@ and manifest point straight at the commit recorded above.
 
 Hibiki modifications
 --------------------
+overlay/.../MihonImageProxy.kt:
+  Consume and close the extension's network response inside the Rx emission,
+  before blocking for detached ImageData. The call adapter cancels its socket
+  on unsubscribe; reading ResponseBody after toBlocking().single() loses the
+  live response. The overlay retains the source client and image interceptors.
+  A real loopback HTTP body regression supplements the in-memory fixtures.
+
 overlay/.../HostProxyPolicy.kt and .../network/NetworkHelper.kt:
   JVM HTTP clients resolve the host's authenticated loopback proxy policy per
   URL (FUSHI_MIHON_PROXY_POLICY_PORT; token uses FUSHI_MIHON_TOKEN). The host

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -64,6 +64,9 @@ and manifest point straight at the commit recorded above.
 Hibiki modifications
 --------------------
 overlay/.../DalvikHandler.kt:
+  Typed source HttpException responses retain their original HTTP 400-599
+  transport status and carry errorKind/sourceStatusCode. Internal failures
+  retain bridge/500; legacy code/type/stack fields remain available.
   Route both bare FilterList results and legacy FiltersResponse wrappers through
   the explicit filter wire codec. Select options use their display toString,
   never arbitrary extension-object bean serialization; array/wrapper shapes,

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -63,6 +63,14 @@ and manifest point straight at the commit recorded above.
 
 Hibiki modifications
 --------------------
+overlay/.../DexAllocationRepair.kt:
+  Original DEX may allocate a concrete subtype whose constructor was inlined,
+  then invoke the direct superclass constructor on that same register. Recover
+  the concrete JVM allocation only with original-DEX receiver/control-flow
+  proof and unambiguous allocation counts. A synthetic forwarding constructor
+  preserves the verified superclass call when the subtype no longer declares
+  it. Unknown/ambiguous flows remain unchanged; no source names are special-cased.
+
 overlay/.../MihonImageProxy.kt:
   Consume and close the extension's network response inside the Rx emission,
   before blocking for detached ImageData. The call adapter cancels its socket
@@ -158,8 +166,9 @@ Security boundary (must not be weakened)
   the size, not the destination: the URL is chosen by the source site, exactly
   as in upstream's own /image/<uuid> page path, which is inherent to Mihon's
   "the site tells the client where the image is" contract.
-- The upstream process identity is retained: Main.kt, ServerWindow.kt,
-  MExtensionServerLoader and MihonImageProxy are untouched, and the Hibiki
+- The upstream process identity is retained: Main.kt, ServerWindow.kt and
+  MExtensionServerLoader are untouched; MihonImageProxy has a response-lifetime
+  overlay described above. The Hibiki
   host only ever terminates the Process handle it started (never a port or
   process-name scan). The upstream wire key __mangatan_bridge_context__ is
   deliberately kept; only the capability identifier is renamed to

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -67,6 +67,8 @@ overlay/.../HostProxyPolicy.kt and .../network/NetworkHelper.kt:
   JVM HTTP clients resolve the host's authenticated loopback proxy policy per
   URL (FUSHI_MIHON_PROXY_POLICY_PORT; token uses FUSHI_MIHON_TOKEN). The host
   retains auto/manual/direct, local bypass, NO_PROXY and Basic credentials.
+  JVM socket:// selector callbacks connect the already-selected TCP endpoint
+  directly; they must not reapply HTTP policy to the origin or proxy transport.
   NetworkHelper uses HTTP/1.1 with zero idle connections so even an active
   HTTP/2 connection cannot bypass a new proxy selection after settings change.
   Existing calls finish normally; each new call incurs connection/TLS setup.

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/DalvikHandler.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/DalvikHandler.kt
@@ -3,6 +3,7 @@ package mextensionserver.controller
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.online.HttpSource
 import fi.iki.elonen.NanoHTTPD
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -84,15 +85,7 @@ class DalvikHandler {
                     MihonInvoker.invokeMethod(loadedExtension, dataBody)
                 }
 
-            val serializableResult =
-                if (result is FiltersResponse) {
-                    mapOf(
-                        "filterList" to
-                            result.filterList?.map { filter -> filter.toBridgeMap() }.orEmpty(),
-                    )
-                } else {
-                    result
-                }
+            val serializableResult = filterResponseForBridge(result)
             val responseJson = objectMapper.writeValueAsString(serializableResult)
             NanoHTTPD.newFixedLengthResponse(
                 NanoHTTPD.Response.Status.OK,
@@ -146,6 +139,14 @@ class DalvikHandler {
         )
     }
 }
+
+/** Preserve both supported response envelopes without serializing extension objects. */
+internal fun filterResponseForBridge(result: Any?): Any? =
+    when (result) {
+        is FilterList -> result.map { it.toBridgeMap() }
+        is FiltersResponse -> mapOf("filterList" to result.filterList?.map { it.toBridgeMap() }.orEmpty())
+        else -> result
+    }
 
 private fun Filter<*>.toBridgeMap(): Map<String, Any?> {
     val filter = this

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/DalvikHandler.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/DalvikHandler.kt
@@ -98,20 +98,22 @@ class DalvikHandler {
             errorResponse(error)
         }
 
-    private fun errorResponse(error: Throwable): NanoHTTPD.Response {
+    internal fun errorResponse(error: Throwable): NanoHTTPD.Response {
         logger.error(error) { "Error handling request" }
+        // Only the typed source HTTP failure establishes an upstream status.
+        // Exception messages (including ones mentioning HTTP) are not a protocol.
+        val sourceStatusCode =
+            (error as? eu.kanade.tachiyomi.network.HttpException)?.code?.takeIf { it in 400..599 }
         val status =
-            when (error) {
-                is eu.kanade.tachiyomi.network.HttpException -> {
-                    when (error.code) {
-                        400 -> NanoHTTPD.Response.Status.BAD_REQUEST
-                        401 -> NanoHTTPD.Response.Status.UNAUTHORIZED
-                        403 -> NanoHTTPD.Response.Status.FORBIDDEN
-                        404 -> NanoHTTPD.Response.Status.NOT_FOUND
-                        else -> NanoHTTPD.Response.Status.INTERNAL_ERROR
+            if (sourceStatusCode != null) {
+                NanoHTTPD.Response.Status.lookup(sourceStatusCode)
+                    ?: object : NanoHTTPD.Response.IStatus {
+                        override fun getRequestStatus(): Int = sourceStatusCode
+
+                        override fun getDescription(): String = "$sourceStatusCode Source HTTP error"
                     }
-                }
-                else -> NanoHTTPD.Response.Status.INTERNAL_ERROR
+            } else {
+                NanoHTTPD.Response.Status.INTERNAL_ERROR
             }
         // 桌面端此前只回 `error`（= e.message），Java 栈仅存在于本进程 stdout，而宿主
         // 把 sidecar 的 stdout/stderr 直接丢弃，于是扩展加载类错误（NoSuchMethodError /
@@ -124,6 +126,8 @@ class DalvikHandler {
                     "error" to (error.message ?: error.javaClass.simpleName),
                     "errorType" to error.javaClass.name,
                     "stackTrace" to error.stackTraceToString().take(MAX_STACK_TRACE_CHARS),
+                    "errorKind" to if (sourceStatusCode != null) "sourceHttp" else "bridge",
+                    "sourceStatusCode" to sourceStatusCode,
                     "code" to
                         if (error is eu.kanade.tachiyomi.network.HttpException) {
                             error.code

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/impl/HostProxyPolicy.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/impl/HostProxyPolicy.kt
@@ -67,7 +67,8 @@ object HostProxyPolicy : ProxySelector() {
             connection.connectTimeout = 3000
             connection.readTimeout = 3000
             connection.setRequestProperty("Authorization", "Bearer $token")
-            if (connection.responseCode != 200) throw IOException("Host proxy policy is unavailable")
+            val status = connection.responseCode
+            if (status != 200) throw IOException("Host proxy policy is unavailable (HTTP $status)")
             val json = connection.inputStream.use { mapper.readTree(it) }
             return Policy(json.path("directive").asText(), json.path("username").asText(), json.path("password").asText())
         } finally {
@@ -89,7 +90,16 @@ object HostProxyPolicy : ProxySelector() {
             }
         }
 
-    override fun select(uri: URI): List<Proxy> = proxies(lookup(uri).directive)
+    override fun select(uri: URI): List<Proxy> {
+        // The JVM also consults its global selector from SocksSocketImpl after
+        // the HTTP client has already selected a route. This socket URI names
+        // that route's TCP endpoint (possibly the HTTP proxy), not an origin URL.
+        // Applying the host's HTTP policy again would reject the socket scheme
+        // or proxy the proxy connection. Only this transport lookup is DIRECT;
+        // origin HTTP(S) lookups still require a successful host policy response.
+        if (uri.scheme.equals("socket", ignoreCase = true)) return listOf(Proxy.NO_PROXY)
+        return proxies(lookup(uri).directive)
+    }
 
     override fun connectFailed(
         uri: URI,

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/impl/MihonImageProxy.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/impl/MihonImageProxy.kt
@@ -1,0 +1,113 @@
+package mextensionserver.impl
+
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.online.HttpSource
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+
+/**
+ * Keeps page requests inside the extension's OkHttp client.
+ *
+ * Some extensions use interceptors to turn a synthetic page URL into image
+ * bytes. Returning that URL to the caller bypasses the interceptor, so page
+ * entries are registered here and exposed through a loopback URL instead.
+ */
+internal object MihonImageProxy {
+    private const val MAX_ENTRIES = 4096
+
+    data class ImageData(
+        val bytes: ByteArray,
+        val contentType: String,
+    )
+
+    private data class Entry(
+        val key: String,
+        val source: HttpSource,
+        val page: Page,
+    )
+
+    private val lock = Any()
+    private val entriesByToken = LinkedHashMap<String, Entry>(16, 0.75f, true)
+    private val tokensByKey = mutableMapOf<String, String>()
+
+    @Volatile
+    private var port: Int = 0
+
+    fun configure(port: Int) {
+        require(port > 0) { "Image proxy port must be positive" }
+        this.port = port
+    }
+
+    fun register(
+        source: HttpSource,
+        page: Page,
+    ): String? {
+        val currentPort = port
+        if (currentPort <= 0) return null
+
+        val key =
+            buildString {
+                append(System.identityHashCode(source))
+                append('\u0000')
+                append(page.index)
+                append('\u0000')
+                append(page.url)
+                append('\u0000')
+                append(page.imageUrl.orEmpty())
+            }
+        val token =
+            synchronized(lock) {
+                tokensByKey[key]?.let { existingToken ->
+                    entriesByToken[existingToken] = Entry(key, source, page)
+                    return@synchronized existingToken
+                }
+
+                while (entriesByToken.size >= MAX_ENTRIES) {
+                    val iterator = entriesByToken.entries.iterator()
+                    val eldest = iterator.next()
+                    iterator.remove()
+                    tokensByKey.remove(eldest.value.key)
+                }
+
+                UUID.randomUUID().toString().also { newToken ->
+                    entriesByToken[newToken] = Entry(key, source, page)
+                    tokensByKey[key] = newToken
+                }
+            }
+
+        return "http://127.0.0.1:$currentPort/image/$token"
+    }
+
+    fun fetch(token: String): ImageData? {
+        val entry = synchronized(lock) { entriesByToken[token] } ?: return null
+        if (entry.page.imageUrl == null) {
+            entry.page.imageUrl =
+                runBlocking {
+                    entry.source.getImageUrl(entry.page)
+                }
+        }
+        return entry.source
+            .fetchImage(entry.page)
+            .map { response ->
+                // The Rx call adapter cancels its socket on unsubscription.
+                // Consume and close the body while onNext still owns the call;
+                // only detached image bytes may cross the blocking boundary.
+                response.use {
+                    val body = requireNotNull(it.body) { "Extension returned an empty image response" }
+                    ImageData(
+                        bytes = body.bytes(),
+                        contentType = body.contentType()?.toString() ?: "application/octet-stream",
+                    )
+                }
+            }.toBlocking()
+            .single()
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            entriesByToken.clear()
+            tokensByKey.clear()
+        }
+        port = 0
+    }
+}

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/util/DexAllocationRepair.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/util/DexAllocationRepair.kt
@@ -25,7 +25,6 @@ import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.Type
-import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
@@ -39,7 +38,7 @@ import kotlin.streams.asSequence
  * Restore exact DEX allocation types lost by dex2jar. R8 can inline a concrete
  * subclass constructor and invoke its superclass constructor on the original
  * new-instance register. DEX permits this, but JVM NEW and <init> owners must
- * match. The converter can instead emit NEW of that abstract superclass.
+ * match. The converter can instead emit NEW of that superclass, including Object.
  *
  * BUG-2406: SchaleNetwork's original p0 is a concrete Filter.Group subclass
  * with no methods or fields. getFilterList allocates p0, builds arguments in a
@@ -50,6 +49,8 @@ import kotlin.streams.asSequence
  * constructors are reused. A missing forwarding constructor is emitted only
  * when original DEX proves the allocation register invokes the accessible direct
  * superclass constructor with that descriptor. Ambiguity remains untouched.
+ * Concrete superclass substitutions additionally require receiver evidence for
+ * every allocation, even when the subclass already has a matching constructor.
  */
 object DexAllocationRepair {
     private val logger = KotlinLogging.logger {}
@@ -68,7 +69,7 @@ object DexAllocationRepair {
                 .getOrNull()
                 ?: return
         runCatching { rewriteJar(jarFile, evidence.first, evidence.second) }
-            .onFailure { logger.warn(it) { "Unable to repair abstract allocations in $jarFile" } }
+            .onFailure { logger.warn(it) { "Unable to repair generalized allocations in $jarFile" } }
     }
 
     /**
@@ -81,7 +82,7 @@ object DexAllocationRepair {
     ) {
         if (allocations.isEmpty()) return
         runCatching { rewriteJar(jarFile, allocations) }
-            .onFailure { logger.warn(it) { "Unable to repair abstract allocations in $jarFile" } }
+            .onFailure { logger.warn(it) { "Unable to repair generalized allocations in $jarFile" } }
     }
 
     /** `owner#name#desc` → 该方法里 `new-instance` 的 internal name 列表（可重复）。 */
@@ -307,11 +308,11 @@ object DexAllocationRepair {
         changedClasses: MutableSet<String>,
     ): Boolean {
         val instructions = method.instructions.toArray()
-        val abstractNews =
+        val jarNews =
             instructions
                 .filterIsInstance<TypeInsnNode>()
-                .filter { it.opcode == Opcodes.NEW && shapes[it.desc]?.isInstantiable == false }
-        if (abstractNews.isEmpty()) return false
+                .filter { it.opcode == Opcodes.NEW && shapes[it.desc] != null }
+        if (jarNews.isEmpty()) return false
 
         val dexNews = allocations[methodKey(owner, method.name, method.desc)] ?: return false
         val jarCounts =
@@ -323,21 +324,21 @@ object DexAllocationRepair {
         val dexCounts = dexNews.groupingBy { it }.eachCount()
 
         var changed = false
-        abstractNews.map(TypeInsnNode::desc).distinct().forEach { abstractType ->
+        jarNews.map(TypeInsnNode::desc).distinct().forEach { ancestorType ->
             // dex 里本来就分配过这个类型 → 不是泛化造成的，交给别的 pass，别动。
-            if ((dexCounts[abstractType] ?: 0) != 0) return@forEach
-            val missing = jarCounts[abstractType] ?: return@forEach
+            if ((dexCounts[ancestorType] ?: 0) != 0) return@forEach
+            val missing = jarCounts[ancestorType] ?: return@forEach
 
             val candidates =
                 dexCounts
-                    .filterKeys { it != abstractType && isSubclassOf(it, abstractType, shapes) }
+                    .filterKeys { it != ancestorType && isSubclassOf(it, ancestorType, shapes) }
                     .filter { (type, dexCount) -> dexCount - (jarCounts[type] ?: 0) == missing }
                     .keys
             val replacement =
                 candidates.singleOrNull() ?: run {
                     logger.warn {
-                        "Ambiguous abstract allocation in $owner.${method.name}: " +
-                            "NEW $abstractType ×$missing, candidates=$candidates — left as-is"
+                        "Ambiguous generalized allocation in $owner.${method.name}: " +
+                            "NEW $ancestorType ×$missing, candidates=$candidates — left as-is"
                     }
                     return@forEach
                 }
@@ -346,43 +347,51 @@ object DexAllocationRepair {
 
             // A descriptor mismatch alone is not evidence of inlining. Only
             // the original DEX receiver proof can authorize a forwarding ctor.
-            val constructorDescriptors = constructorDescriptorsFor(method, abstractType)
+            val pairs = allocationPairs(method, ancestorType) ?: return@forEach
+            val constructorDescriptors = pairs.map { it.second.desc }.toSet()
             val missingDescriptors = constructorDescriptors - replacementShape.constructors
             val evidence = constructors[methodKey(owner, method.name, method.desc)].orEmpty()
+
+            fun hasConstructorEvidence(descriptor: String): Boolean =
+                evidence.count { it == ConstructorEvidence(replacement, ancestorType, descriptor) } ==
+                    pairs.count { it.second.desc == descriptor }
+
+            // A concrete parent allocation can be intentional. Allocation counts
+            // alone never authorize changing its runtime type: require the original
+            // DEX to prove every substituted receiver called this parent constructor.
+            if (shapes[ancestorType]?.isInstantiable == true &&
+                !constructorDescriptors.all(::hasConstructorEvidence)
+            ) {
+                return@forEach
+            }
             val replacementNode = classes[replacement]
             val canForward =
                 replacementNode != null &&
-                    replacementNode.superName == abstractType &&
+                    replacementNode.superName == ancestorType &&
                     missingDescriptors.all { descriptor ->
-                        evidence.count { it == ConstructorEvidence(replacement, abstractType, descriptor) } ==
-                            method.instructions.toArray().filterIsInstance<MethodInsnNode>().count {
-                                it.opcode == Opcodes.INVOKESPECIAL &&
-                                    it.name == "<init>" &&
-                                    it.owner == abstractType &&
-                                    it.desc == descriptor
-                            } &&
-                            descriptor in shapes[abstractType]?.accessibleConstructors.orEmpty()
+                        hasConstructorEvidence(descriptor) &&
+                            descriptor in shapes[ancestorType]?.accessibleConstructors.orEmpty()
                     }
             if (missingDescriptors.isNotEmpty() && !canForward) {
                 logger.warn {
-                    "Skipping abstract allocation in $owner.${method.name}: " +
+                    "Skipping generalized allocation in $owner.${method.name}: " +
                         "$replacement has no constructor matching $constructorDescriptors " +
                         "(dex2jar likely inlined the constructor) — left as-is"
                 }
                 return@forEach
             }
 
-            if (rewriteAllocations(method, abstractType, replacement)) {
+            if (rewriteAllocations(method, ancestorType, replacement)) {
                 missingDescriptors.forEach { descriptor ->
                     if (replacementNode!!.methods.none { it.name == "<init>" && it.desc == descriptor }) {
-                        replacementNode.methods.add(forwardingConstructor(abstractType, descriptor))
+                        replacementNode.methods.add(forwardingConstructor(ancestorType, descriptor))
                         changedClasses += replacement
                     }
                 }
                 changed = true
                 logger.info {
                     "Restored dex allocation in $owner.${method.name}: " +
-                        "NEW $abstractType → NEW $replacement (×$missing)"
+                        "NEW $ancestorType → NEW $replacement (×$missing)"
                 }
             }
         }
@@ -407,23 +416,8 @@ object DexAllocationRepair {
             visitEnd()
         }
 
-    /** 该方法里所有以 [abstractType] 为 owner 的构造调用描述符。 */
-    private fun constructorDescriptorsFor(
-        method: MethodNode,
-        abstractType: String,
-    ): Set<String> =
-        method.instructions
-            .toArray()
-            .filterIsInstance<MethodInsnNode>()
-            .filter {
-                it.opcode == Opcodes.INVOKESPECIAL &&
-                    it.name == "<init>" &&
-                    it.owner == abstractType
-            }.map(MethodInsnNode::desc)
-            .toSet()
-
     /**
-     * 把 `NEW abstractType` 及与之配对的 `INVOKESPECIAL abstractType.<init>` 换成
+     * 把 `NEW ancestorType` 及与之配对的 `INVOKESPECIAL ancestorType.<init>` 换成
      * [replacement]。
      *
      * 按栈序配对：只有紧跟其后、尚未认领的那条 `<init>` 才算这次分配的构造调用。子类
@@ -432,38 +426,43 @@ object DexAllocationRepair {
      */
     private fun rewriteAllocations(
         method: MethodNode,
-        abstractType: String,
+        ancestorType: String,
         replacement: String,
     ): Boolean {
+        val pairs = allocationPairs(method, ancestorType) ?: return false
+        pairs.forEach { (allocation, constructor) ->
+            allocation.desc = replacement
+            constructor.owner = replacement
+        }
+        return true
+    }
+
+    /** Pair NEW with its constructor, excluding this/super constructor calls. */
+    private fun allocationPairs(
+        method: MethodNode,
+        ancestorType: String,
+    ): List<Pair<TypeInsnNode, MethodInsnNode>>? {
         val pending = ArrayDeque<TypeInsnNode>()
-        val rewrites = mutableListOf<AbstractInsnNode>()
+        val pairs = mutableListOf<Pair<TypeInsnNode, MethodInsnNode>>()
         method.instructions.toArray().forEach { insn ->
             when {
                 insn is TypeInsnNode &&
                     insn.opcode == Opcodes.NEW &&
-                    insn.desc == abstractType -> pending.addLast(insn)
+                    insn.desc == ancestorType -> pending.addLast(insn)
 
                 insn is MethodInsnNode &&
                     insn.opcode == Opcodes.INVOKESPECIAL &&
                     insn.name == "<init>" &&
-                    insn.owner == abstractType &&
+                    insn.owner == ancestorType &&
                     pending.isNotEmpty() -> {
-                    rewrites += pending.removeLast()
-                    rewrites += insn
+                    pairs += pending.removeLast() to insn
                 }
             }
         }
         // 配不上对的分配点原样留着：宁可保留一个明确的 InstantiationError，也不要
         // 制造出 NEW 与 <init> 类型不一致的、过不了校验器的字节码。
-        if (rewrites.isEmpty() || pending.isNotEmpty()) return false
-        rewrites.forEach { insn ->
-            when (insn) {
-                is TypeInsnNode -> insn.desc = replacement
-                is MethodInsnNode -> insn.owner = replacement
-                else -> Unit
-            }
-        }
-        return true
+        if (pairs.isEmpty() || pending.isNotEmpty()) return null
+        return pairs
     }
 
     private fun isSubclassOf(

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/util/DexAllocationRepair.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/util/DexAllocationRepair.kt
@@ -1,6 +1,22 @@
 package mextensionserver.util
 
+import com.googlecode.d2j.node.DexCodeNode
 import com.googlecode.d2j.node.DexFileNode
+import com.googlecode.d2j.node.insn.AbstractMethodStmtNode
+import com.googlecode.d2j.node.insn.BaseSwitchStmtNode
+import com.googlecode.d2j.node.insn.ConstStmtNode
+import com.googlecode.d2j.node.insn.DexLabelStmtNode
+import com.googlecode.d2j.node.insn.DexStmtNode
+import com.googlecode.d2j.node.insn.FieldStmtNode
+import com.googlecode.d2j.node.insn.FillArrayDataStmtNode
+import com.googlecode.d2j.node.insn.FilledNewArrayStmtNode
+import com.googlecode.d2j.node.insn.JumpStmtNode
+import com.googlecode.d2j.node.insn.MethodStmtNode
+import com.googlecode.d2j.node.insn.Stmt0RNode
+import com.googlecode.d2j.node.insn.Stmt1RNode
+import com.googlecode.d2j.node.insn.Stmt2R1NNode
+import com.googlecode.d2j.node.insn.Stmt2RNode
+import com.googlecode.d2j.node.insn.Stmt3RNode
 import com.googlecode.d2j.node.insn.TypeStmtNode
 import com.googlecode.d2j.reader.MultiDexFileReader
 import com.googlecode.d2j.reader.Op
@@ -8,6 +24,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodInsnNode
@@ -19,44 +36,20 @@ import java.nio.file.Path
 import kotlin.streams.asSequence
 
 /**
- * 用原始 dex 里携带的精确分配类型，修回 dex2jar 泛化掉的 `NEW`。
+ * Restore exact DEX allocation types lost by dex2jar. R8 can inline a concrete
+ * subclass constructor and invoke its superclass constructor on the original
+ * new-instance register. DEX permits this, but JVM NEW and <init> owners must
+ * match. The converter can instead emit NEW of that abstract superclass.
  *
- * ## 这个 pass 修的是什么
+ * BUG-2406: SchaleNetwork's original p0 is a concrete Filter.Group subclass
+ * with no methods or fields. getFilterList allocates p0, builds arguments in a
+ * loop, then invokes Group.<init>(String,List) directly. This is not a missing
+ * host API and must not be repaired by making the abstract API concrete.
  *
- * dex 的 `new-instance` 指令自带精确类型，但 dex2jar 在把寄存器式 dex 翻成栈式
- * JVM 字节码时要做类型推断；当同一个分配点在控制流上与别的分支合并，它会把类型
- * 取成两者的**公共父类**。如果那个父类是抽象类，产出的字节码就变成 `NEW <抽象类>`
- * ——JVM 规范明令禁止，运行到那条指令必然 `InstantiationError`。
- *
- * 实测（keiyoushi koharu 扩展，`Lp;.getFilterList`）：
- *
- *   dex : new-instance Lp0;                      (p0 = public final, extends Filter$Group)
- *   jar : NEW eu/kanade/tachiyomi/source/model/Filter$Group
- *         INVOKESPECIAL eu/kanade/tachiyomi/source/model/Filter$Group.<init>(String, List)
- *
- * 同一个方法里另外 8 个 `Lb1;`（同样 extends Filter$Group、构造器签名同为
- * `(String, List)`）却完好无损——所以这不是「宿主少了什么类」，而是单个分配点被
- * 泛化。症状是打开该源的搜索页直接 500：
- *
- *   java.lang.InstantiationError: eu.kanade.tachiyomi.source.model.Filter$Group
- *       at p.getFilterList(Unknown Source)
- *       at mextensionserver.impl.MihonInvoker.invokeFiltersManga(MihonInvoker.kt:178)
- *
- * `NEW` 与配对的 `INVOKESPECIAL <init>` **两处 owner 都被改写**，所以没法只看字节码
- * 本地恢复，必须回到原始 dex 取真值。
- *
- * ## 判据（可判定，不猜）
- *
- * - 只碰 `NEW T` 且 T 是抽象类或接口。这类指令**一定**是转换 bug——合法字节码不可能
- *   实例化抽象类，所以不存在「本来就对、被我改坏」的情况。
- * - 候选只从**同一方法的原始 dex 分配集合**里取，不从全 jar 猜。
- * - 必须能唯一对账：dex 里有、jar 里少掉的具体子类恰好一个，且缺口数正好等于
- *   `NEW T` 的条数。有歧义就原样放过——宁可继续报 `InstantiationError`
- *   （错误明确、可追）也不写进一个语义错误的 filter 类型。
- *
- * 与上游 [BytecodeEditor] 的 `repairAllocation` 不重叠：那条走的是「按期望类型在全
- * jar 里挑兼容候选」，兜底甚至会任选一个未认领的无参构造类；这里只用原始 dex 的真值
- * 对账，且只处理抽象类分配。
+ * Exact allocation counts identify a unique missing subclass. Existing matching
+ * constructors are reused. A missing forwarding constructor is emitted only
+ * when original DEX proves the allocation register invokes the accessible direct
+ * superclass constructor with that descriptor. Ambiguity remains untouched.
  */
 object DexAllocationRepair {
     private val logger = KotlinLogging.logger {}
@@ -69,12 +62,13 @@ object DexAllocationRepair {
         dexFile: Path,
         jarFile: Path,
     ) {
-        val allocations =
+        val evidence =
             runCatching { readDexAllocations(dexFile) }
                 .onFailure { logger.warn(it) { "Unable to read dex allocations from $dexFile" } }
                 .getOrNull()
                 ?: return
-        restoreWithAllocations(jarFile, allocations)
+        runCatching { rewriteJar(jarFile, evidence.first, evidence.second) }
+            .onFailure { logger.warn(it) { "Unable to repair abstract allocations in $jarFile" } }
     }
 
     /**
@@ -91,12 +85,13 @@ object DexAllocationRepair {
     }
 
     /** `owner#name#desc` → 该方法里 `new-instance` 的 internal name 列表（可重复）。 */
-    private fun readDexAllocations(dexFile: Path): Map<String, List<String>> {
+    private fun readDexAllocations(dexFile: Path): Pair<Map<String, List<String>>, Map<String, List<ConstructorEvidence>>> {
         val reader = MultiDexFileReader.open(Files.readAllBytes(dexFile))
         val fileNode = DexFileNode()
         reader.accept(fileNode)
 
         val allocations = mutableMapOf<String, MutableList<String>>()
+        val constructors = mutableMapOf<String, List<ConstructorEvidence>>()
         fileNode.clzs.forEach { classNode ->
             classNode.methods?.forEach { methodNode ->
                 val code = methodNode.codeNode ?: return@forEach
@@ -115,14 +110,129 @@ object DexAllocationRepair {
                         methodNode.method.desc,
                     )
                 allocations.getOrPut(key) { mutableListOf() }.addAll(news)
+                constructors[key] = readConstructorEvidence(code)
             }
         }
-        return allocations
+        return allocations to constructors
+    }
+
+    internal data class ConstructorEvidence(
+        val type: String,
+        val owner: String,
+        val descriptor: String,
+    )
+
+    /**
+     * R8 may erase a constructor in DEX and call its superclass on the allocated
+     * register directly. Prove that register still denotes this allocation:
+     * no overwrite or alias escapes, and no outside jump/handler enters the
+     * interval. Internal loops (for example building constructor arguments) are
+     * permitted. Debug labels are not control-flow entries.
+     */
+    internal fun readConstructorEvidence(code: DexCodeNode): List<ConstructorEvidence> {
+        val statements = code.stmts
+        val labels =
+            statements
+                .withIndex()
+                .mapNotNull { (index, statement) ->
+                    (statement as? DexLabelStmtNode)?.let { it.label to index }
+                }.toMap()
+        val edges =
+            statements.withIndex().flatMap { (index, statement) ->
+                val targets =
+                    when (statement) {
+                        is JumpStmtNode -> listOf(statement.label)
+                        is BaseSwitchStmtNode -> statement.labels.toList()
+                        else -> emptyList()
+                    }
+                targets.mapNotNull { labels[it]?.let { target -> index to target } }
+            }
+        val handlers =
+            code.tryStmts
+                .orEmpty()
+                .flatMap { it.handler.toList() }
+                .mapNotNull(labels::get)
+        return statements.withIndex().mapNotNull { (start, statement) ->
+            val allocation = statement as? TypeStmtNode ?: return@mapNotNull null
+            if (allocation.op != Op.NEW_INSTANCE) return@mapNotNull null
+            val register = allocation.a
+            for (end in start + 1 until statements.size) {
+                val current = statements[end]
+                if (current is MethodStmtNode && register in current.args) {
+                    if (current.op !in setOf(Op.INVOKE_DIRECT, Op.INVOKE_DIRECT_RANGE) ||
+                        current.method.name != "<init>" ||
+                        current.args.firstOrNull() != register ||
+                        current.args.drop(1).contains(register)
+                    ) {
+                        break
+                    }
+                    if (edges.any { (source, target) -> target in start + 1..end && source !in start..end } ||
+                        handlers.any { it in start + 1..end }
+                    ) {
+                        break
+                    }
+                    return@mapNotNull ConstructorEvidence(
+                        internalName(allocation.type),
+                        internalName(current.method.owner),
+                        current.method.desc,
+                    )
+                }
+                if (touchesRegister(current, register)) break
+            }
+            null
+        }
+    }
+
+    /** Unknown instruction shapes invalidate the proof instead of guessing. */
+    private fun touchesRegister(
+        statement: DexStmtNode,
+        register: Int,
+    ): Boolean {
+        val op = statement.op ?: return statement !is DexLabelStmtNode
+        val operands =
+            when (statement) {
+                is ConstStmtNode -> listOf(statement.a)
+                is TypeStmtNode -> listOf(statement.a, statement.b)
+                is Stmt1RNode -> listOf(statement.a)
+                is Stmt2RNode -> listOf(statement.a, statement.b)
+                is Stmt2R1NNode -> listOf(statement.distReg, statement.srcReg)
+                is Stmt3RNode -> listOf(statement.a, statement.b, statement.c)
+                is FieldStmtNode -> listOf(statement.a, statement.b)
+                is AbstractMethodStmtNode -> statement.args.toList()
+                is JumpStmtNode -> listOf(statement.a, statement.b)
+                is BaseSwitchStmtNode -> listOf(statement.a)
+                is FilledNewArrayStmtNode -> statement.args.toList()
+                is FillArrayDataStmtNode -> listOf(statement.ra)
+                is Stmt0RNode -> emptyList()
+                else -> return true
+            }
+        if (register in operands) return true
+        val destination =
+            when (statement) {
+                is ConstStmtNode -> statement.a
+                is TypeStmtNode -> if (op == Op.CHECK_CAST) -1 else statement.a
+                is Stmt1RNode -> if (op.name.startsWith("MOVE_")) statement.a else -1
+                is Stmt2RNode -> statement.a
+                is Stmt2R1NNode -> statement.distReg
+                is Stmt3RNode -> if (op.name.startsWith("APUT")) -1 else statement.a
+                is FieldStmtNode -> if (op.name.startsWith("IGET") || op.name.startsWith("SGET")) statement.a else -1
+                is AbstractMethodStmtNode, is JumpStmtNode, is BaseSwitchStmtNode,
+                is FilledNewArrayStmtNode, is FillArrayDataStmtNode, is Stmt0RNode,
+                -> -1
+                else -> return true
+            }
+        if (destination < 0) return false
+        val wide =
+            op.name.contains("WIDE") ||
+                op.name.substringBefore("_2ADDR").endsWith("_LONG") ||
+                op.name.substringBefore("_2ADDR").endsWith("_DOUBLE")
+        return register == destination || (wide && register == destination + 1)
     }
 
     private fun rewriteJar(
         jarFile: Path,
         allocations: Map<String, List<String>>,
+        constructors: Map<String, List<ConstructorEvidence>> = emptyMap(),
     ) {
         FileSystems.newFileSystem(jarFile, null as ClassLoader?)?.use { fs ->
             val classFiles =
@@ -153,6 +263,12 @@ object DexAllocationRepair {
                                 .filter { it.name == "<init>" }
                                 .map(MethodNode::desc)
                                 .toSet(),
+                        accessibleConstructors =
+                            node.methods
+                                .filter {
+                                    it.name == "<init>" && it.access and (Opcodes.ACC_PUBLIC or Opcodes.ACC_PROTECTED) != 0
+                                }.map(MethodNode::desc)
+                                .toSet(),
                     )
             }
 
@@ -162,14 +278,19 @@ object DexAllocationRepair {
             // 于是这个 pass 一个分配点都修不到。查不到就回落到宿主 classpath 反射，
             // 与运行期的解析路径一致。
             val shapes = ClassShapeResolver(info)
+            val changedClasses = mutableSetOf<String>()
+            val byName = nodes.associate { it.second.name to it.second }
 
             nodes.forEach { (path, node) ->
                 var changed = false
-                node.methods.forEach { method ->
-                    if (repairMethod(node.name, method, allocations, shapes)) changed = true
+                node.methods.toList().forEach { method ->
+                    if (repairMethod(node.name, method, allocations, shapes, constructors, byName, changedClasses)) changed = true
                 }
-                if (!changed) return@forEach
-                val writer = ClassWriter(0)
+                if (changed) changedClasses += node.name
+            }
+            nodes.forEach { (path, node) ->
+                if (node.name !in changedClasses) return@forEach
+                val writer = ClassWriter(ClassWriter.COMPUTE_MAXS)
                 node.accept(writer)
                 Files.write(path, writer.toByteArray())
             }
@@ -181,6 +302,9 @@ object DexAllocationRepair {
         method: MethodNode,
         allocations: Map<String, List<String>>,
         shapes: ClassShapeResolver,
+        constructors: Map<String, List<ConstructorEvidence>>,
+        classes: Map<String, ClassNode>,
+        changedClasses: MutableSet<String>,
     ): Boolean {
         val instructions = method.instructions.toArray()
         val abstractNews =
@@ -220,14 +344,26 @@ object DexAllocationRepair {
             val replacementShape = shapes[replacement] ?: return@forEach
             if (!replacementShape.isInstantiable) return@forEach
 
-            // 只改 owner 是不够的：dex2jar 有时把整个构造**内联**掉，连描述符一起换成父类
-            // 的（实测 koharu 的 `Lp0;`——它在 dex 里是 `<init>(Lp;)V` 的 Kotlin 内部类，
-            // 却被转成了 `Filter$Group.<init>(String, List)`，栈上的实参也跟着变了）。
-            // 那种情况下光把 owner 改回 p0 只会把 InstantiationError 换成
-            // NoSuchMethodError——同样不可用，还更难查。候选类必须真的有这个签名的构造器
-            // 才动手；否则原样留着那个语义明确的 InstantiationError。
+            // A descriptor mismatch alone is not evidence of inlining. Only
+            // the original DEX receiver proof can authorize a forwarding ctor.
             val constructorDescriptors = constructorDescriptorsFor(method, abstractType)
-            if (constructorDescriptors.any { it !in replacementShape.constructors }) {
+            val missingDescriptors = constructorDescriptors - replacementShape.constructors
+            val evidence = constructors[methodKey(owner, method.name, method.desc)].orEmpty()
+            val replacementNode = classes[replacement]
+            val canForward =
+                replacementNode != null &&
+                    replacementNode.superName == abstractType &&
+                    missingDescriptors.all { descriptor ->
+                        evidence.count { it == ConstructorEvidence(replacement, abstractType, descriptor) } ==
+                            method.instructions.toArray().filterIsInstance<MethodInsnNode>().count {
+                                it.opcode == Opcodes.INVOKESPECIAL &&
+                                    it.name == "<init>" &&
+                                    it.owner == abstractType &&
+                                    it.desc == descriptor
+                            } &&
+                            descriptor in shapes[abstractType]?.accessibleConstructors.orEmpty()
+                    }
+            if (missingDescriptors.isNotEmpty() && !canForward) {
                 logger.warn {
                     "Skipping abstract allocation in $owner.${method.name}: " +
                         "$replacement has no constructor matching $constructorDescriptors " +
@@ -237,6 +373,12 @@ object DexAllocationRepair {
             }
 
             if (rewriteAllocations(method, abstractType, replacement)) {
+                missingDescriptors.forEach { descriptor ->
+                    if (replacementNode!!.methods.none { it.name == "<init>" && it.desc == descriptor }) {
+                        replacementNode.methods.add(forwardingConstructor(abstractType, descriptor))
+                        changedClasses += replacement
+                    }
+                }
                 changed = true
                 logger.info {
                     "Restored dex allocation in $owner.${method.name}: " +
@@ -246,6 +388,24 @@ object DexAllocationRepair {
         }
         return changed
     }
+
+    private fun forwardingConstructor(
+        parent: String,
+        descriptor: String,
+    ): MethodNode =
+        MethodNode(Opcodes.ACC_PUBLIC or Opcodes.ACC_SYNTHETIC, "<init>", descriptor, null, null).apply {
+            visitCode()
+            visitVarInsn(Opcodes.ALOAD, 0)
+            var local = 1
+            Type.getArgumentTypes(descriptor).forEach { argument ->
+                visitVarInsn(argument.getOpcode(Opcodes.ILOAD), local)
+                local += argument.size
+            }
+            visitMethodInsn(Opcodes.INVOKESPECIAL, parent, "<init>", descriptor, false)
+            visitInsn(Opcodes.RETURN)
+            visitMaxs(local, local)
+            visitEnd()
+        }
 
     /** 该方法里所有以 [abstractType] 为 owner 的构造调用描述符。 */
     private fun constructorDescriptorsFor(
@@ -346,11 +506,24 @@ object DexAllocationRepair {
                     )
                 ClassShape(
                     superName = loaded.superclass?.name?.replace('.', '/'),
-                    isAbstract = java.lang.reflect.Modifier.isAbstract(loaded.modifiers),
+                    isAbstract =
+                        java.lang.reflect.Modifier
+                            .isAbstract(loaded.modifiers),
                     isInterface = loaded.isInterface,
                     constructors =
                         loaded.declaredConstructors
-                            .map { org.objectweb.asm.Type.getConstructorDescriptor(it) }
+                            .map {
+                                org.objectweb.asm.Type
+                                    .getConstructorDescriptor(it)
+                            }.toSet(),
+                    accessibleConstructors =
+                        loaded.declaredConstructors
+                            .filter {
+                                java.lang.reflect.Modifier
+                                    .isPublic(it.modifiers) ||
+                                    java.lang.reflect.Modifier
+                                        .isProtected(it.modifiers)
+                            }.map { Type.getConstructorDescriptor(it) }
                             .toSet(),
                 )
             }.getOrNull()
@@ -375,6 +548,7 @@ object DexAllocationRepair {
         val isAbstract: Boolean,
         val isInterface: Boolean,
         val constructors: Set<String> = emptySet(),
+        val accessibleConstructors: Set<String> = emptySet(),
     ) {
         val isInstantiable: Boolean get() = !isAbstract && !isInterface
     }

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/controller/DalvikErrorResponseTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/controller/DalvikErrorResponseTest.kt
@@ -1,0 +1,53 @@
+package mextensionserver.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import eu.kanade.tachiyomi.network.HttpException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DalvikErrorResponseTest {
+    @Test
+    fun `source HTTP failures retain status and typed origin across response serialization`() {
+        // 599 also exercises statuses missing from NanoHTTPD's fixed enum.
+        for (statusCode in listOf(403, 429, 500, 502, 503, 599)) {
+            val error = HttpException(statusCode)
+            val response = DalvikHandler().errorResponse(error)
+            assertEquals(statusCode, response.status.requestStatus)
+            val body = response.data.use { jacksonObjectMapper().readTree(it) }
+            assertEquals("sourceHttp", body["errorKind"].asText())
+            assertTrue(body["sourceStatusCode"].isIntegralNumber)
+            assertEquals(statusCode, body["sourceStatusCode"].asInt())
+            assertEquals(statusCode, body["code"].asInt())
+            assertEquals(error.javaClass.name, body["errorType"].asText())
+            assertEquals(error.message, body["error"].asText())
+            assertTrue(body["stackTrace"].asText().contains("HttpException"))
+        }
+    }
+
+    @Test
+    fun `internal failures remain bridge failures regardless of HTTP-like message`() {
+        for (error in listOf(IllegalStateException("HTTP error 502"), NoSuchMethodError("missing method"))) {
+            val response = DalvikHandler().errorResponse(error)
+            assertEquals(500, response.status.requestStatus)
+            val body = response.data.use { jacksonObjectMapper().readTree(it) }
+            assertEquals("bridge", body["errorKind"].asText())
+            assertTrue(body["sourceStatusCode"].isNull)
+            assertEquals(500, body["code"].asInt())
+            assertEquals(error.javaClass.name, body["errorType"].asText())
+            assertEquals(error.message, body["error"].asText())
+            assertTrue(body["stackTrace"].asText().isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `invalid source HTTP status cannot become a successful bridge response`() {
+        for (statusCode in listOf(200, 399, 600)) {
+            val response = DalvikHandler().errorResponse(HttpException(statusCode))
+            assertEquals(500, response.status.requestStatus)
+            val body = response.data.use { jacksonObjectMapper().readTree(it) }
+            assertEquals("bridge", body["errorKind"].asText())
+            assertTrue(body["sourceStatusCode"].isNull)
+        }
+    }
+}

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/controller/FilterResponseTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/controller/FilterResponseTest.kt
@@ -1,0 +1,50 @@
+package mextensionserver.controller
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import mextensionserver.model.FiltersResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class FilterResponseTest {
+    private class Label {
+        override fun toString(): String = "すべて"
+    }
+
+    @Test
+    fun `bare invoker FilterList serializes option labels and typed nested states`() {
+        val filters =
+            FilterList(
+                object : Filter.Select<Label>("並び順", arrayOf(Label())) {},
+                object : Filter.Group<Filter<*>>(
+                    "絞り込み",
+                    listOf(object : Filter.TriState("完結", Filter.TriState.STATE_EXCLUDE) {}),
+                ) {},
+                object : Filter.Sort("更新", arrayOf("新着"), Filter.Sort.Selection(0, false)) {},
+            )
+        val mapper = jacksonObjectMapper()
+        val json = mapper.readTree(mapper.writeValueAsString(filterResponseForBridge(filters)))
+        assertTrue(json.isArray)
+        assertEquals("select", json[0]["type"].asText())
+        assertEquals("すべて", json[0]["values"][0].asText())
+        assertEquals(0, json[0]["state"].asInt())
+        assertEquals("group", json[1]["type"].asText())
+        assertEquals("triState", json[1]["children"][0]["type"].asText())
+        assertEquals(2, json[1]["children"][0]["state"].asInt())
+        assertEquals("sort", json[2]["type"].asText())
+        assertEquals(false, json[2]["state"]["ascending"].asBoolean())
+    }
+
+    @Test
+    fun `legacy response keeps its envelope and unrelated results stay unchanged`() {
+        val mapper = jacksonObjectMapper()
+        val wrapped = FiltersResponse(FilterList(object : Filter.Select<Label>("並び順", arrayOf(Label())) {}))
+        val json = mapper.readTree(mapper.writeValueAsString(filterResponseForBridge(wrapped)))
+        assertEquals("すべて", json["filterList"][0]["values"][0].asText())
+        val unrelated = mapOf("mangas" to emptyList<String>())
+        assertSame(unrelated, filterResponseForBridge(unrelated))
+    }
+}

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/impl/HostProxyPolicyTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/impl/HostProxyPolicyTest.kt
@@ -7,6 +7,8 @@ import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.net.ProxySelector
+import java.net.ServerSocket
+import java.net.Socket
 import java.net.SocketAddress
 import java.net.URI
 import java.util.concurrent.atomic.AtomicInteger
@@ -15,6 +17,58 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 class HostProxyPolicyTest {
+    @Test
+    fun globallyInstalledPolicyDoesNotReapplyHttpRoutingToTcpSockets() {
+        val previous = ProxySelector.getDefault()
+        try {
+            ProxySelector.setDefault(HostProxyPolicy)
+            ServerSocket(0).use { server ->
+                server.soTimeout = 3000
+                Socket().use { socket ->
+                    socket.connect(InetSocketAddress("127.0.0.1", server.localPort), 3000)
+                    server.accept().use { accepted ->
+                        socket.getOutputStream().write(42)
+                        accepted.soTimeout = 3000
+                        assertEquals(42, accepted.getInputStream().read())
+                    }
+                }
+            }
+        } finally {
+            ProxySelector.setDefault(previous)
+        }
+    }
+
+    @Test
+    fun globallyInstalledPolicyPreservesSelectedHttpProxyTransport() {
+        val previous = ProxySelector.getDefault()
+        val proxy = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        var requestedUri: String? = null
+        proxy.createContext("/") { exchange ->
+            requestedUri = exchange.requestURI.toString()
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+        }
+        proxy.start()
+        val client =
+            HostProxyPolicy
+                .configureClient(OkHttpClient.Builder())
+                .proxy(Proxy(Proxy.Type.HTTP, InetSocketAddress("127.0.0.1", proxy.address.port)))
+                .callTimeout(java.time.Duration.ofSeconds(3))
+                .build()
+        try {
+            ProxySelector.setDefault(HostProxyPolicy)
+            client.newCall(Request.Builder().url("http://source.invalid/chapter").build()).execute().use {
+                assertEquals(200, it.code)
+            }
+            assertEquals("http://source.invalid/chapter", requestedUri)
+        } finally {
+            ProxySelector.setDefault(previous)
+            proxy.stop(0)
+            client.connectionPool.evictAll()
+            client.dispatcher.executorService.shutdownNow()
+        }
+    }
+
     @Test
     fun proxyAuthenticationDoesNotLeakAcrossRedirectToDirectOrigin() {
         val origin = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/impl/MihonImageProxyTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/impl/MihonImageProxyTest.kt
@@ -1,0 +1,179 @@
+package mextensionserver.impl
+
+import com.sun.net.httpserver.HttpServer
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.HttpSource
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import rx.Observable
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URI
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MihonImageProxyTest {
+    @Test
+    fun `consumes network image body before the observable cancels its call`() {
+        val expected = ByteArray(256 * 1024) { (it % 251).toByte() }
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/image") { exchange ->
+            exchange.responseHeaders.add("Content-Type", "image/jpeg")
+            exchange.sendResponseHeaders(200, expected.size.toLong())
+            exchange.responseBody.use { it.write(expected) }
+        }
+        server.start()
+        val networkClient =
+            OkHttpClient
+                .Builder()
+                .proxy(Proxy.NO_PROXY)
+                .callTimeout(java.time.Duration.ofSeconds(5))
+                .build()
+        val source =
+            object : TestHttpSource() {
+                override val client = networkClient
+            }
+        try {
+            MihonImageProxy.configure(39641)
+            val page = Page(0, imageUrl = "http://127.0.0.1:${server.address.port}/image")
+            val proxyUrl = requireNotNull(MihonImageProxy.register(source, page))
+            val token = URI(proxyUrl).path.substringAfterLast('/')
+            val image = requireNotNull(MihonImageProxy.fetch(token))
+            assertEquals("image/jpeg", image.contentType)
+            assertContentEquals(expected, image.bytes)
+        } finally {
+            server.stop(0)
+            networkClient.connectionPool.evictAll()
+            networkClient.dispatcher.executorService.shutdownNow()
+        }
+    }
+
+    @AfterTest
+    fun clearProxy() {
+        MihonImageProxy.clear()
+    }
+
+    @Test
+    fun `fetches images through the extension client`() {
+        val source = TestHttpSource()
+        val fragment = "{\"name\":\"001.jpg\",\"offset\":55}"
+        val page = Page(0, imageUrl = "https://example.test/volume.cbz#$fragment")
+        MihonImageProxy.configure(39641)
+
+        val proxyUrl = requireNotNull(MihonImageProxy.register(source, page))
+        val token = URI(proxyUrl).path.substringAfterLast('/')
+        val image = requireNotNull(MihonImageProxy.fetch(token))
+
+        assertTrue(proxyUrl.startsWith("http://127.0.0.1:39641/image/"))
+        assertEquals(fragment, source.seenFragment)
+        assertEquals("image/jpeg", image.contentType)
+        assertContentEquals(source.imageBytes, image.bytes)
+    }
+
+    @Test
+    fun `resolves missing image urls through the extension`() {
+        val source = TestHttpSource()
+        val page = Page(0, url = "/reader-page")
+        MihonImageProxy.configure(39641)
+
+        val proxyUrl = requireNotNull(MihonImageProxy.register(source, page))
+        val token = URI(proxyUrl).path.substringAfterLast('/')
+        MihonImageProxy.fetch(token)
+
+        assertEquals(1, source.imageUrlFetches)
+        assertEquals(source.resolvedImageUrl, page.imageUrl)
+    }
+
+    @Test
+    fun `resolves missing image urls through native 1_6 API`() {
+        val source = NativeImageUrlHttpSource()
+        val page = Page(0, url = "/reader-page")
+        MihonImageProxy.configure(39641)
+
+        val proxyUrl = requireNotNull(MihonImageProxy.register(source, page))
+        val token = URI(proxyUrl).path.substringAfterLast('/')
+        MihonImageProxy.fetch(token)
+
+        assertEquals(1, source.imageUrlFetches)
+        assertEquals(source.resolvedImageUrl, page.imageUrl)
+    }
+
+    private open class TestHttpSource : HttpSource() {
+        val imageBytes = byteArrayOf(0xff.toByte(), 0xd8.toByte(), 0xff.toByte(), 0xd9.toByte())
+        val resolvedImageUrl = "https://example.test/resolved.jpg"
+        var seenFragment: String? = null
+        var imageUrlFetches = 0
+
+        override val name = "Test source"
+        override val lang = "en"
+        override val baseUrl = "https://example.test"
+        override val supportsLatest = false
+        override val client =
+            OkHttpClient
+                .Builder()
+                .addInterceptor { chain ->
+                    seenFragment = chain.request().url.fragment
+                    Response
+                        .Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(imageBytes.toResponseBody("image/jpeg".toMediaType()))
+                        .build()
+                }.build()
+
+        override fun fetchImageUrl(page: Page): Observable<String> {
+            imageUrlFetches++
+            return Observable.just(resolvedImageUrl)
+        }
+
+        override fun imageRequest(page: Page): Request = Request.Builder().url(requireNotNull(page.imageUrl)).build()
+
+        override fun popularMangaRequest(page: Int): Request = unused()
+
+        override fun popularMangaParse(response: Response): MangasPage = unused()
+
+        override fun searchMangaRequest(
+            page: Int,
+            query: String,
+            filters: FilterList,
+        ): Request = unused()
+
+        override fun searchMangaParse(response: Response): MangasPage = unused()
+
+        override fun latestUpdatesRequest(page: Int): Request = unused()
+
+        override fun latestUpdatesParse(response: Response): MangasPage = unused()
+
+        override fun mangaDetailsParse(response: Response): SManga = unused()
+
+        override fun chapterListParse(response: Response): List<SChapter> = unused()
+
+        override fun pageListParse(response: Response): List<Page> = unused()
+
+        override fun imageUrlParse(response: Response): String = unused()
+
+        private fun unused(): Nothing = error("Not used by this test")
+    }
+
+    private class NativeImageUrlHttpSource : TestHttpSource() {
+        override suspend fun getImageUrl(page: Page): String {
+            imageUrlFetches++
+            return resolvedImageUrl
+        }
+
+        override fun fetchImageUrl(page: Page): Observable<String> = error("The bridge must use getImageUrl")
+    }
+}

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexAllocationRepairTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexAllocationRepairTest.kt
@@ -90,10 +90,9 @@ class DexAllocationRepairTest {
 
     @Test
     fun `leaves the allocation alone when the candidate has no matching constructor`() {
-        // dex2jar 有时把构造整个内联掉，连描述符一起换成父类的（koharu 的 Lp0; 在 dex 里
-        // 是 `<init>(Lp;)V` 的 Kotlin 内部类，却被转成了父类的 `(String, List)`）。这时
-        // 光把 owner 改回去只会把 InstantiationError 换成 NoSuchMethodError——一样不可用、
-        // 还更难查。必须原样放过。
+        // Allocation counts alone cannot prove which constructor ran in DEX.
+        // Without receiver/constructor evidence, do not invent a forwarding
+        // constructor or replace InstantiationError with NoSuchMethodError.
         val jar = buildFixture(concreteCtorDesc = "(Ljava/lang/String;)V")
         try {
             DexAllocationRepair.restoreWithAllocations(

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexConcreteAllocationTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexConcreteAllocationTest.kt
@@ -1,0 +1,159 @@
+package mextensionserver.util
+
+import com.googlecode.d2j.Method
+import com.googlecode.d2j.dex.Dex2jar
+import com.googlecode.d2j.dex.writer.DexFileWriter
+import com.googlecode.d2j.reader.MultiDexFileReader
+import com.googlecode.d2j.reader.Op
+import org.objectweb.asm.Opcodes
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DexConcreteAllocationTest {
+    @Test
+    fun `real dex conversion preserves concrete item type for typed collection arrays`() {
+        withFixture { dex, jar ->
+            // Comic Days shape: R8 erases Item's constructor, then the filter
+            // constructor materializes List<Item> using Collection.toArray(Item[]).
+            assertFailsWith<ArrayStoreException> { invoke(jar) }
+            DexAllocationRepair.restore(dex, jar)
+            DexAllocationRepair.restore(dex, jar)
+            val items = invoke(jar) as Array<*>
+            assertEquals("ErasedItem", items.single()!!.javaClass.name)
+            assertEquals("Japanese option", items.single().toString())
+            assertEquals(
+                1,
+                items
+                    .single()!!
+                    .javaClass.declaredConstructors.size,
+            )
+        }
+    }
+
+    @Test
+    fun `allocation counts alone cannot rewrite a concrete Object allocation`() {
+        withFixture(existingConstructor = true) { _, jar ->
+            DexAllocationRepair.restoreWithAllocations(
+                jar,
+                mapOf("ItemFactory#create#()[LErasedItem;" to listOf("ErasedItem")),
+            )
+            assertFailsWith<ArrayStoreException> { invoke(jar) }
+        }
+    }
+
+    @Test
+    fun `retains real Object allocation even when another subclass allocation was erased`() {
+        withFixture(realObject = true) { dex, jar ->
+            DexAllocationRepair.restore(dex, jar)
+            assertEquals("java.lang.Object", invoke(jar)!!.javaClass.name)
+        }
+    }
+
+    @Test
+    fun `does not choose between multiple erased concrete subclasses`() {
+        withFixture(ambiguous = true) { dex, jar ->
+            DexAllocationRepair.restore(dex, jar)
+            assertFailsWith<ArrayStoreException> { invoke(jar) }
+        }
+    }
+
+    private fun invoke(jar: Path): Any? =
+        URLClassLoader(arrayOf(jar.toUri().toURL()), javaClass.classLoader).use { loader ->
+            try {
+                loader.loadClass("ItemFactory").getMethod("create").invoke(null)
+            } catch (wrapped: java.lang.reflect.InvocationTargetException) {
+                throw wrapped.cause!!
+            }
+        }
+
+    private fun withFixture(
+        realObject: Boolean = false,
+        ambiguous: Boolean = false,
+        existingConstructor: Boolean = false,
+        verify: (Path, Path) -> Unit,
+    ) {
+        val dex = Files.createTempFile("concrete-allocation", ".dex")
+        val jar = Files.createTempFile("concrete-allocation", ".jar")
+        try {
+            val writer = DexFileWriter()
+            val item = writer.visit(Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL, "LErasedItem;", "Ljava/lang/Object;", null)
+            if (existingConstructor) {
+                val initializer = item.visitMethod(Opcodes.ACC_PUBLIC, Method("LErasedItem;", "<init>", emptyArray(), "V"))
+                initializer.visitCode().apply {
+                    visitRegister(1)
+                    visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(0), Method("Ljava/lang/Object;", "<init>", emptyArray(), "V"))
+                    visitStmt0R(Op.RETURN_VOID)
+                    visitEnd()
+                }
+                initializer.visitEnd()
+            }
+            val toString = item.visitMethod(Opcodes.ACC_PUBLIC, Method("LErasedItem;", "toString", emptyArray(), "Ljava/lang/String;"))
+            toString.visitCode().apply {
+                visitRegister(2)
+                visitConstStmt(Op.CONST_STRING, 0, "Japanese option")
+                visitStmt1R(Op.RETURN_OBJECT, 0)
+                visitEnd()
+            }
+            toString.visitEnd()
+            item.visitEnd()
+            if (ambiguous) writer.visit(Opcodes.ACC_PUBLIC, "LOtherItem;", "Ljava/lang/Object;", null).visitEnd()
+            val factory = writer.visit(Opcodes.ACC_PUBLIC, "LItemFactory;", "Ljava/lang/Object;", null)
+            val method =
+                factory.visitMethod(
+                    Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+                    Method("LItemFactory;", "create", emptyArray(), if (realObject) "Ljava/lang/Object;" else "[LErasedItem;"),
+                )
+            method.visitCode().apply {
+                visitRegister(4)
+                visitTypeStmt(Op.NEW_INSTANCE, 0, -1, "LErasedItem;")
+                visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(0), Method("Ljava/lang/Object;", "<init>", emptyArray(), "V"))
+                if (realObject || ambiguous) {
+                    visitTypeStmt(Op.NEW_INSTANCE, 1, -1, if (realObject) "Ljava/lang/Object;" else "LOtherItem;")
+                    visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(1), Method("Ljava/lang/Object;", "<init>", emptyArray(), "V"))
+                    // Make both allocations observable so converter optimization
+                    // cannot drop the evidence whose ambiguity we are testing.
+                    visitMethodStmt(
+                        Op.INVOKE_STATIC,
+                        intArrayOf(0, 1),
+                        Method("Ljava/util/Objects;", "equals", arrayOf("Ljava/lang/Object;", "Ljava/lang/Object;"), "Z"),
+                    )
+                }
+                if (realObject) {
+                    visitStmt1R(Op.RETURN_OBJECT, 1)
+                } else {
+                    visitMethodStmt(
+                        Op.INVOKE_STATIC,
+                        intArrayOf(0),
+                        Method("Ljava/util/Collections;", "singletonList", arrayOf("Ljava/lang/Object;"), "Ljava/util/List;"),
+                    )
+                    visitStmt1R(Op.MOVE_RESULT_OBJECT, 1)
+                    visitConstStmt(Op.CONST_4, 2, 0)
+                    visitTypeStmt(Op.NEW_ARRAY, 2, 2, "[LErasedItem;")
+                    visitMethodStmt(
+                        Op.INVOKE_INTERFACE,
+                        intArrayOf(1, 2),
+                        Method("Ljava/util/List;", "toArray", arrayOf("[Ljava/lang/Object;"), "[Ljava/lang/Object;"),
+                    )
+                    visitStmt1R(Op.MOVE_RESULT_OBJECT, 3)
+                    visitTypeStmt(Op.CHECK_CAST, 3, -1, "[LErasedItem;")
+                    visitStmt1R(Op.RETURN_OBJECT, 3)
+                }
+                visitEnd()
+            }
+            method.visitEnd()
+            factory.visitEnd()
+            writer.visitEnd()
+            Files.write(dex, writer.toByteArray())
+            Dex2jar.from(MultiDexFileReader.open(Files.readAllBytes(dex))).to(jar)
+            BytecodeEditor.fixAndroidClasses(jar)
+            verify(dex, jar)
+        } finally {
+            Files.deleteIfExists(dex)
+            Files.deleteIfExists(jar)
+        }
+    }
+}

--- a/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexInlinedConstructorTest.kt
+++ b/third_party/m_extension_server/overlay/server/src/test/kotlin/mextensionserver/util/DexInlinedConstructorTest.kt
@@ -1,0 +1,210 @@
+package mextensionserver.util
+
+import com.googlecode.d2j.DexLabel
+import com.googlecode.d2j.Field
+import com.googlecode.d2j.Method
+import com.googlecode.d2j.dex.Dex2jar
+import com.googlecode.d2j.dex.writer.DexFileWriter
+import com.googlecode.d2j.node.DexCodeNode
+import com.googlecode.d2j.reader.MultiDexFileReader
+import com.googlecode.d2j.reader.Op
+import eu.kanade.tachiyomi.source.model.Filter
+import org.objectweb.asm.Opcodes
+import java.net.URLClassLoader
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class DexInlinedConstructorTest {
+    abstract class WideParent(
+        val count: Long,
+        val ratio: Double,
+    )
+
+    abstract class PrivateParent private constructor(
+        val unused: Int,
+    )
+
+    private val parent = "Leu/kanade/tachiyomi/source/model/Filter\$Group;"
+    private val constructor = Method(parent, "<init>", arrayOf("Ljava/lang/String;", "Ljava/util/List;"), "V")
+
+    @Test
+    fun `forwarding constructor preserves wide arguments and local slots`() {
+        withHostParent(WideParent::class.java, arrayOf("J", "D")) { loader ->
+            val value = loader.loadClass("HostParentFactory").getMethod("create").invoke(null) as WideParent
+            assertEquals(9876543210L, value.count)
+            assertEquals(2.5, value.ratio)
+            assertEquals("HostParentChild", value.javaClass.name)
+        }
+    }
+
+    @Test
+    fun `does not synthesize a call to inaccessible superclass constructor`() {
+        withHostParent(PrivateParent::class.java, arrayOf("I")) { loader ->
+            assertFailsWith<InstantiationError> {
+                try {
+                    loader.loadClass("HostParentFactory").getMethod("create").invoke(null)
+                } catch (wrapped: java.lang.reflect.InvocationTargetException) {
+                    throw wrapped.cause!!
+                }
+            }
+        }
+    }
+
+    private fun withHostParent(
+        parentClass: Class<*>,
+        arguments: Array<String>,
+        verify: (URLClassLoader) -> Unit,
+    ) {
+        val dex = Files.createTempFile("host-parent-constructor", ".dex")
+        val jar = Files.createTempFile("host-parent-constructor", ".jar")
+        try {
+            val descriptor = "L${parentClass.name.replace('.', '/')};"
+            val writer = DexFileWriter()
+            writer.visit(Opcodes.ACC_PUBLIC, "LHostParentChild;", descriptor, null).visitEnd()
+            val factory = writer.visit(Opcodes.ACC_PUBLIC, "LHostParentFactory;", "Ljava/lang/Object;", null)
+            val method =
+                factory.visitMethod(
+                    Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+                    Method("LHostParentFactory;", "create", emptyArray(), descriptor),
+                )
+            method.visitCode().apply {
+                visitRegister(5)
+                visitTypeStmt(Op.NEW_INSTANCE, 0, -1, "LHostParentChild;")
+                if (arguments.contentEquals(arrayOf("I"))) {
+                    visitConstStmt(Op.CONST_4, 1, 1)
+                } else if (arguments.isNotEmpty()) {
+                    visitConstStmt(Op.CONST_WIDE, 1, 9876543210L)
+                    visitConstStmt(Op.CONST_WIDE, 3, java.lang.Double.doubleToRawLongBits(2.5))
+                }
+                visitMethodStmt(
+                    Op.INVOKE_DIRECT_RANGE,
+                    if (arguments.size == 1) intArrayOf(0, 1) else intArrayOf(0, 1, 2, 3, 4),
+                    Method(descriptor, "<init>", arguments, "V"),
+                )
+                visitStmt1R(Op.RETURN_OBJECT, 0)
+                visitEnd()
+            }
+            method.visitEnd()
+            factory.visitEnd()
+            writer.visitEnd()
+            Files.write(dex, writer.toByteArray())
+            // Isolate this pass: BytecodeEditor has a separate constructor
+            // redirect pass, which would mask the inaccessible-parent boundary.
+            Dex2jar.from(MultiDexFileReader.open(Files.readAllBytes(dex))).to(jar)
+            DexAllocationRepair.restore(dex, jar)
+            URLClassLoader(arrayOf(jar.toUri().toURL()), javaClass.classLoader).use(verify)
+        } finally {
+            Files.deleteIfExists(dex)
+            Files.deleteIfExists(jar)
+        }
+    }
+
+    @Test
+    fun `real dex conversion preserves erased subclass and superclass arguments through a loop`() {
+        val dex = Files.createTempFile("inlined-constructor", ".dex")
+        val jar = Files.createTempFile("inlined-constructor", ".jar")
+        try {
+            val writer = DexFileWriter()
+            writer.visit(Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL, "LErasedGroup;", parent, null).visitEnd()
+            val factory = writer.visit(Opcodes.ACC_PUBLIC, "LInlinedFactory;", "Ljava/lang/Object;", null)
+            val method =
+                factory.visitMethod(
+                    Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+                    Method("LInlinedFactory;", "create", emptyArray(), parent),
+                )
+            method.visitCode().apply {
+                visitRegister(4)
+                visitTypeStmt(Op.NEW_INSTANCE, 0, -1, "LErasedGroup;")
+                visitConstStmt(Op.CONST_STRING, 1, "Japanese filters")
+                visitMethodStmt(
+                    Op.INVOKE_STATIC,
+                    intArrayOf(),
+                    Method("Ljava/util/Collections;", "emptyList", emptyArray(), "Ljava/util/List;"),
+                )
+                visitStmt1R(Op.MOVE_RESULT_OBJECT, 2)
+                visitConstStmt(Op.CONST_4, 3, 1)
+                val loop = DexLabel()
+                visitLabel(loop)
+                visitStmt2R1N(Op.ADD_INT_LIT8, 3, 3, -1)
+                visitJumpStmt(Op.IF_NEZ, 3, -1, loop)
+                visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(0, 1, 2), constructor)
+                visitStmt1R(Op.RETURN_OBJECT, 0)
+                visitEnd()
+            }
+            method.visitEnd()
+            factory.visitEnd()
+            writer.visitEnd()
+            Files.write(dex, writer.toByteArray())
+            PackageTools.dex2jar(dex.toFile(), jar.toFile())
+            // A repeated repair must not duplicate the generated constructor.
+            DexAllocationRepair.restore(dex, jar)
+            URLClassLoader(arrayOf(jar.toUri().toURL()), javaClass.classLoader).use { loader ->
+                val value = loader.loadClass("InlinedFactory").getMethod("create").invoke(null) as Filter.Group<*>
+                assertEquals("ErasedGroup", value.javaClass.name)
+                assertEquals("Japanese filters", value.name)
+                assertTrue(value.state.isEmpty())
+                assertEquals(1, value.javaClass.declaredConstructors.size)
+            }
+        } finally {
+            Files.deleteIfExists(dex)
+            Files.deleteIfExists(jar)
+        }
+    }
+
+    @Test
+    fun `proof rejects every register overwrite and alias escape`() {
+        val operations: List<DexCodeNode.() -> Unit> =
+            listOf(
+                { visitConstStmt(Op.CONST_4, 3, 0) },
+                { visitConstStmt(Op.CONST_WIDE, 2, 0L) },
+                { visitStmt1R(Op.MOVE_RESULT_WIDE, 2) },
+                { visitStmt2R(Op.MOVE_WIDE, 2, 7) },
+                { visitStmt2R(Op.INT_TO_LONG, 2, 7) },
+                { visitStmt2R(Op.MOVE_OBJECT, 4, 3) },
+                { visitStmt2R1N(Op.ADD_INT_LIT8, 3, 7, 1) },
+                { visitStmt3R(Op.ADD_DOUBLE, 2, 6, 8) },
+                { visitStmt3R(Op.AGET_WIDE, 2, 6, 8) },
+                { visitFieldStmt(Op.SGET_WIDE, 2, -1, Field("LHolder;", "wide", "J")) },
+                { visitFieldStmt(Op.IPUT_OBJECT, 3, 5, Field("LHolder;", "value", "Ljava/lang/Object;")) },
+                { visitStmt3R(Op.APUT_OBJECT, 3, 5, 6) },
+                { visitFilledNewArrayStmt(Op.FILLED_NEW_ARRAY, intArrayOf(3), "[Ljava/lang/Object;") },
+                { visitTypeStmt(Op.CHECK_CAST, 3, -1, parent) },
+                { visitMethodStmt(Op.INVOKE_STATIC, intArrayOf(3), Method("LHolder;", "escape", arrayOf(parent), "V")) },
+            )
+        operations.forEachIndexed { index, operation ->
+            val code = allocationCode(operation)
+            assertTrue(DexAllocationRepair.readConstructorEvidence(code).isEmpty(), "unsafe operation $index")
+        }
+    }
+
+    @Test
+    fun `proof rejects control flow entering after allocation`() {
+        val entry = DexLabel()
+        val code = DexCodeNode()
+        code.visitJumpStmt(Op.IF_EQZ, 7, -1, entry)
+        code.visitTypeStmt(Op.NEW_INSTANCE, 3, -1, "LErasedGroup;")
+        code.visitLabel(entry)
+        code.visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(3, 4, 5), constructor)
+        assertTrue(DexAllocationRepair.readConstructorEvidence(code).isEmpty())
+    }
+
+    @Test
+    fun `proof rejects exception handler entering after allocation`() {
+        val start = DexLabel()
+        val end = DexLabel()
+        val handler = DexLabel()
+        val code = allocationCode { visitLabel(handler) }
+        code.visitTryCatch(start, end, arrayOf(handler), arrayOf("Ljava/lang/Throwable;"))
+        assertTrue(DexAllocationRepair.readConstructorEvidence(code).isEmpty())
+    }
+
+    private fun allocationCode(intervening: DexCodeNode.() -> Unit): DexCodeNode =
+        DexCodeNode().apply {
+            visitTypeStmt(Op.NEW_INSTANCE, 3, -1, "LErasedGroup;")
+            intervening()
+            visitMethodStmt(Op.INVOKE_DIRECT, intArrayOf(3, 4, 5), constructor)
+        }
+}


### PR DESCRIPTION
修复 Windows Mihon 漫画运行时的代理、图片读取与筛选器兼容问题（BUG-2404～2409）。原始症状包括代理策略500、图片HTTP200后破图、SchaleNetwork的Filter$Group实例化错误，以及Comic Days的ArrayStoreException和筛选选项JSON序列化错误。

- HTTP(S)原始请求继续遵循宿主代理；底层socket不再重复HTTP选路。
- 图片响应在Rx订阅结束前读取并关闭，返回与网络生命周期脱离的字节。
- 根据原始DEX的具体分配类型、构造接收者与控制流证据恢复被泛化的类型，并在证据完整时补直接父类转发构造。具体父类（含Object）也须构造证据，禁止仅按计数猜测；合法Object、歧义与不明确数据流保持不变。
- 裸FilterList和历史包装响应统一使用已有显式wire codec，保留type/state/values/children及顺序；自定义选项用显示toString输出，避免对任意扩展对象做Bean序列化。

桌面运行时同时按结构化错误来源分类：源站HTTP400–599保留原状态并显示SOURCE_HTTP_n，桥接内部错误保留BRIDGE_HTTP_n；兼容旧版类型化HttpException响应，非JSON网关失败仍保留HTTP状态，完整栈保留。Kotlin修改通过overlay落地，upstream_src保持原样。

验证：
- 最终全JVM44项通过、0跳过；Kotlin format/lint、shadowJar、Windows runtime smoke通过。
- 真实Socket、256KiB HTTP图片及DEX转换测试包含修复前失败证据；覆盖typed toArray、日文标签、宽参数、不可访问构造、循环、幂等、负向数据流及wire形状。
- Dart宿主策略、vendored server与出站纪律共35项通过；首次PDFium依赖下载超时，配置构建进程代理后通过。
- 用户安装APK实测：SchaleNetwork四语言filtersManga由500恢复200；Comic Days保留日文选项，filtersManga恢复200。
- Windows安装版原路径复测：Rawkuma目标作品图片与翻页正常；SchaleNetwork ALL/JA、Comic Days原书名查询均正常结束，当前查询返回空结果。

新增错误映射Dart定向/真实Java运行时集成7项通过；flutter analyze --no-pub通过。验证来源失败后共享Java进程不重启，原始异常栈不丢失。未验证：整书离线下载、其他平台、PR CI；未跑全量Flutter测试、未重建或替换用户主程序。错误显示分类需包含本次Dart改动的新主程序。カドコミ外部502/403本身不在本补丁内，本PR只纠正错误归因。