### PR TITLE
fix(theme): 统一表面层级阶梯，页面底/导航窗格/卡片不再糊成一片（BUG-2422）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2227 条。点号进各自文件。
+> 共 2228 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2422](bugs/BUG-2422-settings-surface-ladder-flat.md) | ✅ | ✅ | 设置页页面底/导航窗格/卡片三层对比度仅1.05糊成一片（M3阶梯最挤段+全局关阴影） |
 | [BUG-2418](bugs/BUG-2418-popup-dismiss-animation-toggle.md) | ✅ | ✅ | 滑动关闭弹窗的动画只能靠开墨水屏模式关掉，没有独立开关 |
 | [BUG-2417](bugs/BUG-2417-stat-session-collection-title.md) | ✅ | ✅ | 统计「最近会话」标题单行截断且不带合集名 |
 | [BUG-2416](bugs/BUG-2416-reader-nested-popup-coordinate-space.md) | ✅ | ✅ | 阅读器嵌套查词混用屏幕与浮层坐标导致遮字 |

--- a/docs/bugs/BUG-2422-settings-surface-ladder-flat.md
+++ b/docs/bugs/BUG-2422-settings-surface-ladder-flat.md
@@ -1,0 +1,53 @@
+## BUG-2422 · 设置页页面底/导航窗格/卡片三层对比度仅1.05糊成一片（M3阶梯最挤段+全局关阴影）
+- **报告**：2026-09-10（用户：shishamo，「设置页色彩管理还是有点问题，总感觉不对劲」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/components/fushi_design_tokens.dart:190-192`（token 映射落在 M3 阶梯最挤的一段）× `fushi/lib/src/models/theme_notifier.dart:155/1306/1320`（全局 `elevation: 0` + `surfaceTint: Colors.transparent`，把 M3 用来承担层次的阴影与叠层都关掉了）。
+- **[x] ① 已修复** — `fushi/lib/src/models/theme_notifier.dart` 新增 `applyFushiSurfaceLadder`，三条主题路径出口统一收口；`deriveSurfaceRolesFrom` 改走 HCT tone 增量。提交见本 PR。
+- **[x] ② 已加自动化测试** — `fushi/test/models/theme_surface_ladder_test.dart`（9 条，钉关系不钉色值，覆盖 7 个预设 × 亮暗 + 中性派生 + 系统取色）。
+- **备注**：五平台共用同一条 Material 渲染路径，故此修复全平台生效。
+
+### 复现与量化
+
+对用户截图（亮色 / 系统主题 / 界面缩放 96%）逐像素采样：
+
+| 层 | token | 实测 | 对上一层对比度 |
+|---|---|---|---|
+| 页面底 / 详情窗格 | `surface` | `#F9F9FF` | — |
+| 导航窗格 | `surfaceContainerLow` | `#F3F3FA` | **1.053** |
+| section 卡片 | `surfaceContainer` | `#EDEDF4` | **1.055** |
+
+三层总跨度 **1.11**，全部低于大面积色块的可辨阈值——「看得出有东西但分不清边界」。
+
+（同时排除一个非 bug：截图里「墨水屏模式」那行更深的横条是 `InkWell` 的 hover 叠层，实测 4% 黑，237→228 完全吻合，鼠标当时停在该行。）
+
+### 根因
+
+M3 baseline 亮色六级容器色是 tone 100/98/96/94/92/90，相邻只差 2 tone（≈1.05）。M3 的设计意图是让 **elevation 阴影 + surfaceTint 叠层**承担层次，色差只作辅助。Hibiki 是「扁平 + 描边」的视觉语言，全局 `elevation: 0`、`surfaceTint` 一律透明——阴影和叠层都不存在，层次就只剩这 1.05。
+
+而 `FushiSurfaceColors.fromScheme` 的映射恰好落在阶梯最挤的一段：`page=surface(98)` / `group=surfaceContainerLow(96)` / `card=surfaceContainer(94)`，这三层是设置页、书架、媒体库最常同屏出现的组合；间距最大的 High / Highest 反倒给了搜索框和菜单这些小面积控件。
+
+同源的另外三处：
+
+1. **深色阶梯不均匀**：实测相邻 1.079 / **1.045** / 1.147 / 1.167，导航窗格→卡片恰好是最小的一跳。
+2. **钉死底色前后层次一跳**：`deriveSurfaceRolesFrom` 按固定比例向黑/白 `Color.lerp`，比例照抄 M3 baseline；且 sRGB 混色非感知均匀，同样 4% 的比例纯白底下清晰、**纯黑底下只有 1.062**（gamma 在暗端压得厉害），钉死纯黑的自定义主题层级基本看不见。
+3. **同一「系统」主题两端不一致**：Android 走 `CorePalette.toColorScheme()`（系统壁纸调色板），桌面走 `fromSeed(accent)`，两者推出的中性阶梯间距不同，此前无任何收口。
+
+### 修复
+
+`applyFushiSurfaceLadder(ColorScheme)`：只改 tone，色相/彩度锚定原 `surfaceContainer` 的 HCT，主题性格不变。
+
+```
+亮色  100 / 99.5 / 96.5 / 93.5 / 90.5 / 87
+深色    3 /    5 /  9.5 /   14 /   19 / 24
+```
+
+| 关系 | 改前 | 改后 |
+|---|---|---|
+| 亮色 相邻层 | 1.051 ~ 1.054 | 1.074 ~ 1.100 |
+| 亮色 页面底↔卡片 | 1.111 | **1.160** |
+| 深色 相邻层 | 1.039 ~ 1.167（不均） | 1.086 ~ 1.176（均匀） |
+| 深色 页面底↔卡片 | 1.130 | **1.203** |
+| 钉死纯黑 第一级 | 1.062 | ≥ 1.07 |
+
+亮色下探到 tone 93.5 就打住：tone 90 是 `secondaryContainer` 等 `*Container` 角色的地盘，卡片压到 92.5 时实测选中态对卡片从 1.109 掉到 **1.069**，列表选中项反而糊掉；收到 93.5 后是 1.098，与改前持平。深色无此约束（`secondaryContainer` 在 tone 30）。
+
+墨水屏（`buildEinkColorScheme` 全塌成纯黑白，层次由描边承担）与用户钉死底色（`deriveSurfaceRolesFrom`）各自保持语义，不过阶梯。

--- a/fushi/lib/src/models/theme_notifier.dart
+++ b/fushi/lib/src/models/theme_notifier.dart
@@ -172,7 +172,9 @@ ColorScheme buildFushiColorScheme({
         ? _readableOnColor(accentContainer)
         : base.onPrimaryContainer,
   );
-  if (surfaceRoles == null) return _hibikiSchemeCache[key] = withRoles;
+  if (surfaceRoles == null) {
+    return _hibikiSchemeCache[key] = applyFushiSurfaceLadder(withRoles);
+  }
   return _hibikiSchemeCache[key] = withRoles.copyWith(
     surface: surfaceRoles.surface,
     surfaceDim: surfaceRoles.surfaceDim,
@@ -222,24 +224,98 @@ typedef SurfaceRoles = ({
   Color onInverseSurface,
 });
 
-/// 以 [surface] 为页面底色，按 M3 容器层级向对比端（底色偏亮 → 黑，偏暗 → 白）
-/// 各混入少量灰推出分组 / 卡片 / 搜索框 / 菜单四级底色与文字、描边、反色。
-/// 层级比例参照 M3 亮色 tone 100/96/94/92/90 的间距；纯白底下卡片是极浅灰、
-/// 层次仍在。编辑页预览与词典弹窗都复用它，保证所见即所得。
+/// Hibiki 的表面层级 tone 表（顺序：containerLowest / surface / containerLow /
+/// container / containerHigh / containerHighest）。
+///
+/// M3 baseline 的六级容器色在亮色下是 tone 100/98/96/94/92/90——相邻只差 2
+/// tone，折合 WCAG 对比度约 **1.05**，远低于大面积色块的可辨阈值。M3 本来指望
+/// elevation 阴影与 surfaceTint 叠层承担层次，色差只作辅助；但 Hibiki 是
+/// 「扁平 + 描边」的视觉语言，全局 `elevation: 0` 且 surfaceTint 一律
+/// [Colors.transparent]，阴影和叠层都不存在——层次就只剩这 1.05 的色差。
+///
+/// 更糟的是 [FushiSurfaceColors] 的映射恰好落在阶梯最挤的一段：
+/// page=surface(98) / group=surfaceContainerLow(96) / card=surfaceContainer(94)，
+/// 这三层是设置页、书架、媒体库里最常同屏出现的组合，总跨度却只有 1.11；而
+/// 间距最大的 High / Highest 反倒给了搜索框和菜单这些小面积控件。结果就是页面
+/// 底、导航窗格、卡片糊成一片，既不像分层也不像扁平。
+///
+/// 这里把六级重新排布：相邻层 ≥ 1.07、页面↔卡片 1.16（原 1.11），并把深色下
+/// baseline 本身就不均匀的阶梯（1.079 / 1.045 / 1.147 / 1.167）拉齐。**只改
+/// tone，色相与彩度沿用原方案**，所以每个主题的性格不变，只是层级看得见了。
+///
+/// 亮色下探到 93.5 就打住，是因为 tone 90 是 `secondaryContainer` 等
+/// `*Container` 角色的地盘：卡片再往下压就会贴上选中态的明度，列表选中项反而
+/// 糊掉（压到 92.5 时实测 secondaryContainer↔卡片从 1.109 掉到 1.069）。深色
+/// 没有这个约束——那边 `secondaryContainer` 在 tone 30，离得远。
+const List<double> _lightSurfaceTones =
+    <double>[100, 99.5, 96.5, 93.5, 90.5, 87];
+const List<double> _darkSurfaceTones = <double>[3, 5, 9.5, 14, 19, 24];
+
+/// 把 [scheme] 的六级表面按 [_lightSurfaceTones] / [_darkSurfaceTones] 重算。
+///
+/// 三条主题路径（系统取色 / 内置预设 / 自定义 seed）出口都过这一道，所以层级
+/// 关系是全应用、全平台唯一的：Android 的 `CorePalette.toColorScheme()`（来自
+/// 系统壁纸）与桌面的 `fromSeed(accent)` 原本会推出**间距不同**的两套阶梯，
+/// 同一个「系统」主题在手机和桌面观感并不一致，收口后两端一致。
+///
+/// 两种情况不覆盖：墨水屏由 [buildEinkColorScheme] 全塌成纯黑白（层次改由描边
+/// 承担），用户钉死底色则走 [deriveSurfaceRolesFrom] 从钉死的那个色推同比例
+/// 阶梯——都在各自出口保持语义。
+ColorScheme applyFushiSurfaceLadder(ColorScheme scheme) {
+  final bool light = scheme.brightness == Brightness.light;
+  final List<double> tones = light ? _lightSurfaceTones : _darkSurfaceTones;
+  // 锚定原方案的中性色相 / 彩度：tonalSpot 给中性色 chroma 6、monochrome 给 0，
+  // 取 surfaceContainer 的 HCT 就能原样继承，不必区分 variant。
+  final Hct anchor = Hct.fromInt(scheme.surfaceContainer.toARGB32());
+  Color at(double tone) =>
+      Color(Hct.from(anchor.hue, anchor.chroma, tone).toInt());
+  return scheme.copyWith(
+    surfaceContainerLowest: at(tones[0]),
+    surface: at(tones[1]),
+    surfaceContainerLow: at(tones[2]),
+    surfaceContainer: at(tones[3]),
+    surfaceContainerHigh: at(tones[4]),
+    surfaceContainerHighest: at(tones[5]),
+    // dim / bright 是页面底自己的暗 / 亮变体，必须跟着走：亮色把 highest 压到
+    // tone 87 之后，baseline 的 dim(亮 87 / 暗 6) 不再比 highest 暗，语义就倒了。
+    surfaceBright: at(light ? tones[1] : 26),
+    surfaceDim: at(light ? 85 : 4),
+  );
+}
+
+/// 以 [surface] 为页面底色，向对比端（底色偏亮 → 暗，偏暗 → 亮）逐级推出分组 /
+/// 卡片 / 搜索框 / 菜单四级底色与文字、描边、反色。
+///
+/// 层级走 HCT **tone 增量**，间距与 [applyFushiSurfaceLadder] 同源，用户钉底色
+/// 前后层次不会一跳。原先是按固定比例向黑 / 白 `Color.lerp`，有两个毛病：比例
+/// 照抄 M3 baseline，比新阶梯挤将近一半；而且 sRGB 混色不是感知均匀的——同样
+/// 4% 的比例，纯白底下推出的层次清晰可辨，纯黑底下只有 1.06 的对比度（gamma
+/// 在暗端压得厉害），钉死纯黑的自定义主题层级基本是看不见的。
+///
+/// 编辑页预览与词典弹窗都复用它，保证所见即所得。
 SurfaceRoles deriveSurfaceRolesFrom(Color surface) {
   final bool dark =
       ThemeData.estimateBrightnessForColor(surface) == Brightness.dark;
   final Color contrast = dark ? Colors.white : Colors.black;
   Color step(double t) => Color.lerp(surface, contrast, t)!;
+  // 钉死的底色自己在 HCT 里的位置就是阶梯起点，其余各级按 tone 增量往对比端
+  // 走；夹到 [0,100] 是为了钉纯白 / 纯黑这两个端点仍有层次可推。
+  final Hct anchor = Hct.fromInt(surface.toARGB32());
+  Color tone(double delta) {
+    final double t =
+        (anchor.tone + (dark ? delta : -delta)).clamp(0, 100).toDouble();
+    return Color(Hct.from(anchor.hue, anchor.chroma, t).toInt());
+  }
+
   return (
     surface: surface,
-    surfaceDim: step(0.13),
+    surfaceDim: dark ? tone(-1) : tone(14.5),
     surfaceBright: surface,
     surfaceContainerLowest: surface,
-    surfaceContainerLow: step(0.03),
-    surfaceContainer: step(0.05),
-    surfaceContainerHigh: step(0.08),
-    surfaceContainerHighest: step(0.11),
+    surfaceContainerLow: tone(dark ? 4.5 : 3),
+    surfaceContainer: tone(dark ? 9 : 6),
+    surfaceContainerHigh: tone(dark ? 14 : 9),
+    surfaceContainerHighest: tone(dark ? 19 : 12.5),
     onSurface: dark ? const Color(0xDEFFFFFF) : const Color(0xDE000000),
     onSurfaceVariant: dark ? const Color(0x99FFFFFF) : const Color(0x99000000),
     outline: step(0.5),
@@ -1110,12 +1186,14 @@ class ThemeNotifier extends ChangeNotifier {
       return buildEinkColorScheme(brightness);
     }
     if (appThemeKey == 'system-theme') {
-      return buildSystemThemeColorScheme(
+      // 系统取色的中性阶梯有两个来源（Android 壁纸调色板 / 桌面 accent seed），
+      // 间距各不相同；同预设与自定义主题一样收口到统一阶梯。
+      return applyFushiSurfaceLadder(buildSystemThemeColorScheme(
         brightness: brightness,
         palette: _systemPalette,
         accent: _systemAccentColor,
         fallbackSeed: _seedColor,
-      );
+      ));
     }
     return buildFushiColorScheme(
       seedColor: _seedColor,

--- a/fushi/test/models/theme_surface_ladder_test.dart
+++ b/fushi/test/models/theme_surface_ladder_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
+
+/// 表面层级阶梯（[applyFushiSurfaceLadder]）的不变式。
+///
+/// 背景：M3 baseline 的六级容器色相邻只差 2 tone（对比度 ≈ 1.05），本意是让
+/// elevation 阴影与 surfaceTint 叠层承担层次。Hibiki 是「扁平 + 描边」的语言，
+/// 全局 `elevation: 0` 且 surfaceTint 一律透明，于是层次只剩这 1.05 的色差；
+/// 而 token 映射（page=surface / group=surfaceContainerLow / card=
+/// surfaceContainer）恰好落在阶梯最挤的一段，三层总跨度只有 1.11——设置页、
+/// 书架、媒体库里页面底、导航窗格、卡片就糊成一片。
+///
+/// 这里钉的是**关系**不是色值：单调、相邻可辨、页面↔卡片够开，同时不能为了拉
+/// 开层级把选中态和描边挤掉（亮色下 tone 90 是 `*Container` 角色的地盘，卡片
+/// 压过头 secondaryContainer 就贴上来了）。色值本身随主题走，不该钉死。
+void main() {
+  double contrast(Color a, Color b) {
+    final double la = a.computeLuminance(), lb = b.computeLuminance();
+    final double hi = la > lb ? la : lb;
+    final double lo = la > lb ? lb : la;
+    return (hi + 0.05) / (lo + 0.05);
+  }
+
+  /// 由低层级到高层级（M3 语义：越"高"离内容越近）。
+  List<Color> ladder(ColorScheme s) => <Color>[
+        s.surfaceContainerLowest,
+        s.surface,
+        s.surfaceContainerLow,
+        s.surfaceContainer,
+        s.surfaceContainerHigh,
+        s.surfaceContainerHighest,
+      ];
+
+  const List<String> ladderNames = <String>[
+    'surfaceContainerLowest',
+    'surface',
+    'surfaceContainerLow',
+    'surfaceContainer',
+    'surfaceContainerHigh',
+    'surfaceContainerHighest',
+  ];
+
+  /// 全部内置预设 × 亮暗，外加一个中性派生（monochrome）方案。
+  Map<String, ColorScheme> allSchemes() {
+    final Map<String, ColorScheme> out = <String, ColorScheme>{};
+    ThemeNotifier.themePresets.forEach((
+      String key,
+      ({Color seed, Brightness brightness, DynamicSchemeVariant variant}) v,
+    ) {
+      for (final Brightness b in Brightness.values) {
+        out['$key/${b.name}'] = buildFushiColorScheme(
+          seedColor: v.seed,
+          brightness: b,
+          variant: v.variant,
+        );
+      }
+    });
+    for (final Brightness b in Brightness.values) {
+      out['neutral-derived/${b.name}'] = buildFushiColorScheme(
+        seedColor: const Color(0xFF0B57D0),
+        brightness: b,
+        neutralDerived: true,
+      );
+      // 系统取色（桌面走 accent seed 这条）也必须过同一道阶梯。
+      out['system-accent/${b.name}'] = applyFushiSurfaceLadder(
+        buildSystemThemeColorScheme(
+          brightness: b,
+          fallbackSeed: const Color(0xFF1F4959),
+          accent: const Color(0xFF7A4EAB),
+        ),
+      );
+    }
+    return out;
+  }
+
+  test('六级严格单调：亮色逐级变深，深色逐级变亮', () {
+    allSchemes().forEach((String name, ColorScheme s) {
+      final List<Color> l = ladder(s);
+      final bool light = s.brightness == Brightness.light;
+      for (int i = 1; i < l.length; i++) {
+        final double prev = l[i - 1].computeLuminance();
+        final double cur = l[i].computeLuminance();
+        expect(
+          light ? cur < prev : cur > prev,
+          isTrue,
+          reason: '$name: ${ladderNames[i]} 没有比 ${ladderNames[i - 1]} 更'
+              '${light ? '深' : '亮'}（$prev → $cur）',
+        );
+      }
+    });
+  });
+
+  test('相邻层可辨：surface 之上每一级 ≥ 1.07', () {
+    allSchemes().forEach((String name, ColorScheme s) {
+      final List<Color> l = ladder(s);
+      // 从 index 1(surface) 起算：Lowest↔surface 在亮色下是纯白与近纯白，
+      // 本来就该几乎无差（它是"比页面还远"的那一层，极少与页面同屏相邻）。
+      for (int i = 2; i < l.length; i++) {
+        expect(
+          contrast(l[i], l[i - 1]),
+          greaterThanOrEqualTo(1.07),
+          reason: '$name: ${ladderNames[i]} 对 ${ladderNames[i - 1]} 只有 '
+              '${contrast(l[i], l[i - 1]).toStringAsFixed(3)}',
+        );
+      }
+    });
+  });
+
+  test('页面底↔卡片 ≥ 1.14（改前 M3 baseline 只有 1.11）', () {
+    allSchemes().forEach((String name, ColorScheme s) {
+      expect(
+        contrast(s.surface, s.surfaceContainer),
+        greaterThanOrEqualTo(1.14),
+        reason: '$name: page↔card 只有 '
+            '${contrast(s.surface, s.surfaceContainer).toStringAsFixed(3)}',
+      );
+    });
+  });
+
+  test('拉开层级不能挤掉选中态与描边', () {
+    allSchemes().forEach((String name, ColorScheme s) {
+      // 亮色下 tone 90 是 secondaryContainer 的地盘：卡片再往下压，列表选中项
+      // 就贴上卡片底色糊掉（实测压到 tone 92.5 时掉到 1.069）。
+      expect(
+        contrast(s.secondaryContainer, s.surfaceContainer),
+        greaterThanOrEqualTo(1.085),
+        reason: '$name: 选中态对卡片只有 '
+            '${contrast(s.secondaryContainer, s.surfaceContainer).toStringAsFixed(3)}',
+      );
+      // 扁平 + 描边的语言里，卡片边界靠 outlineVariant 承担。
+      expect(
+        contrast(s.outlineVariant, s.surfaceContainer),
+        greaterThanOrEqualTo(1.35),
+        reason: '$name: 卡片描边对卡片只有 '
+            '${contrast(s.outlineVariant, s.surfaceContainer).toStringAsFixed(3)}',
+      );
+    });
+  });
+
+  test('阶梯只改 tone：色相与彩度沿用原方案', () {
+    const Color seed = Color(0xFF8B7355);
+    for (final Brightness b in Brightness.values) {
+      final ColorScheme base = ColorScheme.fromSeed(
+        seedColor: seed,
+        brightness: b,
+      );
+      final ColorScheme out = applyFushiSurfaceLadder(base);
+      final Hct anchor = Hct.fromInt(base.surfaceContainer.toARGB32());
+      for (final Color c in ladder(out)) {
+        final Hct h = Hct.fromInt(c.toARGB32());
+        // 阶梯两端贴近纯白 / 纯黑，sRGB 装不下那点彩度，HCT 往回量化时 chroma
+        // 会掉、hue 随之失去意义（同 isAchromaticSeed 的道理）。这些格子只要求
+        // 彩度不高于锚点，不比色相。
+        if (h.chroma < anchor.chroma - 1.5) {
+          expect(h.tone, anyOf(greaterThan(96.0), lessThan(6.0)));
+          continue;
+        }
+        // 中性表面的彩度只有 4 上下，sRGB 在这一带能落的点很稀，HCT 往返量化
+        // 漂几度是常态。这里要抓的是「阶梯把暖色主题算成冷色」这类真回归，
+        // 不是量化噪声，所以容差给到 12°。
+        final double d = (h.hue - anchor.hue).abs();
+        expect(
+          d > 180 ? 360 - d : d,
+          lessThan(12.0),
+          reason: '色相漂了：${anchor.hue} → ${h.hue}（tone ${h.tone}）',
+        );
+        expect(h.chroma, closeTo(anchor.chroma, 1.5));
+      }
+      // 主题色角色一个都不碰。
+      expect(out.primary, base.primary);
+      expect(out.secondaryContainer, base.secondaryContainer);
+      expect(out.outlineVariant, base.outlineVariant);
+      expect(out.onSurface, base.onSurface);
+    }
+  });
+
+  test('dim / bright 仍是页面底的暗 / 亮变体', () {
+    // surfaceDim / surfaceBright 是页面底自己的两个变体（不是容器阶梯的端点）：
+    // dim 永远比 surface 暗、bright 永远不比它暗，两种亮度模式下都如此。亮色把
+    // highest 压到 tone 87 之后，M3 baseline 的 dim(87) 会不再比 highest 暗，
+    // 所以这两个必须跟着阶梯一起调。
+    allSchemes().forEach((String name, ColorScheme s) {
+      expect(
+        s.surfaceDim.computeLuminance(),
+        lessThan(s.surface.computeLuminance()),
+        reason: '$name: surfaceDim 没比页面底暗',
+      );
+      expect(
+        s.surfaceBright.computeLuminance(),
+        greaterThanOrEqualTo(s.surface.computeLuminance()),
+        reason: '$name: surfaceBright 比页面底还暗',
+      );
+      expect(
+        s.surfaceDim.computeLuminance(),
+        lessThan(s.surfaceContainerHighest.computeLuminance()),
+        reason: '$name: surfaceDim 没落在容器阶梯的暗端之外',
+      );
+    });
+  });
+
+  test('墨水屏不过阶梯：表面仍全塌成纯黑白', () {
+    for (final Brightness b in Brightness.values) {
+      final ColorScheme s = buildEinkColorScheme(b);
+      for (final Color c in ladder(s)) {
+        expect(c, s.surface, reason: 'eink 的表面必须全等于底色');
+      }
+    }
+  });
+
+  test('钉死底色的梯度与统一阶梯同量级（不会前后一跳）', () {
+    for (final Color pinned in <Color>[Colors.white, Colors.black]) {
+      final SurfaceRoles r = deriveSurfaceRolesFrom(pinned);
+      final List<Color> l = <Color>[
+        r.surface,
+        r.surfaceContainerLow,
+        r.surfaceContainer,
+        r.surfaceContainerHigh,
+        r.surfaceContainerHighest,
+      ];
+      for (int i = 1; i < l.length; i++) {
+        expect(
+          contrast(l[i], l[i - 1]),
+          greaterThanOrEqualTo(1.07),
+          reason: '钉死 $pinned：第 $i 级只有 ${contrast(l[i], l[i - 1])}',
+        );
+      }
+      expect(
+        contrast(r.surface, r.surfaceContainer),
+        greaterThanOrEqualTo(1.14),
+      );
+    }
+  });
+
+  test('三条主题路径出口都过阶梯（源码守卫）', () {
+    final String src = File(
+      'lib/src/models/theme_notifier.dart',
+    ).readAsStringSync();
+    // system-theme 分支：Android 壁纸调色板与桌面 accent seed 推出的阶梯间距
+    // 本来就不同，不收口这里两端观感不一致。
+    expect(
+      RegExp(
+        r'applyFushiSurfaceLadder\(\s*buildSystemThemeColorScheme\(',
+      ).hasMatch(src),
+      isTrue,
+      reason: 'system-theme 分支必须过 applyFushiSurfaceLadder',
+    );
+    // 预设 / 自定义分支：未钉死 surface 时的出口。
+    expect(
+      src.contains('_hibikiSchemeCache[key] = applyFushiSurfaceLadder('),
+      isTrue,
+      reason: 'buildFushiColorScheme 未钉死 surface 的出口必须过阶梯',
+    );
+  });
+}

--- a/fushi/test/models/theme_surface_override_test.dart
+++ b/fushi/test/models/theme_surface_override_test.dart
@@ -28,8 +28,10 @@ void main() {
         lum(r.surfaceContainerHighest),
         lessThan(lum(r.surfaceContainerHigh)),
       );
-      // 卡片只是极浅灰（层次仍在但不抢戏）。
-      expect(lum(r.surfaceContainer), greaterThan(0.85));
+      // 卡片只是浅灰（层次看得见但不抢戏）。阈值随梯度一起从 0.85 放到 0.82：
+      // 这套比例现在对齐 applyFushiSurfaceLadder 的 tone 阶梯，原先照抄 M3
+      // baseline 的间距挤了将近一半，用户钉底色前后层次会明显一跳。
+      expect(lum(r.surfaceContainer), greaterThan(0.82));
       expect(r.onSurface, const Color(0xDE000000));
       expect(lum(r.outline), lessThan(lum(r.outlineVariant)));
     });
@@ -73,7 +75,7 @@ void main() {
       );
     });
 
-    test('不给 surface：与旧输出完全一致（零变化）', () {
+    test('不给 surface：走统一阶梯，钉死路径不外溢', () {
       final ColorScheme a = buildFushiColorScheme(
         seedColor: seed,
         brightness: Brightness.light,
@@ -82,10 +84,19 @@ void main() {
         seedColor: seed,
         brightness: Brightness.light,
       );
-      expect(a.surface, b.surface);
-      expect(a.surfaceContainer, b.surfaceContainer);
+      // 不钉 surface 时表面来自 applyFushiSurfaceLadder（不再是 M3 baseline
+      // 原样）——但必须是那个函数算的，不能是钉死路径的 deriveSurfaceRolesFrom
+      // 漏进来。
+      final ColorScheme laddered = applyFushiSurfaceLadder(b);
+      expect(a.surface, laddered.surface);
+      expect(a.surfaceContainer, laddered.surfaceContainer);
+      expect(a.surfaceContainerHighest, laddered.surfaceContainerHighest);
+      // 阶梯只碰表面：主题色角色与 surfaceTint 仍与 fromSeed 一致。
       expect(a.surfaceTint, b.surfaceTint);
       expect(a.inversePrimary, b.inversePrimary);
+      expect(a.primary, b.primary);
+      expect(a.secondaryContainer, b.secondaryContainer);
+      expect(a.outlineVariant, b.outlineVariant);
     });
 
     test('memo key 区分 surface', () {


### PR DESCRIPTION
## 问题

用户反馈「设置页色彩管理还是有点问题，总感觉不对劲」。沿真实代码路径量化后，这不是审美偏好，是可测的层级失效。

对用户截图逐像素采样（亮色 / 系统主题）：

| 层 | token | 实测色 | 对上一层的对比度 |
|---|---|---|---|
| 页面底 / 详情窗格 | `surface` | `#F9F9FF` | — |
| 导航窗格 | `surfaceContainerLow` | `#F3F3FA` | **1.053** |
| section 卡片 | `surfaceContainer` | `#EDEDF4` | **1.055** |

三层总跨度只有 **1.11**，全部落在大面积色块的可辨阈值以下——既不像分层也不像扁平，就是「看得出有东西但分不清边界」。

### 根因

M3 baseline 的六级容器色在亮色下是 tone 100/98/96/94/92/90，相邻只差 2 tone（≈1.05）。M3 的本意是让 **elevation 阴影 + surfaceTint 叠层**承担层次，色差只作辅助。但 Hibiki 是「扁平 + 描边」的视觉语言：全局 `elevation: 0`（`cardTheme` / `appBarTheme` / `navigationBarTheme`），`surfaceTint` 一律 `Colors.transparent`。**阴影和叠层都被关掉了，层次信息就只剩这 1.05 的色差。**

更糟的是 `FushiSurfaceColors.fromScheme` 的映射恰好落在阶梯最挤的一段：`page=surface(98)` / `group=surfaceContainerLow(96)` / `card=surfaceContainer(94)`——这三层是设置页、书架、媒体库里最常同屏出现的组合；而间距最大的 High / Highest 反倒给了搜索框和菜单这些小面积控件。

另外三个同源问题：

- **深色阶梯本身不均匀**：实测相邻 1.079 / **1.045** / 1.147 / 1.167，`surfaceContainerLow → surfaceContainer`（导航窗格→卡片）恰好是最小的一跳。
- **钉死底色的自定义主题层次会一跳**：`deriveSurfaceRolesFrom` 按固定比例向黑/白 `Color.lerp`，比例照抄 M3 baseline，比阶梯挤将近一半。而且 sRGB 混色不是感知均匀的——同样 4% 的比例，纯白底下层次清晰，**纯黑底下只有 1.062**（gamma 在暗端压得厉害），钉死纯黑的主题层级基本看不见。
- **同一个「系统」主题在手机和桌面观感不一致**：Android 走 `CorePalette.toColorScheme()`（系统壁纸调色板），桌面走 `fromSeed(accent)`，两者推出的中性阶梯间距本来就不同，此前没有任何收口。

## 改动

新增 `applyFushiSurfaceLadder(ColorScheme)`：**只改 tone，色相与彩度沿用原方案**（锚定 `surfaceContainer` 的 HCT），所以每个主题的性格不变，只是层级变得看得见。

```
亮色  100 / 99.5 / 96.5 / 93.5 / 90.5 / 87
深色    3 /    5 /  9.5 /   14 /   19 / 24
```

三条主题路径（系统取色 / 内置预设 / 自定义 seed）出口统一收口，因此层级关系是全应用、全平台唯一的。设置页五平台共用同一条 Material 渲染路径（`isCupertinoPlatform` 只看主题里的 `designSystem`，不看 `Platform.isXxx`），所以这一处改动 Android / iOS / macOS / Windows / Linux 全都吃到。

两种情况按语义保持不变：墨水屏由 `buildEinkColorScheme` 全塌成纯黑白（层次改由描边承担），用户钉死底色走 `deriveSurfaceRolesFrom`（改为同源的 HCT tone 增量，顺带修掉上面那条纯黑底 1.062）。

### 效果（实测对比度）

| 关系 | 改前 | 改后 |
|---|---|---|
| 亮色 相邻层 | 1.051 ~ 1.054 | **1.074 ~ 1.100** |
| 亮色 页面底↔卡片 | 1.111 | **1.160** |
| 深色 相邻层 | 1.039 ~ 1.167（不均） | **1.086 ~ 1.176（均匀）** |
| 深色 页面底↔卡片 | 1.130 | **1.203** |
| 钉死纯黑 第一级 | 1.062 | **≥ 1.07** |

亮色下探到 tone 93.5 就打住是有约束的：tone 90 是 `secondaryContainer` 等 `*Container` 角色的地盘，卡片再往下压就会贴上选中态的明度——压到 92.5 时实测 `secondaryContainer ↔ 卡片`从 1.109 掉到 **1.069**，列表选中项反而糊掉。收到 93.5 后是 1.098，与改前基本持平。深色没有这个约束（那边 `secondaryContainer` 在 tone 30）。

## 测试

新增 `test/models/theme_surface_ladder_test.dart`，**钉关系不钉色值**（色值随主题走，钉死就成了阻碍）：

- 六级严格单调（亮色逐级变深 / 深色逐级变亮）
- 相邻层 ≥ 1.07、页面底↔卡片 ≥ 1.14
- 拉开层级不能挤掉选中态（≥1.085）与卡片描边（≥1.35）—— 这条就是上面那个 1.069 回归的守卫
- 阶梯只改 tone：色相/彩度沿用原方案，主题色角色一个都不碰
- `dim` / `bright` 仍是页面底的暗/亮变体
- 墨水屏不过阶梯（表面仍全塌成纯黑白）
- 钉死底色的梯度与统一阶梯同量级
- 三条主题路径出口都过阶梯（源码守卫）

覆盖全部 7 个内置预设 × 亮暗 + 中性派生 + 系统取色。

同时更新 `theme_surface_override_test.dart` 两条既有守卫（它们正确钉住了被改的语义）：「不给 surface 与 fromSeed 完全一致」改为「走统一阶梯、且钉死路径不外溢」；`deriveSurfaceRolesFrom` 纯白卡片的亮度阈值随梯度从 0.85 放到 0.82。

**验证**：`flutter analyze` 0 issue；主题相关定向测试 135 条、`test/goldens` 43 条、目录枚举型守卫整批 364 条全绿。


关联：BUG-2422

https://claude.ai/code/session_016fCeuRncouf4kNBimqGWen
