### PR TITLE
feat(manga): 已配对互联对端作为漫画源，按页在线读（不必先下整卷）

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 78081 (4593 per locale)
+/// Strings: 78115 (4595 per locale)
 ///
-/// Built on 2026-09-10 at 00:16 UTC
+/// Built on 2026-09-10 at 01:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6377,6 +6377,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Installed ${installed}, skipped ${skipped}, failed ${failed}';
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -17174,6 +17178,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -28199,6 +28209,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -39278,6 +39294,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -50391,6 +50413,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -61306,6 +61334,12 @@ class _StringsId extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -72314,6 +72348,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -82698,6 +82738,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -93093,6 +93139,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -104057,6 +104109,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -115075,6 +115133,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -126070,6 +126134,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -136864,6 +136934,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -147774,6 +147850,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -158655,6 +158737,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 // Path: <root>
@@ -168650,6 +168738,10 @@ class _StringsZhCn extends _StringsEn {
       '已安装 ${installed} 个，跳过 ${skipped} 个，失败 ${failed} 个';
   @override
   String get mihon_extension_bulk_install_nothing => '当前筛选下的扩展都已经装过了。';
+  @override
+  String get manga_source_interconnect_subtitle => '浏览已配对设备上的漫画库';
+  @override
+  String get manga_source_interconnect_disabled => '在设置里开启 Fushi 互联后即可使用此来源';
 }
 
 // Path: <root>
@@ -178718,6 +178810,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get mihon_extension_bulk_install_nothing =>
       'Every extension matching the current filters is already installed.';
+  @override
+  String get manga_source_interconnect_subtitle =>
+      'Browse the manga library on your paired device';
+  @override
+  String get manga_source_interconnect_disabled =>
+      'Turn on Fushi Interconnect in settings to use this source';
 }
 
 /// Flat map(s) containing all translations.
@@ -188174,6 +188272,10 @@ extension on _StringsEn {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -197625,6 +197727,10 @@ extension on _StringsAr {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -207121,6 +207227,10 @@ extension on _StringsDe {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -216608,6 +216718,10 @@ extension on _StringsEs {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -226104,6 +226218,10 @@ extension on _StringsFr {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -235571,6 +235689,10 @@ extension on _StringsId {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -245060,6 +245182,10 @@ extension on _StringsIt {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -254476,6 +254602,10 @@ extension on _StringsJa {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -263896,6 +264026,10 @@ extension on _StringsKo {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -273378,6 +273512,10 @@ extension on _StringsNl {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -282855,6 +282993,10 @@ extension on _StringsPtBr {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -292339,6 +292481,10 @@ extension on _StringsRu {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -301795,6 +301941,10 @@ extension on _StringsTh {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -311266,6 +311416,10 @@ extension on _StringsTr {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -320731,6 +320885,10 @@ extension on _StringsVi {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }
@@ -330113,6 +330271,10 @@ extension on _StringsZhCn {
             '已安装 ${installed} 个，跳过 ${skipped} 个，失败 ${failed} 个';
       case 'mihon_extension_bulk_install_nothing':
         return '当前筛选下的扩展都已经装过了。';
+      case 'manga_source_interconnect_subtitle':
+        return '浏览已配对设备上的漫画库';
+      case 'manga_source_interconnect_disabled':
+        return '在设置里开启 Fushi 互联后即可使用此来源';
       default:
         return null;
     }
@@ -339507,6 +339669,10 @@ extension on _StringsZhHk {
             'Installed ${installed}, skipped ${skipped}, failed ${failed}';
       case 'mihon_extension_bulk_install_nothing':
         return 'Every extension matching the current filters is already installed.';
+      case 'manga_source_interconnect_subtitle':
+        return 'Browse the manga library on your paired device';
+      case 'manga_source_interconnect_disabled':
+        return 'Turn on Fushi Interconnect in settings to use this source';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "从该仓库安装 ${count} 个扩展？扩展会运行来自源站的代码。",
   "mihon_extension_bulk_install_progress": "正在安装 ${current}/${total}：${name}",
   "mihon_extension_bulk_install_done": "已安装 ${installed} 个，跳过 ${skipped} 个，失败 ${failed} 个",
-  "mihon_extension_bulk_install_nothing": "当前筛选下的扩展都已经装过了。"
+  "mihon_extension_bulk_install_nothing": "当前筛选下的扩展都已经装过了。",
+  "manga_source_interconnect_subtitle": "浏览已配对设备上的漫画库",
+  "manga_source_interconnect_disabled": "在设置里开启 Fushi 互联后即可使用此来源"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4591,5 +4591,7 @@
   "mihon_extension_bulk_install_confirm": "Install ${count} extensions from this repository? Extensions run code from their sources.",
   "mihon_extension_bulk_install_progress": "Installing ${current}/${total}: ${name}",
   "mihon_extension_bulk_install_done": "Installed ${installed}, skipped ${skipped}, failed ${failed}",
-  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed."
+  "mihon_extension_bulk_install_nothing": "Every extension matching the current filters is already installed.",
+  "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
+  "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source"
 }

--- a/fushi/lib/src/media/manga/interconnect/interconnect_manga_browse_page.dart
+++ b/fushi/lib/src/media/manga/interconnect/interconnect_manga_browse_page.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi/src/media/manga/interconnect/interconnect_manga_source.dart';
+import 'package:fushi/src/media/manga/library/manga_series_page.dart';
+import 'package:fushi/src/media/manga/library/online_manga_library_service.dart';
+import 'package:fushi/src/media/media_search_text.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+import 'package:fushi/src/sync/remote_cover_image.dart';
+import 'package:fushi/utils.dart';
+
+/// 浏览**已配对互联对端**的漫画库，与浏览一个扩展源同构。
+///
+/// 与书架上那条既有的「远端漫画」分区分工明确：那条是**下载**（把整卷搬过来再本地
+/// 读），这一页是**源**（不下载，直接在对端上翻页）——正是 Suwayomi 作为 Tachiyomi
+/// 源时的形态。两条路并存，用户按需选。
+///
+/// 清单不新开端点，走的还是 `/api/library/books` 里 `format=='manga'` 的那些行。
+class InterconnectMangaBrowsePage extends ConsumerStatefulWidget {
+  const InterconnectMangaBrowsePage({super.key, this.backend});
+
+  /// 测试注入口；生产恒用单例。
+  final InterconnectSyncBackend? backend;
+
+  @override
+  ConsumerState<InterconnectMangaBrowsePage> createState() =>
+      _InterconnectMangaBrowsePageState();
+}
+
+class _InterconnectMangaBrowsePageState
+    extends ConsumerState<InterconnectMangaBrowsePage> {
+  final TextEditingController _searchController = TextEditingController();
+  late final InterconnectSyncBackend _backend =
+      widget.backend ?? InterconnectSyncBackend.instance;
+  List<RemoteBookInfo> _items = const <RemoteBookInfo>[];
+  String _query = '';
+  bool _loading = true;
+  Object? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final List<RemoteBookInfo> items = await InterconnectMangaCatalog(
+        _backend,
+      ).listSeries();
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _loading = false;
+      });
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  /// 搜索在本端过滤已拉回的清单，不再往对端发请求：对端的书清单是一次性全量返回的
+  /// （没有分页端点），再发一次只是把同一份数据重拉一遍。归一化走全应用统一的
+  /// [matchesMediaSearch]，与书架/视频库的搜索口径一致。
+  List<RemoteBookInfo> get _visible => filterByMediaSearch<RemoteBookInfo>(
+        _items,
+        _query,
+        (RemoteBookInfo book) => <String>{book.displayName, book.title},
+      );
+
+  void _openSeries(RemoteBookInfo book) {
+    final AppModel appModel = ref.read(appProvider);
+    Navigator.of(context).push(
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (BuildContext context) => MangaSeriesPage(
+          target: SourceMangaSeriesTarget(
+            adapter: InterconnectLibraryAdapter(backend: _backend),
+            service: OnlineMangaLibraryService(
+              database: appModel.database,
+              rootDirectory: appModel.interconnectMangaLibraryRoot,
+              adapter: InterconnectLibraryAdapter(backend: _backend),
+            ),
+            seed: InterconnectMangaCatalog.entryFor(book),
+            sourceLabel: t.audio_source_fushi_interconnect,
+            remoteCoverBuilder: (BuildContext context) => _RemoteMangaCover(
+              backend: _backend,
+              book: book,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => FushiPageScaffold(
+        title: t.audio_source_fushi_interconnect,
+        automaticallyImplyLeading: false,
+        headerCompact: true,
+        leading: BackButton(
+          key: const ValueKey<String>('interconnect_manga_back'),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        headerBottom: Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: TextField(
+            key: const ValueKey<String>('interconnect_manga_search'),
+            controller: _searchController,
+            textInputAction: TextInputAction.search,
+            decoration: InputDecoration(
+              hintText: t.mihon_source_search,
+              prefixIcon: const Icon(Icons.search),
+            ),
+            onChanged: (String value) => setState(() => _query = value),
+          ),
+        ),
+        body: _buildResults(),
+      );
+
+  Widget _buildResults() {
+    if (_loading && _items.isEmpty) {
+      return Center(child: adaptiveIndicator(context: context));
+    }
+    if (_error != null && _items.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text('$_error', textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              TextButton(
+                key: const ValueKey<String>('interconnect_manga_retry'),
+                onPressed: () => unawaited(_load()),
+                child: Text(t.retry),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    final List<RemoteBookInfo> visible = _visible;
+    if (visible.isEmpty) {
+      return Center(child: Text(t.mihon_source_no_results));
+    }
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final int columns = (constraints.maxWidth / 180).floor().clamp(2, 8);
+        return RefreshIndicator(
+          onRefresh: _load,
+          child: GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columns,
+              childAspectRatio: 0.62,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+            ),
+            itemCount: visible.length,
+            itemBuilder: (BuildContext context, int index) {
+              final RemoteBookInfo book = visible[index];
+              return FushiCard(
+                padding: EdgeInsets.zero,
+                onTap: () => _openSeries(book),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    Expanded(
+                      child: _RemoteMangaCover(backend: _backend, book: book),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Text(
+                        book.displayName,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// 对端封面。
+///
+/// 必须走 [RemoteCoverImage] 而不是 `Image.network`：自签证书的对端需要
+/// `badCertificateCallback`，Flutter 内部那条 HttpClient 拿不到（BUG-569）。
+class _RemoteMangaCover extends StatelessWidget {
+  const _RemoteMangaCover({required this.backend, required this.book});
+
+  final InterconnectSyncBackend backend;
+  final RemoteBookInfo book;
+
+  @override
+  Widget build(BuildContext context) {
+    final String? url = book.coverUrl;
+    if (url == null || url.isEmpty) {
+      return const ColoredBox(
+        color: Colors.black12,
+        child: Center(child: Icon(Icons.menu_book_outlined)),
+      );
+    }
+    return Image(
+      image: RemoteCoverImage(url, backend, cacheKey: book.downloadId),
+      fit: BoxFit.cover,
+      errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
+          const ColoredBox(
+        color: Colors.black12,
+        child: Center(child: Icon(Icons.broken_image_outlined)),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/interconnect/interconnect_manga_source.dart
+++ b/fushi/lib/src/media/manga/interconnect/interconnect_manga_source.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+
+import 'package:fushi_core/fushi_core.dart';
+
+import 'package:fushi/src/media/manga/library/online_manga_library_entry.dart';
+import 'package:fushi/src/media/manga/library/online_manga_runtime_adapter.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_reader_chapter.dart';
+import 'package:fushi/src/media/manga/interconnect/interconnect_reader_chapter.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+
+/// 互联漫画源里的一部「作品」。
+///
+/// 对端的漫画在本仓是 `EpubBooks` 里 `format=='manga'` 的一行，**一本 = 一卷**、卷内
+/// 无章节结构。所以这里一部作品 = 对端的一本，其唯一一章就是整卷；这与 mokuro 那套
+/// 「一卷一个 `.mokuro`」的现实一致，不为了凑「多章」去猜卷号。
+///
+/// 清单不新开端点：漫画本来就在 `/api/library/books` 里带 `format=='manga'` +
+/// `hasMangaContent` 出现（那两个 additive 字段是互联漫画包批次留下的）。
+class InterconnectMangaCatalog {
+  const InterconnectMangaCatalog(this.backend);
+
+  final InterconnectSyncBackend backend;
+
+  /// 对端库里**有内容可读**的漫画。
+  ///
+  /// `hasMangaContent` 是 host 侧 `hasExportableMangaContent` 的结论（非空页表 + 每页
+  /// 图都在），与页表端点的准入判据同源——所以列出来的每一本都翻得开，不会出现
+  /// BUG-2400 那种「清单说有、点开说没有」的占位空合集。
+  Future<List<RemoteBookInfo>> listSeries() async {
+    final List<RemoteBookInfo> books = await backend.listRemoteBooks();
+    return <RemoteBookInfo>[
+      for (final RemoteBookInfo book in books)
+        if (BookFormat.parseOrEpub(book.format) == BookFormat.manga &&
+            book.hasMangaContent)
+          book,
+    ];
+  }
+
+  /// 把一条对端漫画做成书架条目（加入书架 / 直接开读共用同一份身份推导）。
+  static OnlineMangaLibraryEntry entryFor(RemoteBookInfo book) {
+    // downloadId = bookKey 优先、title 兜底，与 books 端点的路径段取值逐字同源。
+    final String seriesKey = book.downloadId;
+    return OnlineMangaLibraryEntry(
+      runtime: OnlineMangaRuntimeKind.interconnect,
+      extensionPackage: kInterconnectMangaPackage,
+      sourceId: kInterconnectMangaSourceId,
+      series: OnlineMangaSeries(
+        key: seriesKey,
+        // 身份用 title、展示用 displayName：对端用户改过的名字随清单下发，但永不参与
+        // 键推导（BUG-1488 定的身份红线）。
+        title: book.displayName,
+        coverUrl: book.coverUrl,
+        raw: <String, Object?>{
+          'bookKey': seriesKey,
+          'title': book.title,
+          if (book.mangaReadingMode != null)
+            'readingMode': book.mangaReadingMode,
+        },
+      ),
+      chapters: <OnlineMangaChapter>[chapterFor(seriesKey)],
+    );
+  }
+
+  /// 整卷那一章。
+  ///
+  /// [key] 用对端 bookKey 而不是常量 `'volume'`：`manga_chapter_states` 的主键是
+  /// (bookUid, chapterKey)，用书自己的键能保证同一本在任何时候都定位到同一行，也
+  /// 免得将来对端真的分出章节时与旧行撞键。
+  static OnlineMangaChapter chapterFor(String seriesKey) => OnlineMangaChapter(
+        key: seriesKey,
+        name: '',
+        raw: <String, Object?>{'bookKey': seriesKey},
+      );
+}
+
+/// 把已配对的互联对端接进书架 / 作品页 / 阅读器的那条契约实现。
+///
+/// 这是本仓第三个在线漫画运行时（Mihon / Aidoku 之后）。契约本身一行没动——
+/// `OnlineMangaRuntimeAdapter` 的类文档说的就是「加第三个运行时不需要动书架、作品页
+/// 和阅读器任何一行」，这次兑现了它。
+class InterconnectLibraryAdapter implements OnlineMangaRuntimeAdapter {
+  const InterconnectLibraryAdapter({InterconnectSyncBackend? backend})
+      : _backend = backend;
+
+  final InterconnectSyncBackend? _backend;
+
+  InterconnectSyncBackend get backend =>
+      _backend ?? InterconnectSyncBackend.instance;
+
+  @override
+  OnlineMangaRuntimeKind get kind => OnlineMangaRuntimeKind.interconnect;
+
+  /// 五端都可用：互联客户端是纯 Dart HTTP，没有 Mihon 那样的原生宿主门槛，也没有
+  /// Aidoku 那样的 Apple 限制。对端在不在线是**运行时**问题（[refresh] 会如实报错），
+  /// 不是平台支持问题——把它编码成「本平台不支持」会给出完全错误的出路。
+  @override
+  bool get isSupportedOnThisPlatform => true;
+
+  @override
+  Future<String?> sourceLabel(OnlineMangaLibraryEntry entry) async => null;
+
+  @override
+  Future<OnlineMangaRefreshResult> refresh(
+    OnlineMangaLibraryEntry entry,
+  ) async {
+    final RemoteMangaManifest manifest = await _manifest(entry, 'details');
+    return OnlineMangaRefreshResult(
+      series: OnlineMangaSeries(
+        key: entry.series.key,
+        // 标题以对端**当前**清单为准会多要一次 listRemoteBooks；页表里已经带了
+        // 书名，直接用它，空则保留书架上已有的。
+        title: manifest.title.isEmpty ? entry.series.title : manifest.title,
+        coverUrl: entry.series.coverUrl,
+        raw: <String, Object?>{
+          ...entry.series.raw,
+          if (manifest.readingMode != null) 'readingMode': manifest.readingMode,
+        },
+      ),
+      chapters: <OnlineMangaChapter>[
+        InterconnectMangaCatalog.chapterFor(entry.series.key),
+      ],
+    );
+  }
+
+  @override
+  Future<OnlineMangaReaderChapter> openChapter({
+    required OnlineMangaLibraryEntry entry,
+    required OnlineMangaChapter chapter,
+    required Directory managedDirectory,
+    required bool persistProgress,
+    int? initialPage,
+  }) async {
+    final RemoteMangaManifest manifest = await _manifest(entry, 'pages');
+    if (manifest.pages.isEmpty) {
+      throw const OnlineMangaUnavailable(
+        OnlineMangaUnavailableReason.runtimeFailure,
+        'The peer returned a manga volume with no pages',
+        stage: 'pages',
+      );
+    }
+    return InterconnectReaderChapter(
+      backend: backend,
+      bookKey: manifest.bookKey.isEmpty ? entry.series.key : manifest.bookKey,
+      title: manifest.title.isEmpty ? entry.series.title : manifest.title,
+      pages: manifest.pages,
+      managedDirectory: managedDirectory,
+      persistProgress: persistProgress,
+      initialPage: initialPage,
+    );
+  }
+
+  /// 封面走对端清单里已经带好的绝对 `coverUrl`（host 按 client 实际请求地址回填，
+  /// 与指纹钉扎一致），因此复用互联自己的封面通道——**不能**用裸 HTTP：自签证书的
+  /// 对端需要 `badCertificateCallback`，普通 client 拿不到。
+  @override
+  Future<List<int>> fetchCover(
+    OnlineMangaLibraryEntry entry,
+    String url,
+  ) async {
+    try {
+      return await backend.fetchRemoteCover(url);
+    } on Object catch (error) {
+      throw OnlineMangaUnavailable(
+        OnlineMangaUnavailableReason.runtimeFailure,
+        '$error',
+        cause: error,
+        stage: 'cover',
+      );
+    }
+  }
+
+  Future<RemoteMangaManifest> _manifest(
+    OnlineMangaLibraryEntry entry,
+    String stage,
+  ) async {
+    try {
+      return await backend.remoteMangaManifest(entry.series.key);
+    } on MangaInterconnectUnsupported catch (error) {
+      // 对端能力缺失 ≠ 这一本坏了：分类成 sourceDisabled，作品页据此引导用户去升级
+      // 对端 / 打开对端的库服务，而不是给一个永远不会成功的「重试」。
+      throw OnlineMangaUnavailable(
+        OnlineMangaUnavailableReason.sourceDisabled,
+        '$error',
+        cause: error,
+        stage: stage,
+      );
+    } on Object catch (error) {
+      throw OnlineMangaUnavailable(
+        OnlineMangaUnavailableReason.runtimeFailure,
+        '$error',
+        cause: error,
+        stage: stage,
+      );
+    }
+  }
+}

--- a/fushi/lib/src/media/manga/interconnect/interconnect_manga_source_row.dart
+++ b/fushi/lib/src/media/manga/interconnect/interconnect_manga_source_row.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fushi/src/media/manga/interconnect/interconnect_manga_browse_page.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi/utils.dart';
+
+/// 「Fushi 互联」在漫画「来源」一节里的一行（与 [MokuroMoeSourceRow] 同构、同级）。
+///
+/// 开关**刻意不在这里**：互联总开关是全应用一个（同步设置页、本地扫描根那一节都能
+/// 改），在漫画源里再放一个会让用户以为它只管漫画。这一行只反映它当前是不是开着，
+/// 关着时禁用并直说去哪儿开——与 mokuro.moe 那种「源自己的开关」不是一回事。
+///
+/// 订阅 [SyncRepository.interconnectEnabledRevision] 的理由与 `MediaSourcesView`
+/// 一致（BUG-1560）：总开关的另一个写入口在同步设置页，不订阅这条广播的话，从那里
+/// 打开互联后回到本页仍是旧状态。
+class InterconnectMangaSourceRow extends ConsumerStatefulWidget {
+  const InterconnectMangaSourceRow({super.key});
+
+  @override
+  ConsumerState<InterconnectMangaSourceRow> createState() =>
+      _InterconnectMangaSourceRowState();
+}
+
+class _InterconnectMangaSourceRowState
+    extends ConsumerState<InterconnectMangaSourceRow> {
+  bool? _enabled;
+
+  @override
+  void initState() {
+    super.initState();
+    SyncRepository.interconnectEnabledRevision.addListener(_onChanged);
+    unawaited(_reload());
+  }
+
+  @override
+  void dispose() {
+    SyncRepository.interconnectEnabledRevision.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  void _onChanged() => unawaited(_reload());
+
+  Future<void> _reload() async {
+    final AppModel appModel = ref.read(appProvider);
+    final bool value = await SyncRepository(
+      appModel.database,
+    ).isInterconnectEnabled();
+    if (!mounted || _enabled == value) return;
+    setState(() => _enabled = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool enabled = _enabled ?? false;
+    return FushiCard(
+      padding: EdgeInsets.zero,
+      child: FushiListItem(
+        key: const ValueKey<String>('manga_source_interconnect'),
+        leading: const Icon(Icons.devices_outlined),
+        title: Text(t.audio_source_fushi_interconnect),
+        subtitle: Text(
+          enabled
+              ? t.manga_source_interconnect_subtitle
+              : t.manga_source_interconnect_disabled,
+        ),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: enabled
+            ? () => Navigator.of(context).push(
+                  adaptivePageRoute<void>(
+                    context: context,
+                    builder: (BuildContext context) =>
+                        const InterconnectMangaBrowsePage(),
+                  ),
+                )
+            : null,
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/interconnect/interconnect_reader_chapter.dart
+++ b/fushi/lib/src/media/manga/interconnect/interconnect_reader_chapter.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi/src/media/manga/mihon/manga_page_provider.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_reader_chapter.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+import 'package:fushi/src/utils/misc/error_log_service.dart';
+
+/// 对端一卷漫画，交给本仓共享的漫画阅读器。
+///
+/// 因为走的是同一个 [OnlineMangaReaderChapter] 契约，在线读对端漫画与读 Mihon /
+/// Aidoku 源共用 OCR、查词制卡、跨页/条漫版式、缩放、快捷键、统计与进度——本类
+/// 不含任何阅读 UI。
+class InterconnectReaderChapter extends OnlineMangaReaderChapter {
+  const InterconnectReaderChapter({
+    required this.backend,
+    required this.bookKey,
+    required this.title,
+    required this.pages,
+    required this.managedDirectory,
+    required this.persistProgress,
+    this.initialPage,
+  });
+
+  final InterconnectSyncBackend backend;
+
+  /// 对端 `epub_books.bookKey`，也是页图端点的路径段。
+  final String bookKey;
+
+  @override
+  final String title;
+
+  final List<RemoteMangaPageInfo> pages;
+
+  @override
+  final Directory managedDirectory;
+
+  @override
+  final bool persistProgress;
+
+  @override
+  final int? initialPage;
+
+  /// 对端库里的漫画没有「源语言」这一维（那是扩展源 manifest 的概念），返回 null 让
+  /// 消费方回退用户偏好——Lens OCR 本来就这么兜底。
+  @override
+  String? get sourceLanguage => null;
+
+  @override
+  String? get author => null;
+
+  @override
+  int get pageCount => pages.length;
+
+  /// 页缓存身份。
+  ///
+  /// 掺进 [InterconnectSyncBackend.coverCacheNamespace]（配对凭据哈希）而不是对端
+  /// 地址：换 IP 不该让整卷缓存作废，换对端则必须——两台机器上同名同页序的书不是
+  /// 同一份内容，共用缓存会让另一台的页图串味显示。
+  @override
+  List<String> get pageIdentities => <String>[
+        for (final RemoteMangaPageInfo page in pages)
+          sha256
+              .convert(
+                utf8.encode(
+                  <String>[
+                    backend.coverCacheNamespace,
+                    bookKey,
+                    '${page.index}',
+                    page.name,
+                  ].join(''),
+                ),
+              )
+              .toString(),
+      ];
+
+  @override
+  String get identityFileName => '.interconnect-chapter.json';
+
+  @override
+  Future<MangaReaderSession> openPageSession() => InterconnectMangaPageProvider(
+        backend: backend,
+        bookKey: bookKey,
+        pages: pages,
+        identities: pageIdentities,
+        cacheRoot: Directory(p.join(managedDirectory.path, 'page-cache')),
+      ).open();
+}
+
+/// 逐页向对端要图，落一份磁盘缓存。
+///
+/// 与 Aidoku 那条 HTTP 取图路径同构，但**不自己造 HTTP client**：互联对端可能是自签
+/// 证书 + TOFU 指纹钉扎，只有 [InterconnectSyncBackend] 手上那条会话带得动
+/// `badCertificateCallback` 与 Basic 凭据。裸 `http.Client` 在钉扎对端上必然握手失败。
+class InterconnectMangaPageProvider implements MangaPageProvider {
+  const InterconnectMangaPageProvider({
+    required this.backend,
+    required this.bookKey,
+    required this.pages,
+    required this.identities,
+    required this.cacheRoot,
+  });
+
+  final InterconnectSyncBackend backend;
+  final String bookKey;
+  final List<RemoteMangaPageInfo> pages;
+  final List<String> identities;
+  final Directory cacheRoot;
+
+  @override
+  Future<MangaReaderSession> open() async {
+    await cacheRoot.create(recursive: true);
+    return _InterconnectMangaReaderSession(
+      backend: backend,
+      bookKey: bookKey,
+      pages: pages,
+      identities: identities,
+      cacheRoot: cacheRoot,
+    );
+  }
+}
+
+class _InterconnectMangaReaderSession implements MangaReaderSession {
+  _InterconnectMangaReaderSession({
+    required this.backend,
+    required this.bookKey,
+    required this.pages,
+    required this.identities,
+    required this.cacheRoot,
+  });
+
+  final InterconnectSyncBackend backend;
+  final String bookKey;
+  final List<RemoteMangaPageInfo> pages;
+  final List<String> identities;
+  final Directory cacheRoot;
+
+  /// 同一页的并发请求合并成一次下载（翻页 + 预取会同时点到同一页）。
+  final Map<int, Future<File>> _inFlight = <int, Future<File>>{};
+  bool _closed = false;
+
+  @override
+  int get pageCount => pages.length;
+
+  @override
+  Future<MangaPageBytes> page(int index) async {
+    final File file = await _file(index);
+    final Uint8List bytes = await file.readAsBytes();
+    final ({int width, int height})? dimensions = await mangaImageDimensions(
+      bytes,
+    );
+    return MangaPageBytes(
+      bytes: bytes,
+      contentType: mangaImageContentType(bytes),
+      // 尺寸以**真实字节**为准，页表里对端报的尺寸只在解不出来时兜底：mokuro 的
+      // 尺寸是 OCR 生产者报告的，与磁盘上的图未必逐像素一致，而 OCR 命中区判定
+      // 用的就是这个尺寸，取错会让整页文本框整体偏移。
+      width: dimensions?.width ?? _page(index).width,
+      height: dimensions?.height ?? _page(index).height,
+    );
+  }
+
+  @override
+  Future<File?> localFile(int index) => _file(index);
+
+  @override
+  String cacheIdentity(int index) => identities[index];
+
+  @override
+  Future<void> prefetchAround(int index) async {
+    final List<Future<File>> work = <Future<File>>[];
+    for (int candidate = index - 2; candidate <= index + 2; candidate++) {
+      if (candidate >= 0 && candidate < pages.length && candidate != index) {
+        work.add(_file(candidate));
+      }
+    }
+    // 预取失败绝不能冒泡：它是后台预热，把它变成异常等于让相邻页的网络抖动打断
+    // 当前这一页的正常阅读。
+    await Future.wait<void>(
+      work.map(
+        (Future<File> future) => future.then<void>((File _) {},
+            onError: (
+              Object error,
+              StackTrace stack,
+            ) {}),
+      ),
+    );
+  }
+
+  RemoteMangaPageInfo _page(int index) {
+    if (_closed) {
+      throw StateError('The interconnect manga reader session is closed');
+    }
+    if (index < 0 || index >= pages.length) {
+      throw RangeError.index(index, pages, 'index');
+    }
+    return pages[index];
+  }
+
+  Future<File> _file(int index) {
+    _page(index);
+    return _inFlight.putIfAbsent(index, () async {
+      try {
+        final File target = File(
+          p.join(cacheRoot.path, '${identities[index]}.img'),
+        );
+        if (await target.exists() && await target.length() > 0) return target;
+        final Uint8List bytes = await backend.fetchRemoteMangaPage(
+          bookKey,
+          pages[index].index,
+        );
+        if (bytes.isEmpty) {
+          throw StateError(
+              'Peer returned an empty manga page: $bookKey#$index');
+        }
+        // 先写 .tmp 再 rename：半截文件被下一次 `exists && length > 0` 当成有效缓存
+        // 就是一页永久坏图（与 Mihon / Aidoku 两条缓存路径同一纪律）。
+        final File staged = File('${target.path}.tmp');
+        await staged.writeAsBytes(bytes, flush: true);
+        await staged.rename(target.path);
+        return target;
+      } on Object catch (error, stack) {
+        ErrorLogService.instance.log(
+          'InterconnectReader.page[$index] $bookKey',
+          error,
+          stack,
+        );
+        rethrow;
+      } finally {
+        _inFlight.remove(index);
+      }
+    });
+  }
+
+  @override
+  Future<void> close() async {
+    _closed = true;
+  }
+}

--- a/fushi/lib/src/media/manga/library/online_manga_library_entry.dart
+++ b/fushi/lib/src/media/manga/library/online_manga_library_entry.dart
@@ -8,7 +8,13 @@ import 'package:flutter/foundation.dart';
 /// 用户库里的 `sourceMetadata` JSON。
 enum OnlineMangaRuntimeKind {
   mihon('mihon'),
-  aidoku('aidoku');
+  aidoku('aidoku'),
+
+  /// 已配对的互联对端（把对端漫画库当成一个源，按页在线读）。
+  ///
+  /// 它没有「扩展包」，`extensionPackage` 恒是 [kInterconnectMangaPackage]、
+  /// `sourceId` 恒是对端库那一维的常量，`seriesKey` = 对端 `bookKey`。
+  interconnect('interconnect');
 
   const OnlineMangaRuntimeKind(this.wireValue);
 
@@ -21,6 +27,23 @@ enum OnlineMangaRuntimeKind {
     return null;
   }
 }
+
+/// 互联漫画源在书架身份里占的「扩展包」位。
+///
+/// 互联源没有扩展包，但 [OnlineMangaLibraryService.bookKeyFor] 的身份三元组
+/// （包 / 源 / 作品）是**存量键推导**，不能为了这一个源改形状——那会让所有已入库的
+/// 在线漫画变成找不到的孤儿。所以这里给一个固定占位值，让三元组保持原样。
+///
+/// ⚠️ 值已进用户库的 `epub_books.bookKey` 与磁盘目录名，**永不可改**。
+const String kInterconnectMangaPackage = 'fushi.interconnect';
+
+/// 互联漫画源在书架身份里占的「源 id」位。
+///
+/// 恒定而不含对端地址：换 IP / 重新配对不该让书架条目全部失配（对端身份变化由
+/// `InterconnectSyncBackend.sessionIdentityRevision` 驱动缓存失效，不由键表达）。
+///
+/// ⚠️ 同样已进 bookKey，**永不可改**。
+const String kInterconnectMangaSourceId = 'library';
 
 /// 归一化后的章节。
 ///

--- a/fushi/lib/src/media/manga/manga_sources_page.dart
+++ b/fushi/lib/src/media/manga/manga_sources_page.dart
@@ -18,6 +18,7 @@ import 'package:fushi/src/media/manga/mihon/mihon_extensions_page.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_manager.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_models.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_runtime_factory.dart';
+import 'package:fushi/src/media/manga/interconnect/interconnect_manga_source_row.dart';
 import 'package:fushi/src/media/manga/online/mokuro_moe_source_row.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/pages/implementations/media_sources_view.dart';
@@ -970,6 +971,10 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
                             const SizedBox(height: 8),
                             // 内置在线源：与扩展提供的源同节同级（见类文档）。
                             const MokuroMoeSourceRow(),
+                            const SizedBox(height: 8),
+                            // 已配对互联对端的漫画库也是一个「在线源」：不下整卷，
+                            // 直接在对端上翻页（Suwayomi 作为 Tachiyomi 源的形态）。
+                            const InterconnectMangaSourceRow(),
                             if (manager == null) _unavailableNote(),
                           ],
                         ),

--- a/fushi/lib/src/media/manga/manga_storage.dart
+++ b/fushi/lib/src/media/manga/manga_storage.dart
@@ -115,4 +115,47 @@ class MangaStorage {
   /// [File]。用于落盘与封面定位。
   static File destFile(String bookDir, String destRel) =>
       File(p.joinAll(<String>[bookDir, ...destRel.split('/')]));
+
+  /// 书目录（`extractDir`）下的页图根：`<bookDir>/images`。
+  ///
+  /// 阅读器算的是 `dirname(extractDir/epubPath)/images`，而 `epubPath` 恒是书目录
+  /// 直属的 [kMangaJsonFileName]，两者等价。互联 host 供图时也必须落在这个根内。
+  static Directory imagesDirectory(String bookDir) =>
+      Directory(p.join(bookDir, kImagesDirName));
+
+  /// `manga.json` 里的 `url` → 相对 [imagesDirectory] 的正斜杠路径。
+  ///
+  /// 本仓两种存量写法都要吃：本仓导入器写的是含 `images/` 前缀的相对路径，旧版
+  /// `.mokuro` 直接写 `foo.jpg`。
+  static String pageRelativePath(String storedUrl) {
+    String normalized = storedUrl.replaceAll(r'\', '/');
+    while (normalized.startsWith('./')) {
+      normalized = normalized.substring(2);
+    }
+    if (normalized.toLowerCase().startsWith('$kImagesDirName/')) {
+      return normalized.substring(kImagesDirName.length + 1);
+    }
+    return normalized;
+  }
+
+  /// 纯路径解析 + 穿越守卫：[relative] 在 [imagesRoot] 内解析到**存在的**文件时返回
+  /// 规范绝对路径（保留磁盘真实大小写），越界或缺文件一律 null。
+  ///
+  /// BUG-1221 的两种路径形式必须并存：越界判定用 `p.canonicalize`（Windows 上整体
+  /// 小写化，`../` 逃逸不会被大小写差异绕过），返回值用 `p.absolute` + `p.normalize`
+  /// （同样绝对化并折叠 `.`/`..`，但保留大小写——返回值会流出本次读取，被制卡当作
+  /// Anki 封面源路径，小写化会让大小写敏感平台上 `existsSync` 直接 false）。
+  ///
+  /// 归位到本层（原先是阅读器 widget 的静态方法）是因为互联 host 供图必须用**同一条**
+  /// 穿越守卫：安全边界靠复制粘贴维持，抄漏一处就是真漏洞。
+  static String? resolvePageFilePath(String imagesRoot, String relative) {
+    final String decoded = Uri.decodeComponent(relative);
+    final String joined = p.join(imagesRoot, decoded);
+    if (!p.isWithin(p.canonicalize(imagesRoot), p.canonicalize(joined))) {
+      return null;
+    }
+    final String filePath = p.normalize(p.absolute(joined));
+    if (!File(filePath).existsSync()) return null;
+    return filePath;
+  }
 }

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -29,6 +29,7 @@ import 'package:fushi/src/ocr/system_ocr_channel.dart'
     show SystemOcrUnavailableException;
 import 'package:fushi/src/media/manga/manga_overlay_html.dart';
 import 'package:fushi/src/media/manga/manga_reading_mode.dart';
+import 'package:fushi/src/media/manga/manga_storage.dart';
 import 'package:fushi/src/media/manga/manga_reading_stats.dart';
 import 'package:fushi/src/media/manga/manga_view_prefs.dart';
 import 'package:fushi/src/media/manga/manga_spread_model.dart';
@@ -563,17 +564,8 @@ class MangaFushiPage extends BaseSourcePage {
   ///
   /// 注意比 EPUB 侧多一个 `p.absolute`：本函数的契约是返回**绝对**路径，而
   /// `p.normalize` 与 `canonicalize` 不同、**不会**绝对化。
-  static String? resolveMangaResource(String imagesRoot, String relative) {
-    final String decoded = Uri.decodeComponent(relative);
-    final String joined = p.join(imagesRoot, decoded);
-    if (!p.isWithin(p.canonicalize(imagesRoot), p.canonicalize(joined))) {
-      return null;
-    }
-    final String filePath = p.normalize(p.absolute(joined));
-    final File file = File(filePath);
-    if (!file.existsSync()) return null;
-    return filePath;
-  }
+  static String? resolveMangaResource(String imagesRoot, String relative) =>
+      MangaStorage.resolvePageFilePath(imagesRoot, relative);
 
   /// 纯函数：`manga.local` 图片 URL → 树内文件路径；host 不对/越界/缺文件 → null。
   static String? resolveImageUrlToFile(String imagesRoot, String imgUrl) {
@@ -587,16 +579,8 @@ class MangaFushiPage extends BaseSourcePage {
   /// 将 manga.json 中相对漫画根目录的 `images/foo.jpg` 转为相对
   /// [_imagesDir]（其本身已经是 `<book>/images`）的 `foo.jpg`。旧版
   /// `.mokuro` 直接保存 `foo.jpg`，因此两种格式都要兼容。
-  static String mangaImageRelativePath(String storedUrl) {
-    String normalized = storedUrl.replaceAll(r'\', '/');
-    while (normalized.startsWith('./')) {
-      normalized = normalized.substring(2);
-    }
-    if (normalized.toLowerCase().startsWith('images/')) {
-      return normalized.substring('images/'.length);
-    }
-    return normalized;
-  }
+  static String mangaImageRelativePath(String storedUrl) =>
+      MangaStorage.pageRelativePath(storedUrl);
 
   /// Resolve the exact image for a 0-based manga [pageIndex].
   ///

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -62,6 +62,7 @@ import 'package:fushi/src/models/dictionary_repository.dart';
 import 'package:fushi/src/models/media_history_repository.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/media/manga/library/online_manga_library_entry.dart';
+import 'package:fushi/src/media/manga/interconnect/interconnect_manga_source.dart';
 import 'package:fushi/src/media/manga/library/online_manga_library_service.dart';
 import 'package:fushi/src/media/manga/library/online_manga_runtime_adapter.dart';
 import 'package:fushi/src/media/manga/manga_ocr_provider.dart';
@@ -3975,8 +3976,22 @@ class AppModel with ChangeNotifier {
           rootDirectory: aidokuLibraryRoot,
           adapter: AidokuLibraryAdapter(),
         );
+      // 互联对端同样不碰 [mihonManager]：它五端都可用，而 mihonManager 在
+      // iOS/Linux 上直接抛 UnsupportedError。
+      case OnlineMangaRuntimeKind.interconnect:
+        return OnlineMangaLibraryService(
+          database: database,
+          rootDirectory: interconnectMangaLibraryRoot,
+          adapter: const InterconnectLibraryAdapter(),
+        );
     }
   }
+
+  /// 互联漫画源书架条目的本地落盘根（占位 manga.json、封面、章节页缓存）。
+  ///
+  /// 与 Aidoku 的根平级、各自独立：删一个源的缓存不该波及另一个。
+  Directory get interconnectMangaLibraryRoot =>
+      Directory(path.join(databaseDirectory.path, 'interconnect_manga'));
 
   /// Aidoku 书架条目的本地落盘根（占位 manga.json、封面、章节页缓存）。
   ///

--- a/fushi/lib/src/sync/fushi_library_host_service.dart
+++ b/fushi/lib/src/sync/fushi_library_host_service.dart
@@ -702,6 +702,130 @@ class RemoteBookProgress {
       );
 }
 
+/// 互联漫画源：对端一卷漫画的**页表**（`GET /api/library/manga/<bookKey>/manifest`）。
+///
+/// 漫画在本仓是 `EpubBooks` 里 `format=='manga'` 的一行，磁盘布局
+/// `<extractDir>/{manga.json, images/…}`，**一本 = 一卷**、卷内无章节。所以互联漫画源
+/// 把「一本」映射成「一部作品的唯一一章」，页表就是 `manga.json` 的 `pages` 顺序。
+///
+/// 刻意**不带 OCR 文本框**：mokuro 的 blocks 一卷可达数 MB，而在线漫画阅读器
+/// （`MangaFushiPage` 的 onlineChapter 路径）本来就走它自己的在线 OCR 链路。复用对端
+/// 已有的 blocks 是独立议题（要动共享阅读器的 OCR 入口），不在本端点契约里。
+class RemoteMangaManifest {
+  const RemoteMangaManifest({
+    required this.bookKey,
+    required this.title,
+    required this.pages,
+    this.readingMode,
+  });
+
+  /// 对端 `epub_books.bookKey`：既是清单里的身份，也是页图端点的路径段。
+  final String bookKey;
+  final String title;
+
+  /// 对端该书的按本阅读模式（`'spread'|'webtoon'`；null = 跟随自动判定）。
+  final String? readingMode;
+
+  final List<RemoteMangaPageInfo> pages;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'bookKey': bookKey,
+        'title': title,
+        if (readingMode != null) 'readingMode': readingMode,
+        'pages': <Map<String, Object?>>[
+          for (final RemoteMangaPageInfo page in pages) page.toJson(),
+        ],
+      };
+
+  static RemoteMangaManifest fromJson(Map<String, Object?> json) {
+    final Object? rawPages = json['pages'];
+    return RemoteMangaManifest(
+      bookKey: json['bookKey']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      readingMode: json['readingMode']?.toString(),
+      pages: <RemoteMangaPageInfo>[
+        if (rawPages is List<Object?>)
+          for (final Object? page in rawPages)
+            if (page is Map<Object?, Object?>)
+              RemoteMangaPageInfo.fromJson(page.cast<String, Object?>()),
+      ],
+    );
+  }
+}
+
+/// [RemoteMangaManifest] 里的一页。
+///
+/// [width]/[height] 是 `manga.json` 里 OCR 生产者报告的像素尺寸（**不是**解码图片得
+/// 到的），可能缺失（0）——阅读器对在线章节本来就先用中性尺寸 bootstrap、再按真实
+/// 字节纠正，所以缺失不影响正确性，只是少一次几何预热。
+class RemoteMangaPageInfo {
+  const RemoteMangaPageInfo({
+    required this.index,
+    required this.name,
+    this.width = 0,
+    this.height = 0,
+  });
+
+  /// 0 基页序，同时是页图端点的路径段。
+  final int index;
+
+  /// 页图在对端 `images/` 下的正斜杠相对路径。**仅供展示与缓存身份**，client 绝不
+  /// 拿它拼路径读盘——取图恒走 [index] 端点，路径解析留在 host 侧那一道穿越守卫里。
+  final String name;
+
+  final int width;
+  final int height;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'index': index,
+        'name': name,
+        if (width > 0) 'width': width,
+        if (height > 0) 'height': height,
+      };
+
+  static RemoteMangaPageInfo fromJson(Map<String, Object?> json) =>
+      RemoteMangaPageInfo(
+        index: _jsonInt(json['index']) ?? 0,
+        name: json['name']?.toString() ?? '',
+        width: _jsonInt(json['width']) ?? 0,
+        height: _jsonInt(json['height']) ?? 0,
+      );
+}
+
+/// 对端不提供互联漫画源（老版本 Fushi，或库服务关着）。
+///
+/// 与「这本书读不出来」严格分开：前者是**对端能力**问题，出路是让对端升级 / 打开
+/// 库服务；后者是这一本的问题，出路是换一本。混成一句「加载失败 + 重试」会让用户对着
+/// 一个永远不会成功的按钮反复重试（`OnlineMangaUnavailableReason` 分类的同一教训）。
+class MangaInterconnectUnsupported implements Exception {
+  const MangaInterconnectUnsupported();
+
+  @override
+  String toString() =>
+      'MangaInterconnectUnsupported: the paired peer does not serve manga pages';
+}
+
+/// 互联漫画源的 host 能力（**可选**，与 [FushiLibraryHostService] 分开声明）。
+///
+/// 分开是本仓对可选能力的既定范式（`AudiobookDelayHost` / `InterconnectServiceConfigHost`
+/// / `VideoDeletionHost` 同款）：server 用 `is MangaLibraryHost` 协商，没实现的 host
+/// 一律 404 且 `/api/capabilities` 不报 `manga` 位。塞进主接口会把它变成必需能力——
+/// 十几个只关心自己那一域的实现（含测试替身）会被迫实现两个与它们无关的方法，而
+/// 「这台 host 不供漫画页」本来就是一种合法状态，不该用抛异常的桩来表达。
+abstract interface class MangaLibraryHost {
+  /// host 端漫画 [bookKey] 的页表（互联漫画源按页在线阅读，不必先下整卷）。
+  ///
+  /// 该书不存在、不是漫画、或没有可读内容（占位合集 / 缺 `manga.json` / 空页表）时抛
+  /// [StateError] → 端点 404。[bookKey] 含路径穿越字符时抛 [ArgumentError]。
+  Future<RemoteMangaManifest> mangaManifest(String bookKey);
+
+  /// host 端漫画 [bookKey] 第 [index] 页（0 基）的页图文件。
+  ///
+  /// 越界、缺文件、或解析出的路径逃出该书 `images/` 目录时抛 [StateError] → 端点 404
+  /// （穿越只在 host 侧这一道守卫上判，client 永远不参与路径解析）。
+  Future<File> mangaPageFile(String bookKey, int index);
+}
+
 /// 书籍阅读进度跨设备冲突解决（TODO-767）——「取较新时间戳」last-write-wins，
 /// 与视频/有声书统一的单维 LWW [resolvePositionLww] 同范式（取较新者；时间戳相等时
 /// 取「读得更远」者）。本函数是其双维（sectionIndex + normCharOffset）变体，且胜者

--- a/fushi/lib/src/sync/fushi_sync_server.dart
+++ b/fushi/lib/src/sync/fushi_sync_server.dart
@@ -499,6 +499,9 @@ class FushiSyncServer {
         reqPath.startsWith('/api/library/books/')) {
       return _handleLibraryBooks(request, method, reqPath);
     }
+    if (reqPath.startsWith('/api/library/manga/')) {
+      return _handleLibraryManga(request, method, reqPath);
+    }
     if (reqPath == '/api/library/localaudio' ||
         reqPath.startsWith('/api/library/localaudio/')) {
       return _handleLibraryLocalAudio(request, method, reqPath);

--- a/fushi/lib/src/sync/fushi_sync_server/library.part.dart
+++ b/fushi/lib/src/sync/fushi_sync_server/library.part.dart
@@ -265,6 +265,80 @@ extension _FushiSyncServerLibrary on FushiSyncServer {
     return _coverFile(await service.bookCoverPath(bookId));
   }
 
+  /// 互联漫画源：页表 + 按页取图（**只读**，GET only）。
+  ///
+  /// 两条路径都在 `/api/library/manga/<bookKey>/` 下：
+  /// * `…/manifest` → [RemoteMangaManifest]（一本 = 一卷 = 一章的页表）
+  /// * `…/pages/<index>` → 该页图字节（`serveFileWithRange`，与封面 / 视频同款）
+  ///
+  /// 与书域 `/api/library/books/<id>` 的整卷 zip 下载**并存不重叠**：那条是「把这本
+  /// 搬过来」，这条是「我在你那儿翻页」。老 host 没有本路径 → 404，新 client 据此
+  /// 显示「对端版本过低」，不会退化成静默空列表。
+  ///
+  /// 鉴权：走 [_authMiddleware] 的常规 Basic（与词典 / 书 / 封面同门槛），**没有**视频
+  /// `…/stream?token=` 那种豁免——页图由 client 自己的 HTTP 栈按序取，不经外部播放器，
+  /// 不需要可外泄的短时 token。
+  Future<shelf.Response> _handleLibraryManga(
+    shelf.Request request,
+    String method,
+    String reqPath,
+  ) async {
+    if (_libraryService == null) {
+      return shelf.Response.notFound('Library service off');
+    }
+    // 能力协商（`is MangaLibraryHost`）与 `/api/capabilities` 的 `manga` 位同一判据。
+    // 声明成 Object? 是为了让 `is!` 真的收窄类型——`MangaLibraryHost` 不是
+    // `FushiLibraryHostService` 的子类型，对后者的变量做 `is!` 不产生类型提升。
+    final Object svc = _libraryService;
+    if (svc is! MangaLibraryHost) {
+      return shelf.Response.notFound('Manga library not available');
+    }
+    if (method != 'GET') return shelf.Response(405);
+
+    const String prefix = '/api/library/manga/';
+    final String rest = reqPath.substring(prefix.length);
+    const String manifestSuffix = '/manifest';
+    const String pagesMarker = '/pages/';
+
+    if (rest.endsWith(manifestSuffix)) {
+      final String bookKey =
+          rest.substring(0, rest.length - manifestSuffix.length);
+      final shelf.Response? unsafe = _rejectUnsafeAssetId(bookKey, 'book key');
+      if (unsafe != null) return unsafe;
+      try {
+        final RemoteMangaManifest manifest = await svc.mangaManifest(bookKey);
+        return shelf.Response.ok(
+          jsonEncode(manifest.toJson()),
+          headers: <String, String>{'Content-Type': 'application/json'},
+        );
+      } on StateError {
+        return shelf.Response.notFound('Manga not found');
+      } on ArgumentError {
+        return shelf.Response.forbidden('Invalid book key');
+      }
+    }
+
+    final int marker = rest.indexOf(pagesMarker);
+    if (marker > 0) {
+      final String bookKey = rest.substring(0, marker);
+      final shelf.Response? unsafe = _rejectUnsafeAssetId(bookKey, 'book key');
+      if (unsafe != null) return unsafe;
+      final int? index =
+          int.tryParse(rest.substring(marker + pagesMarker.length));
+      if (index == null) return shelf.Response.notFound('Missing page index');
+      try {
+        final File page = await svc.mangaPageFile(bookKey, index);
+        return serveFileWithRange(page, request);
+      } on StateError {
+        return shelf.Response.notFound('Manga page not found');
+      } on ArgumentError {
+        return shelf.Response.forbidden('Invalid book key');
+      }
+    }
+
+    return shelf.Response.notFound('Unknown manga route');
+  }
+
   Future<shelf.Response> _handleLibraryLocalAudio(
     shelf.Request request,
     String method,

--- a/fushi/lib/src/sync/fushi_sync_server/pairing.part.dart
+++ b/fushi/lib/src/sync/fushi_sync_server/pairing.part.dart
@@ -349,6 +349,10 @@ extension _FushiSyncServerPairing on FushiSyncServer {
         'books': lib,
         'audio': lib,
         'videos': lib,
+        // 互联漫画源（按页在线阅读，`/api/library/manga/**`）。老 host 无此字段 →
+        // client 的漫画「来源」页把这一行标成「对端版本过低」，而不是让用户点进去
+        // 对着一屏 404 反复重试。与既有 `mangaOcr` 能力位同一范式。
+        'manga': _libraryService is MangaLibraryHost,
         'serviceConfig': _securityContext != null &&
             _libraryService is InterconnectServiceConfigHost,
         // 互联「配置文件」（Profile）双向搬运：与 serviceConfig 同门槛（必须 TLS）。

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -1045,6 +1045,64 @@ class InterconnectSyncBackend extends SyncBackend
     _ops!.checkStatus(res.statusCode, 'PUT /api/library/books/$title');
   }
 
+  // ── 互联漫画源（按页在线阅读）────────────────────────────────────────
+  // 与上面的 books 通道**并存不重叠**：那条搬的是整卷 zip（「把这本搬过来」），
+  // 这条搬的是页（「我在你那儿翻页」）。作品清单**不新开端点**——漫画本来就在
+  // `/api/library/books` 里带 `format=='manga'` + `hasMangaContent` 出现。
+
+  /// 对端漫画 [bookKey] 的页表。
+  ///
+  /// 老 host（没有 `/api/library/manga/**`）与关掉库服务的 host 都返回 404，这里
+  /// 统一抛 [MangaInterconnectUnsupported]，由源页翻译成「对端 Fushi 版本过低」，
+  /// 而不是退化成一本没有页的空章节让阅读器对着空白转圈。
+  Future<RemoteMangaManifest> remoteMangaManifest(String bookKey) async {
+    await _ensureResolved();
+    final String path =
+        '/api/library/manga/${Uri.encodeComponent(bookKey)}/manifest';
+    final HttpClientRequest req =
+        await _ops!.buildRequest('GET', '$_apiBase$path');
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      throw const MangaInterconnectUnsupported();
+    }
+    if (res.statusCode >= 400) {
+      _ops!.checkStatus(
+        res.statusCode,
+        'GET $path',
+        serverReason: await readSyncErrorBody(res),
+      );
+    }
+    final String body = await _readBodyBounded(res);
+    final Object? decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      throw const FormatException('Invalid manga manifest response');
+    }
+    return RemoteMangaManifest.fromJson(decoded.cast<String, Object?>());
+  }
+
+  /// 取对端漫画 [bookKey] 第 [index] 页（0 基）的页图字节。
+  ///
+  /// 走 [requestTimeout] 封顶而不是大文件那套 stall 超时：一页图是几百 KB 量级，
+  /// 且阅读器等着它渲染——挂住不如尽早失败让上层重试。
+  Future<Uint8List> fetchRemoteMangaPage(String bookKey, int index) async {
+    await _ensureResolved();
+    final String path =
+        '/api/library/manga/${Uri.encodeComponent(bookKey)}/pages/$index';
+    final HttpClientRequest req =
+        await _ops!.buildRequest('GET', '$_apiBase$path');
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      throw const MangaInterconnectUnsupported();
+    }
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      await res.drain<void>();
+      throw SyncBackendError('GET $path -> ${res.statusCode}');
+    }
+    return consolidateHttpClientResponseBytes(res).timeout(requestTimeout);
+  }
+
   /// 通知对端 host 删除书名为 [title] 的书。
   Future<void> deleteRemoteBook(String title) async {
     await _ensureResolved();

--- a/fushi/lib/src/sync/local_library_host_service.dart
+++ b/fushi/lib/src/sync/local_library_host_service.dart
@@ -25,8 +25,11 @@ import 'package:fushi/src/media/video/series_playback_prefs.dart'
         effectiveSeriesAudioTrackId,
         effectiveSeriesDelayMs,
         effectiveSeriesSecondaryDelayMs;
+import 'package:fushi/src/media/manga/manga_storage.dart' show MangaStorage;
+import 'package:fushi/src/media/manga/mokuro_payload.dart'
+    show MokuroPayload, parseMangaJson;
 import 'package:fushi/src/sync/manga_sync_package.dart'
-    show hasExportableMangaContent, repackageMangaBook;
+    show hasExportableMangaContent, kMangaPackageMarker, repackageMangaBook;
 import 'package:fushi/src/stats/stat_facts.dart';
 import 'package:fushi/src/sync/aggregate_snapshot.dart';
 import 'package:fushi/src/sync/override_title_lookup.dart';
@@ -52,6 +55,7 @@ import 'package:path/path.dart' as p;
 
 part 'local_library_host_service/dictionaries.part.dart';
 part 'local_library_host_service/books.part.dart';
+part 'local_library_host_service/manga.part.dart';
 part 'local_library_host_service/local_audio.part.dart';
 part 'local_library_host_service/audiobooks.part.dart';
 part 'local_library_host_service/videos.part.dart';
@@ -84,6 +88,7 @@ String? _existingFilePath(String? path) {
 abstract class _LocalLibraryHostBase
     implements
         FushiLibraryHostService,
+        MangaLibraryHost,
         DeletionTombstoneHost,
         VideoDeletionHost,
         VideoPlaybackSyncHost,
@@ -137,6 +142,7 @@ class LocalLibraryHostService extends _LocalLibraryHostBase
         _LocalLibraryHostShared,
         _LocalLibraryHostDictionaries,
         _LocalLibraryHostBooks,
+        _LocalLibraryHostManga,
         _LocalLibraryHostLocalAudio,
         _LocalLibraryHostAudiobooks,
         _LocalLibraryHostVideos,

--- a/fushi/lib/src/sync/local_library_host_service/manga.part.dart
+++ b/fushi/lib/src/sync/local_library_host_service/manga.part.dart
@@ -1,0 +1,87 @@
+part of '../local_library_host_service.dart';
+
+/// 漫画域：互联漫画源的页表与页图供给（**只读**）。
+///
+/// 与书域刻意分开：书域那三个端点（导出 / 导入 / 删除）搬的是「整卷 zip 包」，语义是
+/// 「把这本书搬到我这儿来」；本域搬的是「页」，语义是「我在你那儿翻页」。前者早已存在
+/// （`repackageMangaBook` + `/api/library/books/<id>`），后者才是把对端库当成一个**漫画
+/// 源**（浏览 → 在线读）所缺的那半条链。
+///
+/// 一本 = 一卷 = 一章：漫画在本仓是 `EpubBooks` 里 `format=='manga'` 的一行，磁盘布局
+/// `<extractDir>/{manga.json, images/…}`，卷内没有章节结构。互联漫画源据此把「一本」
+/// 映射成「一部作品的唯一一章」。
+mixin _LocalLibraryHostManga on _LocalLibraryHostBase, _LocalLibraryHostShared {
+  @override
+  Future<RemoteMangaManifest> mangaManifest(String bookKey) async {
+    _assertSafeName(bookKey);
+    final EpubBookRow row = await _requireMangaRow(bookKey);
+    final MokuroPayload payload = _readMangaPayload(row);
+    return RemoteMangaManifest(
+      bookKey: row.bookKey,
+      title: row.title,
+      readingMode: row.mangaReadingMode,
+      pages: <RemoteMangaPageInfo>[
+        for (int i = 0; i < payload.images.length; i++)
+          RemoteMangaPageInfo(
+            index: i,
+            name: MangaStorage.pageRelativePath(payload.images[i].url),
+            width: payload.images[i].size.width.round(),
+            height: payload.images[i].size.height.round(),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Future<File> mangaPageFile(String bookKey, int index) async {
+    _assertSafeName(bookKey);
+    final EpubBookRow row = await _requireMangaRow(bookKey);
+    final MokuroPayload payload = _readMangaPayload(row);
+    if (index < 0 || index >= payload.images.length) {
+      throw StateError('manga page out of range: $bookKey#$index');
+    }
+    // 路径解析 + 穿越守卫恒在 host 侧（client 只送 index，从不送路径）。用的是本仓
+    // 阅读器读本地漫画时的**同一个** `MangaStorage.resolvePageFilePath`——安全边界靠
+    // 复制粘贴维持，抄漏一处就是真漏洞。
+    final String? path = MangaStorage.resolvePageFilePath(
+      MangaStorage.imagesDirectory(row.extractDir).path,
+      MangaStorage.pageRelativePath(payload.images[index].url),
+    );
+    if (path == null) {
+      throw StateError('manga page not found: $bookKey#$index');
+    }
+    return File(path);
+  }
+
+  /// [bookKey] 对应的漫画行；不存在 / 不是漫画 / 无可读内容一律 [StateError] → 404。
+  ///
+  /// 「有内容」判据复用清单侧的 [hasExportableMangaContent]，与 `/api/library/books`
+  /// 的 `hasMangaContent` 严格同源：否则会出现「清单说有、翻页说没有」的分裂——正是
+  /// BUG-2400 里那种「占位空合集被标成可下载」的形状。
+  Future<EpubBookRow> _requireMangaRow(String bookKey) async {
+    final EpubBookRow? row = _findBookByTitleOrKey(
+      await _db.getAllEpubBooks(),
+      bookKey,
+    );
+    if (row == null) {
+      throw StateError('manga book not found: $bookKey');
+    }
+    if (BookFormat.parseOrEpub(row.format) != BookFormat.manga) {
+      throw StateError('book is not manga: $bookKey');
+    }
+    if (!hasExportableMangaContent(row.extractDir)) {
+      throw StateError('manga book has no readable content: $bookKey');
+    }
+    return row;
+  }
+
+  /// 读该书的 `manga.json`。行里的 `epubPath` 才是权威文件名（与阅读器一致），
+  /// 缺列时回落到布局常量。
+  MokuroPayload _readMangaPayload(EpubBookRow row) {
+    final String fileName =
+        row.epubPath.isEmpty ? kMangaPackageMarker : row.epubPath;
+    return parseMangaJson(
+      File(p.join(row.extractDir, fileName)).readAsStringSync(),
+    );
+  }
+}

--- a/fushi/test/media/manga/interconnect_manga_source_test.dart
+++ b/fushi/test/media/manga/interconnect_manga_source_test.dart
@@ -1,0 +1,337 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/interconnect/interconnect_manga_source.dart';
+import 'package:fushi/src/media/manga/interconnect/interconnect_reader_chapter.dart';
+import 'package:fushi/src/media/manga/library/online_manga_library_entry.dart';
+import 'package:fushi/src/media/manga/library/online_manga_library_service.dart';
+import 'package:fushi/src/media/manga/library/online_manga_runtime_adapter.dart';
+import 'package:fushi/src/media/manga/mihon/manga_page_provider.dart';
+import 'package:fushi/src/media/manga/mihon/mihon_reader_chapter.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/fushi_sync_server.dart';
+import 'package:fushi/src/sync/interconnect_sync_backend.dart';
+import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 互联漫画源端到端：真 [FushiSyncServer] + 真 [InterconnectSyncBackend] + 真适配器
+/// + 真页缓存。
+///
+/// 不 mock backend 的理由：这个源的全部价值就在「HTTP 往返 + 鉴权 + 缓存」这条链上，
+/// 把 backend 换成假的等于把被测对象换掉了。
+class _MangaHost extends Fake
+    implements FushiLibraryHostService, MangaLibraryHost {
+  _MangaHost(this.pageBytes);
+
+  final List<List<int>> pageBytes;
+  int manifestCalls = 0;
+  final List<int> servedPages = <int>[];
+
+  @override
+  Future<List<RemoteBookInfo>> listBooks() async => <RemoteBookInfo>[
+        const RemoteBookInfo(
+          title: 'よつばと！1',
+          bookKey: 'yotsuba-1',
+          hasContent: false,
+          format: 'manga',
+          hasMangaContent: true,
+          mangaReadingMode: 'spread',
+        ),
+        // 有 manga 行但没内容（占位合集）：不该出现在源里。
+        const RemoteBookInfo(
+          title: '空合集',
+          bookKey: 'empty',
+          hasContent: false,
+          format: 'manga',
+        ),
+        // 普通 EPUB：漫画源里不该出现。
+        const RemoteBookInfo(
+          title: '吾輩は猫である',
+          bookKey: 'neko',
+          hasContent: true,
+        ),
+      ];
+
+  @override
+  Future<RemoteMangaManifest> mangaManifest(String bookKey) async {
+    manifestCalls++;
+    if (bookKey != 'yotsuba-1') {
+      throw StateError('manga book not found: $bookKey');
+    }
+    return RemoteMangaManifest(
+      bookKey: 'yotsuba-1',
+      title: 'よつばと！1',
+      readingMode: 'spread',
+      pages: <RemoteMangaPageInfo>[
+        for (int i = 0; i < pageBytes.length; i++)
+          RemoteMangaPageInfo(index: i, name: 'p$i.jpg'),
+      ],
+    );
+  }
+
+  @override
+  Future<File> mangaPageFile(String bookKey, int index) async {
+    if (bookKey != 'yotsuba-1' || index < 0 || index >= pageBytes.length) {
+      throw StateError('manga page out of range: $bookKey#$index');
+    }
+    servedPages.add(index);
+    final File file = File(
+      '${Directory.systemTemp.createTempSync('hbk_page').path}/p$index.jpg',
+    );
+    file.writeAsBytesSync(pageBytes[index]);
+    return file;
+  }
+}
+
+/// 老版本 host：库服务在，但不供漫画页。
+class _LegacyHost extends Fake implements FushiLibraryHostService {
+  @override
+  Future<List<RemoteBookInfo>> listBooks() async => const <RemoteBookInfo>[
+        RemoteBookInfo(
+          title: 'よつばと！1',
+          bookKey: 'yotsuba-1',
+          hasContent: false,
+          format: 'manga',
+          hasMangaContent: true,
+        ),
+      ];
+}
+
+Future<InterconnectSyncBackend> _buildBackend({
+  required String base,
+  required String token,
+}) async {
+  final SyncRepository repo = SyncRepository(
+    FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory())),
+  );
+  await repo.setFushiClientUrls(<FushiClientUrl>[
+    FushiClientUrl(url: base, enabled: true),
+  ]);
+  await repo.setFushiClientToken(token);
+  final InterconnectSyncBackend backend = InterconnectSyncBackend.withProbe(
+    (String url, String tok) async => true,
+  );
+  await backend.restoreAuth(repo);
+  await backend.authenticate(repo: repo);
+  return backend;
+}
+
+void main() {
+  // 刻意**不**装 TestWidgetsFlutterBinding：它会把所有 HttpClient 请求短路成 400，
+  // 而本文件的全部价值就在真 HTTP 往返上（同 `fushi_client_live_book_test.dart`）。
+  const String token = 'manga-source-token';
+  // 每页 4 字节，末位是页序：能逐字节断言「第 N 页拿到的确实是第 N 页」。
+  final List<List<int>> pageBytes = <List<int>>[
+    <int>[0xFF, 0xD8, 0xFF, 0],
+    <int>[0xFF, 0xD8, 0xFF, 1],
+    <int>[0xFF, 0xD8, 0xFF, 2],
+  ];
+
+  late _MangaHost host;
+  late FushiSyncServer server;
+  late InterconnectSyncBackend backend;
+  late Directory managed;
+
+  setUp(() async {
+    host = _MangaHost(pageBytes);
+    server = FushiSyncServer(
+      syncDataDir: Directory.systemTemp.createTempSync('hbk_mangasrc').path,
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: host,
+    );
+    await server.start();
+    backend = await _buildBackend(
+      base: 'http://127.0.0.1:${server.port}',
+      token: token,
+    );
+    managed = Directory.systemTemp.createTempSync('hbk_mangasrc_managed');
+  });
+
+  tearDown(() async {
+    await server.stop();
+    if (managed.existsSync()) managed.deleteSync(recursive: true);
+  });
+
+  OnlineMangaLibraryEntry entryOf(RemoteBookInfo book) =>
+      InterconnectMangaCatalog.entryFor(book);
+
+  test('源清单只留「是漫画且有内容」的对端条目', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    expect(series.map((RemoteBookInfo b) => b.bookKey), <String>['yotsuba-1']);
+  });
+
+  test('书架身份用 interconnect 前缀，与其它运行时天然不撞键空间', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final String bookKey = OnlineMangaLibraryService.bookKeyOf(
+      entryOf(series.single),
+    );
+    expect(bookKey, startsWith('interconnect-'));
+    // 同一本反复推导必须逐字稳定——它同时是主键和磁盘目录名。
+    expect(
+        bookKey, OnlineMangaLibraryService.bookKeyOf(entryOf(series.single)));
+  });
+
+  test('refresh 给出整卷那一章', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final OnlineMangaRefreshResult result =
+        await InterconnectLibraryAdapter(backend: backend).refresh(
+      entryOf(series.single),
+    );
+    expect(result.series.title, 'よつばと！1');
+    expect(result.chapters.length, 1);
+    expect(result.chapters.single.key, 'yotsuba-1');
+    expect(result.series.raw['readingMode'], 'spread');
+  });
+
+  test('开章 → 逐页真取到对端字节，且页序不串', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final OnlineMangaLibraryEntry entry = entryOf(series.single);
+    final OnlineMangaReaderChapter chapter =
+        await InterconnectLibraryAdapter(backend: backend).openChapter(
+      entry: entry,
+      chapter: entry.chapters.single,
+      managedDirectory: managed,
+      persistProgress: false,
+    );
+    expect(chapter.pageCount, 3);
+    expect(chapter.pageIdentities.toSet().length, 3, reason: '每页身份必须互不相同');
+
+    final MangaReaderSession session = await chapter.openPageSession();
+    addTearDown(session.close);
+    for (int i = 0; i < 3; i++) {
+      final MangaPageBytes page = await session.page(i);
+      expect(page.bytes, Uint8List.fromList(pageBytes[i]));
+    }
+    expect(host.servedPages, <int>[0, 1, 2]);
+  });
+
+  test('页图落磁盘缓存，第二次读不再打对端', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final OnlineMangaLibraryEntry entry = entryOf(series.single);
+    final OnlineMangaReaderChapter chapter =
+        await InterconnectLibraryAdapter(backend: backend).openChapter(
+      entry: entry,
+      chapter: entry.chapters.single,
+      managedDirectory: managed,
+      persistProgress: false,
+    );
+    final MangaReaderSession session = await chapter.openPageSession();
+    addTearDown(session.close);
+
+    await session.page(0);
+    expect(host.servedPages, <int>[0]);
+    await session.page(0);
+    expect(host.servedPages, <int>[0], reason: '命中磁盘缓存就不该再向对端要一次');
+  });
+
+  test('预取失败不冒泡（相邻页抖动不该打断当前页阅读）', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final OnlineMangaLibraryEntry entry = entryOf(series.single);
+    final OnlineMangaReaderChapter chapter =
+        await InterconnectLibraryAdapter(backend: backend).openChapter(
+      entry: entry,
+      chapter: entry.chapters.single,
+      managedDirectory: managed,
+      persistProgress: false,
+    );
+    final MangaReaderSession session = await chapter.openPageSession();
+    addTearDown(session.close);
+    await server.stop(); // 对端下线 → 预取全部失败
+    await expectLater(session.prefetchAround(1), completes);
+  });
+
+  test('身份掺入配对凭据命名空间：换对端不复用上一台的页缓存', () async {
+    final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+      backend,
+    ).listSeries();
+    final OnlineMangaLibraryEntry entry = entryOf(series.single);
+    final InterconnectReaderChapter chapter = InterconnectReaderChapter(
+      backend: backend,
+      bookKey: 'yotsuba-1',
+      title: 'よつばと！1',
+      pages: const <RemoteMangaPageInfo>[
+        RemoteMangaPageInfo(index: 0, name: 'p0.jpg'),
+      ],
+      managedDirectory: managed,
+      persistProgress: false,
+    );
+    final InterconnectSyncBackend other = await _buildBackend(
+      base: 'http://127.0.0.1:${server.port}',
+      token: 'a-different-token',
+    );
+    final InterconnectReaderChapter otherChapter = InterconnectReaderChapter(
+      backend: other,
+      bookKey: 'yotsuba-1',
+      title: 'よつばと！1',
+      pages: const <RemoteMangaPageInfo>[
+        RemoteMangaPageInfo(index: 0, name: 'p0.jpg'),
+      ],
+      managedDirectory: managed,
+      persistProgress: false,
+    );
+    expect(entry.series.key, 'yotsuba-1');
+    expect(
+      chapter.pageIdentities.single,
+      isNot(otherChapter.pageIdentities.single),
+    );
+  });
+
+  group('对端不供漫画页（老版本 Fushi）', () {
+    late FushiSyncServer legacy;
+    late InterconnectSyncBackend legacyBackend;
+
+    setUp(() async {
+      legacy = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk_legacy').path,
+        port: 0,
+        token: token,
+        allowLan: false,
+        libraryService: _LegacyHost(),
+      );
+      await legacy.start();
+      legacyBackend = await _buildBackend(
+        base: 'http://127.0.0.1:${legacy.port}',
+        token: token,
+      );
+    });
+
+    tearDown(() async => legacy.stop());
+
+    test('清单照常列出（books 端点是老端点），但开章报「源不可用」而不是「重试」', () async {
+      final List<RemoteBookInfo> series = await InterconnectMangaCatalog(
+        legacyBackend,
+      ).listSeries();
+      expect(series.single.bookKey, 'yotsuba-1');
+
+      await expectLater(
+        InterconnectLibraryAdapter(backend: legacyBackend).refresh(
+          entryOf(series.single),
+        ),
+        throwsA(
+          isA<OnlineMangaUnavailable>().having(
+            (OnlineMangaUnavailable e) => e.reason,
+            'reason',
+            OnlineMangaUnavailableReason.sourceDisabled,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/fushi/test/sync/fushi_sync_server_manga_library_test.dart
+++ b/fushi/test/sync/fushi_sync_server_manga_library_test.dart
@@ -1,0 +1,246 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/fushi_sync_server.dart';
+
+/// 互联漫画源的 host 端点（`/api/library/manga/**`）。
+///
+/// 用真 [FushiSyncServer] + 真 HTTP + 真文件，而不是直接调 service：这批端点的价值
+/// 全在「路由 / 鉴权 / 能力协商 / 404 分型 / Range 下发」这几层上，绕开它们测等于什么
+/// 都没测。
+class _MangaHost extends Fake
+    implements FushiLibraryHostService, MangaLibraryHost {
+  _MangaHost(this.manifest, this.pageFiles);
+
+  final RemoteMangaManifest manifest;
+  final List<File> pageFiles;
+
+  @override
+  Future<RemoteMangaManifest> mangaManifest(String bookKey) async {
+    if (bookKey.contains('..') || bookKey.contains('/')) {
+      throw ArgumentError('unsafe book key');
+    }
+    if (bookKey != manifest.bookKey) {
+      throw StateError('manga book not found: $bookKey');
+    }
+    return manifest;
+  }
+
+  @override
+  Future<File> mangaPageFile(String bookKey, int index) async {
+    if (bookKey != manifest.bookKey) {
+      throw StateError('manga book not found: $bookKey');
+    }
+    if (index < 0 || index >= pageFiles.length) {
+      throw StateError('manga page out of range: $bookKey#$index');
+    }
+    return pageFiles[index];
+  }
+}
+
+/// 只实现主接口、**不**实现 [MangaLibraryHost] 的 host：老版本 / 精简 host 的形状。
+class _NoMangaHost extends Fake implements FushiLibraryHostService {}
+
+void main() {
+  const String token = 'tkn-manga';
+  const List<int> pngBytes = <int>[0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4, 5, 6];
+
+  late Directory tmp;
+  late FushiSyncServer server;
+  late String base;
+
+  String authHeader() => 'Basic ${base64Encode(utf8.encode('hibiki:$token'))}';
+
+  Future<HttpClientResponse> get(
+    String path, {
+    bool authorize = true,
+    String? range,
+  }) async {
+    final HttpClient client = HttpClient();
+    final HttpClientRequest req = await client.getUrl(Uri.parse('$base$path'));
+    if (authorize) req.headers.set('authorization', authHeader());
+    if (range != null) req.headers.set(HttpHeaders.rangeHeader, range);
+    final HttpClientResponse res = await req.close();
+    client.close();
+    return res;
+  }
+
+  setUp(() async {
+    tmp = Directory.systemTemp.createTempSync('hbk_manga_srv');
+    final List<File> pages = <File>[
+      for (int i = 0; i < 3; i++)
+        File('${tmp.path}/p$i.png')..writeAsBytesSync(<int>[...pngBytes, i]),
+    ];
+    server = FushiSyncServer(
+      syncDataDir: tmp.path,
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: _MangaHost(
+        RemoteMangaManifest(
+          bookKey: 'vol1',
+          title: 'よつばと！1',
+          readingMode: 'spread',
+          pages: const <RemoteMangaPageInfo>[
+            RemoteMangaPageInfo(
+              index: 0,
+              name: 'p001.png',
+              width: 1200,
+              height: 1700,
+            ),
+            RemoteMangaPageInfo(index: 1, name: 'p002.png'),
+            RemoteMangaPageInfo(index: 2, name: 'sub/p003.png'),
+          ],
+        ),
+        pages,
+      ),
+    );
+    await server.start();
+    base = 'http://127.0.0.1:${server.port}';
+  });
+
+  tearDown(() async {
+    await server.stop();
+    try {
+      tmp.deleteSync(recursive: true);
+    } on FileSystemException {
+      // best-effort
+    }
+  });
+
+  test('能力位随 MangaLibraryHost 一起出现', () async {
+    final HttpClientResponse res = await get('/api/capabilities');
+    expect(res.statusCode, 200);
+    final Map<String, Object?> json =
+        (jsonDecode(await res.transform(utf8.decoder).join()) as Map)
+            .cast<String, Object?>();
+    final Map<String, Object?> live =
+        (json['liveLibrary']! as Map).cast<String, Object?>();
+    expect(live['manga'], isTrue);
+  });
+
+  test('页表带页序、尺寸与阅读模式', () async {
+    final HttpClientResponse res =
+        await get('/api/library/manga/vol1/manifest');
+    expect(res.statusCode, 200);
+    final RemoteMangaManifest manifest = RemoteMangaManifest.fromJson(
+      (jsonDecode(await res.transform(utf8.decoder).join()) as Map)
+          .cast<String, Object?>(),
+    );
+    expect(manifest.bookKey, 'vol1');
+    expect(manifest.title, 'よつばと！1');
+    expect(manifest.readingMode, 'spread');
+    expect(manifest.pages.length, 3);
+    expect(manifest.pages.first.width, 1200);
+    expect(manifest.pages.first.height, 1700);
+    // 尺寸缺失编成 0（wire 上不写键），client 侧据此回落真实字节尺寸。
+    expect(manifest.pages[1].width, 0);
+    // 子目录结构原样保留——两页同名不同目录不能塌成一个。
+    expect(manifest.pages[2].name, 'sub/p003.png');
+  });
+
+  test('按页取图返回该页字节', () async {
+    final HttpClientResponse res = await get('/api/library/manga/vol1/pages/1');
+    expect(res.statusCode, 200);
+    final List<int> bytes = <int>[
+      await for (final List<int> chunk in res) ...chunk,
+    ];
+    expect(bytes, <int>[...pngBytes, 1]);
+  });
+
+  test('页图支持 Range（阅读器可断点续取大页图）', () async {
+    final HttpClientResponse res = await get(
+      '/api/library/manga/vol1/pages/0',
+      range: 'bytes=0-3',
+    );
+    expect(res.statusCode, 206);
+    expect(res.headers.value(HttpHeaders.acceptRangesHeader), 'bytes');
+    final List<int> bytes = <int>[
+      await for (final List<int> chunk in res) ...chunk,
+    ];
+    expect(bytes, pngBytes.sublist(0, 4));
+  });
+
+  test('越界页 / 不存在的书都是 404，不是 500', () async {
+    expect((await get('/api/library/manga/vol1/pages/99')).statusCode, 404);
+    expect((await get('/api/library/manga/nope/manifest')).statusCode, 404);
+  });
+
+  test('未鉴权一律 401——漫画页图没有视频 stream 那种 token 豁免', () async {
+    expect(
+      (await get('/api/library/manga/vol1/manifest', authorize: false))
+          .statusCode,
+      401,
+    );
+    expect(
+      (await get('/api/library/manga/vol1/pages/0', authorize: false))
+          .statusCode,
+      401,
+    );
+  });
+
+  test('写方法一律 405（本域只读）', () async {
+    final HttpClient client = HttpClient();
+    final HttpClientRequest req = await client.deleteUrl(
+      Uri.parse('$base/api/library/manga/vol1/manifest'),
+    );
+    req.headers.set('authorization', authHeader());
+    final HttpClientResponse res = await req.close();
+    expect(res.statusCode, 405);
+    await res.drain<void>();
+    client.close();
+  });
+
+  test('穿越形状的 bookKey 进不了 service', () async {
+    // `..` 会被路由前缀切分成别的形状，这里断言的是「无论怎么切，都不是 2xx」。
+    expect(
+      (await get('/api/library/manga/..%2F..%2Fetc/manifest')).statusCode,
+      isNot(inInclusiveRange(200, 299)),
+    );
+  });
+
+  group('不提供漫画能力的 host', () {
+    late FushiSyncServer bare;
+    late String bareBase;
+
+    setUp(() async {
+      bare = FushiSyncServer(
+        syncDataDir: Directory.systemTemp.createTempSync('hbk_manga_bare').path,
+        port: 0,
+        token: token,
+        allowLan: false,
+        libraryService: _NoMangaHost(),
+      );
+      await bare.start();
+      bareBase = 'http://127.0.0.1:${bare.port}';
+    });
+
+    tearDown(() async => bare.stop());
+
+    Future<HttpClientResponse> bareGet(String path) async {
+      final HttpClient client = HttpClient();
+      final HttpClientRequest req = await client.getUrl(
+        Uri.parse('$bareBase$path'),
+      );
+      req.headers.set('authorization', authHeader());
+      final HttpClientResponse res = await req.close();
+      client.close();
+      return res;
+    }
+
+    test('能力位为 false 且端点 404（新 client 据此提示对端版本过低）', () async {
+      final HttpClientResponse caps = await bareGet('/api/capabilities');
+      final Map<String, Object?> json =
+          (jsonDecode(await caps.transform(utf8.decoder).join()) as Map)
+              .cast<String, Object?>();
+      expect(
+        ((json['liveLibrary']! as Map).cast<String, Object?>())['manga'],
+        isFalse,
+      );
+      expect(
+          (await bareGet('/api/library/manga/vol1/manifest')).statusCode, 404);
+    });
+  });
+}

--- a/fushi/test/sync/local_library_host_service_manga_test.dart
+++ b/fushi/test/sync/local_library_host_service_manga_test.dart
@@ -1,0 +1,211 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/fushi_library_host_service.dart';
+import 'package:fushi/src/sync/local_library_host_service.dart';
+import 'package:fushi/src/sync/manga_sync_package.dart';
+import 'package:fushi/src/sync/sync_asset_package_service.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+/// 互联漫画源的 host 实现层：真 DB + 真磁盘。
+///
+/// 端点那一层（路由/鉴权/404）在 `fushi_sync_server_manga_library_test.dart`；这里
+/// 钉的是**页表怎么从 manga.json 推出来**、以及**页图路径解析这道穿越守卫**。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FushiDatabase db;
+  late Directory tmp;
+  late LocalLibraryHostService svc;
+
+  setUp(() {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    tmp = Directory.systemTemp.createTempSync('hbk_host_manga');
+    svc = LocalLibraryHostService(
+      db: db,
+      dictionaryResourceRoot: Directory.systemTemp,
+      packages: SyncAssetPackageService(db: db),
+      refreshDictionaryCache: () async {},
+      runExclusive: (Future<void> Function() body) => body(),
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  /// 一本真漫画：`<dir>/manga.json` + `<dir>/images/**`，与导入器落盘布局一致。
+  Future<String> insertManga({
+    required String bookKey,
+    List<String> pageUrls = const <String>['images/p1.jpg', 'images/p2.jpg'],
+    bool writeImages = true,
+    String? readingMode,
+  }) async {
+    final Directory dir = Directory(p.join(tmp.path, bookKey))
+      ..createSync(recursive: true);
+    final List<Map<String, Object?>> pages = <Map<String, Object?>>[];
+    for (int i = 0; i < pageUrls.length; i++) {
+      if (writeImages) {
+        final File image = File(
+          p.joinAll(<String>[dir.path, ...pageUrls[i].split('/')]),
+        );
+        image.parent.createSync(recursive: true);
+        image.writeAsBytesSync(<int>[0xFF, 0xD8, 0xFF, i]);
+      }
+      pages.add(<String, Object?>{
+        'url': pageUrls[i],
+        'width': 800,
+        'height': 1200,
+        'blocks': <Object?>[],
+      });
+    }
+    File(
+      p.join(dir.path, kMangaPackageMarker),
+    ).writeAsStringSync(jsonEncode(<String, Object?>{'pages': pages}));
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: bookKey,
+        title: bookKey,
+        epubPath: kMangaPackageMarker,
+        extractDir: dir.path,
+        chapterCount: 1,
+        chaptersJson: '[]',
+        importedAt: DateTime.now().millisecondsSinceEpoch,
+        format: Value(BookFormat.manga.dbValue),
+        mangaReadingMode: Value(readingMode),
+      ),
+    );
+    return dir.path;
+  }
+
+  test('页表按 manga.json 顺序给出页序、尺寸与阅读模式', () async {
+    await insertManga(bookKey: 'vol1', readingMode: 'webtoon');
+    final RemoteMangaManifest manifest = await svc.mangaManifest('vol1');
+    expect(manifest.bookKey, 'vol1');
+    expect(manifest.readingMode, 'webtoon');
+    expect(manifest.pages.map((RemoteMangaPageInfo e) => e.index), <int>[0, 1]);
+    // `images/` 前缀被剥掉：name 是相对 images 根的路径，与阅读器读本地时同一口径。
+    expect(manifest.pages.map((RemoteMangaPageInfo e) => e.name), <String>[
+      'p1.jpg',
+      'p2.jpg',
+    ]);
+    expect(manifest.pages.first.width, 800);
+    expect(manifest.pages.first.height, 1200);
+  });
+
+  test('页图按 index 解析到真实文件，字节与页序对应', () async {
+    await insertManga(bookKey: 'vol1');
+    expect((await svc.mangaPageFile('vol1', 0)).readAsBytesSync(), <int>[
+      0xFF,
+      0xD8,
+      0xFF,
+      0,
+    ]);
+    expect((await svc.mangaPageFile('vol1', 1)).readAsBytesSync(), <int>[
+      0xFF,
+      0xD8,
+      0xFF,
+      1,
+    ]);
+  });
+
+  test('子目录结构保留：同名不同目录的两页不塌成一页', () async {
+    await insertManga(
+      bookKey: 'vol1',
+      pageUrls: const <String>['images/a/p1.jpg', 'images/b/p1.jpg'],
+    );
+    final RemoteMangaManifest manifest = await svc.mangaManifest('vol1');
+    expect(manifest.pages.map((RemoteMangaPageInfo e) => e.name), <String>[
+      'a/p1.jpg',
+      'b/p1.jpg',
+    ]);
+    final File first = await svc.mangaPageFile('vol1', 0);
+    final File second = await svc.mangaPageFile('vol1', 1);
+    expect(first.path, isNot(second.path));
+  });
+
+  test('页图路径逃出 images/ 一律 StateError（→ 端点 404），绝不 serve', () async {
+    await insertManga(
+      bookKey: 'vol1',
+      pageUrls: const <String>['../../secret.txt'],
+      writeImages: false,
+    );
+    File(p.join(tmp.path, 'secret.txt')).writeAsStringSync('nope');
+    await expectLater(
+      svc.mangaPageFile('vol1', 0),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('越界页 StateError', () async {
+    await insertManga(bookKey: 'vol1');
+    await expectLater(svc.mangaPageFile('vol1', 5), throwsA(isA<StateError>()));
+    await expectLater(
+        svc.mangaPageFile('vol1', -1), throwsA(isA<StateError>()));
+  });
+
+  test('非漫画的书不给页表（EPUB 行不该经漫画通道泄出内容）', () async {
+    final Directory dir = Directory(p.join(tmp.path, 'novel'))
+      ..createSync(recursive: true);
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: 'novel',
+        title: 'novel',
+        epubPath: 'original.epub',
+        extractDir: dir.path,
+        chapterCount: 1,
+        chaptersJson: '[]',
+        importedAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    await expectLater(
+      svc.mangaManifest('novel'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('占位空合集不给页表——与清单的 hasMangaContent 判据同源（BUG-2400）', () async {
+    await insertManga(
+      bookKey: 'empty',
+      pageUrls: const <String>[],
+      writeImages: false,
+    );
+    await expectLater(
+      svc.mangaManifest('empty'),
+      throwsA(isA<StateError>()),
+    );
+    // 清单侧对同一本的结论必须一致，否则就是「列表说有、点开说没有」。
+    final RemoteBookInfo row = (await svc.listBooks()).firstWhere(
+      (RemoteBookInfo b) => b.bookKey == 'empty',
+    );
+    expect(row.hasMangaContent, isFalse);
+  });
+
+  test('缺页图的书不给页表（清单也不会声称有内容）', () async {
+    await insertManga(bookKey: 'missing', writeImages: false);
+    await expectLater(
+      svc.mangaManifest('missing'),
+      throwsA(isA<StateError>()),
+    );
+    final RemoteBookInfo row = (await svc.listBooks()).firstWhere(
+      (RemoteBookInfo b) => b.bookKey == 'missing',
+    );
+    expect(row.hasMangaContent, isFalse);
+  });
+
+  test('穿越形状的 bookKey 一律 ArgumentError', () async {
+    await expectLater(
+      svc.mangaManifest('../etc/passwd'),
+      throwsA(isA<ArgumentError>()),
+    );
+    await expectLater(
+      svc.mangaPageFile('../etc/passwd', 0),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+}


### PR DESCRIPTION
## 做了什么

把**已配对的互联对端**接成本仓第三个在线漫画运行时（Mihon / Aidoku 之后），形态对标 **Suwayomi 作为 Tachiyomi 源**：

> 来源页 →「Fushi 互联」→ 对端漫画网格 → 作品页（可加入书架）→ 共享阅读器**逐页在线读**

与既有的「远端漫画下载」**并存不重叠**：那条是把整卷 zip 搬过来再本地读（`repackageMangaBook` + `/api/library/books/<id>`，互联漫画包批次已完成）；这条是不落地、直接在对端上翻页。两条路用户按需选。

## host 侧（只读，两个端点）

| 端点 | 返回 |
|---|---|
| `GET /api/library/manga/<bookKey>/manifest` | 页表（一本 = 一卷 = 一章） |
| `GET /api/library/manga/<bookKey>/pages/<index>` | 页图字节（`serveFileWithRange`） |

- **能力协商**：`/api/capabilities` 的 `liveLibrary.manga`，与既有 `mangaOcr` 同范式。老 host 无此位 → 新 client 提示「对端版本过低」，而不是让用户对着 404 反复点重试。
- **能力声明走可选接口 `MangaLibraryHost`**，不塞进 `FushiLibraryHostService`——与 `AudiobookDelayHost` / `InterconnectServiceConfigHost` / `VideoDeletionHost` 同款。理由：「这台 host 不供漫画页」本来就是合法状态，不该逼十几个只关心自己那一域的实现（含测试替身）去写两个与它们无关的抛异常桩。
- **鉴权**走常规 Basic，**没有**视频 `…/stream?token=` 那种豁免：页图由 client 自己的 HTTP 栈按序取，不经外部播放器，不需要可外泄的短时 token。

**作品清单不新开端点**：漫画本来就在 `/api/library/books` 里带 `format=='manga'` + `hasMangaContent` 出现（互联漫画包批次留下的 additive 字段）。准入判据与 `hasExportableMangaContent` 严格同源，杜绝 BUG-2400 那种「清单说有、点开说没有」的占位空合集。

## client 侧

- `OnlineMangaRuntimeKind.interconnect`（wireValue 已进 `bookKey`，永不可改）；`AppModel.onlineMangaLibraryService` 那个无 default 的 switch 强制补了分支。
- `InterconnectLibraryAdapter` 实现**既有的** `OnlineMangaRuntimeAdapter` 契约。该契约的类文档写着「加第三个运行时不需要动书架、作品页和阅读器任何一行」——这次兑现了它：书架、作品页、`manga_chapter_states`、进度、OCR、查词制卡**全部零改动复用**，契约本身一行没动。
- 页图走 `InterconnectSyncBackend` 自己的会话而**不是**裸 `http.Client`：自签证书 + TOFU 指纹钉扎的对端，只有它带得动 `badCertificateCallback` 与 Basic 凭据（BUG-569 的教训）。
- 页缓存身份掺入配对凭据命名空间：换 IP 不作废缓存，换对端必作废——两台机器上同名同页序的书不是同一份内容，共用缓存会让另一台的页图串味显示。

## 顺带归位

`mangaImageRelativePath` / `resolveMangaResource` 两个纯函数从阅读器 widget 搬进 `MangaStorage`（阅读器保留同名转发，公开 API 不变）。host 供图必须用**同一道**穿越守卫——安全边界靠复制粘贴维持，抄漏一处就是真漏洞。

## 已知取舍（明说，不藏）

在线读对端漫画时 **OCR 仍走既有在线 OCR 链路**（含把 OCR 卸载给对端的 `/api/ocr/job`），**没有**复用对端已经存好的 mokuro blocks。复用它要动共享阅读器 `MangaFushiPage`（3000+ 行）的 OCR 入口，属独立议题，不塞进本 PR。

## 测试（27 条新增，全部真 server / 真 HTTP / 真磁盘，无 mock backend）

- `fushi_sync_server_manga_library_test.dart`（9）：路由、Range、401（无 token 豁免）、405 只读、404 分型、能力位随接口出现/缺席
- `local_library_host_service_manga_test.dart`（9）：页表推导、子目录不塌、越界、非漫画不经漫画通道泄内容、空合集与清单判据同源、**页 url 写成 `../../secret.txt` 时拒绝 serve**
- `interconnect_manga_source_test.dart`（8）：端到端逐页取真字节、页序不串、磁盘缓存命中不再打对端、预取失败不冒泡、身份跨对端不复用、老 host 报 `sourceDisabled` 而非 `runtimeFailure`

## 验证

- `flutter analyze` 全量（含 test）**零问题**
- `test/media/manga` **736 绿**、`test/sync` **2580 绿**、`test/i18n` **118 绿**
- 51 条目录枚举型守卫整批 **368 绿**——其中 `book_format_discipline_guard` 抓出本 PR 一处裸 `format == 'manga'` 比较，已改为 `BookFormat.parseOrEpub`
- i18n 两个新 key 经 `i18n_sync.dart --add` + `dart run slang` 生成，未手改任何 json
- 格式按本仓逐文件混合风格处理：改动的既有文件逐个判定上游原文是 tall 还是 3.6-clean 后再格式化；上游两种都 dirty 的三个文件（`manga_sources_page` / `manga_fushi_page` / `interconnect_sync_backend`）**一行都没 format**，只做定点插入

**未做真机复测**：没有在真实配对的两台设备上跑过完整链路，所以不宣称「已验证可用」——自动化覆盖到端到端 HTTP 往返与页字节正确性为止。

https://claude.ai/code/session_01SSpi85PQXWsYJo2J2utNvo
