### PR TITLE
fix(sync): 同步冲突卡片书名换行展示，同系列多条冲突不再只剩同一前缀（BUG-2423）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2230 条。点号进各自文件。
+> 共 2231 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2423](bugs/BUG-2423-sync-conflict-title-truncated.md) | ✅ | ✅ | 同步冲突卡片书名单行省略，同系列多条冲突只剩同一前缀无法分辨 |
 | [BUG-2421](bugs/BUG-2421-favorite-words-cross-device-gaps.md) | 🚧 | 🚧 | 收藏的单词跨端看不到：wire 丢归属 + 云同步绑死统计开关 + 备份按统计表删除 |
 | [BUG-2420](bugs/BUG-2420-import-dialog-says-epub-for-18-formats.md) | ✅ | 🚧 | 书籍导入 UI 通篇写死 EPUB，实际支持 18 种格式 |
 | [BUG-2419](bugs/BUG-2419-windows-pdf-import-hangs-pdfium-missing.md) | ✅ | ✅ | Windows PDF 导入永久卡在「导入 EPUB…」：pdfium.dll 从未进入安装包 |

--- a/docs/bugs/BUG-2423-sync-conflict-title-truncated.md
+++ b/docs/bugs/BUG-2423-sync-conflict-title-truncated.md
@@ -1,0 +1,13 @@
+## BUG-2423 · 同步冲突卡片书名单行省略，同系列多条冲突只剩同一前缀无法分辨
+- **报告**：2026-09-10（用户截图：手机端「本地 vs 远端」弹窗里两条冲突都显示为「無職転生 ～異世界行った…」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/sync/sync_compare_dialog.dart:1341`（`_buildEntry` 里标题 `Text` 写死 `maxLines: 1` + `TextOverflow.ellipsis`）。
+  书名是冲突行唯一的身份（裁决结果 `_choices` 也是按 `entry.title` 索引），而轻小说 / 有声书标题动辄二三十字，
+  分岐点（卷号、副标题）在尾部。省略号恰好把那段切掉，同一系列的两条冲突渲染结果逐像素相同，
+  用户无法判断自己在给哪一本选「本地 / 跳过 / 远端」——而选错直接覆盖阅读进度，不可撤销。
+- **[x] ① 已修复** — `maxLines: 1` 改为 `maxLines: 3`（换行展示，3 行封顶避免异常长标题把卡片拉得无界），
+  `fushi/lib/src/sync/sync_compare_dialog.dart`。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/sync_compare_layout_test.dart`：「长书名换行展示：同系列的两条冲突不能只剩同一个前缀」。
+  真 widget 行为：播两本只差尾部卷号的长标题冲突，对标题 `RenderParagraph` 断言 `didExceedMaxLines == false`（没被省略）
+  且 `getBoxesForSelection` 行数 > 1（真的换了行，否则对 `maxLines: 1` 也会误绿）。已反向验证：把 `maxLines` 改回 1 这条即红。
+- **备注**：同弹窗的词典行（`_buildDictEntry`）也是 `maxLines: 1`，本次未动——词典名普遍短且未被报告，
+  若后续出现同类报告再按同一处方修。

--- a/fushi/lib/src/sync/sync_compare_dialog.dart
+++ b/fushi/lib/src/sync/sync_compare_dialog.dart
@@ -1334,11 +1334,15 @@ class _SyncCompareDialogState extends State<SyncCompareDialog> {
             children: [
               _directionIcon(entry, theme),
               const SizedBox(width: 6),
+              // 书名是这一行唯一的身份（`_choices` 也按 title 索引），而轻小说 /
+              // 有声书标题动辄二三十字。单行省略后同一系列的多条冲突只剩下
+              // 同一个前缀（「無職転生 ～異世界行った…」），用户无法分辨自己在给
+              // 哪一本裁决。改成换行展示，3 行封顶以免异常长的标题把卡片拉得无界。
               Expanded(
                 child: Text(
                   entry.title,
                   style: theme.textTheme.titleSmall,
-                  maxLines: 1,
+                  maxLines: 3,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),

--- a/fushi/test/sync/sync_compare_layout_test.dart
+++ b/fushi/test/sync/sync_compare_layout_test.dart
@@ -1,9 +1,11 @@
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/sync/sync_compare_dialog.dart';
+import 'package:fushi/src/sync/ttu_filename.dart';
 import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/utils/components/fushi_tag.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -171,5 +173,40 @@ void main() {
     expect(find.byType(FilterChip), findsNothing);
     expect(find.text(t.sync_compare_all_books), findsNothing);
     expect(find.text(t.sync_compare_apply(count: 2)), findsOneWidget);
+  });
+
+  testWidgets('长书名换行展示：同系列的两条冲突不能只剩同一个前缀',
+      (WidgetTester tester) async {
+    // 书名是冲突行唯一的身份（`_choices` 也按 title 索引）。它曾经写死
+    // maxLines: 1，同一系列的两卷被省略号截在分岐点之前，两行渲染完全一样，
+    // 用户无法分辨自己在给哪一本选「本地 / 跳过 / 远端」。
+    const String prefix =
+        'Mushoku Tensei - Isekai Ittara Honki Dasu - Deluxe Edition - Volume ';
+    const List<String> titles = <String>['${prefix}01', '${prefix}02'];
+
+    final FushiDatabase db = _memDb();
+    addTearDown(db.close);
+    final Map<String, RemoteBookFixture> remote = <String, RemoteBookFixture>{};
+    for (int i = 0; i < titles.length; i++) {
+      final EpubBookRow b = await seedCompareBook(db, titles[i]);
+      await seedComparePosition(db, b.uid, updatedAt: 120, fraction: 0.6);
+      await db.setSyncBaseline(sanitizeTtuFilename(titles[i]), 'progress', 50);
+      remote[titles[i]] =
+          RemoteBookFixture(folderId: 'f$i', timestampMs: 130, fraction: 0.7);
+    }
+    await pump(tester, db, FakeCompareBackend(remote), conflictsOnly: true);
+
+    for (final String title in titles) {
+      final Finder text = find.text(title);
+      expect(text, findsOneWidget, reason: '完整书名必须在树里');
+      final RenderParagraph paragraph =
+          tester.renderObject<RenderParagraph>(text);
+      expect(paragraph.didExceedMaxLines, isFalse,
+          reason: '书名不得被省略号截掉——截掉的恰好是区分两条冲突的那段');
+      final List<TextBox> lines = paragraph.getBoxesForSelection(
+          TextSelection(baseOffset: 0, extentOffset: title.length));
+      expect(lines.length, greaterThan(1),
+          reason: '这么长的标题在对话框宽度下必然要换行；不换行就说明又被限成了单行');
+    }
   });
 }


### PR DESCRIPTION
## 问题

用户在手机端「本地 vs 远端」冲突弹窗里看到两条冲突，书名都显示成
`無職転生 ～異世界行った…`——完全一样，无法判断自己在给哪一本选「本地 / 跳过 / 远端」。

## 根因

`fushi/lib/src/sync/sync_compare_dialog.dart` `_buildEntry` 里标题 `Text` 写死
`maxLines: 1` + `TextOverflow.ellipsis`。

书名是冲突行唯一的身份（裁决结果 `_choices` 也是按 `entry.title` 索引的），
而轻小说 / 有声书标题动辄二三十字、**分歧点（卷号、副标题）恰好在尾部**，
省略号切掉的正是区分两条冲突的那一段。选错的代价不是显示问题——它直接覆盖
阅读进度，且不可撤销。

## 改动

标题改为换行展示，`maxLines: 3` 封顶（避免异常长的标题把卡片拉得无界）。
只动了这一处；同弹窗的词典行（`_buildDictEntry`）也是 `maxLines: 1`，但词典名普遍短
且未被报告，本次未动，已在 bug 文件备注里记下。

## 验证

- `flutter analyze`（fushi 全量）：No issues found。
- `flutter test test/sync/sync_compare_layout_test.dart test/sync/sync_compare_dialog_labels_test.dart test/sync/sync_compare_conflict_test.dart test/sync/sync_compare_delete_test.dart test/tools/bugs_per_file_guard_test.dart`：21 passed，退出码 0。
- golden `test/goldens/sync_compare_dialog_golden_test.dart --tags golden`：通过（场景里是短标题，排版不变，无需重出图）。
- 新增测试反向验证过：把 `maxLines` 改回 1，新用例立刻红在 `didExceedMaxLines`。

新增用例（`test/sync/sync_compare_layout_test.dart`）走真 widget 行为：播两本只差尾部卷号的
长标题冲突，对标题 `RenderParagraph` 断言 `didExceedMaxLines == false`（没被省略）
且行盒数 > 1（确实换了行——否则这条测试对 `maxLines: 1` 也会误绿）。

BUG-2423。

https://claude.ai/code/session_015dZ4dCkihFGvRe6bLoy37a
