### PR TITLE
feat(lookup): 滑动关闭弹窗的动画可单独关掉，不必开墨水屏模式（BUG-2405）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2216 条。点号进各自文件。
+> 共 2217 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2405](bugs/BUG-2405-popup-dismiss-animation-toggle.md) | ✅ | ✅ | 滑动关闭弹窗的动画只能靠开墨水屏模式关掉，没有独立开关 |
 | [BUG-2403](bugs/BUG-2403-video-doubleclick-ignores-mouse-button.md) | ✅ | ✅ | 视频页双击判定不看鼠标按钮号，右键双击画面切全屏 |
 | [BUG-2402](bugs/BUG-2402-mobile-library-layout.md) | ✅ | ✅ | 手机标签页头留白与筛选工具堆叠 |
 | [BUG-2400](bugs/BUG-2400-remote-manga-empty-content.md) | ✅ | ✅ | 远端空漫画合集被标记为可下载内容 |

--- a/docs/bugs/BUG-2405-popup-dismiss-animation-toggle.md
+++ b/docs/bugs/BUG-2405-popup-dismiss-animation-toggle.md
@@ -1,0 +1,41 @@
+## BUG-2405 · 滑动关闭弹窗的动画只能靠开墨水屏模式关掉，没有独立开关
+- **报告**：2026-09-10（用户：滑动关闭弹窗是有个动画的，我需要添加一个功能是关闭弹窗这个动画需要关掉这个动画）
+- **真实性**：✅ 真缺口 —— 松手后的「补间滑出屏外 / 弹回原位」（200ms easeOut）此前**唯一**的关闭
+  途径是 `einkSafeDuration`（`adaptive_platform.dart:66`），即只有开「外观 › 墨水屏模式」才顺带归零。
+  想要瞬时关闭就得连带吃下纯黑白主题 + 线式高亮，两件事被强行绑在一起。设置里既有的两项滑关设置
+  （`lookup.enable_swipe_to_close` 管功能开不开、`reading_controls.dismiss_swipe_sensitivity` 管
+  阈值）都不碰动画。补间落点有两处：`swipe_dismiss_wrapper.dart:79`（弹窗顶栏可拖区 + 独立查词窗
+  整窗滑关）与 `dictionary_popup_layer.dart:1348`（弹窗正文横拖关）。
+- **[x] ① 已修复** —— 新增偏好 `popup_dismiss_animation`（默认 **true** = 保持既有手感）+ 设置项
+  「弹窗关闭动画」（`reading_controls.popup_dismiss_animation`，设置 › 查词，紧邻既有两项滑关设置，
+  `ReaderPlacement(lookup, order 6)` 同时出现在阅读器快捷设置）。
+  - 两处补间收进**唯一入口** `popupDismissAnimationDuration(context, duration)`
+    （`swipe_dismiss_wrapper.dart`）：用户开关关掉 → `Duration.zero`；否则再过
+    `einkSafeDuration`（墨水屏仍然归零）。两条来源正交，eink 不被用户开关覆盖。
+  - **顺带修掉一处真的会「关了没用」的时序 bug**：两处原本都在 `didChangeDependencies` 里缓存
+    `_controller.duration`，而那只在**依赖**（这里是 `Theme`）变化时重跑。用户在设置里翻开关只触发
+    rebuild、不触发 `didChangeDependencies`，控制器会一直留着上一次的 200ms —— 开关要等到下次主题
+    切换或弹窗重建才生效。改成**用时取值**：`_applyDismissDuration()` 在每次启动补间前一刻调用
+    （wrapper 的 `_finishDrag`、detector 的 `_finishHorizontalDrag` / `_springBack`），两条来源都
+    当场生效，不依赖任何重建时机。这条是写测试时被「同一条拖动」对照用例逼出来的。
+  - 跟手期的 `Transform.translate` 不动 —— 手指按住时的实时跟随不是补间动画，去掉会让滑关失去方向
+    反馈（沿用 BUG-2283 备注的结论）。`Duration.zero` 的 `animateTo` 当帧 complete，`onDismiss` 仍在
+    完成回调里触发，关窗时序不变。
+- **[x] ② 已加自动化测试** —— `fushi/test/widgets/swipe_dismiss_wrapper_test.dart` 新增 group
+  「SwipeDismissWrapper『弹窗关闭动画』开关」5 条，判别力沿用同文件 eink 组的「只 pump 一帧」手法
+  （补间还在时该帧不可能 dismiss，归零后当帧就 dismiss）：默认开着仍在补间、关掉当帧即 `onDismiss`、
+  同一条拖动下两者结果必须不同（开关真的改变行为）、**eink 下即使开关开着也仍归零**（两条来源正交）、
+  关掉且未过阈值时弹回已归位且不误关。`tearDown` 还原单例偏好，避免泄漏到同进程后续用例。
+  判别力验证：临时摘掉 `popupDismissAnimationDuration` 里的开关分支 → 正好这 3 条新用例红、eink 那批
+  仍绿；恢复后 23/23 绿（含既有 18 条）。
+  另在 `test/settings/settings_schema_coverage_test.dart` 的 `kCoveredElsewhere` 登记本行（与兄弟行
+  `lookup/Swipe dismiss sensitivity`、`lookup/Swipe to close popup` 同款理由：生效点是
+  `AnimationController.duration`，既非 reader CSS 也非主题树，harness 无适用 T4 渲染探针）。
+  `test/settings` + `test/i18n` 共 500 条绿、`stillUnaccounted=0`；`dictionary_popup_swipe_close_test`
+  / `dictionary_popup_layer_test` / `reader_caret_scripts_test` 94 条绿；`flutter analyze` 零问题。
+- **备注**：
+  - i18n 经 `tool/i18n_sync.dart --add` 同步 17 种语言，`dart run slang` 重新生成。
+  - **真机未验**：本机没有 Android 墨水屏设备，改动本身是纯 Flutter 侧补间时长，已由 widget 行为
+    测试覆盖；真机只需确认设置项可见、翻动后滑关立即变瞬时。
+  - 与 [BUG-2403](BUG-2403-eink-popup-touch-instant-scroll.md) 是同一批用户诉求的两半：那条管**上下
+    滑动**（内容滚动瞬时化），本条管**侧滑关闭**（关闭动画可单独关）。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 77945 (4585 per locale)
+/// Strings: 77979 (4587 per locale)
 ///
-/// Built on 2026-09-09 at 20:23 UTC
+/// Built on 2026-09-10 at 00:09 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6358,6 +6358,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Path mapping and target video source';
   String get settings_downloads_encryption_title => 'Peer encryption';
   String get settings_service_disabled => 'Disabled';
+  String get popup_dismiss_animation => 'Popup close animation';
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -17128,6 +17131,11 @@ class _StringsAr extends _StringsEn {
   String get settings_downloads_encryption_title => 'تشفير الاتصال بالأقران';
   @override
   String get settings_service_disabled => 'معطّل';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -28126,6 +28134,11 @@ class _StringsDe extends _StringsEn {
   String get settings_downloads_encryption_title => 'Peer-Verschlüsselung';
   @override
   String get settings_service_disabled => 'Deaktiviert';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -39178,6 +39191,11 @@ class _StringsEs extends _StringsEn {
   String get settings_downloads_encryption_title => 'Cifrado entre pares';
   @override
   String get settings_service_disabled => 'Desactivado';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -50264,6 +50282,11 @@ class _StringsFr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Chiffrement entre pairs';
   @override
   String get settings_service_disabled => 'Désactivé';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -61152,6 +61175,11 @@ class _StringsId extends _StringsEn {
   String get settings_downloads_encryption_title => 'Enkripsi peer';
   @override
   String get settings_service_disabled => 'Dinonaktifkan';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -72133,6 +72161,11 @@ class _StringsIt extends _StringsEn {
   String get settings_downloads_encryption_title => 'Crittografia dei peer';
   @override
   String get settings_service_disabled => 'Disattivato';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -82490,6 +82523,11 @@ class _StringsJa extends _StringsEn {
   String get settings_downloads_encryption_title => 'ピア通信の暗号化';
   @override
   String get settings_service_disabled => '無効';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -92858,6 +92896,11 @@ class _StringsKo extends _StringsEn {
   String get settings_downloads_encryption_title => '피어 암호화';
   @override
   String get settings_service_disabled => '사용 안 함';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -103795,6 +103838,11 @@ class _StringsNl extends _StringsEn {
   String get settings_downloads_encryption_title => 'Peer-versleuteling';
   @override
   String get settings_service_disabled => 'Uitgeschakeld';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -114786,6 +114834,11 @@ class _StringsPtBr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Criptografia entre pares';
   @override
   String get settings_service_disabled => 'Desativado';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -125754,6 +125807,11 @@ class _StringsRu extends _StringsEn {
       'Шифрование соединений с пирами';
   @override
   String get settings_service_disabled => 'Отключено';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -136521,6 +136579,11 @@ class _StringsTh extends _StringsEn {
   String get settings_downloads_encryption_title => 'การเข้ารหัสระหว่างเพียร์';
   @override
   String get settings_service_disabled => 'ปิดใช้งาน';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -147404,6 +147467,11 @@ class _StringsTr extends _StringsEn {
   String get settings_downloads_encryption_title => 'Eş şifrelemesi';
   @override
   String get settings_service_disabled => 'Devre dışı';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -158258,6 +158326,11 @@ class _StringsVi extends _StringsEn {
   String get settings_downloads_encryption_title => 'Mã hóa kết nối peer';
   @override
   String get settings_service_disabled => 'Đã tắt';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 // Path: <root>
@@ -168227,6 +168300,11 @@ class _StringsZhCn extends _StringsEn {
   String get settings_downloads_encryption_title => '节点加密';
   @override
   String get settings_service_disabled => '已停用';
+  @override
+  String get popup_dismiss_animation => '弹窗关闭动画';
+  @override
+  String get popup_dismiss_animation_hint =>
+      '滑动关闭查词弹窗时播放滑出动画。关掉则瞬间关闭（墨水屏模式下始终关闭）';
 }
 
 // Path: <root>
@@ -178268,6 +178346,11 @@ class _StringsZhHk extends _StringsEn {
   String get settings_downloads_encryption_title => '節點通訊加密';
   @override
   String get settings_service_disabled => '已停用';
+  @override
+  String get popup_dismiss_animation => 'Popup close animation';
+  @override
+  String get popup_dismiss_animation_hint =>
+      'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
 }
 
 /// Flat map(s) containing all translations.
@@ -187699,6 +187782,10 @@ extension on _StringsEn {
         return 'Peer encryption';
       case 'settings_service_disabled':
         return 'Disabled';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -197125,6 +197212,10 @@ extension on _StringsAr {
         return 'تشفير الاتصال بالأقران';
       case 'settings_service_disabled':
         return 'معطّل';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -206596,6 +206687,10 @@ extension on _StringsDe {
         return 'Peer-Verschlüsselung';
       case 'settings_service_disabled':
         return 'Deaktiviert';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -216058,6 +216153,10 @@ extension on _StringsEs {
         return 'Cifrado entre pares';
       case 'settings_service_disabled':
         return 'Desactivado';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -225529,6 +225628,10 @@ extension on _StringsFr {
         return 'Chiffrement entre pairs';
       case 'settings_service_disabled':
         return 'Désactivé';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -234971,6 +235074,10 @@ extension on _StringsId {
         return 'Enkripsi peer';
       case 'settings_service_disabled':
         return 'Dinonaktifkan';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -244435,6 +244542,10 @@ extension on _StringsIt {
         return 'Crittografia dei peer';
       case 'settings_service_disabled':
         return 'Disattivato';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -253826,6 +253937,10 @@ extension on _StringsJa {
         return 'ピア通信の暗号化';
       case 'settings_service_disabled':
         return '無効';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -263221,6 +263336,10 @@ extension on _StringsKo {
         return '피어 암호화';
       case 'settings_service_disabled':
         return '사용 안 함';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -272678,6 +272797,10 @@ extension on _StringsNl {
         return 'Peer-versleuteling';
       case 'settings_service_disabled':
         return 'Uitgeschakeld';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -282130,6 +282253,10 @@ extension on _StringsPtBr {
         return 'Criptografia entre pares';
       case 'settings_service_disabled':
         return 'Desativado';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -291589,6 +291716,10 @@ extension on _StringsRu {
         return 'Шифрование соединений с пирами';
       case 'settings_service_disabled':
         return 'Отключено';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -301020,6 +301151,10 @@ extension on _StringsTh {
         return 'การเข้ารหัสระหว่างเพียร์';
       case 'settings_service_disabled':
         return 'ปิดใช้งาน';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -310466,6 +310601,10 @@ extension on _StringsTr {
         return 'Eş şifrelemesi';
       case 'settings_service_disabled':
         return 'Devre dışı';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -319906,6 +320045,10 @@ extension on _StringsVi {
         return 'Mã hóa kết nối peer';
       case 'settings_service_disabled':
         return 'Đã tắt';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }
@@ -329264,6 +329407,10 @@ extension on _StringsZhCn {
         return '节点加密';
       case 'settings_service_disabled':
         return '已停用';
+      case 'popup_dismiss_animation':
+        return '弹窗关闭动画';
+      case 'popup_dismiss_animation_hint':
+        return '滑动关闭查词弹窗时播放滑出动画。关掉则瞬间关闭（墨水屏模式下始终关闭）';
       default:
         return null;
     }
@@ -338633,6 +338780,10 @@ extension on _StringsZhHk {
         return '節點通訊加密';
       case 'settings_service_disabled':
         return '已停用';
+      case 'popup_dismiss_animation':
+        return 'Popup close animation';
+      case 'popup_dismiss_animation_hint':
+        return 'Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode).';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Completed downloads",
   "settings_downloads_routing_hint": "Path mapping and target video source",
   "settings_downloads_encryption_title": "Peer encryption",
-  "settings_service_disabled": "Disabled"
+  "settings_service_disabled": "Disabled",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "التنزيلات المكتملة",
   "settings_downloads_routing_hint": "تعيين المسارات ومصدر الفيديو المستهدف",
   "settings_downloads_encryption_title": "تشفير الاتصال بالأقران",
-  "settings_service_disabled": "معطّل"
+  "settings_service_disabled": "معطّل",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Abgeschlossene Downloads",
   "settings_downloads_routing_hint": "Pfadzuordnung und Ziel-Videoquelle",
   "settings_downloads_encryption_title": "Peer-Verschlüsselung",
-  "settings_service_disabled": "Deaktiviert"
+  "settings_service_disabled": "Deaktiviert",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Descargas completadas",
   "settings_downloads_routing_hint": "Asignación de rutas y fuente de vídeo de destino",
   "settings_downloads_encryption_title": "Cifrado entre pares",
-  "settings_service_disabled": "Desactivado"
+  "settings_service_disabled": "Desactivado",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Téléchargements terminés",
   "settings_downloads_routing_hint": "Correspondance des chemins et source vidéo cible",
   "settings_downloads_encryption_title": "Chiffrement entre pairs",
-  "settings_service_disabled": "Désactivé"
+  "settings_service_disabled": "Désactivé",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Unduhan selesai",
   "settings_downloads_routing_hint": "Pemetaan jalur dan sumber video tujuan",
   "settings_downloads_encryption_title": "Enkripsi peer",
-  "settings_service_disabled": "Dinonaktifkan"
+  "settings_service_disabled": "Dinonaktifkan",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Download completati",
   "settings_downloads_routing_hint": "Mappatura dei percorsi e sorgente video di destinazione",
   "settings_downloads_encryption_title": "Crittografia dei peer",
-  "settings_service_disabled": "Disattivato"
+  "settings_service_disabled": "Disattivato",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "完了したダウンロード",
   "settings_downloads_routing_hint": "パスの対応付けと保存先の動画ソース",
   "settings_downloads_encryption_title": "ピア通信の暗号化",
-  "settings_service_disabled": "無効"
+  "settings_service_disabled": "無効",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "완료된 다운로드",
   "settings_downloads_routing_hint": "경로 매핑 및 대상 동영상 소스",
   "settings_downloads_encryption_title": "피어 암호화",
-  "settings_service_disabled": "사용 안 함"
+  "settings_service_disabled": "사용 안 함",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Voltooide downloads",
   "settings_downloads_routing_hint": "Padkoppeling en doelvideobron",
   "settings_downloads_encryption_title": "Peer-versleuteling",
-  "settings_service_disabled": "Uitgeschakeld"
+  "settings_service_disabled": "Uitgeschakeld",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Downloads concluídos",
   "settings_downloads_routing_hint": "Mapeamento de caminhos e fonte de vídeo de destino",
   "settings_downloads_encryption_title": "Criptografia entre pares",
-  "settings_service_disabled": "Desativado"
+  "settings_service_disabled": "Desativado",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Завершённые загрузки",
   "settings_downloads_routing_hint": "Сопоставление путей и целевой источник видео",
   "settings_downloads_encryption_title": "Шифрование соединений с пирами",
-  "settings_service_disabled": "Отключено"
+  "settings_service_disabled": "Отключено",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "การดาวน์โหลดที่เสร็จสิ้น",
   "settings_downloads_routing_hint": "การแมปเส้นทางและแหล่งวิดีโอปลายทาง",
   "settings_downloads_encryption_title": "การเข้ารหัสระหว่างเพียร์",
-  "settings_service_disabled": "ปิดใช้งาน"
+  "settings_service_disabled": "ปิดใช้งาน",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Tamamlanan indirmeler",
   "settings_downloads_routing_hint": "Yol eşleme ve hedef video kaynağı",
   "settings_downloads_encryption_title": "Eş şifrelemesi",
-  "settings_service_disabled": "Devre dışı"
+  "settings_service_disabled": "Devre dışı",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "Tải xuống đã hoàn tất",
   "settings_downloads_routing_hint": "Ánh xạ đường dẫn và nguồn video đích",
   "settings_downloads_encryption_title": "Mã hóa kết nối peer",
-  "settings_service_disabled": "Đã tắt"
+  "settings_service_disabled": "Đã tắt",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "下载完成后",
   "settings_downloads_routing_hint": "路径映射与目标视频来源",
   "settings_downloads_encryption_title": "节点加密",
-  "settings_service_disabled": "已停用"
+  "settings_service_disabled": "已停用",
+  "popup_dismiss_animation": "弹窗关闭动画",
+  "popup_dismiss_animation_hint": "滑动关闭查词弹窗时播放滑出动画。关掉则瞬间关闭（墨水屏模式下始终关闭）"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4583,5 +4583,7 @@
   "settings_downloads_routing_title": "已完成的下載",
   "settings_downloads_routing_hint": "路徑對應與目標影片來源",
   "settings_downloads_encryption_title": "節點通訊加密",
-  "settings_service_disabled": "已停用"
+  "settings_service_disabled": "已停用",
+  "popup_dismiss_animation": "Popup close animation",
+  "popup_dismiss_animation_hint": "Play a slide-out animation when a lookup popup is closed by swiping. Turn it off to close instantly (always off in e-ink mode)."
 }

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -1336,6 +1336,21 @@ class ReaderFushiSource extends ReaderMediaSource {
     );
   }
 
+  /// 滑动关闭查词弹窗时，松手后是否播放「补间滑出屏外 / 弹回原位」动画。默认 true
+  /// （保持既有手感）；关掉则松手当帧就关，与墨水屏模式下的行为一致。唯一消费点是
+  /// [popupDismissAnimationDuration]。
+  bool get popupDismissAnimation => getPreference<bool>(
+        key: 'popup_dismiss_animation',
+        defaultValue: true,
+      );
+
+  Future<void> setPopupDismissAnimation(bool value) async {
+    await setPreference<bool>(
+      key: 'popup_dismiss_animation',
+      value: value,
+    );
+  }
+
   /// 鼠标滚轮翻页节流间隔（毫秒），越大翻页越慢。默认 450ms。
   int get wheelPageTurnInterval =>
       readerSettings?.wheelPageTurnInterval ??

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -1340,12 +1340,18 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
       ..addStatusListener(_onStatus);
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // 墨水屏模式：滑出/弹回补间归零（Duration.zero 的 forward 立即 complete，
-    // onDismiss 时序不变，只是不再画补间帧）。跟随主题切换双向生效。
-    _controller.duration = einkSafeDuration(context, _kSlideDuration);
+  /// 滑出/弹回补间的时长**用时取值**，不缓存（`Duration.zero` 的 forward 立即
+  /// complete，onDismiss 时序不变，只是不再画补间帧）。
+  ///
+  /// 曾经写在 `didChangeDependencies` 里，但那只在**依赖**（这里是 `Theme`）变化时
+  /// 重跑：用户在设置里翻「弹窗关闭动画」只触发 rebuild、不触发
+  /// `didChangeDependencies`，控制器会一直留着上一次的 200ms，表现成「关了没用」的
+  /// 空开关。取值改在每次启动补间前一刻，两条来源（用户开关 / 墨水屏）都当场生效。
+  void _applyDismissDuration() {
+    _controller.duration = popupDismissAnimationDuration(
+      context,
+      _kSlideDuration,
+    );
   }
 
   @override
@@ -1445,6 +1451,7 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
   }
 
   void _finishHorizontalDrag() {
+    _applyDismissDuration();
     final double accumulated = _dragX;
     // 双向水平：左右皆可，对齐手机 `_dragX.abs()`。
     if (accumulated.abs() > _threshold) {
@@ -1463,6 +1470,7 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
   }
 
   void _springBack() {
+    _applyDismissDuration();
     _dragStartX = _dragX;
     _dragTargetX = 0;
     _dismissing = false;

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -440,6 +440,12 @@ class ReaderSettings {
   Future<void> setDismissSwipeSensitivity(double v) =>
       _set<double>('dismiss_swipe_sensitivity', v);
 
+  /// 滑动关闭查词弹窗时，松手后是否播放「补间滑出屏外 / 弹回原位」动画。默认 true
+  /// （保持既有手感）；关掉则松手当帧就关，与墨水屏模式下的行为一致。
+  bool get popupDismissAnimation => _get<bool>('popup_dismiss_animation', true);
+  Future<void> setPopupDismissAnimation(bool v) =>
+      _set<bool>('popup_dismiss_animation', v);
+
   /// TODO-407②：查词弹窗是否允许"水平滑动关闭"（[SwipeDismissWrapper]）。桌面端
   /// （Windows/Linux）鼠标左键框选正文与滑动手势的位移序列同形，默认关闭滑动关闭、
   /// 用顶栏 X 兜底；触摸为主的平台（macOS/iOS/Android）默认开启。未持久化覆盖时

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -695,6 +695,25 @@ SettingsDestination buildLookupDestination() {
               notifyReaderSettingsChanged(settingsContext);
             },
           ),
+          // 用户诉求（2026-09-10）：滑动关闭弹窗那段滑出/弹回动画要能**单独**关掉。
+          // 此前唯一的关闭途径是开墨水屏模式（externally 顺带归零），想要瞬时关闭
+          // 就得连带吃下纯黑白主题。与上面两项同属查词弹窗滑关行为，紧邻摆放。
+          // 默认 true = 保持既有手感；墨水屏模式下无论本开关如何都已归零。
+          SettingsSwitchItem(
+            id: 'reading_controls.popup_dismiss_animation',
+            title: t.popup_dismiss_animation,
+            subtitle: t.popup_dismiss_animation_hint,
+            icon: Icons.animation_outlined,
+            reader: const ReaderPlacement(group: ReaderGroup.lookup, order: 6),
+            value: (SettingsContext settingsContext) =>
+                settingsContext.readerSource.popupDismissAnimation,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.readerSource.setPopupDismissAnimation(
+                value,
+              );
+              notifyReaderSettingsChanged(settingsContext);
+            },
+          ),
           // 防截屏（用户诉求）：桌面查词浮窗经 native
           // SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE) 从截图/录屏/串流中
           // 排除。默认关（用户要求，2026-07）。仅 Windows——display affinity 是 Win32 能力。

--- a/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
+++ b/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
     show einkSafeDuration;
 
@@ -10,6 +11,30 @@ import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
 /// （桌面拖正文关一层，TODO-716）共用，避免两份魔法数漂移。
 double swipeDismissThreshold(double sensitivity) =>
     30 + (1.0 - sensitivity) * 160;
+
+/// 查词弹窗「滑动关闭」松手补间时长的**唯一**入口——两个滑关实现（本文件的
+/// [SwipeDismissWrapper]＝弹窗顶栏可拖区与独立查词窗整窗，以及
+/// `dictionary_popup_layer.dart` 的 `_BodySwipeDismissDetector`＝弹窗正文横拖）
+/// 都必须经这里取时长，别再各自写三元。
+///
+/// 两条归零来源：
+///   * 用户显式关掉「弹窗关闭动画」（`popup_dismiss_animation`，设置 › 查词）——
+///     用户诉求就是「滑动关闭那段动画能单独关掉」，而不是只能靠开墨水屏模式顺带关；
+///   * 墨水屏模式（[einkSafeDuration]）——慢刷新屏上这段 200ms 位移+淡出是一串灰阶
+///     残影，此前是唯一的关闭途径。
+///
+/// [Duration.zero] 的 `animateTo` 当帧就 complete，`onDismiss` 仍在完成回调里触发，
+/// 关窗时序不变，只是不再画中间帧。跟手期的 `Transform.translate` 不受影响——手指
+/// 按住时的实时跟随不是补间动画，去掉会让滑关失去方向反馈（BUG-2283 备注）。
+Duration popupDismissAnimationDuration(
+  BuildContext context,
+  Duration duration,
+) {
+  if (!ReaderFushiSource.instance.popupDismissAnimation) {
+    return Duration.zero;
+  }
+  return einkSafeDuration(context, duration);
+}
 
 // BUG-1757：`BarrierSwipeDismissTracker` 已迁到 `lookup_dismiss_barrier.dart`，
 // 并入唯一的 barrier 构造入口 [LookupDismissBarrier]。页面不再自己持有 tracker、
@@ -69,14 +94,18 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
           ..addStatusListener(_onAnimStatus);
   }
 
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // 墨水屏模式：松手后的「补间滑出屏外 / 弹回原位」归零。[Duration.zero] 的
-    // `animateTo` 当帧就 complete，`onDismiss` 时序不变（仍在完成回调里关一层），
-    // 只是不再画中间帧——慢刷新屏上这段 200ms 位移+淡出是一串灰阶残影。
-    // 与弹窗正文的 `_BodySwipeDismissDetector` 同款处理，跟随主题切换双向生效。
-    _controller.duration = einkSafeDuration(context, _kSwipeSlideDuration);
+  /// 松手补间的时长**用时取值**，不缓存。
+  ///
+  /// 曾经写在 `didChangeDependencies` 里，但那只在**依赖**（这里是 `Theme`）变化时重跑：
+  /// 用户在设置里翻「弹窗关闭动画」只触发 rebuild、不触发 `didChangeDependencies`，
+  /// 于是控制器一直留着上一次的 200ms——开关要等到下次主题切换或弹窗重建才生效，
+  /// 表现成「关了没用」的空开关。取值改在每次启动补间前一刻，两条来源（用户开关 /
+  /// 墨水屏）都当场生效，不依赖任何重建时机。
+  void _applyDismissDuration() {
+    _controller.duration = popupDismissAnimationDuration(
+      context,
+      _kSwipeSlideDuration,
+    );
   }
 
   @override
@@ -149,6 +178,7 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
   }
 
   void _finishDrag() {
+    _applyDismissDuration();
     if (_decided && _isHorizontal && _dragX.abs() > _threshold) {
       // TODO-890：过阈值后不再 opacity 瞬灭，而是朝拖动方向补间滑出屏外（卡片宽 +
       // 边距）再在完成回调里 onDismiss——与 _BodySwipeDismissDetector 动画一致。

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -413,6 +413,13 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'test/shortcuts/global_space_no_activate_test.dart + main.dart 门控安装 FushiFocusRoot/Ring',
   'lookup/Swipe dismiss sensitivity':
       'test/widgets/swipe_dismiss_wrapper_test.dart',
+  // BUG-2405：滑动关闭弹窗的「关闭动画」开关（默认 true，关掉＝松手当帧就关）。与上面
+  // 两项滑关设置同源、同一条 MediaSource 偏好通道，harness 里同样观测不到写穿与生效：
+  // 生效点是 AnimationController.duration 被设成 Duration.zero，既不是 reader CSS
+  // 也不是主题树，没有适用的 T4 渲染探针。由专项 widget 行为测试覆盖（「只 pump 一帧」
+  // 判别：开着当帧仍在补间、关掉当帧就 onDismiss，另含 eink 不被开关覆盖一条）。
+  'lookup/Popup close animation':
+      'test/widgets/swipe_dismiss_wrapper_test.dart',
   'reading/Reverse keyboard left/right page-turn direction':
       'test/reader/reader_space_pause_test.dart + test/shortcuts/global_navigation_test.dart',
   // TODO-436/407②：查词弹窗"滑动关闭"开关。归「查词」分组（destId=lookup）。生效点

--- a/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
+++ b/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
 import 'package:fushi/src/utils/misc/swipe_dismiss_wrapper.dart';
 
@@ -465,6 +466,117 @@ void main() {
 
       expect(dismissed, isFalse);
       // 补间归零 ⇒ 已回到原位，没有任何待跑的帧（pumpAndSettle 不会再推进动画）。
+      final Transform transform = tester.widget<Transform>(
+        find.byType(Transform).first,
+      );
+      expect(transform.transform.getTranslation().x, 0);
+    });
+  });
+
+  // BUG-2405：用户诉求是「滑动关闭那段动画能**单独**关掉」，此前唯一途径是开墨水屏
+  // 模式顺带归零（想要瞬时关闭就得连带吃下纯黑白主题）。新开关 popup_dismiss_animation
+  // 默认 true=保持既有手感，关掉则松手当帧就关。判别力同上：只 pump 一帧。
+  group('SwipeDismissWrapper「弹窗关闭动画」开关', () {
+    tearDown(() async {
+      // 单例偏好：必须还原，否则泄漏到同进程后续用例。
+      await ReaderFushiSource.instance.setPopupDismissAnimation(true);
+    });
+
+    // key：同一个用例里连跑两次时必须换 State。第一次滑关后 wrapper 停在退场态
+    // （_dismissing=true，等宿主换 child），而这里的 child 是 const、跨 build 恒
+    // identical，didUpdateWidget 的「换了 child 才复位」判不出来，第二次拖动会被
+    // _beginDrag/_handleDragDelta 的 `if (_dismissing) return` 整个吃掉。
+    Widget buildApp({
+      required bool eink,
+      required VoidCallback onDismiss,
+      Key? key,
+    }) {
+      return MaterialApp(
+        theme: ThemeData(
+          extensions: <ThemeExtension<dynamic>>[FushiEinkTheme(eink)],
+        ),
+        home: Scaffold(
+          body: SwipeDismissWrapper(
+            key: key,
+            onDismiss: onDismiss,
+            child: const SizedBox(
+              width: 300,
+              height: 100,
+              child: ColoredBox(color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+    }
+
+    /// 过阈值横拖后松手，只 pump **一帧**，回报此刻是否已 dismiss。
+    Future<bool> dragAndPumpOneFrame(
+      WidgetTester tester, {
+      required bool animation,
+      bool eink = false,
+      Key? key,
+    }) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(animation);
+      bool dismissed = false;
+      await tester.pumpWidget(
+        buildApp(eink: eink, onDismiss: () => dismissed = true, key: key),
+      );
+      final Offset center = tester.getCenter(find.byType(SizedBox).first);
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(200, 0));
+      await gesture.up();
+      await tester.pump();
+      return dismissed;
+    }
+
+    testWidgets('默认（开关开着、非 eink）：松手当帧仍在补间', (WidgetTester tester) async {
+      expect(await dragAndPumpOneFrame(tester, animation: true), isFalse);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('开关关掉：补间归零，松手当帧即 onDismiss', (WidgetTester tester) async {
+      expect(await dragAndPumpOneFrame(tester, animation: false), isTrue);
+    });
+
+    testWidgets('同一条拖动：开着仍在补间、关掉当帧就关（开关真的改变行为）', (
+      WidgetTester tester,
+    ) async {
+      final bool onStillTweening = await dragAndPumpOneFrame(
+        tester,
+        animation: true,
+        key: const ValueKey<String>('animation-on'),
+      );
+      await tester.pumpAndSettle();
+      final bool offDismissedNow = await dragAndPumpOneFrame(
+        tester,
+        animation: false,
+        key: const ValueKey<String>('animation-off'),
+      );
+      expect(onStillTweening, isFalse);
+      expect(offDismissedNow, isTrue);
+      expect(onStillTweening, isNot(equals(offDismissedNow)));
+    });
+
+    testWidgets('eink 下即使开关开着也仍归零（eink 不被开关覆盖）', (WidgetTester tester) async {
+      expect(
+        await dragAndPumpOneFrame(tester, animation: true, eink: true),
+        isTrue,
+      );
+    });
+
+    testWidgets('开关关掉、未过阈值：弹回不留补间且不误关', (WidgetTester tester) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(false);
+      bool dismissed = false;
+      await tester.pumpWidget(
+        buildApp(eink: false, onDismiss: () => dismissed = true),
+      );
+      final Offset center = tester.getCenter(find.byType(SizedBox).first);
+      final TestGesture gesture = await tester.startGesture(center);
+      await gesture.moveBy(const Offset(60, 0));
+      await gesture.up();
+      await tester.pump();
+
+      expect(dismissed, isFalse);
       final Transform transform = tester.widget<Transform>(
         find.byType(Transform).first,
       );


### PR DESCRIPTION
## 问题

滑动关闭查词弹窗时，松手后有一段「补间滑出屏外 / 弹回原位」（200ms easeOut）。此前**唯一**的关闭途径是 `einkSafeDuration`（`adaptive_platform.dart:66`）——也就是只有开「外观 › 墨水屏模式」才顺带归零。想要瞬时关闭就得连带吃下纯黑白主题 + 线式高亮，两件本不相干的事被强行绑在一起。

设置里既有的两项滑关设置都不碰动画：`lookup.enable_swipe_to_close` 管这个功能开不开，`reading_controls.dismiss_swipe_sensitivity` 管位移阈值。

补间落点有两处：`swipe_dismiss_wrapper.dart:79`（弹窗顶栏可拖区 + 独立查词窗整窗滑关）与 `dictionary_popup_layer.dart:1348`（弹窗正文横拖关）。

## 修法

新增偏好 `popup_dismiss_animation`（默认 **true** = 保持既有手感）+ 设置项「弹窗关闭动画」（`reading_controls.popup_dismiss_animation`，设置 › 查词，紧邻既有两项滑关设置；`ReaderPlacement(lookup, order 6)` 同时出现在阅读器快捷设置）。

两处补间收进**唯一入口** `popupDismissAnimationDuration(context, duration)`（放在 `swipe_dismiss_wrapper.dart`，与既有的阈值公式 `swipeDismissThreshold` 同处，本就是滑关的单一真相源）：用户开关关掉 → `Duration.zero`；否则再过 `einkSafeDuration`（墨水屏仍然归零）。**两条来源正交，eink 不被用户开关覆盖。**

### 顺带修掉一处真的会「关了没用」的时序 bug

两处原本都在 `didChangeDependencies` 里缓存 `_controller.duration`，而那只在**依赖**（这里是 `Theme`）变化时重跑。用户在设置里翻开关只触发 rebuild、不触发 `didChangeDependencies`，控制器会一直留着上一次的 200ms —— 开关要等到下次主题切换或弹窗重建才生效。

改成**用时取值**：`_applyDismissDuration()` 在每次启动补间前一刻调用（wrapper 的 `_finishDrag`，detector 的 `_finishHorizontalDrag` / `_springBack`），两条来源都当场生效，不依赖任何重建时机。

这条不是预先想到的——是写「同一条拖动：开着仍在补间、关掉当帧就关」这个对照用例时被逼出来的。

### 不动的部分

跟手期的 `Transform.translate` 保持原样：手指按住时的实时跟随不是补间动画，去掉会让滑关失去方向反馈（沿用 BUG-2283 备注的结论）。`Duration.zero` 的 `animateTo` 当帧 complete，`onDismiss` 仍在完成回调里触发，关窗时序不变，只是不再画中间帧。

## 测试

`fushi/test/widgets/swipe_dismiss_wrapper_test.dart` 新增 group 5 条，判别力沿用同文件 eink 组的「只 pump 一帧」手法（补间还在时该帧不可能 dismiss，归零后当帧就 dismiss）：

- 默认（开关开着、非 eink）：松手当帧仍在补间
- 开关关掉：补间归零，松手当帧即 `onDismiss`
- 同一条拖动下两者结果必须不同（开关真的改变行为）
- **eink 下即使开关开着也仍归零**（两条来源正交）
- 开关关掉且未过阈值：弹回已归位且不误关

`tearDown` 还原单例偏好，避免泄漏到同进程后续用例。

- **判别力验证**：临时摘掉 `popupDismissAnimationDuration` 里的开关分支 → 正好这 3 条新用例红、eink 那批仍绿；恢复后 23/23 绿（含既有 18 条）。
- 另在 `test/settings/settings_schema_coverage_test.dart` 的 `kCoveredElsewhere` 登记本行，理由与兄弟行 `lookup/Swipe dismiss sensitivity`、`lookup/Swipe to close popup` 同款：生效点是 `AnimationController.duration`，既非 reader CSS 也非主题树，harness 无适用 T4 渲染探针。
- `test/settings` + `test/i18n` 共 500 条绿，`stillUnaccounted=0`；`dictionary_popup_swipe_close_test` / `dictionary_popup_layer_test` / `reader_caret_scripts_test` 94 条绿；`flutter analyze` 零问题。

## 其他

- i18n 经 `tool/i18n_sync.dart --add` 同步 17 种语言，`dart run slang` 重新生成 `strings.g.dart`（按上游该文件的既有格式 `--language-version=3.6` 格式化，避免整份重排）。
- **真机未验**：改动是纯 Flutter 侧补间时长，已由 widget 行为测试覆盖；真机只需确认设置项可见、翻动后滑关立即变瞬时。
- 与 #1379（BUG-2403）是同一批用户诉求的两半：那条管**上下滑动**（弹窗内容滚动瞬时化，触摸路径此前没接线），本条管**侧滑关闭**（关闭动画可单独关）。两条互不依赖，可独立合入。

https://claude.ai/code/session_01PcCxyhsuiU7TUHQPBtRfAd
