### PR TITLE
feat(ocr): 补上 Apple 侧系统 OCR 的原生半边（Vision）

### DIFF
--- a/fushi/apple/FushiSystemOcr.swift
+++ b/fushi/apple/FushiSystemOcr.swift
@@ -1,0 +1,222 @@
+import Foundation
+import ImageIO
+import Vision
+
+#if os(iOS)
+import Flutter
+#else
+import FlutterMacOS
+#endif
+
+/// Apple 侧的「系统自带 OCR」：`app.fushi.reader/system_ocr` 的 iOS / macOS 实现。
+///
+/// Dart 侧（`lib/src/ocr/system_ocr_channel.dart`）与 Android 侧（ML Kit，
+/// `SystemOcrChannel.java`）早就在了，这里补的是 Apple 的那半边。模型是系统组件
+/// （Vision 随 OS 走），所以「安装后不用下载模型也能用」在这两个平台上天然成立，
+/// 一个字节都不上传。
+///
+/// **契约逐字对齐 Android 那份**，四条容易写错的：
+///
+/// 1. **坐标是送检图的绝对像素、原点左上**。Vision 给的 `boundingBox` 是归一化的
+///    且原点在**左下**，所以 y 必须翻过来：`top = (1 - maxY) * H`。翻错不会报错，
+///    只会让整页透明文字层错位——和「这页没字」在设备上看起来一样。
+/// 2. **不发 `vertical`**。Vision 和 ML Kit 都不报竖排，Dart 侧按包围盒长宽比统一
+///    推断（`parseSystemOcrPayload`）。这里发一个自己猜的值等于让同一件事有两套
+///    判据，Android 侧的注释也是这么定的。
+/// 3. **`width` / `height` 是解码后 CGImage 的像素尺寸**，与坐标同一个分母。用
+///    `CGImageSource` 而不是 `UIImage`：后者会把 EXIF 方向应用进去，尺寸和坐标系
+///    就和 Android 的 `BitmapFactory`（rotation 0，不应用 EXIF）对不上了。
+/// 4. **语言不受支持要单独报 `MODEL_UNAVAILABLE`**，不能混进 `RECOGNIZE_FAILED`。
+///    Dart 侧把前者转成 `SystemOcrUnavailableException`，调用方据此换引擎；报成后者
+///    会让用户去怀疑图片。iOS 15 的 Vision 没有日语/中文/韩语（那是 iOS 16 起的
+///    revision 3），走的正是这条路。
+///
+/// 部署目标（iOS 15.1 / macOS 13.4）高于 `VNRecognizeTextRequest`（iOS 13 / macOS
+/// 10.15）与实例版 `supportedRecognitionLanguages()`（iOS 15 / macOS 12），所以全文
+/// 不需要 `#available` 分支。
+enum FushiSystemOcr {
+  /// 与 Dart 的 `kSystemOcrChannel`、Android 的 `ChannelNames.SYSTEM_OCR` 同名。
+  static let channelName = "app.fushi.reader/system_ocr"
+
+  /// Vision 跑 `.accurate` 是几百毫秒级的活，不能占着主线程；回调统一切回主线程。
+  private static let queue = DispatchQueue(
+    label: "app.fushi.reader.system-ocr",
+    qos: .userInitiated)
+
+  static func register(binaryMessenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger)
+    channel.setMethodCallHandler { call, result in
+      handle(call, result: result)
+    }
+  }
+
+  static func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAvailable":
+      // 必须便宜地回答：不做真识别，也不触发任何下载（Dart 侧把这个答案缓存进
+      // 一次能力探测）。查一次支持语言表就够了。
+      result(!supportedLanguages().isEmpty)
+    case "recognize":
+      recognize(call, result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - recognize
+
+  private static func recognize(
+    _ call: FlutterMethodCall,
+    result: @escaping FlutterResult
+  ) {
+    guard let args = call.arguments as? [String: Any],
+          let typed = args["bytes"] as? FlutterStandardTypedData,
+          !typed.data.isEmpty
+    else {
+      result(
+        FlutterError(
+          code: "INVALID_IMAGE",
+          message: "image bytes must not be empty",
+          details: nil))
+      return
+    }
+    let data = typed.data
+    let language = (args["language"] as? String) ?? ""
+
+    let supported = supportedLanguages()
+    let languages = visionLanguages(for: language, supported: supported)
+    if languages.isEmpty {
+      // 这条不是「识别失败」：本机的 Vision 认不了这门语言（iOS 15 没有 CJK），
+      // 调用方该换引擎而不是重试这张图。
+      result(
+        FlutterError(
+          code: "MODEL_UNAVAILABLE",
+          message:
+            "Vision has no recognition model for \"\(language)\" on this system",
+          details: nil))
+      return
+    }
+
+    queue.async {
+      func reply(_ value: Any?) {
+        DispatchQueue.main.async { result(value) }
+      }
+      guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+      else {
+        reply(
+          FlutterError(
+            code: "INVALID_IMAGE",
+            message: "could not decode image bytes",
+            details: nil))
+        return
+      }
+      let width = image.width
+      let height = image.height
+      guard width > 0, height > 0 else {
+        reply(
+          FlutterError(
+            code: "INVALID_IMAGE",
+            message: "decoded image has no size",
+            details: nil))
+        return
+      }
+
+      let request = VNRecognizeTextRequest()
+      request.recognitionLevel = .accurate
+      request.usesLanguageCorrection = true
+      request.recognitionLanguages = languages
+      // `.up` 而不是从 EXIF 推：上面用 CGImageSource 拿的就是未旋转的像素缓冲，
+      // 坐标分母也是它的宽高，两处必须同一个方向。
+      let handler = VNImageRequestHandler(
+        cgImage: image,
+        orientation: .up,
+        options: [:])
+      do {
+        try handler.perform([request])
+      } catch {
+        reply(
+          FlutterError(
+            code: "RECOGNIZE_FAILED",
+            message: error.localizedDescription,
+            details: nil))
+        return
+      }
+      reply(
+        payload(
+          observations: request.results ?? [],
+          width: width,
+          height: height))
+    }
+  }
+
+  /// 把 Vision 的观测结果拼成 Dart 侧 `parseSystemOcrPayload` 认得的那份 map。
+  ///
+  /// 一个 observation 一行，不做任何分组——气泡合并在 Dart / JS 那边，Android 侧
+  /// 同样如此，两边都拼一套只会拼出两种结果。
+  static func payload(
+    observations: [VNRecognizedTextObservation],
+    width: Int,
+    height: Int
+  ) -> [String: Any] {
+    let w = CGFloat(width)
+    let h = CGFloat(height)
+    var lines: [[String: Any]] = []
+    for observation in observations {
+      guard let candidate = observation.topCandidates(1).first else { continue }
+      let text = candidate.string
+      if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        continue
+      }
+      let box = observation.boundingBox
+      let left = box.minX * w
+      let right = box.maxX * w
+      // Vision 的原点在左下，Dart / Android 的在左上：这里翻 y。
+      let top = (1 - box.maxY) * h
+      let bottom = (1 - box.minY) * h
+      if right <= left || bottom <= top { continue }
+      lines.append([
+        "text": text,
+        "left": Double(left),
+        "top": Double(top),
+        "right": Double(right),
+        "bottom": Double(bottom),
+        // 刻意不发 `vertical`：Vision 不报竖排，Dart 侧按包围盒推断（见类文档）。
+      ])
+    }
+    return [
+      "width": width,
+      "height": height,
+      "lines": lines,
+    ]
+  }
+
+  // MARK: - 语言
+
+  /// 本机 Vision 认得的语言（形如 `en-US` / `ja-JP` / `zh-Hans`）。查不到就当没有。
+  static func supportedLanguages() -> [String] {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    return (try? request.supportedRecognitionLanguages()) ?? []
+  }
+
+  /// 纯函数：把 Dart 传来的**主子标签**（`ja` / `zh` / `en`…）配到本机支持的
+  /// Vision 语言标识上。
+  ///
+  /// 按主子标签前缀配，所以 `zh` 会同时拿到 `zh-Hans` 与 `zh-Hant`（简繁漫画都有，
+  /// 两个都给 Vision 自己挑，顺序沿用系统表）。配不上返回空数组，调用方据此报
+  /// `MODEL_UNAVAILABLE`。
+  static func visionLanguages(for tag: String, supported: [String]) -> [String] {
+    let primary = primarySubtag(tag)
+    if primary.isEmpty { return [] }
+    return supported.filter { primarySubtag($0) == primary }
+  }
+
+  private static func primarySubtag(_ tag: String) -> String {
+    let lowered = tag.lowercased()
+    guard let first = lowered.split(separator: "-").first else { return lowered }
+    return String(first)
+  }
+}

--- a/fushi/ios/Runner.xcodeproj/project.pbxproj
+++ b/fushi/ios/Runner.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */; };
+		FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000002001C0F02 /* FushiSystemOcr.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		61FEF2834CC237156E0983BA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5A058A6A618CF04E7D9DEC /* Pods_Runner.framework */; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiChallengeBrowser.swift; path = ../../apple/FushiChallengeBrowser.swift; sourceTree = "<group>"; };
+		FA171A002B000002001C0F02 /* FushiSystemOcr.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSystemOcr.swift; path = ../../apple/FushiSystemOcr.swift; sourceTree = "<group>"; };
 		0F5A058A6A618CF04E7D9DEC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */,
+				FA171A002B000002001C0F02 /* FushiSystemOcr.swift */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				8F6D7C1A2A3948576E0D1234 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */,
+				FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				8F6D7C1B2A3948576E0D1234 /* SceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,

--- a/fushi/ios/Runner/AppDelegate.swift
+++ b/fushi/ios/Runner/AppDelegate.swift
@@ -46,6 +46,10 @@ import Flutter
   }
 
   private func installChannels(binaryMessenger: FlutterBinaryMessenger) {
+    // 系统自带 OCR（Vision）。Dart 侧与 Android 侧早就在了，这半边一直空着——
+    // 没注册时 Dart 收到 MissingPluginException，isAvailable() 返回 false，引擎
+    // 选项就静默不出现（system_ocr_channel.dart 的注释把这条定为「当前事实」）。
+    FushiSystemOcr.register(binaryMessenger: binaryMessenger)
     challengeBrowser = FushiChallengeBrowser(binaryMessenger: binaryMessenger) {
       UIApplication.shared.connectedScenes
         .compactMap { $0 as? UIWindowScene }

--- a/fushi/macos/Runner.xcodeproj/project.pbxproj
+++ b/fushi/macos/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */; };
+		FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000002001C0F02 /* FushiSystemOcr.swift */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
@@ -65,6 +66,7 @@
 
 /* Begin PBXFileReference section */
 		FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiChallengeBrowser.swift; path = ../../apple/FushiChallengeBrowser.swift; sourceTree = "<group>"; };
+		FA171A002B000002001C0F02 /* FushiSystemOcr.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSystemOcr.swift; path = ../../apple/FushiSystemOcr.swift; sourceTree = "<group>"; };
 		0B7C95E12A53CED1568D4414 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		112D242DE0B0F664C7BC49FA /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -182,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */,
+				FA171A002B000002001C0F02 /* FushiSystemOcr.swift */,
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
@@ -492,6 +495,7 @@
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */,
+				FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/fushi/macos/Runner/AppDelegate.swift
+++ b/fushi/macos/Runner/AppDelegate.swift
@@ -12,6 +12,8 @@ class AppDelegate: FlutterAppDelegate {
     if let windowController =
         mainFlutterWindow?.contentViewController as? MacOSWindowUtilsViewController {
       let controller = windowController.flutterViewController
+      // 系统自带 OCR（Vision）。与 iOS 侧同一份实现（apple/FushiSystemOcr.swift）。
+      FushiSystemOcr.register(binaryMessenger: controller.engine.binaryMessenger)
       challengeBrowser = FushiChallengeBrowser(
         binaryMessenger: controller.engine.binaryMessenger
       ) { [weak self] in self?.mainFlutterWindow }

--- a/fushi/test/build/apple_system_ocr_guard_test.dart
+++ b/fushi/test/build/apple_system_ocr_guard_test.dart
@@ -1,0 +1,139 @@
+/// Apple 侧「系统自带 OCR」（Vision）原生半边的静态守卫。
+///
+/// 这半边**一条 Dart 测试都碰不到**：`system_ocr_manga_service_test.dart` 验的是
+/// `parseSystemOcrPayload` 这个纯函数，注入的是 fake channel；Swift 那边写错什么，
+/// 在本机（Windows）与 CI 的 Dart 测试里全都是绿的，要到真机上打开一本漫画才发现
+/// ——而它的失败形态偏偏和「这页真没字」长得一模一样。所以这里逐条钉住那些
+/// **错了不会报错**的地方。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String swift = File('apple/FushiSystemOcr.swift').readAsStringSync();
+  final String dart =
+      File('lib/src/ocr/system_ocr_channel.dart').readAsStringSync();
+  final String iosDelegate =
+      File('ios/Runner/AppDelegate.swift').readAsStringSync();
+  final String macosDelegate =
+      File('macos/Runner/AppDelegate.swift').readAsStringSync();
+
+  test('channel 名与 Dart 侧常量逐字一致', () {
+    // Dart 那边是 `MethodChannel('app.fushi.reader/system_ocr')`；两边对不上时
+    // Dart 收到的是 MissingPluginException → isAvailable() 返回 false → 引擎选项
+    // 静默消失，看起来就像「这个平台不支持」。
+    expect(dart, contains("MethodChannel('app.fushi.reader/system_ocr')"));
+    expect(swift, contains('"app.fushi.reader/system_ocr"'));
+  });
+
+  test('iOS 与 macOS 两侧都注册了，不许只接一半', () {
+    // 只接一半正是这个仓库反复出现的那类非对称 bug（「设置页能用、导入弹层不能用」
+    // 的同构体）：两个平台共用同一份 Swift，漏注册的那端没有任何编译期信号。
+    expect(iosDelegate, contains('FushiSystemOcr.register(binaryMessenger:'));
+    expect(macosDelegate, contains('FushiSystemOcr.register(binaryMessenger:'));
+  });
+
+  test('两个 Xcode 工程都把这份 Swift 登记进了编译（四处齐全）', () {
+    // pbxproj 漏登记不会有任何报错：文件躺在磁盘上、不进 Sources phase，
+    // `FushiSystemOcr` 就是个未定义符号——但那是在 macOS 上编译时才发现的，
+    // 本机根本编不了 Apple 目标。
+    for (final String path in <String>[
+      'ios/Runner.xcodeproj/project.pbxproj',
+      'macos/Runner.xcodeproj/project.pbxproj',
+    ]) {
+      final String pbx = File(path).readAsStringSync();
+      expect(
+        pbx,
+        contains('path = ../../apple/FushiSystemOcr.swift;'),
+        reason: '$path 缺 PBXFileReference',
+      );
+      expect(
+        pbx,
+        contains('/* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile;'),
+        reason: '$path 缺 PBXBuildFile',
+      );
+      // group children + Sources phase：两处引用各一次，加上上面两条定义，共四处。
+      expect(
+        '/* FushiSystemOcr.swift */,'.allMatches(pbx).length,
+        1,
+        reason: '$path 的 PBXGroup children 里应恰好登记一次',
+      );
+      expect(
+        '/* FushiSystemOcr.swift in Sources */,'.allMatches(pbx).length,
+        1,
+        reason: '$path 的 PBXSourcesBuildPhase 里应恰好登记一次',
+      );
+    }
+  });
+
+  test('payload 键名与 Dart 侧解析器期望的一致', () {
+    // 键名写错 → parseSystemOcrPayload 读到 0 → 退化矩形被丢弃 → 整页零行。
+    for (final String key in <String>[
+      '"width"',
+      '"height"',
+      '"lines"',
+      '"text"',
+      '"left"',
+      '"top"',
+      '"right"',
+      '"bottom"',
+    ]) {
+      expect(swift, contains(key), reason: 'payload 缺键 $key');
+    }
+  });
+
+  test('y 轴翻过来了：Vision 原点在左下，Dart / Android 在左上', () {
+    // 这条是全文件最容易错且**最安静**的一处：不翻 y，整页透明文字层上下颠倒，
+    // 点哪都查不到词，但不会有任何报错。
+    expect(swift, contains('(1 - box.maxY)'));
+    expect(swift, contains('(1 - box.minY)'));
+    // 左右不翻。
+    expect(swift, contains('box.minX * w'));
+    expect(swift, contains('box.maxX * w'));
+  });
+
+  test('不发 vertical：竖排判定只有 Dart 那一套', () {
+    // Vision 与 ML Kit 都不报竖排，Dart 按包围盒长宽比统一推断。Swift 这边自己
+    // 猜一个发过去，等于同一件事有两套判据，两边还会给出不同答案。
+    expect(swift, isNot(contains('"vertical":')));
+    expect(dart, contains('rect.height > rect.width'));
+  });
+
+  test('语言不受支持单独报 MODEL_UNAVAILABLE，不冒充识别失败', () {
+    // iOS 15 的 Vision 没有 CJK（那是 iOS 16 起的 revision 3）。报成
+    // RECOGNIZE_FAILED 会让用户去怀疑图片，而该做的是换引擎。
+    expect(swift, contains('code: "MODEL_UNAVAILABLE"'));
+    expect(swift, contains('code: "RECOGNIZE_FAILED"'));
+    expect(swift, contains('code: "INVALID_IMAGE"'));
+    expect(dart, contains("error.code == 'MODEL_UNAVAILABLE'"));
+    expect(swift, contains('supportedRecognitionLanguages()'));
+  });
+
+  test('用 CGImageSource 解码，且按 .up 送检——尺寸与坐标同一个方向', () {
+    // UIImage / NSImage 会把 EXIF 方向应用进去，尺寸和坐标系就和 Android 的
+    // BitmapFactory（rotation 0）对不上，同一本漫画两个平台的框会不一样。
+    expect(swift, contains('CGImageSourceCreateWithData'));
+    expect(swift, contains('orientation: .up'));
+    expect(swift, isNot(contains('UIImage(')));
+    expect(swift, isNot(contains('NSImage(')));
+  });
+
+  test('识别不占主线程，回调切回主线程', () {
+    expect(swift, contains('DispatchQueue.main.async { result('));
+    expect(swift, contains('queue.async'));
+  });
+
+  test('isAvailable 便宜作答：不做真识别、不触发下载', () {
+    // Dart 侧会把这个答案缓存进一次能力探测（system_ocr_channel.dart 的接口文档）。
+    final int start = swift.indexOf('case "isAvailable":');
+    final int end = swift.indexOf('case "recognize":');
+    expect(start, greaterThan(-1));
+    expect(end, greaterThan(start));
+    final String body = swift.substring(start, end);
+    expect(body, contains('supportedLanguages()'));
+    expect(body, isNot(contains('VNImageRequestHandler')));
+    expect(body, isNot(contains('perform(')));
+  });
+}


### PR DESCRIPTION
## 为什么

`app.fushi.reader/system_ocr` 的 Dart 侧（引擎枚举、auto 回退链、i18n 全在）与 Android 侧（unbundled ML Kit）早就落地了，**Apple 这半边一直是零行**。所以 iOS / macOS 上这个引擎选项静默不出现——Dart 收到 `MissingPluginException`，`isAvailable()` 返回 `false`，被显式当成「当前事实」而非错误。

补上之后，苹果端「安装后不用下载模型也能用」这条路真正成立：Vision 是系统组件，一个字节都不上传。

## 改了什么

- 新增 `fushi/apple/FushiSystemOcr.swift`（iOS / macOS 共用，放置与登记方式照 `FushiChallengeBrowser.swift` 的先例），用 `VNRecognizeTextRequest` 实现 `isAvailable` / `recognize`，payload 契约**逐字对齐 Android 那份**。
- 两个 `AppDelegate` 各注册一次；两个 Xcode 工程各登记四处（PBXBuildFile / PBXFileReference / group children / Sources phase）。

## 四处「错了不会报错、只会静默出错」的地方

1. **坐标翻 y**。Vision 的 `boundingBox` 是归一化的且原点在**左下**，Dart / Android 是绝对像素、原点左上。不翻 → 整页透明文字层上下颠倒，点哪都查不到词，**毫无报错**，在设备上和「这页真没字」长得一样。
2. **不发 `vertical`**。Vision 与 ML Kit 都不报竖排，Dart 侧按包围盒长宽比统一推断（Android 的注释也是这么定的）。这边自己猜一个 = 同一件事两套判据。
3. **用 `CGImageSource` 解码、按 `.up` 送检**，不用 `UIImage`/`NSImage`——后者会把 EXIF 方向应用进去，尺寸与坐标系就和 Android 的 `BitmapFactory`（rotation 0）对不上，同一本漫画两平台的框会不一样。
4. **语言不受支持单独报 `MODEL_UNAVAILABLE`**。iOS 15 的 Vision 没有 CJK（那是 iOS 16 起的 revision 3）。报成 `RECOGNIZE_FAILED` 会让用户去怀疑图片，而该做的是换引擎。

部署目标（iOS 15.1 / macOS 13.4）高于 `VNRecognizeTextRequest`（iOS 13）与实例版 `supportedRecognitionLanguages()`（iOS 15 / macOS 12），所以全文**不需要 `#available` 分支**。

## 测试

这半边**一条 Dart 测试都碰不到**——既有用例验的是 `parseSystemOcrPayload` 纯函数 + fake channel。所以加了 10 条静态守卫，钉住上面每一条，外加「iOS/macOS 两侧都注册」（防那类只接一半的非对称 bug）与「两个 pbxproj 四处齐全」（漏登记 = 未定义符号，只有在 macOS 上编译才会发现）。

守卫做过**变异实测**：把 y 翻转去掉、从 pbxproj 删一处登记，对应用例各自变红，还原后全绿——不是空壳。

`flutter analyze` 全量干净；`test/build test/media/manga/ocr test/native` **572 条绿**。

**Swift 本身的编译由本 PR CI 的 ios / macos job 验证**（本机是 Windows，编不了 Apple 目标）。真机上的识别质量需要一台 Apple 设备实测，我这边没有。

https://claude.ai/code/session_019JNKMR2aLamZinSPMcBw28
