### PR TITLE
统计总览补上查词/制卡/收藏，三个 tab 共用一份计数面

### DIFF
--- a/fushi/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/reading_statistics_page.dart
@@ -19,7 +19,6 @@ import 'package:fushi/src/stats/stat_facts.dart';
 import 'package:fushi/src/stats/stat_window.dart';
 import 'package:fushi/src/stats/study_sessions.dart';
 import 'package:fushi/utils.dart';
-import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi_core/fushi_core.dart';
 
 /// 「按书」列表的排序键：字数 / 时长 / 阅读速度（cph）。
@@ -192,7 +191,11 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       // 「阅读」里拆出来单列，页数是漫画独有的第三个量纲）已在里面按 title 反查
       // 库表补好，段自带身份。本页只取阅读域（书 + 漫画）的日面；统计页不需要
       // 活动行，activityLimit 传 0。
-      final StatFacts facts = await loadStatFacts(db, activityLimit: 0);
+      final StatFacts facts = await loadStatFacts(
+        db,
+        activityLimit: 0,
+        includeCounters: true,
+      );
       _bookFacts = facts.dailyBooks.toList();
       _dailyFacts = facts.daily;
       _sessions = facts.sessions.where((StudySession s) => s.isBook).toList();
@@ -202,25 +205,27 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       final List<EpubBookMeta> epubRows = facts.epubRows;
       _ambiguousBookTitles = ambiguousBookTitles(epubRows);
       _computeAggregates();
-      final List<FavoriteWordRow> favs = await db.getFavoriteWordsBySource(
-        kStatSourceBook,
+      // 计数面（查词 / 制卡 / 收藏）与事实面同一次加载：总览 tab 是跨域视图，
+      // 它的四个数字必须恰好等于本 tab 与视频 tab 之和；三页各查一遍时，口径一漂
+      // 就静默对不上。按 source 切片的判据只在 [StatCounterFacts] 里写一遍。
+      final StatCounterFacts counterFacts = facts.counters;
+      final List<FavoriteWordRow> favs = counterFacts.favoriteWordsFor(
+        StatSourceKind.book,
       );
-      final List<MiningStatisticRow> mined = await db
-          .getMiningStatisticsBySource(kStatSourceBook);
       _favorited = bucketActivityByDateKey(
-        favs.map((FavoriteWordRow f) => (f.dateKey, 1)),
+        counterFacts.favoriteWordEvents(source: StatSourceKind.book),
         now,
       );
       _mined = bucketActivityByDateKey(
-        mined.map((MiningStatisticRow m) => (m.dateKey, m.count)),
+        counterFacts.minedEvents(source: StatSourceKind.book),
         now,
       );
-      // TODO-1204：查词/制卡 per-book 计数（新表）。汇总用 lookupCount 分桶，
-      // per-book tile 按 title 聚合（无书查词 title='' 跳过，只进汇总）。
-      final List<LookupMiningCounterRow> counters = await db
-          .getLookupMiningCountersBySource(kStatSourceBook);
+      // 查词/制卡 per-book 计数：汇总用 lookupCount 分桶，per-book tile 按 title
+      // 聚合（无书查词 title='' 跳过，只进汇总）。
+      final List<LookupMiningCounterRow> counters = counterFacts
+          .lookupCountersFor(StatSourceKind.book);
       _lookup = bucketActivityByDateKey(
-        counters.map((LookupMiningCounterRow c) => (c.dateKey, c.lookupCount)),
+        counterFacts.lookupEvents(source: StatSourceKind.book),
         now,
       );
       _bookCounters = aggregateStatCountersByTitle(counters);
@@ -243,17 +248,8 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       // BUG-893：写入端此前不带 dateKey，旧的 `dateKey != null` 过滤把所有书内收藏
       // 滤光 → 统计恒为 0。改用 `dateKey ?? statDateKey(createdAt)` 回退——createdAt
       // 恒非空，已存的无 dateKey 收藏也按创建日归桶（与写入端补 dateKey 双向修复）。
-      final List<FavoriteSentence> favSentences =
-          await FavoriteSentenceRepository(db).getAll();
       _favoritedSentences = bucketActivityByDateKey(
-        favSentences
-            .where(
-              (FavoriteSentence s) => s.source != kFavoriteSentenceSourceVideo,
-            )
-            .map(
-              (FavoriteSentence s) =>
-                  (s.dateKey ?? statDateKey(s.createdAt), 1),
-            ),
+        counterFacts.favoriteSentenceEvents(source: StatSourceKind.book),
         now,
       );
       _loadHourlyData(facts);

--- a/fushi/lib/src/pages/implementations/statistics_center_page.dart
+++ b/fushi/lib/src/pages/implementations/statistics_center_page.dart
@@ -10,6 +10,7 @@ import 'package:fushi/src/mining/galgame_library.dart';
 import 'package:fushi/src/pages/implementations/game_statistics_page.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/galgame_detail_page.dart';
+import 'package:fushi/src/pages/implementations/stat_activity.dart';
 import 'package:fushi/src/pages/implementations/stat_charts.dart';
 import 'package:fushi/src/pages/implementations/stat_period_detail_sheet.dart';
 import 'package:fushi/src/pages/implementations/stat_session_list.dart';
@@ -103,6 +104,14 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
   Map<int, String> _collectionNamesById = <int, String>{};
   List<GalgameEntry> _games = <GalgameEntry>[];
 
+  /// 跨域计数面分桶（阅读 + 视频两个来源之和；游戏域不写这四张计数面）。时段卡
+  /// 之前只有时长 / 字数，制卡与查词这两个每天都在动的数字在总览上一个都看不到，
+  /// 只能逐个 tab 翻——现在与两个域 tab 的时段卡同形。
+  StatActivityBuckets _lookup = StatActivityBuckets();
+  StatActivityBuckets _mined = StatActivityBuckets();
+  StatActivityBuckets _favorited = StatActivityBuckets();
+  StatActivityBuckets _favoritedSentences = StatActivityBuckets();
+
   @override
   void initState() {
     super.initState();
@@ -113,9 +122,24 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
     try {
       final AppModel appModel = ref.read(appProvider);
       final FushiDatabase db = appModel.database;
-      final StatFacts facts = await loadStatFacts(db, activityLimit: 0);
+      final StatFacts facts = await loadStatFacts(
+        db,
+        activityLimit: 0,
+        includeCounters: true,
+      );
       _daily = facts.daily;
       _sessions = facts.sessions;
+      // 跨域 = 不传 source（两个域 tab 各传自己的那一个），所以总览的四个数字
+      // 恒等于两个 tab 之和：同一批行、同一个分桶函数，没有第二条口径。
+      final DateTime now = DateTime.now();
+      final StatCounterFacts counters = facts.counters;
+      _lookup = bucketActivityByDateKey(counters.lookupEvents(), now);
+      _mined = bucketActivityByDateKey(counters.minedEvents(), now);
+      _favorited = bucketActivityByDateKey(counters.favoriteWordEvents(), now);
+      _favoritedSentences = bucketActivityByDateKey(
+        counters.favoriteSentenceEvents(),
+        now,
+      );
       // BUG-2216：同名 ≥2 本的 title 不进反查表（贴给任意一本都是错贴）。
       _bookKeyByTitle = uniqueBookKeyByTitle(facts.epubRows);
       _ambiguousBookTitles = ambiguousBookTitles(facts.epubRows);
@@ -280,20 +304,40 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
     );
   }
 
-  /// 四张跨域时段卡：主值=学习总时长，副行=学习总字数；点卡 → 完整日面的时段
-  /// 明细 sheet。
+  /// 四张跨域时段卡：主值=学习总时长，副行=学习总字数 + 查词 / 制卡 / 收藏词 /
+  /// 收藏句（与阅读、视频两个域 tab 的时段卡逐行同形，只是这里是跨域求和）；
+  /// 点卡 → 完整日面的时段明细 sheet。
   Widget _buildSummaryCards(StatWindow w) {
     return buildStatPeriodSummaryGrid(context, <StatPeriodSummary>[
-      _periodSummary(t.stat_today, w.isToday),
-      _periodSummary(t.stat_this_week, w.inWeek),
-      _periodSummary(t.stat_this_month, w.inMonth),
-      _periodSummary(t.stat_all_time, (String _) => true),
+      _periodSummary(
+        t.stat_today,
+        w.isToday,
+        (StatActivityBuckets b) => b.today,
+      ),
+      _periodSummary(
+        t.stat_this_week,
+        w.inWeek,
+        (StatActivityBuckets b) => b.week,
+      ),
+      _periodSummary(
+        t.stat_this_month,
+        w.inMonth,
+        (StatActivityBuckets b) => b.month,
+      ),
+      _periodSummary(
+        t.stat_all_time,
+        (String _) => true,
+        (StatActivityBuckets b) => b.all,
+      ),
     ]);
   }
 
+  /// [pick] = 这张卡取分桶里的哪一格（今日 / 本周 / 本月 / 全部），与 [contains]
+  /// 的窗口一一对应：四个计数面只分一次桶，四张卡各取一格。
   StatPeriodSummary _periodSummary(
     String label,
     bool Function(String dateKey) contains,
+    int Function(StatActivityBuckets) pick,
   ) {
     int chars = 0;
     int ms = 0;
@@ -306,7 +350,16 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
       label: label,
       primaryValue: formatStatTime(ms),
       onTap: () => unawaited(_showPeriodDetail(label, contains)),
-      lines: <StatSummaryLine>[StatSummaryLine(value: formatStatChars(chars))],
+      lines: <StatSummaryLine>[
+        StatSummaryLine(value: formatStatChars(chars)),
+        StatSummaryLine(label: t.stat_lookup, value: '${pick(_lookup)}'),
+        StatSummaryLine(label: t.stat_mined, value: '${pick(_mined)}'),
+        StatSummaryLine(label: t.stat_favorited, value: '${pick(_favorited)}'),
+        StatSummaryLine(
+          label: t.stat_favorited_sentence,
+          value: '${pick(_favoritedSentences)}',
+        ),
+      ],
     );
   }
 

--- a/fushi/lib/src/pages/implementations/video_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/video_statistics_page.dart
@@ -111,7 +111,11 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
       // v92：观看事实只走统一事实面（legacy `video_watch_statistics` 日行 +
       // `study_segments` 段，由 loadStatFacts 归一），本页不再直接读表。
       // activityLimit 0：统计页不需要活动流行。
-      final StatFacts facts = await loadStatFacts(db, activityLimit: 0);
+      final StatFacts facts = await loadStatFacts(
+        db,
+        activityLimit: 0,
+        includeCounters: true,
+      );
       final List<StatFact> stats = facts.dailyVideos.toList();
       _videoFacts = stats;
       _sessions = facts.sessions.where((StudySession s) => s.isVideo).toList();
@@ -137,14 +141,15 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
       final DateTime now = DateTime.now();
       _window = StatWindow(now);
       _armMidnightReload(now);
-      final List<FavoriteWordRow> favs = await db.getFavoriteWordsBySource(
-        kStatSourceVideo,
+      // 计数面（查词 / 制卡 / 收藏）与事实面同一次加载：总览 tab 的跨域数字必须
+      // 恰好等于阅读 tab 与本 tab 之和，各页各查一遍就会在口径漂移时静默对不上。
+      final StatCounterFacts counterFacts = facts.counters;
+      final List<FavoriteWordRow> favs = counterFacts.favoriteWordsFor(
+        StatSourceKind.video,
       );
-      final List<MiningStatisticRow> mined = await db
-          .getMiningStatisticsBySource(kStatSourceVideo);
-      // TODO-1204：查词/制卡 per-video 计数（新表）。
-      final List<LookupMiningCounterRow> counters = await db
-          .getLookupMiningCountersBySource(kStatSourceVideo);
+      // 查词/制卡 per-video 计数。
+      final List<LookupMiningCounterRow> counters = counterFacts
+          .lookupCountersFor(StatSourceKind.video);
       // v76：观看 / 计数 / 收藏三个行宇宙进同一次身份分组，tile 自带全部数字
       // （吸收判据全局一致，绝不各分各的再拼——那是计数在同名 tile 间游走的根因）。
       // 库表级同名判定（≥2 个 uid 共享一个 title）喂给吸收否决：与迁移回填的
@@ -165,28 +170,29 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
         },
       );
       _favorited = bucketActivityByDateKey(
-        favs.map((FavoriteWordRow f) => (f.dateKey, 1)),
+        counterFacts.favoriteWordEvents(source: StatSourceKind.video),
         now,
       );
       _mined = bucketActivityByDateKey(
-        mined.map((MiningStatisticRow m) => (m.dateKey, m.count)),
+        counterFacts.minedEvents(source: StatSourceKind.video),
         now,
       );
       _lookup = bucketActivityByDateKey(
-        counters.map((LookupMiningCounterRow c) => (c.dateKey, c.lookupCount)),
+        counterFacts.lookupEvents(source: StatSourceKind.video),
         now,
       );
-      // 视频来源收藏语句（source==video），旧条目无 dateKey 不参与分桶。
-      final List<FavoriteSentence> favSentences =
-          await FavoriteSentenceRepository(db).getAll();
-      final List<FavoriteSentence> videoFavSentences = favSentences
+      // 视频来源收藏语句（source==video）。BUG-893 的读取端回退此前只修了阅读侧：
+      // 本页旧判据是 `dateKey != null`，写入端补 dateKey 之前存下的视频收藏一条不
+      // 计——现在与阅读侧同一个判据（[StatCounterFacts.favoriteSentenceEvents]），
+      // 顺带让总览的跨域和恒等于两个域 tab 之和。
+      final List<FavoriteSentence> videoFavSentences = counterFacts
+          .favoriteSentences
           .where(
-            (FavoriteSentence s) =>
-                s.source == kFavoriteSentenceSourceVideo && s.dateKey != null,
+            (FavoriteSentence s) => s.source == kFavoriteSentenceSourceVideo,
           )
           .toList();
       _favoritedSentences = bucketActivityByDateKey(
-        videoFavSentences.map((FavoriteSentence s) => (s.dateKey!, 1)),
+        counterFacts.favoriteSentenceEvents(source: StatSourceKind.video),
         now,
       );
       // counters 也算有数据（review4-6）：只在视频域查过词（无观看/收藏/制卡）
@@ -195,7 +201,7 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
           stats.isNotEmpty ||
           completed.isNotEmpty ||
           favs.isNotEmpty ||
-          mined.isNotEmpty ||
+          counterFacts.minedEvents(source: StatSourceKind.video).isNotEmpty ||
           counters.isNotEmpty ||
           videoFavSentences.isNotEmpty;
       _loadHourlyData(facts);

--- a/fushi/lib/src/stats/stat_facts.dart
+++ b/fushi/lib/src/stats/stat_facts.dart
@@ -1,4 +1,5 @@
 import 'package:fushi/src/stats/study_sessions.dart';
+import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi_core/fushi_core.dart';
 
 /// 一条学习统计事实的统一形状（v92 统计域重构）。
@@ -59,6 +60,92 @@ class StatFact {
   String get identityKey => mediaKey.isNotEmpty ? mediaKey : title;
 }
 
+/// 「查词 / 制卡 / 收藏词 / 收藏句」四类计数事实（学习事实面之外的**计数面**）。
+///
+/// 与 [StatFact] 严格分列：这四类行没有时长 / 字数 / 页数，粒度是
+/// (dateKey, sourceType)（+ per-book 计数自带的 title / bookKey），混进日面就会
+/// 被所有按 ms / chars 求和的消费方当成零行，还会污染排行与热力图。它们只按
+/// dateKey 分桶（`bucketActivityByDateKey`）。
+///
+/// 三个消费方——统计中心总览 tab、阅读 tab、视频 tab——**共用同一次加载**：总览
+/// 是跨域视图，数字必须恰好等于两个域 tab 之和，各页各查一遍就会在口径漂移时
+/// 静默对不上（此前总览干脆没有这四个数字，域 tab 各查各的）。
+class StatCounterFacts {
+  const StatCounterFacts({
+    this.mining = const <MiningStatisticRow>[],
+    this.lookupCounters = const <LookupMiningCounterRow>[],
+    this.favoriteWords = const <FavoriteWordRow>[],
+    this.favoriteSentences = const <FavoriteSentence>[],
+  });
+
+  static const StatCounterFacts empty = StatCounterFacts();
+
+  /// 制卡的按日全局计数（`mining_statistics`，已按 (sourceType, dateKey) 聚合）。
+  final List<MiningStatisticRow> mining;
+
+  /// 查词 / 制卡的 per-book 计数（`lookup_mining_counters`）。查词数只有这一个
+  /// 来源（查词不落逐次记录，只有按日计数）。
+  final List<LookupMiningCounterRow> lookupCounters;
+
+  /// 收藏词（`favorite_words`，每行一条 = 计 1）。
+  final List<FavoriteWordRow> favoriteWords;
+
+  /// 收藏句（`FavoriteSentenceRepository`，偏好里的 JSON 列表）。
+  final List<FavoriteSentence> favoriteSentences;
+
+  /// 按统计来源过滤 per-book 计数行（[source] 为 null = 跨域全取）。
+  List<LookupMiningCounterRow> lookupCountersFor(StatSourceKind? source) =>
+      source == null
+          ? lookupCounters
+          : lookupCounters
+              .where(
+                  (LookupMiningCounterRow c) => c.sourceType == source.dbValue)
+              .toList();
+
+  /// 按统计来源过滤收藏词行（[source] 为 null = 跨域全取）。
+  List<FavoriteWordRow> favoriteWordsFor(StatSourceKind? source) =>
+      source == null
+          ? favoriteWords
+          : favoriteWords
+              .where((FavoriteWordRow f) => f.sourceType == source.dbValue)
+              .toList();
+
+  /// 查词数事件流（喂 `bucketActivityByDateKey`）。[source] 为 null = 跨域求和。
+  Iterable<(String, int)> lookupEvents({StatSourceKind? source}) =>
+      lookupCountersFor(source)
+          .map((LookupMiningCounterRow c) => (c.dateKey, c.lookupCount));
+
+  /// 制卡数事件流。真相源是 `mining_statistics`（域页历史口径），**不是**
+  /// `lookup_mining_counters.mineCount`——后者是 per-book 分摊面，无书制卡进
+  /// title='' 行，两张表在「哪些制卡能归到书上」这一点上不等价。
+  Iterable<(String, int)> minedEvents({StatSourceKind? source}) => mining
+      .where((MiningStatisticRow m) =>
+          source == null || m.sourceType == source.dbValue)
+      .map((MiningStatisticRow m) => (m.dateKey, m.count));
+
+  /// 收藏词事件流（每行计 1）。
+  Iterable<(String, int)> favoriteWordEvents({StatSourceKind? source}) =>
+      favoriteWordsFor(source).map((FavoriteWordRow f) => (f.dateKey, 1));
+
+  /// 收藏句事件流。收藏句的 `source` 是**另一个值域**（书 / 视频 / 有声书 / 歌词），
+  /// 与 [StatSourceKind] 不同构：视频域取 `source == video`，阅读域取其余全部
+  /// （有声书 / 歌词都算阅读，与阅读统计页历史判据一致）。
+  /// BUG-893：dateKey 缺失（写入端补 dateKey 之前的老条目）回退按 createdAt 归日，
+  /// 否则老收藏全被滤掉、统计恒 0。
+  Iterable<(String, int)> favoriteSentenceEvents({StatSourceKind? source}) =>
+      favoriteSentences
+          .where((FavoriteSentence s) => switch (source) {
+                null => true,
+                StatSourceKind.video =>
+                  s.source == kFavoriteSentenceSourceVideo,
+                StatSourceKind.book => s.source != kFavoriteSentenceSourceVideo,
+              })
+          .map((FavoriteSentence s) => (
+                s.dateKey ?? FushiDatabase.statDateKeyOf(s.createdAt),
+                1,
+              ));
+}
+
 /// 库表按 title 分桶（BUG-2216：legacy 阅读行只有 title，反查库表补身份时同名
 /// ≥2 本不能贴给任意一本——宁可留成无身份组也不错贴）。
 Map<String, List<EpubBookMeta>> _booksByTitle(Iterable<EpubBookMeta> rows) {
@@ -114,6 +201,7 @@ class StatFacts {
     required this.epubRows,
     this.recentGameSessions = const <GalgameSessionRow>[],
     this.gameNamesById = const <String, String>{},
+    this.counters = StatCounterFacts.empty,
     this.activityLimit = 200,
   });
 
@@ -130,6 +218,10 @@ class StatFacts {
 
   /// galgames.id → 显示名（合成游玩事件的 title 快照）。
   final Map<String, String> gameNamesById;
+
+  /// 查词 / 制卡 / 收藏计数面（只在 `loadStatFacts(includeCounters: true)` 时装载，
+  /// 否则是 [StatCounterFacts.empty]——首页时间轴不需要，不白付四个全表读）。
+  final StatCounterFacts counters;
 
   /// [activityRows] 的条数上限（与 legacy 行的取数上限同值）。
   final int activityLimit;
@@ -193,10 +285,12 @@ const int kRecentGameSessionsLimit = 200;
 Future<StatFacts> loadStatFacts(
   FushiDatabase db, {
   int activityLimit = 200,
+  bool includeCounters = false,
 }) async {
-  // 九个全表读互不依赖：一次全部发出去让 Drift 后台执行器流水线化，而不是每个都
-  // 等上一个往返回来（首页与三个统计页每次打开都走这里）。先 Future.wait 挂上
-  // 监听，某个失败时其余错误不会成为无人接的未处理异常。
+  // 十个全表读互不依赖（[includeCounters] 时再挂计数面的四个）：一次全部发出去让
+  // Drift 后台执行器流水线化，而不是每个都等上一个往返回来（首页与三个统计页每次
+  // 打开都走这里）。先 Future.wait 挂上监听，某个失败时其余错误不会成为无人接的
+  // 未处理异常。
   final Future<List<EpubBookMeta>> epubRowsF = db.getEpubBookMetas();
   final Future<List<ReadingStatisticRow>> readingF =
       db.getAllReadingStatistics();
@@ -222,6 +316,10 @@ Future<StatFacts> loadStatFacts(
       db.getRecentGalgameSessions(
     limit: activityLimit <= 0 ? kRecentGameSessionsLimit : activityLimit,
   );
+  // 计数面：四个来源一起挂进同一批并发读（统计页要，首页时间轴不要）。
+  final Future<StatCounterFacts> countersF = includeCounters
+      ? _loadCounterFacts(db)
+      : Future<StatCounterFacts>.value(StatCounterFacts.empty);
   await Future.wait<Object?>(<Future<Object?>>[
     epubRowsF,
     readingF,
@@ -233,6 +331,7 @@ Future<StatFacts> loadStatFacts(
     gameActivityF,
     segmentsF,
     recentGameSessionsF,
+    countersF,
   ]);
 
   final List<EpubBookMeta> epubRows = await epubRowsF;
@@ -398,7 +497,31 @@ Future<StatFacts> loadStatFacts(
     epubRows: epubRows,
     recentGameSessions: recentGameSessions,
     gameNamesById: gameNamesById,
+    counters: await countersF,
     activityLimit: activityLimit,
+  );
+}
+
+/// 计数面的四个全表读（与主事实面同一批并发）。收藏句在偏好里（一条 JSON），
+/// 其余三张是按日聚合的小表。
+Future<StatCounterFacts> _loadCounterFacts(FushiDatabase db) async {
+  final Future<List<MiningStatisticRow>> miningF = db.getAllMiningStatistics();
+  final Future<List<LookupMiningCounterRow>> countersF =
+      db.getAllLookupMiningCounters();
+  final Future<List<FavoriteWordRow>> favoriteWordsF = db.getAllFavoriteWords();
+  final Future<List<FavoriteSentence>> favoriteSentencesF =
+      FavoriteSentenceRepository(db).getAll();
+  await Future.wait<Object?>(<Future<Object?>>[
+    miningF,
+    countersF,
+    favoriteWordsF,
+    favoriteSentencesF,
+  ]);
+  return StatCounterFacts(
+    mining: await miningF,
+    lookupCounters: await countersF,
+    favoriteWords: await favoriteWordsF,
+    favoriteSentences: await favoriteSentencesF,
   );
 }
 

--- a/fushi/test/pages/favorited_sentence_stats_bug893_test.dart
+++ b/fushi/test/pages/favorited_sentence_stats_bug893_test.dart
@@ -2,20 +2,32 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/pages/implementations/stat_activity.dart';
+import 'package:fushi/src/stats/stat_facts.dart';
 import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
 
 // BUG-893：阅读统计「收藏语句」计数恒为 0。根因——reader 书内收藏写入端不带 dateKey，
 // 读取端又用 `dateKey != null` 过滤，把所有书内收藏滤光。修复：写入补 dateKey +
 // 读取端回退 `dateKey ?? statDateKey(createdAt)`（createdAt 恒非空，已存无 dateKey 收藏也计入）。
 
-/// 复刻 reading_statistics_page._loadData 里收藏语句的分桶映射（read-side 修复逻辑）。
+/// 阅读侧收藏语句的分桶：直接走生产判据（[StatCounterFacts.favoriteSentenceEvents]，
+/// 三个统计 tab 共用的那一个），不再在测试里复刻一份——复刻件与实现漂移时，测试会
+/// 在实现已经坏掉的情况下继续绿。
 StatActivityBuckets bucketFavoritedSentences(
     List<FavoriteSentence> favSentences, DateTime now) {
   return bucketActivityByDateKey(
-    favSentences
-        .where((FavoriteSentence s) => s.source != kFavoriteSentenceSourceVideo)
-        .map(
-            (FavoriteSentence s) => (s.dateKey ?? statDateKey(s.createdAt), 1)),
+    StatCounterFacts(favoriteSentences: favSentences)
+        .favoriteSentenceEvents(source: StatSourceKind.book),
+    now,
+  );
+}
+
+/// 视频侧同判据（BUG-893 的读取端回退此前只修了阅读侧）。
+StatActivityBuckets bucketVideoFavoritedSentences(
+    List<FavoriteSentence> favSentences, DateTime now) {
+  return bucketActivityByDateKey(
+    StatCounterFacts(favoriteSentences: favSentences)
+        .favoriteSentenceEvents(source: StatSourceKind.video),
     now,
   );
 }
@@ -87,6 +99,50 @@ void main() {
     });
   });
 
+  group('video side shares the same fallback', () {
+    test('无 dateKey 的视频收藏按 createdAt 计入（此前视频侧仍在漏）', () {
+      final favs = <FavoriteSentence>[
+        FavoriteSentence(
+          text: 'v1',
+          bookTitle: 'V',
+          createdAt: DateTime(2026, 7, 18, 9),
+          source: kFavoriteSentenceSourceVideo,
+        ),
+        FavoriteSentence(
+            text: 'b1', bookTitle: 'B', createdAt: DateTime(2026, 7, 18, 9)),
+      ];
+      final b = bucketVideoFavoritedSentences(favs, now);
+      expect(b.today, 1, reason: '视频那条无 dateKey 也要计入');
+      expect(b.all, 1, reason: '书内那条不算进视频域');
+    });
+
+    test('跨域（source 不传）= 两个域之和', () {
+      final favs = <FavoriteSentence>[
+        FavoriteSentence(
+          text: 'v1',
+          bookTitle: 'V',
+          createdAt: DateTime(2026, 7, 18, 9),
+          source: kFavoriteSentenceSourceVideo,
+        ),
+        FavoriteSentence(
+            text: 'b1', bookTitle: 'B', createdAt: DateTime(2026, 7, 18, 9)),
+        FavoriteSentence(
+            text: 'b2', bookTitle: 'B', createdAt: DateTime(2026, 7, 17, 9)),
+      ];
+      final StatActivityBuckets all = bucketActivityByDateKey(
+        StatCounterFacts(favoriteSentences: favs).favoriteSentenceEvents(),
+        now,
+      );
+      expect(
+        all.all,
+        bucketFavoritedSentences(favs, now).all +
+            bucketVideoFavoritedSentences(favs, now).all,
+        reason: '总览 tab 的跨域数字必须恰好是两个域 tab 之和',
+      );
+      expect(all.all, 3);
+    });
+  });
+
   group('source guards (lock the fix)', () {
     test('reader 书内收藏写入端补了 dateKey', () {
       final String src =
@@ -105,12 +161,22 @@ void main() {
           reason: 'BUG-893 回归：书内收藏不带 dateKey → 统计恒 0');
     });
 
-    test('阅读统计读取端回退 createdAt，不再用 dateKey != null 过滤收藏语句', () {
+    test('读取端回退 createdAt，不再用 dateKey != null 过滤收藏语句', () {
+      // 判据已从两个统计页收敛进 StatCounterFacts（总览 tab 也要同一份）。
       final String src =
-          File('lib/src/pages/implementations/reading_statistics_page.dart')
-              .readAsStringSync();
-      expect(src.contains('s.dateKey ?? statDateKey(s.createdAt)'), isTrue,
+          File('lib/src/stats/stat_facts.dart').readAsStringSync();
+      expect(
+          src.contains('s.dateKey ?? FushiDatabase.statDateKeyOf(s.createdAt)'),
+          isTrue,
           reason: 'BUG-893：读取端须回退 createdAt，兼容已存无 dateKey 收藏');
+      for (final String page in <String>[
+        'lib/src/pages/implementations/reading_statistics_page.dart',
+        'lib/src/pages/implementations/video_statistics_page.dart',
+      ]) {
+        expect(File(page).readAsStringSync().contains('s.dateKey != null'),
+            isFalse,
+            reason: '$page 不许再自己按 dateKey 非空过滤收藏语句');
+      }
     });
   });
 }

--- a/fushi/test/pages/sentence_favorites_todo047_guard_test.dart
+++ b/fushi/test/pages/sentence_favorites_todo047_guard_test.dart
@@ -264,7 +264,15 @@ void main() {
       );
       expect(src, contains('_favoritedSentences'));
       expect(src, contains('t.stat_favorited_sentence'));
-      expect(src, contains('FavoriteSentenceRepository'));
+      expect(
+        src,
+        contains('favoriteSentenceEvents(source: StatSourceKind.book)'),
+        reason: '取数与分桶判据收敛进 StatCounterFacts（三个统计 tab 共用一份）',
+      );
+    });
+
+    test('收藏语句的来源切分与日期回退判据只在 StatCounterFacts 里', () {
+      final String src = read('lib/src/stats/stat_facts.dart');
       expect(
         src,
         contains('s.source != kFavoriteSentenceSourceVideo'),
@@ -272,9 +280,14 @@ void main() {
       );
       expect(
         src,
-        contains('s.dateKey ?? statDateKey(s.createdAt)'),
-        reason: 'BUG-893：书内旧收藏无 dateKey 按 createdAt 回退归桶'
-            '（旧的 `dateKey != null` 过滤把所有书内收藏滤光 → 统计恒 0，已根治）',
+        contains('s.source == kFavoriteSentenceSourceVideo'),
+        reason: '视频来源归视频统计',
+      );
+      expect(
+        src,
+        contains('s.dateKey ?? FushiDatabase.statDateKeyOf(s.createdAt)'),
+        reason: 'BUG-893：旧收藏无 dateKey 按 createdAt 回退归桶'
+            '（旧的 `dateKey != null` 过滤把它们滤光 → 统计恒 0，已根治）',
       );
     });
 
@@ -284,8 +297,17 @@ void main() {
       );
       expect(src, contains('_favoritedSentences'));
       expect(src, contains('t.stat_favorited_sentence'));
-      expect(src, contains('s.source == kFavoriteSentenceSourceVideo'));
-      expect(src, contains('s.dateKey != null'));
+      expect(
+        src,
+        contains('favoriteSentenceEvents(source: StatSourceKind.video)'),
+      );
+      expect(
+        src,
+        isNot(contains('s.dateKey != null')),
+        reason: 'BUG-893 的读取端回退此前只修了阅读侧；视频侧也不许再按 '
+            'dateKey 非空过滤（写入端补 dateKey 之前的视频收藏会被整批漏掉，'
+            '且总览的跨域和会不等于两个域 tab 之和）',
+      );
     });
   });
 }

--- a/fushi/test/pages/statistics_center_static_test.dart
+++ b/fushi/test/pages/statistics_center_static_test.dart
@@ -31,6 +31,53 @@ void main() {
     expect(center, contains('showStatPeriodDetailSheet('));
   });
 
+  test('总览时段卡带查词 / 制卡 / 收藏（与两个域 tab 的卡逐行同形）', () {
+    for (final String label in <String>[
+      't.stat_lookup',
+      't.stat_mined',
+      't.stat_favorited',
+      't.stat_favorited_sentence',
+    ]) {
+      expect(
+        center,
+        contains(label),
+        reason: '总览此前只有时长 / 字数，每天都在动的制卡与查词一个都看不到',
+      );
+    }
+  });
+
+  test('总览的计数面与两个域 tab 同一次加载、同一份切分判据', () {
+    // 跨域 = 不传 source；域 tab 各传自己那一个。三处都从 StatFacts.counters 取，
+    // 谁也不再自己查 mining_statistics / lookup_mining_counters / favorite_words
+    // ——否则总览的数字不再恒等于两个域 tab 之和，且没有任何测试能发现。
+    expect(center, contains('includeCounters: true'));
+    expect(center, contains('facts.counters'));
+    for (final (String path, String source) in <(String, String)>[
+      (
+        'lib/src/pages/implementations/reading_statistics_page.dart',
+        'StatSourceKind.book',
+      ),
+      (
+        'lib/src/pages/implementations/video_statistics_page.dart',
+        'StatSourceKind.video',
+      ),
+    ]) {
+      final String src = File(path).readAsStringSync();
+      expect(src, contains('includeCounters: true'), reason: path);
+      expect(src, contains('facts.counters'), reason: path);
+      expect(src, contains('lookupEvents(source: $source)'), reason: path);
+      expect(src, contains('minedEvents(source: $source)'), reason: path);
+      for (final String dao in <String>[
+        'getMiningStatisticsBySource(',
+        'getLookupMiningCountersBySource(',
+        'getFavoriteWordsBySource(',
+        'FavoriteSentenceRepository(',
+      ]) {
+        expect(src, isNot(contains(dao)), reason: '$path 不许再单独取计数面（$dao）');
+      }
+    }
+  });
+
   test('三个统计页都支持 embedded 分支（buildEmbeddedStatTab）', () {
     for (final String path in <String>[
       'lib/src/pages/implementations/reading_statistics_page.dart',

--- a/fushi/test/stats/stat_counter_facts_test.dart
+++ b/fushi/test/stats/stat_counter_facts_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/stat_activity.dart';
+import 'package:fushi/src/stats/stat_facts.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 统计中心「总览」tab 的查词 / 制卡 / 收藏数字（此前总览只有时长与字数，这四个
+/// 每天都在动的数字一个都看不到，只能逐个域 tab 翻）。
+///
+/// 口径的硬约束：总览是跨域视图，它的每个数字必须**恰好**等于阅读 tab 与视频 tab
+/// 之和——所以三处只许有一份取数与一份切分判据（[StatCounterFacts]）。
+MiningStatisticRow _mining(String source, String dateKey, int count) =>
+    MiningStatisticRow(
+        id: 0, sourceType: source, dateKey: dateKey, count: count);
+
+LookupMiningCounterRow _counter(
+  String source,
+  String dateKey, {
+  int lookups = 0,
+  int mines = 0,
+  String title = '',
+}) =>
+    LookupMiningCounterRow(
+      id: 0,
+      bookKey: '',
+      title: title,
+      sourceType: source,
+      dateKey: dateKey,
+      lookupCount: lookups,
+      mineCount: mines,
+    );
+
+FavoriteWordRow _word(String source, String dateKey) => FavoriteWordRow(
+      id: 0,
+      expression: 'あ',
+      reading: 'あ',
+      glossary: '',
+      sourceType: source,
+      title: '',
+      dateKey: dateKey,
+      createdAt: 0,
+    );
+
+int _sum(Iterable<(String, int)> events) =>
+    events.fold<int>(0, (int a, (String, int) e) => a + e.$2);
+
+void main() {
+  const String today = '2026-07-18';
+  const String yesterday = '2026-07-17';
+  final DateTime now = DateTime(2026, 7, 18, 20);
+
+  final StatCounterFacts facts = StatCounterFacts(
+    mining: <MiningStatisticRow>[
+      _mining(kStatSourceBook, today, 3),
+      _mining(kStatSourceBook, yesterday, 2),
+      _mining(kStatSourceVideo, today, 5),
+    ],
+    lookupCounters: <LookupMiningCounterRow>[
+      _counter(kStatSourceBook, today, lookups: 10, mines: 3, title: '本'),
+      _counter(kStatSourceVideo, today, lookups: 7, mines: 5),
+      _counter(kStatSourceVideo, yesterday, lookups: 1),
+    ],
+    favoriteWords: <FavoriteWordRow>[
+      _word(kStatSourceBook, today),
+      _word(kStatSourceVideo, today),
+      _word(kStatSourceVideo, yesterday),
+    ],
+    favoriteSentences: <FavoriteSentence>[
+      FavoriteSentence(
+          text: 'b', bookTitle: 'B', createdAt: DateTime(2026, 7, 18, 9)),
+      FavoriteSentence(
+        text: 'v',
+        bookTitle: 'V',
+        createdAt: DateTime(2026, 7, 18, 9),
+        source: kFavoriteSentenceSourceVideo,
+      ),
+    ],
+  );
+
+  group('按来源切片', () {
+    test('查词只算本域，不传 source 则跨域求和', () {
+      expect(_sum(facts.lookupEvents(source: StatSourceKind.book)), 10);
+      expect(_sum(facts.lookupEvents(source: StatSourceKind.video)), 8);
+      expect(_sum(facts.lookupEvents()), 18);
+    });
+
+    test('制卡走 mining_statistics，不是 per-book 的 mineCount', () {
+      // 两张表在「无书制卡能不能归到书上」这点上不等价：本例 counters 的 mineCount
+      // 合计 8，全局计数 10——总览必须与域页取同一张表，否则跨域和对不上。
+      expect(_sum(facts.minedEvents(source: StatSourceKind.book)), 5);
+      expect(_sum(facts.minedEvents(source: StatSourceKind.video)), 5);
+      expect(_sum(facts.minedEvents()), 10);
+    });
+
+    test('收藏词按行计 1', () {
+      expect(_sum(facts.favoriteWordEvents(source: StatSourceKind.book)), 1);
+      expect(_sum(facts.favoriteWordEvents(source: StatSourceKind.video)), 2);
+      expect(_sum(facts.favoriteWordEvents()), 3);
+    });
+
+    test('per-book 计数行切片给 tile 用（阅读页按 title 聚合）', () {
+      expect(facts.lookupCountersFor(StatSourceKind.book).single.title, '本');
+      expect(facts.lookupCountersFor(StatSourceKind.video), hasLength(2));
+      expect(facts.lookupCountersFor(null), hasLength(3));
+    });
+  });
+
+  group('跨域 = 两域之和（总览与两个域 tab 对得上）', () {
+    final Map<String, Iterable<(String, int)> Function(StatSourceKind?)> flows =
+        <String, Iterable<(String, int)> Function(StatSourceKind?)>{
+      '查词': (StatSourceKind? s) => facts.lookupEvents(source: s),
+      '制卡': (StatSourceKind? s) => facts.minedEvents(source: s),
+      '收藏词': (StatSourceKind? s) => facts.favoriteWordEvents(source: s),
+      '收藏句': (StatSourceKind? s) => facts.favoriteSentenceEvents(source: s),
+    };
+    flows.forEach((
+      String name,
+      Iterable<(String, int)> Function(StatSourceKind?) of,
+    ) {
+      test('$name 跨域合计 = book + video', () {
+        final StatActivityBuckets all = bucketActivityByDateKey(of(null), now);
+        final StatActivityBuckets book =
+            bucketActivityByDateKey(of(StatSourceKind.book), now);
+        final StatActivityBuckets video =
+            bucketActivityByDateKey(of(StatSourceKind.video), now);
+        expect(all.all, book.all + video.all, reason: '全部');
+        expect(all.today, book.today + video.today, reason: '今日');
+        expect(all.week, book.week + video.week, reason: '本周');
+        expect(all.month, book.month + video.month, reason: '本月');
+      });
+    });
+  });
+
+  test('分桶按 dateKey 落窗口（今日只算今天那几行）', () {
+    final StatActivityBuckets lookups =
+        bucketActivityByDateKey(facts.lookupEvents(), now);
+    expect(lookups.today, 17, reason: '10 + 7，昨天那 1 次不算');
+    expect(lookups.all, 18);
+    final StatActivityBuckets mined =
+        bucketActivityByDateKey(facts.minedEvents(), now);
+    expect(mined.today, 8, reason: '3 + 5');
+    expect(mined.all, 10);
+  });
+
+  test('空计数面（loadStatFacts 不带 includeCounters）四个流都空', () {
+    expect(StatCounterFacts.empty.lookupEvents(), isEmpty);
+    expect(StatCounterFacts.empty.minedEvents(), isEmpty);
+    expect(StatCounterFacts.empty.favoriteWordEvents(), isEmpty);
+    expect(StatCounterFacts.empty.favoriteSentenceEvents(), isEmpty);
+  });
+}


### PR DESCRIPTION
## 问题

统计中心「总览」tab 的四张时段卡只有**学习时长**（主值）和**字数**（副行）。查词、制卡这两个每天都在动的数字，总览上一个都看不到——要看只能逐个切到阅读 / 视频 tab 各看一遍，再自己心算加起来。而阅读 tab 与视频 tab 的同一张卡，早就有「查词 / 制卡 / 收藏词 / 收藏句」四行。

## 改动

**1. 总览的四张时段卡与两个域 tab 逐行同形**

时长（主值）+ 字数 / 查词 / 制卡 / 收藏词 / 收藏句，跨域求和（阅读 + 视频）。卡片是共享件 `_StatPeriodSummaryCard`，高度自适应，与两个域 tab 完全同构，没有新的布局形态。

**2. 取数收敛进 `loadStatFacts`：新增计数面 `StatCounterFacts`**

`mining_statistics` / `lookup_mining_counters` / `favorite_words` / 收藏句四个来源，由 `includeCounters` 开关装载（默认关，首页时间轴不付这四个全表读的代价），与主事实面同一批并发发出。

它与 `StatFact` **严格分列**：这四类行没有时长 / 字数 / 页数，粒度是 `(dateKey, sourceType)`，混进日面会被所有按 ms / chars 求和的消费方当成零行。

跨域 = 不传 `source`，域 tab 各传自己那一个，于是**总览的每个数字恒等于两个域 tab 之和**——同一批行、同一个分桶函数，不存在第二条口径。两个统计页顺带净删掉各自的四次全表读与各自手写的切分判据（三份口径合成一份）。

**3. 顺带修 BUG-893 在视频侧的残留**

收藏句读取端的 `dateKey ?? createdAt` 回退当时只修了阅读侧；视频统计页仍按 `s.dateKey != null` 过滤，**写入端补 dateKey 之前存下的视频收藏一条都不计**。判据现在只在 `StatCounterFacts.favoriteSentenceEvents` 一处，两侧同律（这也是上面「跨域和 = 两域之和」成立的前提）。

## 测试

- 新增 `fushi/test/stats/stat_counter_facts_test.dart`：按来源切片、**跨域 = book + video**（四个流各一条）、制卡走 `mining_statistics` 而非 `lookup_mining_counters.mineCount`（两张表在「无书制卡能否归到书上」这点不等价）、按 dateKey 落窗口、空计数面。
- `favorited_sentence_stats_bug893_test.dart`：从「在测试里复刻一份分桶逻辑」改成**直接调生产判据**（复刻件与实现漂移时，测试会在实现已坏的情况下继续绿），并补视频侧回退 + 跨域求和用例；源码守卫锚点跟着判据搬到 `stat_facts.dart`，并钉住两个页面不许再自己按 `dateKey != null` 过滤。
- `statistics_center_static_test.dart`：钉总览四行 + 三处共用同一次加载（域页不许再单独取计数面 DAO）。
- `sentence_favorites_todo047_guard_test.dart`：E 组锚点跟随判据搬家。

## 验证

在 `upstream/develop@22ca8da4ee` 上（已 rebase）：

- `flutter analyze`（含 test 目录）：**No issues found**
- 定向：`test/stats` + 统计页 / 守卫共 **200 tests, all passed**
- 「目录枚举型守卫」整批 52 条：**368 tests, all passed**（与 docs/agent/fast-workflow.md 当前基线一致）

未做真机像素复验：卡片是既有共享件、行数与阅读 tab 相同、高度自适应，没有新增布局形态。

https://claude.ai/code/session_01MUKnbjP1X6ot7i6rc2fATD
