### PR TITLE
fix(stats): 最近会话补合集名并放宽标题到两行

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2216 条。点号进各自文件。
+> 共 2217 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2406](bugs/BUG-2406-stat-session-collection-title.md) | ✅ | ✅ | 统计「最近会话」标题单行截断且不带合集名 |
 | [BUG-2403](bugs/BUG-2403-video-doubleclick-ignores-mouse-button.md) | ✅ | ✅ | 视频页双击判定不看鼠标按钮号，右键双击画面切全屏 |
 | [BUG-2402](bugs/BUG-2402-mobile-library-layout.md) | ✅ | ✅ | 手机标签页头留白与筛选工具堆叠 |
 | [BUG-2400](bugs/BUG-2400-remote-manga-empty-content.md) | ✅ | ✅ | 远端空漫画合集被标记为可下载内容 |

--- a/docs/bugs/BUG-2406-stat-session-collection-title.md
+++ b/docs/bugs/BUG-2406-stat-session-collection-title.md
@@ -1,0 +1,8 @@
+## BUG-2406 · 统计「最近会话」标题单行截断且不带合集名
+- **报告**：2026-09-10（用户：统计中心 › 观看 › 最近会话，「Re：从零开始的异世界生活…」被省略号截断；其余行只有「暗中行动」「威胁」这种分集名，看不出属于哪部作品）
+- **真实性**：✅ 真 bug。两处根因都在展示层：
+  - 截断：`fushi/lib/src/pages/implementations/stat_session_list.dart:164` 的 `FushiListItem` 没传 `titleMaxLines`，吃默认值 1（`fushi/lib/src/utils/components/fushi_material_components.dart:160`，BUG-1184 起故意保留默认 1，放宽必须逐调用点显式做）。会话行承载的正是长媒体名，手机宽度下单行 ellipsis 只剩开头几个字。
+  - 缺合集名：会话的 `title` 是段 title 快照 = **条目名**（`fushi/lib/src/stats/study_sessions.dart:44`），合集里就是分集 / 分册名。四个挂会话区块的页面（阅读 / 视频 / 游戏三个域 tab + 统计中心总览）的 `titleOf` 都只回传条目名，而合集归属映射 `_primaryCollectionByEntry` / `_collectionNamesById` 四个页面本来就已加载（时段明细 sheet 用它做组头）——会话流是扁平时间序，没有组头兜底，合集名就此掉了。
+- **[x] ① 已修复** — `stat_session_list.dart` 新增 `StatSessionCollectionOf` 解析器：命中合集的行在条目名上方挂共享的 `buildStatCollectionLabel`（与「按书 / 按视频」tile 同一视觉），删除确认文案走 `合集名 - 条目名`；行标题放宽到 `titleMaxLines: 2`（本区块父容器是页面 sliver / sheet 的 Column，高度自由）。四个页面各按自己的域键契约接线：视频 `video|<bookUid>`、阅读 `epub|<uid>`（经 `_epubUidByBookKey` 换算）、游戏 `game|<galgames.id>`、总览按 `mediaKind` 分派。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/stat_session_list_test.dart`：命中合集的行同时显示合集名与条目名、未命中不挂标签；合集名进删除确认文案；手机宽度（400dp）下长标题真的排到第二行（`RenderParagraph.size.height > 1.5 * preferredLineHeight` 且 `didExceedMaxLines` 为 false）。外加 `fushi/test/pages/stat_pages_skeleton_guard_static_test.dart` 的源码守卫：四个页面的 `buildStatSessionSection(` / `showStatSessionsSheet(` 调用点一个都不许漏传 `collectionOf`（反证过：抽掉视频页那一行守卫即红）。
+- **备注**：合集名与条目名同名时不去重，与 `collectionQualifiedTitle` / 时段明细组头同一惯例。

--- a/fushi/lib/src/pages/implementations/game_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/game_statistics_page.dart
@@ -168,6 +168,7 @@ class _GameStatisticsPageState extends BasePageState<GameStatisticsPage> {
             context,
             sessions: _sessions,
             titleOf: _sessionTitle,
+            collectionOf: _sessionCollectionName,
             onDelete: _deleteSession,
           ),
         ),
@@ -329,6 +330,16 @@ class _GameStatisticsPageState extends BasePageState<GameStatisticsPage> {
     );
     return displayTitleForGame(entry: entry, rawTitle: s.title);
   }
+
+  /// 会话行的所属合集名（BUG-2406：同一系列的分作单看名字认不出属于哪套）。
+  /// 'game|<galgames.id>' 键契约，与时段明细 sheet 的 collectionOf 同一映射。
+  String? _sessionCollectionName(StudySession s) => s.mediaKey.isEmpty
+      ? null
+      : statCollectionName(
+          MediaKind.game.compositeKey(s.mediaKey),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        );
 
   /// 删一次会话：galgame_sessions 骨架行硬删 + 吸收的字数段写零（同一事务），再重聚合。
   Future<void> _deleteSession(StudySession s) async {

--- a/fushi/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/reading_statistics_page.dart
@@ -536,6 +536,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
                     context,
                     sessions: _sessions,
                     titleOf: _sessionTitle,
+                    collectionOf: _sessionCollectionName,
                     onDelete: _deleteSession,
                   ),
                 ),
@@ -1437,6 +1438,17 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
   String _sessionTitle(StudySession s) =>
       ReaderFushiSource.instance.overrideTitleForBookKey(s.mediaKey) ?? s.title;
 
+  /// 会话行的所属合集名（BUG-2406：合集里段 title 是分册名，行上得写清是哪套
+  /// 书）。会话自带 bookKey 身份（段 mediaKey），经 [_epubUidByBookKey] 换算拼
+  /// 'epub|<uid>'，与 [_collectionNameForBook] 同一 v83 键契约。
+  String? _sessionCollectionName(StudySession s) => s.mediaKey.isEmpty
+      ? null
+      : statCollectionName(
+          MediaKind.epub.compositeKey(_epubUidByBookKey[s.mediaKey] ?? s.mediaKey),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        );
+
   /// 删一次会话：段写零（同步安全），再从 DB 重新聚合。
   Future<void> _deleteSession(StudySession s) async {
     await deleteStudySession(appModelNoUpdate.database, s);
@@ -1455,6 +1467,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       title: _bookDisplayTitle(book),
       sessions: sessions,
       titleOf: _sessionTitle,
+      collectionOf: _sessionCollectionName,
       onDelete: (StudySession s) =>
           deleteStudySession(appModelNoUpdate.database, s),
     );

--- a/fushi/lib/src/pages/implementations/stat_session_list.dart
+++ b/fushi/lib/src/pages/implementations/stat_session_list.dart
@@ -19,6 +19,14 @@ import 'package:fushi/utils.dart';
 /// 会话行展示名：段 title 快照 → 调用方按域换成当前显示名（书走 override 书名）。
 typedef StatSessionTitleOf = String Function(StudySession session);
 
+/// 会话行所属合集名（'<mediaType>|<entryKey>' 归属键 → 主合集名，见
+/// [statCollectionName]）；不属于任何合集返回 null。
+///
+/// BUG-2406：段 title 快照是**条目名**，合集里就是分集名（「暗中行动」「威胁」）。
+/// 单看一行认不出是哪部作品——会话流是跨媒体时间序，没有时段明细 sheet 那种
+/// 合集组头兜底，所以合集名必须贴在行上。
+typedef StatSessionCollectionOf = String? Function(StudySession session);
+
 /// 一行的量纲文案：时长 · 字数 · 页数，为 0 的量纲不显示；全 0 显示 0 分钟。
 String formatStatSessionMeta(StudySession s) {
   final List<String> parts = <String>[
@@ -43,6 +51,7 @@ Widget buildStatSessionSection(
   required List<StudySession> sessions,
   required StatSessionTitleOf titleOf,
   required Future<void> Function(StudySession session) onDelete,
+  StatSessionCollectionOf? collectionOf,
   int limit = 8,
 }) {
   final FushiDesignTokens tokens = FushiDesignTokens.of(context);
@@ -74,6 +83,7 @@ Widget buildStatSessionSection(
                     title: t.stat_sessions_show_all,
                     sessions: sessions,
                     titleOf: titleOf,
+                    collectionOf: collectionOf,
                     onDelete: onDelete,
                   ),
                 ),
@@ -90,6 +100,7 @@ Widget buildStatSessionSection(
           StatSessionList(
             sessions: shown,
             titleOf: titleOf,
+            collectionOf: collectionOf,
             onDelete: onDelete,
           ),
       ],
@@ -103,6 +114,7 @@ class StatSessionList extends StatefulWidget {
     required this.sessions,
     required this.titleOf,
     required this.onDelete,
+    this.collectionOf,
     this.onDeleted,
     super.key,
   });
@@ -110,6 +122,9 @@ class StatSessionList extends StatefulWidget {
   final List<StudySession> sessions;
   final StatSessionTitleOf titleOf;
   final Future<void> Function(StudySession session) onDelete;
+
+  /// 行的合集名解析器；不传（或返回 null）的行只显示条目名。
+  final StatSessionCollectionOf? collectionOf;
 
   /// 每删掉一行后回调（sheet 用它记「删过」让调用方关 sheet 后重聚合）。
   final VoidCallback? onDeleted;
@@ -146,7 +161,11 @@ class _StatSessionListState extends State<StatSessionList> {
               size: 18,
               color: colors.onSurfaceVariant,
             ),
-            title: Text(_titleOf(s)),
+            // BUG-2406：媒体名常年比一行宽（长篇番剧标题、带副标题的书名），
+            // 单行 ellipsis 只看得到开头几个字。本区块的父容器（页面 sliver /
+            // sheet 的 Column）高度自由，放到 2 行不会撑破谁。
+            titleMaxLines: 2,
+            title: _buildTitle(context, s),
             subtitle: Text(
               '${formatStatSessionRange(s.startAt, s.endAt)} · '
               '${formatStatSessionMeta(s)}',
@@ -161,15 +180,43 @@ class _StatSessionListState extends State<StatSessionList> {
     );
   }
 
+  /// 行标题：命中合集时在条目名上方挂合集小标签（与「按书 / 按视频」tile
+  /// 同一 [buildStatCollectionLabel] 视觉），未命中只有条目名。
+  Widget _buildTitle(BuildContext context, StudySession s) {
+    final String? collection = _collectionOf(s);
+    final Text title = Text(_titleOf(s));
+    if (collection == null) return title;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        buildStatCollectionLabel(context, collection),
+        title,
+      ],
+    );
+  }
+
   String _titleOf(StudySession s) {
     final String title = widget.titleOf(s);
     return title.isEmpty ? s.mediaKey : title;
   }
 
+  /// 合集名，空串按「无合集」处理（解析器可能给出空名合集）。
+  String? _collectionOf(StudySession s) {
+    final String? name = widget.collectionOf?.call(s);
+    return name == null || name.isEmpty ? null : name;
+  }
+
+  /// 确认框是纯文本单行，合集名走 ' - ' 前缀（[collectionQualifiedTitle] 同口径）。
+  String _confirmName(StudySession s) {
+    final String? collection = _collectionOf(s);
+    final String title = _titleOf(s);
+    return collection == null ? title : '$collection - $title';
+  }
+
   Future<void> _confirmAndDelete(StudySession s) async {
     final bool confirmed = await confirmDeleteStatistics(
       context,
-      '${_titleOf(s)}\n${formatStatSessionRange(s.startAt, s.endAt)}',
+      '${_confirmName(s)}\n${formatStatSessionRange(s.startAt, s.endAt)}',
       message: t.stat_session_delete_message,
     );
     if (!confirmed || !mounted) return;
@@ -187,6 +234,7 @@ Future<bool> showStatSessionsSheet(
   required List<StudySession> sessions,
   required StatSessionTitleOf titleOf,
   required Future<void> Function(StudySession session) onDelete,
+  StatSessionCollectionOf? collectionOf,
 }) async {
   bool deleted = false;
   await adaptiveModalSheet<void>(
@@ -208,6 +256,7 @@ Future<bool> showStatSessionsSheet(
                 StatSessionList(
                   sessions: sessions,
                   titleOf: titleOf,
+                  collectionOf: collectionOf,
                   onDelete: onDelete,
                   onDeleted: () => deleted = true,
                 ),

--- a/fushi/lib/src/pages/implementations/statistics_center_page.dart
+++ b/fushi/lib/src/pages/implementations/statistics_center_page.dart
@@ -183,6 +183,7 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
           context,
           sessions: _sessions,
           titleOf: _sessionTitle,
+          collectionOf: _sessionCollectionName,
           onDelete: _deleteSession,
         ),
       ],
@@ -231,6 +232,27 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
           s.title;
     }
     return s.title;
+  }
+
+  /// 会话行的所属合集名（BUG-2406：会话流混排三域，段 title 是条目名——合集里
+  /// 就是分集 / 分册名）。判据与事实行版 [_entryCollection] 同构，输入换成会话；
+  /// 会话恒自带身份（段 mediaKey），不需要 legacy 的按 title 反查。
+  String? _sessionCollectionName(StudySession s) {
+    if (s.mediaKey.isEmpty) return null;
+    if (s.isBook) {
+      return statCollectionName(
+        MediaKind.epub.compositeKey(
+          _epubUidByBookKey[s.mediaKey] ?? s.mediaKey,
+        ),
+        _primaryCollectionByEntry,
+        _collectionNamesById,
+      );
+    }
+    return statCollectionName(
+      (s.isVideo ? MediaKind.video : MediaKind.game).compositeKey(s.mediaKey),
+      _primaryCollectionByEntry,
+      _collectionNamesById,
+    );
   }
 
   /// 删一次会话：段写零 + 游戏骨架行硬删（同一事务），再整页重聚合。

--- a/fushi/lib/src/pages/implementations/video_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/video_statistics_page.dart
@@ -269,6 +269,7 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
             context,
             sessions: _sessions,
             titleOf: (StudySession s) => s.title,
+            collectionOf: _sessionCollectionName,
             onDelete: _deleteSession,
           ),
         ),
@@ -445,6 +446,7 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
       title: video.title,
       sessions: _sessions.where((StudySession s) => s.mediaKey == uid).toList(),
       titleOf: (StudySession s) => s.title,
+      collectionOf: _sessionCollectionName,
       onDelete: (StudySession s) =>
           deleteStudySession(appModelNoUpdate.database, s),
     );
@@ -492,6 +494,17 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
       _collectionNamesById,
     );
   }
+
+  /// 会话行的所属合集名（BUG-2406：合集里段 title 是分集名，行上得写清是哪部
+  /// 作品）。会话自带 bookUid 身份（段 mediaKey），走与 [_collectionNameForVideo]
+  /// 同一 'video|<bookUid>' 键契约。
+  String? _sessionCollectionName(StudySession s) => s.mediaKey.isEmpty
+      ? null
+      : statCollectionName(
+          MediaKind.video.compositeKey(s.mediaKey),
+          _primaryCollectionByEntry,
+          _collectionNamesById,
+        );
 
   /// 「按视频」一行（游戏页同款 [buildStatMediaRow]）：会话数 / 查词 · 制卡 · 收藏，
   /// 右侧观看时长；点按进该视频的会话 sheet（无身份遗留组没有会话），长按 / 右键删

--- a/fushi/test/pages/stat_pages_skeleton_guard_static_test.dart
+++ b/fushi/test/pages/stat_pages_skeleton_guard_static_test.dart
@@ -17,6 +17,21 @@ const Map<String, String> _pages = <String, String>{
   'game': 'lib/src/pages/implementations/game_statistics_page.dart',
 };
 
+/// 从左括号 [open] 起按括号配对切出整个实参列表（注释已由 [maskComments] 掩掉；
+/// 这些调用点的字符串字面量里没有括号）。
+String _callArguments(String src, int open) {
+  int depth = 0;
+  for (int i = open; i < src.length; i++) {
+    final String c = src[i];
+    if (c == '(') depth++;
+    if (c == ')') {
+      depth--;
+      if (depth == 0) return src.substring(open, i + 1);
+    }
+  }
+  return src.substring(open);
+}
+
 void main() {
   for (final MapEntry<String, String> e in _pages.entries) {
     group(e.key, () {
@@ -68,6 +83,35 @@ void main() {
       'buildStatHourlyFormatChartSection(context, _hourly)',
     ]) {
       expect(foldBody.contains(block), isTrue, reason: '$block 下沉进折叠区，不得删');
+    }
+  });
+
+  /// BUG-2406：会话行的段 title 是**条目名**，合集里就是分集 / 分册名。会话流没有
+  /// 时段明细 sheet 那种合集组头兜底，四个挂会话区块的页面（三个域 tab + 总览）
+  /// 一个都不能漏传合集解析器，否则那一页的行又退回「暗中行动」认不出作品。
+  test('四个页面的会话区块都传 collectionOf', () {
+    const Map<String, String> pagesWithSessions = <String, String>{
+      ..._pages,
+      'center': 'lib/src/pages/implementations/statistics_center_page.dart',
+    };
+    for (final MapEntry<String, String> e in pagesWithSessions.entries) {
+      final String src = maskComments(
+        File(e.value).readAsStringSync().replaceAll('\r\n', '\n'),
+      );
+      for (final String call in <String>[
+        'buildStatSessionSection(',
+        'showStatSessionsSheet(',
+      ]) {
+        int at = src.indexOf(call);
+        while (at >= 0) {
+          expect(
+            _callArguments(src, at + call.length - 1).contains('collectionOf:'),
+            isTrue,
+            reason: '${e.key} 的 $call 漏传合集解析器',
+          );
+          at = src.indexOf(call, at + call.length);
+        }
+      }
     }
   });
 

--- a/fushi/test/pages/stat_session_list_test.dart
+++ b/fushi/test/pages/stat_session_list_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/pages/implementations/stat_session_list.dart';
@@ -7,6 +8,7 @@ import 'package:fushi_core/fushi_core.dart';
 
 /// 统计页会话流（用户 2026-09-08：每个域都要会话级统计，能删误点的会话）的行为守卫：
 ///  * 每行显示 标题 · 起止 · 量纲；空串标题回退 mediaKey；
+///  * BUG-2406：命中合集的行在条目名上方挂合集名，标题最多两行（不再单行截断）；
 ///  * 区块只显示前 [limit] 行，多出来时给「全部会话 (N)」入口进 sheet；
 ///  * 垃圾桶 → 确认框（会话专用文案）→ 点删除才回调 [onDelete] 并移除该行；取消不动。
 StudySession _session(
@@ -35,6 +37,7 @@ Future<void> _pump(
   WidgetTester tester, {
   required List<StudySession> sessions,
   required Future<void> Function(StudySession) onDelete,
+  StatSessionCollectionOf? collectionOf,
   int limit = 8,
 }) async {
   await tester.pumpWidget(
@@ -47,6 +50,7 @@ Future<void> _pump(
                 context,
                 sessions: sessions,
                 titleOf: (StudySession s) => s.title,
+                collectionOf: collectionOf,
                 onDelete: onDelete,
                 limit: limit,
               ),
@@ -80,6 +84,75 @@ void main() {
     expect(find.textContaining(formatStatSessionMeta(_session('a', chars: 1200))),
         findsOneWidget);
     expect(find.text(t.stat_sessions_empty), findsNothing);
+  });
+
+  testWidgets('BUG-2406：命中合集的行带合集名，未命中只有条目名', (
+    WidgetTester tester,
+  ) async {
+    await _pump(
+      tester,
+      sessions: <StudySession>[
+        _session('a', title: '暗中行动', kind: kActivityMediaVideo),
+        _session('b', title: '独立的一本书'),
+      ],
+      collectionOf: (StudySession s) =>
+          s.mediaKey == 'k-a' ? 'Re：从零开始的异世界生活' : null,
+      onDelete: (_) async {},
+    );
+    expect(
+      find.text('Re：从零开始的异世界生活'),
+      findsOneWidget,
+      reason: '分集名单看认不出作品，合集名必须上屏',
+    );
+    expect(find.text('暗中行动'), findsOneWidget, reason: '合集名不顶掉条目名');
+    expect(find.text('独立的一本书'), findsOneWidget);
+    expect(
+      find.byIcon(Icons.folder_outlined),
+      findsOneWidget,
+      reason: '不属于合集的行不挂标签',
+    );
+  });
+
+  testWidgets('BUG-2406：合集名进删除确认文案', (WidgetTester tester) async {
+    await _pump(
+      tester,
+      sessions: <StudySession>[
+        _session('a', title: '暗中行动', kind: kActivityMediaVideo),
+      ],
+      collectionOf: (StudySession s) => '异世界生活',
+      onDelete: (_) async {},
+    );
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('异世界生活 - 暗中行动'), findsOneWidget);
+  });
+
+  testWidgets('BUG-2406：长标题排到第二行而不是单行省略', (WidgetTester tester) async {
+    const String long = 'Re：从零开始的异世界生活 第三期 第七话 暗中行动する者たち';
+    // 手机宽度：用户实报的截图就是这个宽度下的单行截断。
+    tester.view.physicalSize = const Size(400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await _pump(
+      tester,
+      sessions: <StudySession>[
+        _session('a', title: long, kind: kActivityMediaVideo),
+      ],
+      onDelete: (_) async {},
+    );
+    final RenderParagraph title = tester.renderObject<RenderParagraph>(
+      find.text(long),
+    );
+    expect(
+      title.didExceedMaxLines,
+      isFalse,
+      reason: '两行装得下这个长度的媒体名',
+    );
+    expect(
+      title.size.height,
+      greaterThan(title.preferredLineHeight * 1.5),
+      reason: '真的排到了第二行（单行 ellipsis 会停在一行高）',
+    );
   });
 
   testWidgets('空列表显示空态', (WidgetTester tester) async {


### PR DESCRIPTION
## 问题（BUG-2406）

统计中心 › 观看 › 最近会话：

1. 行标题单行 ellipsis，手机宽度下长媒体名只剩开头几个字（用户截图里「Re：从零开始的异世界生活…」）；
2. 其余行只有「暗中行动」「威胁」这种分集名，看不出属于哪部作品。

根因两处都在展示层：

- `stat_session_list.dart` 的 `FushiListItem` 没传 `titleMaxLines`，吃默认值 1（`fushi_material_components.dart:160` 起 BUG-1184 起故意保留默认 1，放宽必须逐调用点显式做）；
- 会话的 `title` 是段 title 快照 = **条目名**（`study_sessions.dart`），合集里就是分集 / 分册名。四个挂会话区块的页面 `titleOf` 都只回传条目名，而合集归属映射 `_primaryCollectionByEntry` / `_collectionNamesById` 四个页面本来就已加载（时段明细 sheet 用它做组头）——会话流是扁平时间序，没有组头兜底，合集名就此掉了。

## 改动

- `stat_session_list.dart`：新增 `StatSessionCollectionOf` 解析器；命中合集的行在条目名上方挂共享的 `buildStatCollectionLabel`（与「按书 / 按视频」tile 同一视觉），删除确认文案走「合集名 - 条目名」；标题放宽到 `titleMaxLines: 2`（本区块父容器是页面 sliver / sheet 的 Column，高度自由，不会撑破谁）。
- 四个页面按各自域键契约接线：视频 `video|<bookUid>`、阅读 `epub|<uid>`（经 `_epubUidByBookKey` 换算）、游戏 `game|<galgames.id>`、总览按 `mediaKind` 分派。合集名与条目名同名时不去重，与 `collectionQualifiedTitle` / 时段明细组头同一惯例。

## 测试

- `fushi/test/pages/stat_session_list_test.dart`：命中合集的行同时显示合集名与条目名、未命中不挂标签；合集名进删除确认文案；手机宽度（400dp）下长标题真的排到第二行（`RenderParagraph.size.height > 1.5 * preferredLineHeight` 且 `didExceedMaxLines` 为 false）。
- `fushi/test/pages/stat_pages_skeleton_guard_static_test.dart`：源码守卫钉死四个页面的 `buildStatSessionSection(` / `showStatSessionsSheet(` 调用点都传 `collectionOf`（反证过：抽掉视频页那一行守卫即红）。
- `flutter analyze` 全量 No issues found；统计域定向测试 56 条全绿。
- 布局改动另用临时 golden 出过 400dp 真实像素预览确认（脚手架已删，不入库）。

https://claude.ai/code/session_01TndQsWoa5dZRcs5hVadQx3