### PR TITLE
feat(asr): 转录弹层可选「系统语音识别（Apple）」，接入 SpeechAnalyzer

### DIFF
--- a/fushi/apple/FushiSpeechTranscriber.swift
+++ b/fushi/apple/FushiSpeechTranscriber.swift
@@ -1,0 +1,340 @@
+import AVFoundation
+import Foundation
+import Speech
+
+#if os(iOS)
+import Flutter
+#else
+import FlutterMacOS
+#endif
+
+/// Apple 侧「不用下我们的模型」的语音转录：`app.fushi.reader/apple_speech`。
+///
+/// 用 iOS 26 / macOS 26 的 `SpeechAnalyzer` + `SpeechTranscriber` 直接转录**本地音频
+/// 文件**，产出句级时间区间与逐词时间戳，交给 Dart 侧拼成与 ONNX 后端**逐字节同构**
+/// 的产物（`transcript.srt` + `transcript.tokens.jsonl`）。
+///
+/// **两道版本闸门，缺一不可**：
+///
+/// - 编译期 `#if compiler(>=6.2)`：`SpeechAnalyzer` 这批符号只存在于 Xcode 26 带的
+///   SDK 里。本仓的 Mac 开发机还在 Xcode 16.4，不隔离的话那边**整个工程编不过**
+///   （CI 用的是 Xcode 26.6，两边都要能编）。老 Xcode 下整段实现消失，只留下
+///   「本机不支持」的应答——功能不可用，但构建不塌。
+/// - 运行期 `if #available(iOS 26, macOS 26, *)`：部署目标是 iOS 15.1 / macOS 13.4，
+///   绝大多数用户机器上这套 API 根本不存在。
+///
+/// **说清楚「不用下模型」的边界**：不用下我们那 1 GB ONNX，但系统的语言资产仍要下
+/// （`AssetInventory.assetInstallationRequest(supporting:)` → `downloadAndInstall()`），
+/// 而且要 `reserve(locale:)`、有 `maximumReservedLocales` 上限。区别是这份资产由
+/// **系统**保管、多 app 共享、不占我们的包体。UI 上如实这么说，别吹成零下载。
+enum FushiSpeechTranscriber {
+  static let channelName = "app.fushi.reader/apple_speech"
+
+  /// 反向通知进度用；`transcribe` 是长任务（整本有声书几小时）。
+  private static var channel: FlutterMethodChannel?
+
+  /// 进行中的转录任务，供 `cancel` 取消。
+  private static var currentTask: Task<Void, Never>?
+
+  static func register(binaryMessenger: FlutterBinaryMessenger) {
+    let created = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger)
+    channel = created
+    created.setMethodCallHandler { call, result in
+      handle(call, result: result)
+    }
+  }
+
+  static func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "isAvailable":
+      result(isAvailable())
+    case "supportedLocales":
+      localeList(installed: false, result: result)
+    case "installedLocales":
+      localeList(installed: true, result: result)
+    case "prepare":
+      prepare(call, result: result)
+    case "transcribe":
+      transcribe(call, result: result)
+    case "cancel":
+      currentTask?.cancel()
+      currentTask = nil
+      result(true)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private static func unsupported(_ result: @escaping FlutterResult) {
+    result(
+      FlutterError(
+        code: "UNSUPPORTED_OS",
+        message: "Apple speech transcription requires iOS 26 / macOS 26",
+        details: nil))
+  }
+
+  #if compiler(>=6.2)
+
+    private static func isAvailable() -> Bool {
+      if #available(iOS 26.0, macOS 26.0, *) {
+        return true
+      }
+      return false
+    }
+
+    private static func localeList(
+      installed: Bool,
+      result: @escaping FlutterResult
+    ) {
+      guard #available(iOS 26.0, macOS 26.0, *) else {
+        result([String]())
+        return
+      }
+      Task {
+        let locales =
+          installed
+          ? await SpeechTranscriber.installedLocales
+          : await SpeechTranscriber.supportedLocales
+        let ids = locales.map { $0.identifier(.bcp47) }
+        await MainActor.run { result(ids) }
+      }
+    }
+
+    /// 确保该语言的资产已装好。已装好时直接成功，不发任何网络请求。
+    private static func prepare(
+      _ call: FlutterMethodCall,
+      result: @escaping FlutterResult
+    ) {
+      guard #available(iOS 26.0, macOS 26.0, *) else {
+        unsupported(result)
+        return
+      }
+      guard let args = call.arguments as? [String: Any],
+        let tag = args["locale"] as? String
+      else {
+        result(
+          FlutterError(
+            code: "INVALID_ARGUMENT", message: "locale is required", details: nil))
+        return
+      }
+      Task {
+        do {
+          guard let locale = await matchedLocale(for: tag) else {
+            await MainActor.run {
+              result(
+                FlutterError(
+                  code: "LOCALE_UNSUPPORTED",
+                  message: "no Apple speech model for \"\(tag)\"",
+                  details: nil))
+            }
+            return
+          }
+          let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [],
+            attributeOptions: [.audioTimeRange])
+          if let request = try await AssetInventory.assetInstallationRequest(
+            supporting: [transcriber])
+          {
+            try await request.downloadAndInstall()
+          }
+          // 预留槽位（有 maximumReservedLocales 上限）；已预留时是幂等的。
+          try await AssetInventory.reserve(locale: locale)
+          await MainActor.run { result(true) }
+        } catch {
+          await MainActor.run {
+            result(
+              FlutterError(
+                code: "ASSET_INSTALL_FAILED",
+                message: error.localizedDescription,
+                details: nil))
+          }
+        }
+      }
+    }
+
+    private static func transcribe(
+      _ call: FlutterMethodCall,
+      result: @escaping FlutterResult
+    ) {
+      guard #available(iOS 26.0, macOS 26.0, *) else {
+        unsupported(result)
+        return
+      }
+      guard let args = call.arguments as? [String: Any],
+        let path = args["path"] as? String,
+        let tag = args["locale"] as? String
+      else {
+        result(
+          FlutterError(
+            code: "INVALID_ARGUMENT",
+            message: "path and locale are required",
+            details: nil))
+        return
+      }
+      currentTask?.cancel()
+      currentTask = Task {
+        var replied = false
+        // 「恰好回调一次」的闸门：下面有正常返回、抛错、取消三条出口。
+        func reply(_ value: Any?) async {
+          if replied { return }
+          replied = true
+          await MainActor.run { result(value) }
+        }
+        do {
+          guard let locale = await matchedLocale(for: tag) else {
+            await reply(
+              FlutterError(
+                code: "LOCALE_UNSUPPORTED",
+                message: "no Apple speech model for \"\(tag)\"",
+                details: nil))
+            return
+          }
+          let url = URL(fileURLWithPath: path)
+          let file = try AVAudioFile(forReading: url)
+          let totalMs = Int(
+            (Double(file.length) / file.fileFormat.sampleRate) * 1000)
+
+          let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [],
+            attributeOptions: [.audioTimeRange])
+          let analyzer = SpeechAnalyzer(modules: [transcriber])
+
+          // 结果流与分析同时跑：results 是 AsyncSequence，start 会把整份文件喂完。
+          let collector = Task { () -> [[String: Any]] in
+            var segments: [[String: Any]] = []
+            for try await value in transcriber.results {
+              guard value.isFinal else { continue }
+              if let segment = segmentPayload(value) {
+                segments.append(segment)
+                let done = (segment["endMs"] as? Int) ?? 0
+                await MainActor.run {
+                  channel?.invokeMethod(
+                    "progress",
+                    arguments: ["processedMs": done, "totalMs": totalMs])
+                }
+              }
+            }
+            return segments
+          }
+
+          try await analyzer.start(inputAudioFile: file, finishAfterFile: true)
+          try await analyzer.finalizeAndFinishThroughEndOfInput()
+          let segments = try await collector.value
+          if Task.isCancelled {
+            await reply(
+              FlutterError(code: "CANCELLED", message: "cancelled", details: nil))
+            return
+          }
+          await reply(["durationMs": totalMs, "segments": segments])
+        } catch {
+          await reply(
+            FlutterError(
+              code: Task.isCancelled ? "CANCELLED" : "TRANSCRIBE_FAILED",
+              message: error.localizedDescription,
+              details: nil))
+        }
+        currentTask = nil
+      }
+    }
+
+    /// 把一条结果拍平成 Dart 侧认得的 map：句级区间 + 逐词区间。
+    ///
+    /// 句级来自 `Result.range`（不需要任何 attributeOption）；逐词来自
+    /// `.audioTimeRange` 给 AttributedString 挂的 `TimeRangeAttribute`。两级都给，
+    /// Dart 侧才能同时产出 SRT 与逐 token sidecar。
+    @available(iOS 26.0, macOS 26.0, *)
+    private static func segmentPayload(
+      _ value: SpeechTranscriber.Result
+    ) -> [String: Any]? {
+      let text = String(value.text.characters)
+      if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        return nil
+      }
+      let start = CMTimeGetSeconds(value.range.start)
+      let end = CMTimeGetSeconds(value.range.end)
+      guard start.isFinite, end.isFinite, end > start else { return nil }
+
+      var tokens: [[String: Any]] = []
+      for run in value.text.runs {
+        guard let range = run.audioTimeRange else { continue }
+        let piece = String(value.text[run.range].characters)
+        if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+          continue
+        }
+        let tokenStart = CMTimeGetSeconds(range.start)
+        guard tokenStart.isFinite else { continue }
+        tokens.append([
+          "text": piece,
+          "startMs": Int(tokenStart * 1000),
+        ])
+      }
+      return [
+        "text": text,
+        "startMs": Int(start * 1000),
+        "endMs": Int(end * 1000),
+        "tokens": tokens,
+      ]
+    }
+
+    /// 把 BCP-47 主子标签（`ja` / `zh`…）配到 Apple 支持的 locale 上。
+    ///
+    /// 先用官方的 `supportedLocale(equivalentTo:)` 做等价匹配，不中再按主子标签
+    /// 前缀在 `supportedLocales` 里找——`ja` 要能配上 `ja-JP`。
+    @available(iOS 26.0, macOS 26.0, *)
+    private static func matchedLocale(for tag: String) async -> Locale? {
+      if let exact = await SpeechTranscriber.supportedLocale(
+        equivalentTo: Locale(identifier: tag))
+      {
+        return exact
+      }
+      let primary = primarySubtag(tag)
+      if primary.isEmpty { return nil }
+      for candidate in await SpeechTranscriber.supportedLocales {
+        if primarySubtag(candidate.identifier(.bcp47)) == primary {
+          return candidate
+        }
+      }
+      return nil
+    }
+
+  #else
+
+    // Xcode 26 之前的 SDK 里没有 SpeechAnalyzer 这批符号。整段实现消失，应答成
+    // 「本机不支持」——功能不可用，但工程仍然编得过（本仓 Mac 开发机是 Xcode 16.4）。
+    private static func isAvailable() -> Bool { false }
+
+    private static func localeList(
+      installed: Bool,
+      result: @escaping FlutterResult
+    ) {
+      result([String]())
+    }
+
+    private static func prepare(
+      _ call: FlutterMethodCall,
+      result: @escaping FlutterResult
+    ) {
+      unsupported(result)
+    }
+
+    private static func transcribe(
+      _ call: FlutterMethodCall,
+      result: @escaping FlutterResult
+    ) {
+      unsupported(result)
+    }
+
+  #endif
+
+  private static func primarySubtag(_ tag: String) -> String {
+    let lowered = tag.lowercased()
+    guard let first = lowered.split(separator: "-").first else { return lowered }
+    return String(first)
+  }
+}

--- a/fushi/ios/Runner.xcodeproj/project.pbxproj
+++ b/fushi/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */; };
 		FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000002001C0F02 /* FushiSystemOcr.swift */; };
+		FA171A002B000003001C0F01 /* FushiSpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		61FEF2834CC237156E0983BA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5A058A6A618CF04E7D9DEC /* Pods_Runner.framework */; };
@@ -35,6 +36,7 @@
 /* Begin PBXFileReference section */
 		FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiChallengeBrowser.swift; path = ../../apple/FushiChallengeBrowser.swift; sourceTree = "<group>"; };
 		FA171A002B000002001C0F02 /* FushiSystemOcr.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSystemOcr.swift; path = ../../apple/FushiSystemOcr.swift; sourceTree = "<group>"; };
+		FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSpeechTranscriber.swift; path = ../../apple/FushiSpeechTranscriber.swift; sourceTree = "<group>"; };
 		0F5A058A6A618CF04E7D9DEC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */,
 				FA171A002B000002001C0F02 /* FushiSystemOcr.swift */,
+				FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				8F6D7C1A2A3948576E0D1234 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
@@ -350,6 +353,7 @@
 			files = (
 				FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */,
 				FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */,
+				FA171A002B000003001C0F01 /* FushiSpeechTranscriber.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				8F6D7C1B2A3948576E0D1234 /* SceneDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,

--- a/fushi/ios/Runner/AppDelegate.swift
+++ b/fushi/ios/Runner/AppDelegate.swift
@@ -50,6 +50,9 @@ import Flutter
     // 没注册时 Dart 收到 MissingPluginException，isAvailable() 返回 false，引擎
     // 选项就静默不出现（system_ocr_channel.dart 的注释把这条定为「当前事实」）。
     FushiSystemOcr.register(binaryMessenger: binaryMessenger)
+    // 系统语音转录（iOS 26 的 SpeechAnalyzer）。老系统上原生侧应答「不支持」，
+    // Dart 侧据此不把这个引擎放进下拉。
+    FushiSpeechTranscriber.register(binaryMessenger: binaryMessenger)
     challengeBrowser = FushiChallengeBrowser(binaryMessenger: binaryMessenger) {
       UIApplication.shared.connectedScenes
         .compactMap { $0 as? UIWindowScene }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 78574 (4622 per locale)
+/// Strings: 78659 (4627 per locale)
 ///
-/// Built on 2026-09-10 at 03:07 UTC
+/// Built on 2026-09-10 at 04:32 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6422,6 +6422,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_source_interconnect_disabled =>
       'Turn on Fushi Interconnect in settings to use this source';
   String get import_step_importing_book => 'Importing book…';
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -17293,6 +17301,19 @@ class _StringsAr extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -28392,6 +28413,19 @@ class _StringsDe extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -39545,6 +39579,19 @@ class _StringsEs extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -50732,6 +50779,19 @@ class _StringsFr extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -61721,6 +61781,19 @@ class _StringsId extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -72803,6 +72876,19 @@ class _StringsIt extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -83261,6 +83347,19 @@ class _StringsJa extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -93730,6 +93829,19 @@ class _StringsKo extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -104768,6 +104880,19 @@ class _StringsNl extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -115860,6 +115985,19 @@ class _StringsPtBr extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -126929,6 +127067,19 @@ class _StringsRu extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -137797,6 +137948,19 @@ class _StringsTh extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -148781,6 +148945,19 @@ class _StringsTr extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -159736,6 +159913,19 @@ class _StringsVi extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 // Path: <root>
@@ -169798,6 +169988,18 @@ class _StringsZhCn extends _StringsEn {
   String get manga_source_interconnect_disabled => '在设置里开启 Fushi 互联后即可使用此来源';
   @override
   String get import_step_importing_book => '导入书籍…';
+  @override
+  String get audiobook_transcribe_engine_system => '系统语音识别（Apple）';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      '用系统自带的语音模型，不下载我们那 1 GB 模型。首次使用时系统仍会下载它自己的语言资产，那份资产由系统保管、多个 app 共用。';
+  @override
+  String get audiobook_transcribe_engine_system_install => '安装语言';
+  @override
+  String get audiobook_transcribe_engine_system_installing => '正在让系统安装该语言…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      '这个引擎在文件中途无法暂停，停止会丢掉当前文件的进度。';
 }
 
 // Path: <root>
@@ -179940,6 +180142,19 @@ class _StringsZhHk extends _StringsEn {
       'Turn on Fushi Interconnect in settings to use this source';
   @override
   String get import_step_importing_book => 'Importing book…';
+  @override
+  String get audiobook_transcribe_engine_system => 'System speech (Apple)';
+  @override
+  String get audiobook_transcribe_engine_system_hint =>
+      'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+  @override
+  String get audiobook_transcribe_engine_system_install => 'Install language';
+  @override
+  String get audiobook_transcribe_engine_system_installing =>
+      'Asking the system to install the language…';
+  @override
+  String get audiobook_transcribe_engine_system_no_pause =>
+      'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
 }
 
 /// Flat map(s) containing all translations.
@@ -189454,6 +189669,16 @@ extension on _StringsEn {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -198963,6 +199188,16 @@ extension on _StringsAr {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -208517,6 +208752,16 @@ extension on _StringsDe {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -218062,6 +218307,16 @@ extension on _StringsEs {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -227616,6 +227871,16 @@ extension on _StringsFr {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -237141,6 +237406,16 @@ extension on _StringsId {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -246688,6 +246963,16 @@ extension on _StringsIt {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -256162,6 +256447,16 @@ extension on _StringsJa {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -265640,6 +265935,16 @@ extension on _StringsKo {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -275180,6 +275485,16 @@ extension on _StringsNl {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -284715,6 +285030,16 @@ extension on _StringsPtBr {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -294257,6 +294582,16 @@ extension on _StringsRu {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -303771,6 +304106,16 @@ extension on _StringsTh {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -313300,6 +313645,16 @@ extension on _StringsTr {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -322823,6 +323178,16 @@ extension on _StringsVi {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }
@@ -332263,6 +332628,16 @@ extension on _StringsZhCn {
         return '在设置里开启 Fushi 互联后即可使用此来源';
       case 'import_step_importing_book':
         return '导入书籍…';
+      case 'audiobook_transcribe_engine_system':
+        return '系统语音识别（Apple）';
+      case 'audiobook_transcribe_engine_system_hint':
+        return '用系统自带的语音模型，不下载我们那 1 GB 模型。首次使用时系统仍会下载它自己的语言资产，那份资产由系统保管、多个 app 共用。';
+      case 'audiobook_transcribe_engine_system_install':
+        return '安装语言';
+      case 'audiobook_transcribe_engine_system_installing':
+        return '正在让系统安装该语言…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return '这个引擎在文件中途无法暂停，停止会丢掉当前文件的进度。';
       default:
         return null;
     }
@@ -341715,6 +342090,16 @@ extension on _StringsZhHk {
         return 'Turn on Fushi Interconnect in settings to use this source';
       case 'import_step_importing_book':
         return 'Importing book…';
+      case 'audiobook_transcribe_engine_system':
+        return 'System speech (Apple)';
+      case 'audiobook_transcribe_engine_system_hint':
+        return 'Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.';
+      case 'audiobook_transcribe_engine_system_install':
+        return 'Install language';
+      case 'audiobook_transcribe_engine_system_installing':
+        return 'Asking the system to install the language…';
+      case 'audiobook_transcribe_engine_system_no_pause':
+        return 'This engine can\'t pause mid-file — stopping discards the current file\'s progress.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "已接入 $name",
   "manga_source_interconnect_subtitle": "浏览已配对设备上的漫画库",
   "manga_source_interconnect_disabled": "在设置里开启 Fushi 互联后即可使用此来源",
-  "import_step_importing_book": "导入书籍…"
+  "import_step_importing_book": "导入书籍…",
+  "audiobook_transcribe_engine_system": "系统语音识别（Apple）",
+  "audiobook_transcribe_engine_system_hint": "用系统自带的语音模型，不下载我们那 1 GB 模型。首次使用时系统仍会下载它自己的语言资产，那份资产由系统保管、多个 app 共用。",
+  "audiobook_transcribe_engine_system_install": "安装语言",
+  "audiobook_transcribe_engine_system_installing": "正在让系统安装该语言…",
+  "audiobook_transcribe_engine_system_no_pause": "这个引擎在文件中途无法暂停，停止会丢掉当前文件的进度。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4620,5 +4620,10 @@
   "audiobook_transcribe_model_custom_added": "Added $name",
   "manga_source_interconnect_subtitle": "Browse the manga library on your paired device",
   "manga_source_interconnect_disabled": "Turn on Fushi Interconnect in settings to use this source",
-  "import_step_importing_book": "Importing book…"
+  "import_step_importing_book": "Importing book…",
+  "audiobook_transcribe_engine_system": "System speech (Apple)",
+  "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
+  "audiobook_transcribe_engine_system_install": "Install language",
+  "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
 }

--- a/fushi/lib/src/asr_host/apple_speech_channel.dart
+++ b/fushi/lib/src/asr_host/apple_speech_channel.dart
@@ -1,0 +1,283 @@
+/// Apple 系统语音转录（iOS 26 / macOS 26 的 `SpeechAnalyzer`）的平台能力面。
+///
+/// 与系统 OCR 那条同一套哲学：原生侧只回答「本机能不能用」和「给一个音频文件返回
+/// 若干条带时间的文本」，切句、拼 SRT、写任务目录全留在 Dart 侧——**产物必须与
+/// ONNX 后端逐字节同构**，否则下游对齐链路要为它开第二条路。
+///
+/// 「不用下模型」的**准确说法**：不用下我们那 1 GB ONNX，但系统的语言资产仍要下
+/// （`AssetInventory`），只是由系统保管、多 app 共享、不占我们的包体。
+library;
+
+import 'package:flutter/services.dart';
+
+import 'package:fushi_asr_core/asr_core.dart';
+
+/// 平台通道。原生侧实现同名方法（`apple/FushiSpeechTranscriber.swift`）。
+const MethodChannel kAppleSpeechChannel =
+    MethodChannel('app.fushi.reader/apple_speech');
+
+/// 原生给回的一条结果：一句话 + 它在音频里的区间 + 逐词起点。
+class AppleSpeechSegment {
+  const AppleSpeechSegment({
+    required this.text,
+    required this.startMs,
+    required this.endMs,
+    this.tokens = const <String>[],
+    this.tokenOffsetsMs = const <int>[],
+  });
+
+  final String text;
+  final int startMs;
+  final int endMs;
+
+  /// 逐词文本与起点（毫秒）。两者等长；原生没给词级时间时同为空。
+  final List<String> tokens;
+  final List<int> tokenOffsetsMs;
+}
+
+/// 一次转录的结果。
+class AppleSpeechResult {
+  const AppleSpeechResult({required this.segments, required this.durationMs});
+
+  final List<AppleSpeechSegment> segments;
+  final int durationMs;
+}
+
+/// 系统语音转录不可用（OS 太老 / 语言没有模型 / 资产装不上）。
+///
+/// 与「这次识别失败」分开：调用方据此该换引擎或提示装语言，而不是重试这个文件。
+class AppleSpeechUnavailable implements Exception {
+  const AppleSpeechUnavailable(this.reason);
+
+  final String reason;
+
+  @override
+  String toString() => 'AppleSpeechUnavailable($reason)';
+}
+
+/// 平台能力接口。测试注 fake，生产走 [MethodChannelAppleSpeech]。
+abstract interface class AppleSpeechPlatform {
+  Future<bool> isAvailable();
+
+  /// 本机这套 API 认得的语言标签（BCP-47，如 `ja-JP`）。
+  Future<List<String>> supportedLocales();
+
+  /// 已经装好资产、可以离线直接跑的语言标签。
+  Future<List<String>> installedLocales();
+
+  /// 确保该语言的资产就位（已就位时不发网络请求）。
+  Future<void> prepare(String locale);
+
+  /// 转录一个本地音频文件。[onProgress] 收原生反向发来的进度。
+  Future<AppleSpeechResult> transcribe({
+    required String path,
+    required String locale,
+    void Function(int processedMs, int totalMs)? onProgress,
+  });
+
+  /// 请求取消进行中的转录。
+  Future<void> cancel();
+}
+
+class MethodChannelAppleSpeech implements AppleSpeechPlatform {
+  MethodChannelAppleSpeech({MethodChannel? channel})
+      : _channel = channel ?? kAppleSpeechChannel;
+
+  final MethodChannel _channel;
+  void Function(int processedMs, int totalMs)? _onProgress;
+  bool _handlerInstalled = false;
+
+  @override
+  Future<bool> isAvailable() async {
+    try {
+      return await _channel.invokeMethod<bool>('isAvailable') ?? false;
+    } on MissingPluginException {
+      // 这个平台没有原生侧——「没有」不是错误，是当前事实（与系统 OCR 同一条纪律）。
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  @override
+  Future<List<String>> supportedLocales() => _locales('supportedLocales');
+
+  @override
+  Future<List<String>> installedLocales() => _locales('installedLocales');
+
+  Future<List<String>> _locales(String method) async {
+    try {
+      final List<Object?>? raw = await _channel.invokeMethod<List<Object?>>(
+        method,
+      );
+      return <String>[
+        for (final Object? entry in raw ?? const <Object?>[])
+          if (entry is String && entry.isNotEmpty) entry,
+      ];
+    } on MissingPluginException {
+      return const <String>[];
+    } on PlatformException {
+      return const <String>[];
+    }
+  }
+
+  @override
+  Future<void> prepare(String locale) async {
+    try {
+      await _channel.invokeMethod<bool>('prepare', <String, Object?>{
+        'locale': locale,
+      });
+    } on MissingPluginException {
+      throw const AppleSpeechUnavailable('missing_plugin');
+    } on PlatformException catch (error) {
+      throw AppleSpeechUnavailable(_reasonOf(error));
+    }
+  }
+
+  @override
+  Future<AppleSpeechResult> transcribe({
+    required String path,
+    required String locale,
+    void Function(int processedMs, int totalMs)? onProgress,
+  }) async {
+    _onProgress = onProgress;
+    if (!_handlerInstalled) {
+      _handlerInstalled = true;
+      _channel.setMethodCallHandler((MethodCall call) async {
+        if (call.method != 'progress') return null;
+        final Map<Object?, Object?> args =
+            (call.arguments as Map<Object?, Object?>?) ??
+                const <Object?, Object?>{};
+        _onProgress?.call(
+          _asInt(args['processedMs']),
+          _asInt(args['totalMs']),
+        );
+        return null;
+      });
+    }
+    try {
+      final Map<Object?, Object?>? raw =
+          await _channel.invokeMapMethod<Object?, Object?>(
+        'transcribe',
+        <String, Object?>{'path': path, 'locale': locale},
+      );
+      if (raw == null) throw const AppleSpeechUnavailable('empty_response');
+      return parseAppleSpeechPayload(raw);
+    } on MissingPluginException {
+      throw const AppleSpeechUnavailable('missing_plugin');
+    } on PlatformException catch (error) {
+      // OS 太老 / 语言没模型 / 资产装不上 → 不可用；其余（含取消）原样抛。
+      const Set<String> unavailable = <String>{
+        'UNSUPPORTED_OS',
+        'LOCALE_UNSUPPORTED',
+        'ASSET_INSTALL_FAILED',
+      };
+      if (unavailable.contains(error.code)) {
+        throw AppleSpeechUnavailable(_reasonOf(error));
+      }
+      rethrow;
+    } finally {
+      _onProgress = null;
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    try {
+      await _channel.invokeMethod<bool>('cancel');
+    } on MissingPluginException {
+      // 没有原生侧就没有在跑的任务，取消是无事可做。
+    } on PlatformException {
+      // 取消失败不该盖过调用方正在处理的那个错误。
+    }
+  }
+
+  static String _reasonOf(PlatformException error) => error.code.toLowerCase();
+}
+
+/// 纯函数：把原生回传的 map 解析成 [AppleSpeechResult]。
+///
+/// 单独抽出来是为了让**契约**有一个可测的落点：Swift 改一个字段名，这里的测试立刻
+/// 红，而不是等到真机上转出一份空字幕——那种失败在设备上看起来和「这段没人说话」
+/// 一模一样。
+///
+/// 容错取向与系统 OCR 那条一致：**逐条丢弃坏行，不整份抛**（一句时间戳错不该毁掉
+/// 整本），但**整份缺时长**要抛——没有分母，进度和结尾 cue 都没法算。
+AppleSpeechResult parseAppleSpeechPayload(Map<Object?, Object?> raw) {
+  final int durationMs = _asInt(raw['durationMs']);
+  if (durationMs <= 0) {
+    throw const AppleSpeechUnavailable('invalid_duration');
+  }
+  final Object? rawSegments = raw['segments'];
+  final List<AppleSpeechSegment> segments = <AppleSpeechSegment>[];
+  if (rawSegments is List) {
+    for (final Object? entry in rawSegments) {
+      if (entry is! Map) continue;
+      final Map<Object?, Object?> map = entry.cast<Object?, Object?>();
+      final String text = (map['text'] ?? '').toString().trim();
+      if (text.isEmpty) continue;
+      final int startMs = _asInt(map['startMs']);
+      final int endMs = _asInt(map['endMs']);
+      // 退化区间：留着会在 SRT 里变成一条零长甚至倒挂的字幕。
+      if (endMs <= startMs) continue;
+      final List<String> tokens = <String>[];
+      final List<int> offsets = <int>[];
+      final Object? rawTokens = map['tokens'];
+      if (rawTokens is List) {
+        for (final Object? token in rawTokens) {
+          if (token is! Map) continue;
+          final Map<Object?, Object?> t = token.cast<Object?, Object?>();
+          final String piece = (t['text'] ?? '').toString();
+          if (piece.isEmpty) continue;
+          tokens.add(piece);
+          offsets.add(_asInt(t['startMs']));
+        }
+      }
+      segments.add(
+        AppleSpeechSegment(
+          text: text,
+          startMs: startMs,
+          endMs: endMs,
+          tokens: tokens,
+          tokenOffsetsMs: offsets,
+        ),
+      );
+    }
+  }
+  return AppleSpeechResult(segments: segments, durationMs: durationMs);
+}
+
+/// 纯函数：把原生结果拼成与 ONNX 后端同构的 cue 列表。
+///
+/// [fileIndex] 是这个音频在整本里的序号，[offsetMs] 是它在拼接时间轴上的起点——
+/// 多文件有声书转出来的是**单时间轴** SRT（与 ONNX 后端一致），所以每个文件的时间
+/// 都要加上前面所有文件的时长。
+///
+/// 逐词起点同样要平移；词数与 [AsrCue.tokens] 不等长会让下游一条都不挂
+/// （`attachAsrCueTokenTiming` 的纪律），所以两个列表在这里就保持等长。
+List<AsrCue> appleSpeechCues(
+  List<AppleSpeechSegment> segments, {
+  required int fileIndex,
+  required int offsetMs,
+}) {
+  return <AsrCue>[
+    for (final AppleSpeechSegment segment in segments)
+      AsrCue(
+        startMs: segment.startMs + offsetMs,
+        endMs: segment.endMs + offsetMs,
+        text: segment.text,
+        audioFileIndex: fileIndex,
+        tokens: segment.tokens,
+        tokenOffsetsMs: <int>[
+          for (final int offset in segment.tokenOffsetsMs) offset + offsetMs,
+        ],
+      ),
+  ];
+}
+
+int _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.round();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}

--- a/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
+++ b/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
@@ -1,0 +1,356 @@
+/// 用 Apple 系统语音转录（iOS 26 / macOS 26）顶替 ONNX 后端的那份转录服务。
+///
+/// **为什么是继承而不是新接口**：转录弹层与设置页吃的是具体类
+/// `AsrTranscriptionService`（上游包里的类，本仓不改）。给它抽一个接口意味着改上游
+/// 包 + 改弹层 880 行 + 改两处生产实例化点 + 改一整套既有测试；而那个类的对外方法
+/// 全是可覆写的实例方法，包里的 widget 测试早就在继承它做 fake。所以这里走同一条
+/// 路：覆写全部会被弹层调到的方法，内部一个 ONNX 符号都不碰。
+///
+/// **产物必须与 ONNX 后端逐字节同构**——同一个任务目录布局（`state.json` /
+/// `transcript.srt` / `transcript.tokens.jsonl`），同一套序列化函数
+/// （`serializeAsrCuesToSrt` / `serializeAsrCueTokens`）。下游的匹配、对齐、
+/// 「这份字幕是不是转录产物」判据（`isAsrGeneratedSubtitlePath` 认的是
+/// `transcript.srt` 旁边有没有 `state.json`）因此一行都不用改。
+///
+/// **任务 id 用自己的模型名**（[kAppleSpeechEngineId]）：换引擎就是另一个任务，
+/// ONNX 转到一半的进度不会被顶掉，切回去还在——与「换模型 = 换任务」同一条规则。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:fushi_asr_core/asr_core.dart';
+
+import 'package:fushi/src/asr_host/apple_speech_channel.dart';
+
+/// 系统语音引擎在「模型选择」里的保留 id。
+///
+/// 不是一个 [AsrModelPack] 的 id：它没有文件、没有变体、不占磁盘。保留 id 落进
+/// 目录的 `choices` 时，`buildAsrModelRegistry` 里 `_packById` 找不到它会**忽略这条
+/// 选择**——这正是我们要的：注册表只管 ONNX 包，引擎选择由 UI 层解释。
+const String kAppleSpeechEngineId = 'system-apple-speech';
+
+class AppleSpeechTranscriptionService extends AsrTranscriptionService {
+  AppleSpeechTranscriptionService({
+    AppleSpeechPlatform? platform,
+    Future<Directory> Function()? jobsRoot,
+  })  : _platform = platform ?? MethodChannelAppleSpeech(),
+        _jobsRootOverride = jobsRoot,
+        super(
+          // 父类构造要一个 backend，但本服务把每一个会用到它的方法都覆写了，
+          // ONNX 那条路在这里结构上不可达（`buildFactory` 永远不会被调）。
+          backend: const AsrIsolateBackend(buildFactory: _unusedOnnxFactory),
+        );
+
+  final AppleSpeechPlatform _platform;
+  final Future<Directory> Function()? _jobsRootOverride;
+
+  static OnnxSessionFactory _unusedOnnxFactory() =>
+      throw StateError('Apple speech backend never builds an ONNX session');
+
+  /// 本机能不能用（OS ≥ 26 且原生侧在）。
+  Future<bool> isAvailable() => _platform.isAvailable();
+
+  Future<Directory> _jobsRoot() async {
+    final Future<Directory> Function()? override = _jobsRootOverride;
+    if (override != null) return override();
+    final Directory support = await asrSupportRootDirectory();
+    return Directory(p.join(support.path, 'asr_jobs'));
+  }
+
+  /// 任务目录：与父类同构（文件名 + 字节数 + 模型 id 的 SHA-1），只是模型 id 换成
+  /// [kAppleSpeechEngineId]。父类那份是 static、按 `asrModelPackFor` 取 id，覆写不到，
+  /// 所以这里连同 [existingState] / [finishedSrtPath] 一起接管。
+  @override
+  Future<Directory> jobDirFor(
+    List<String> audioPaths,
+    AsrLanguage language,
+  ) async {
+    final Directory root = await _jobsRoot();
+    return Directory(
+      p.join(root.path, appleSpeechJobId(audioPaths, language)),
+    );
+  }
+
+  /// 纯函数：由文件名、字节数与引擎 id 派生稳定 id（与父类 `jobIdFor` 同构）。
+  static String appleSpeechJobId(
+    List<String> audioPaths,
+    AsrLanguage language,
+  ) {
+    final StringBuffer sb = StringBuffer();
+    for (final String path in audioPaths) {
+      final File f = File(path);
+      final int bytes = f.existsSync() ? f.lengthSync() : 0;
+      sb
+        ..write(p.basename(path))
+        ..write('|')
+        ..write(bytes)
+        ..write('\n');
+    }
+    sb
+      ..write('model=')
+      ..write(kAppleSpeechEngineId)
+      ..write('@')
+      ..write(language.tag)
+      ..write('\n');
+    return sha1.convert(utf8.encode(sb.toString())).toString();
+  }
+
+  /// 计划：这里的「模型就绪」= 该语言的系统资产已安装。
+  ///
+  /// 没装时 `modelReady` 为 false，弹层照常走「下载模型」那条路，只是按下去调的是
+  /// [downloadModel] → 系统的资产安装。字节数给不出来（系统不报），所以 total 用 0
+  /// ——UI 那边会显示成「需要下载」但不报大小，这比编一个数字诚实。
+  @override
+  Future<AsrTranscribePlan> plan({
+    required AsrLanguage language,
+    required AsrAccelerationPreference preference,
+  }) async {
+    final List<String> installed = await _platform.installedLocales();
+    final bool ready = _matches(installed, language.tag);
+    return AsrTranscribePlan(
+      language: language,
+      variant: AsrEncoderVariant.int8,
+      expectedProvider: OnnxExecutionProvider.cpu,
+      modelStatus: AsrModelStatus(
+        ready: ready,
+        diskBytes: 0,
+        totalBytes: 0,
+        obtainedBytes: 0,
+      ),
+    );
+  }
+
+  /// 「下载模型」= 让系统把该语言的资产装上。装好后 [plan] 就报就绪。
+  @override
+  Stream<ModelDownloadEvent> downloadModel({
+    required AsrLanguage language,
+    required AsrEncoderVariant variant,
+  }) async* {
+    yield const ModelDownloadEvent(
+      fileName: 'system speech assets',
+      receivedBytes: 0,
+      totalBytes: 0,
+    );
+    await _platform.prepare(language.tag);
+    yield const ModelDownloadEvent(
+      fileName: 'system speech assets',
+      receivedBytes: 0,
+      totalBytes: 0,
+      done: true,
+    );
+  }
+
+  @override
+  Future<AsrJobState?> existingState(
+    List<String> audioPaths,
+    AsrLanguage language,
+  ) async {
+    final Directory dir = await jobDirFor(audioPaths, language);
+    final File state = File(p.join(dir.path, AsrJobFiles.state));
+    if (!state.existsSync()) return null;
+    try {
+      final Object? raw = jsonDecode(await state.readAsString());
+      if (raw is! Map<String, Object?>) return null;
+      final AsrJobState parsed = AsrJobState.fromJson(raw);
+      // 音频集合变了（用户换了文件）→ 旧状态作废，当作没有。
+      if (parsed.audioPaths.length != audioPaths.length) return null;
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<String?> finishedSrtPath(
+    List<String> audioPaths,
+    AsrLanguage language,
+  ) async {
+    final AsrJobState? state = await existingState(audioPaths, language);
+    if (state == null || !state.finished) return null;
+    final Directory dir = await jobDirFor(audioPaths, language);
+    final File srt = File(p.join(dir.path, AsrJobFiles.srt));
+    return srt.existsSync() ? srt.path : null;
+  }
+
+  @override
+  Future<void> discard(List<String> audioPaths, AsrLanguage language) async {
+    final Directory dir = await jobDirFor(audioPaths, language);
+    if (dir.existsSync()) await dir.delete(recursive: true);
+  }
+
+  @override
+  Future<AsrRunningTranscription> start({
+    required List<String> audioPaths,
+    required AsrLanguage language,
+    required AsrEncoderVariant variant,
+    required AsrAccelerationPreference preference,
+  }) async {
+    final Directory dir = await jobDirFor(audioPaths, language);
+    await dir.create(recursive: true);
+    return AppleSpeechRunningTranscription(
+      platform: _platform,
+      audioPaths: List<String>.unmodifiable(audioPaths),
+      language: language,
+      jobDir: dir,
+    );
+  }
+
+  /// 该语言标签是否在这组 BCP-47 标签里（按主子标签比：`ja` 命中 `ja-JP`）。
+  static bool _matches(List<String> locales, String tag) {
+    final String primary = _primary(tag);
+    if (primary.isEmpty) return false;
+    for (final String locale in locales) {
+      if (_primary(locale) == primary) return true;
+    }
+    return false;
+  }
+
+  static String _primary(String tag) {
+    final String lowered = tag.toLowerCase();
+    final int dash = lowered.indexOf(RegExp(r'[-_]'));
+    return dash < 0 ? lowered : lowered.substring(0, dash);
+  }
+}
+
+/// 一次正在跑的系统语音转录。
+///
+/// 与 ONNX 那条的**行为差异必须说清**：系统 API 是「喂一个文件、等它转完」，中途
+/// **没有可续跑的检查点**。所以 [requestPause] 只能是取消——本类不发
+/// `AsrTranscribePausedEvent`，弹层的「暂停」在这个引擎下等于放弃当前文件的进度
+/// （已转完的文件仍然留在任务目录里，下次从下一个文件接着来）。
+class AppleSpeechRunningTranscription implements AsrRunningTranscription {
+  AppleSpeechRunningTranscription({
+    required AppleSpeechPlatform platform,
+    required this.audioPaths,
+    required this.language,
+    required this.jobDir,
+  }) : _platform = platform;
+
+  final AppleSpeechPlatform _platform;
+  final List<String> audioPaths;
+  final AsrLanguage language;
+  final Directory jobDir;
+
+  bool _cancelled = false;
+
+  @override
+  OnnxProviderResolution get encoderResolution => const OnnxProviderResolution(
+        requested: <OnnxExecutionProvider>[OnnxExecutionProvider.cpu],
+        effective: OnnxExecutionProvider.cpu,
+      );
+
+  @override
+  bool get greedyGraphAvailable => false;
+
+  @override
+  String? get greedyUnavailableReason => null;
+
+  @override
+  bool get encoderFp16 => false;
+
+  @override
+  AsrDecodeStats? get decodeStats => null;
+
+  @override
+  Stream<AsrTranscribeEvent> run() async* {
+    final Stopwatch clock = Stopwatch()..start();
+    final List<AsrCue> cues = <AsrCue>[];
+    final List<int> fileDurationsMs = <int>[];
+    int offsetMs = 0;
+
+    for (int index = 0; index < audioPaths.length; index++) {
+      if (_cancelled) break;
+      final StreamController<AsrTranscribeProgress> ticks =
+          StreamController<AsrTranscribeProgress>();
+      final int fileIndex = index;
+      final int base = offsetMs;
+      final AppleSpeechResult result = await _platform.transcribe(
+        path: audioPaths[index],
+        locale: language.tag,
+        onProgress: (int processedMs, int totalMs) {
+          if (ticks.isClosed) return;
+          ticks.add(
+            AsrTranscribeProgress(
+              fileIndex: fileIndex,
+              filesTotal: audioPaths.length,
+              processedMs: base + processedMs,
+              totalMs: base + totalMs,
+              speechMs: base + processedMs,
+              segmentsDone: cues.length,
+              elapsed: clock.elapsed,
+            ),
+          );
+        },
+      );
+      unawaited(ticks.close());
+      cues.addAll(
+        appleSpeechCues(
+          result.segments,
+          fileIndex: index,
+          offsetMs: offsetMs,
+        ),
+      );
+      offsetMs += result.durationMs;
+      fileDurationsMs.add(result.durationMs);
+      yield AsrTranscribeProgressEvent(
+        AsrTranscribeProgress(
+          fileIndex: index,
+          filesTotal: audioPaths.length,
+          processedMs: offsetMs,
+          totalMs: offsetMs,
+          speechMs: offsetMs,
+          segmentsDone: cues.length,
+          elapsed: clock.elapsed,
+        ),
+      );
+    }
+
+    if (_cancelled) return;
+
+    // 产物与 ONNX 后端同构：同一套序列化函数、同样的文件名。
+    final File srt = File(p.join(jobDir.path, AsrJobFiles.srt));
+    final File tokens = File(p.join(jobDir.path, AsrJobFiles.cueTokens));
+    await srt.writeAsString(serializeAsrCuesToSrt(cues), flush: true);
+    await tokens.writeAsString(serializeAsrCueTokens(cues), flush: true);
+    await File(p.join(jobDir.path, AsrJobFiles.state)).writeAsString(
+      jsonEncode(
+        AsrJobState(
+          audioPaths: audioPaths,
+          modelId: kAppleSpeechEngineId,
+          fileDurationsMs: fileDurationsMs,
+          resumeSamples: List<int>.filled(audioPaths.length, 0),
+          finished: true,
+        ).toJson(),
+      ),
+      flush: true,
+    );
+
+    yield AsrTranscribeFinishedEvent(
+      AsrTranscribeResult(
+        srtPath: srt.path,
+        segmentsPath: p.join(jobDir.path, AsrJobFiles.segments),
+        cueCount: cues.length,
+        segmentCount: cues.length,
+        totalMs: offsetMs,
+        fileDurationsMs: fileDurationsMs,
+      ),
+    );
+  }
+
+  @override
+  void requestPause({bool discardPending = false}) {
+    // 系统 API 没有可续跑的检查点：暂停只能是取消（见类文档）。
+    _cancelled = true;
+    unawaited(_platform.cancel());
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (!_cancelled) await _platform.cancel();
+  }
+}

--- a/fushi/lib/src/asr_host/asr_engine_options.dart
+++ b/fushi/lib/src/asr_host/asr_engine_options.dart
@@ -1,0 +1,77 @@
+/// 转录弹层「模型」下拉里到底有哪几项。
+///
+/// 在系统语音引擎进来之前，这个下拉的值域就是「服务该语言的 ONNX 包」，一个
+/// [AsrModelPack] 列表就够了。系统语音不是一个包——**它没有文件、没有变体、不占
+/// 磁盘、大小是未知**，硬塞成 `AsrModelPack` 会在 `filesFor()` / `totalBytes()` 这些
+/// 地方抛 `StateError`（那些方法逐角色 `firstWhere`）。所以这里给出一个只表达 UI
+/// 需要的窄类型：**值域是两类东西的和**，一个包 id，或那个保留 id。
+///
+/// 纯函数、无 IO、不碰平台单例——「本机有没有系统语音」由调用方探好了传进来。
+library;
+
+import 'package:fushi_asr_core/asr_core.dart';
+
+import 'package:fushi/src/asr_host/apple_speech_transcription_service.dart';
+import 'package:fushi/src/asr_host/asr_model_catalog.dart';
+
+/// 下拉里的一项。
+class AsrEngineOption {
+  const AsrEngineOption({
+    required this.id,
+    required this.label,
+    this.pack,
+  });
+
+  /// [AsrModelPack.id]，或系统语音的保留 id [kAppleSpeechEngineId]。
+  final String id;
+
+  /// 给用户看的名字。
+  final String label;
+
+  /// ONNX 包（系统语音项为 null）。
+  final AsrModelPack? pack;
+
+  bool get isSystemSpeech => pack == null;
+}
+
+/// 这门语言能选哪些引擎。
+///
+/// 顺序即展示顺序：**ONNX 包在前、系统语音在后**。理由是默认不能变——系统语音在
+/// 支持它的机器上是「另一个可选项」，不是新的默认；而 [selectedAsrEngineId] 在没有
+/// 选择记录时取第一项，取到 ONNX 包才与改动前逐字一致。
+///
+/// [systemSpeechAvailable] 为 false（OS < 26、非 Apple 平台、原生侧没实现）时那一项
+/// **整个不出现**——出现一个点了就报错的选项比没有更糟。
+List<AsrEngineOption> asrEngineOptions({
+  required AsrLanguage language,
+  required AsrModelRegistry registry,
+  required bool systemSpeechAvailable,
+  required String systemSpeechLabel,
+}) {
+  return <AsrEngineOption>[
+    for (final AsrModelPack pack in asrModelChoicesFor(language, registry))
+      AsrEngineOption(id: pack.id, label: pack.displayName, pack: pack),
+    if (systemSpeechAvailable)
+      AsrEngineOption(id: kAppleSpeechEngineId, label: systemSpeechLabel),
+  ];
+}
+
+/// 当前这门语言选中的是哪一项。
+///
+/// 判据顺序：目录里记着的选择 → 命中就用它；没有记录、或记的那项已经不在列表里
+/// （用户移除了自带包、换了台没有系统语音的机器）→ 回落第一项。**不回落 null**：
+/// 下拉必须有个选中值，而「第一项」正是 `asrModelPackFor` 的判据。
+String? selectedAsrEngineId({
+  required AsrLanguage language,
+  required AsrModelCatalog catalog,
+  required List<AsrEngineOption> options,
+}) {
+  if (options.isEmpty) return null;
+  final String? remembered = catalog.choices[language.tag];
+  if (remembered != null) {
+    for (final AsrEngineOption option in options) {
+      if (option.id == remembered) return option.id;
+    }
+  }
+  return options.first.id;
+}

--- a/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
+++ b/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
@@ -19,6 +19,8 @@ import 'package:share_plus/share_plus.dart';
 
 import 'package:fushi_asr_core/asr_core.dart';
 import 'package:fushi/src/asr_host/asr_host.dart';
+import 'package:fushi/src/asr_host/apple_speech_transcription_service.dart';
+import 'package:fushi/src/asr_host/asr_engine_options.dart';
 import 'package:fushi/src/asr_host/asr_model_catalog.dart';
 import 'package:fushi/src/media/audiobook/asr_local_model_dialog.dart';
 import 'package:fushi/src/models/app_model.dart';
@@ -250,6 +252,7 @@ class AsrTranscribeSheet extends StatefulWidget {
     AsrModelCatalog Function()? catalogGetter,
     Future<void> Function(AsrModelCatalog catalog)? catalogSetter,
     this.directoryPicker,
+    this.systemSpeechService,
     super.key,
   })  : catalogGetter = catalogGetter ?? _readAsrModelCatalog,
         catalogSetter = catalogSetter ?? saveAsrModelCatalog;
@@ -282,11 +285,22 @@ class AsrTranscribeSheet extends StatefulWidget {
   /// 「手动指定模型」用的目录选择器；null = 真的系统对话框。
   final Future<String?> Function()? directoryPicker;
 
+  /// 选中「系统语音识别」时用哪个服务；null = 真的 [AppleSpeechTranscriptionService]。
+  /// 测试注入 fake，免得 widget 测试去碰 method channel。
+  final AsrTranscriptionService Function()? systemSpeechService;
+
   @override
   State<AsrTranscribeSheet> createState() => _AsrTranscribeSheetState();
 }
 
 class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
+  /// 当前生效的转录服务。选中系统语音时换成另一份实现（见 [_serviceFor]）——
+  /// 弹层其余部分只与「一个 AsrTranscriptionService」对话，不知道底下是谁。
+  late AsrTranscriptionService _service = widget.service;
+
+  /// 本机有没有系统语音（OS ≥ 26 且原生侧在）。探完才决定下拉里出不出那一项。
+  bool _systemSpeechAvailable = false;
+
   _Phase _phase = _Phase.checking;
   AsrAccelerationPreference _preference = AsrAccelerationPreference.auto;
   AsrLanguage _language = AsrLanguage.japanese;
@@ -317,6 +331,8 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     _language = widget.languageHint ??
         AsrLanguage.fromTag(widget.languageGetter?.call()) ??
         AsrLanguage.japanese;
+    _service = _serviceFor(_selectedEngineId());
+    unawaited(_probeSystemSpeech());
     _refreshPlan();
   }
 
@@ -345,15 +361,15 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     });
     try {
       final AsrLanguage language = _language;
-      final AsrTranscribePlan plan = await widget.service.plan(
+      final AsrTranscribePlan plan = await _service.plan(
         language: language,
         preference: _preference,
       );
-      final String? finished = await widget.service.finishedSrtPath(
+      final String? finished = await _service.finishedSrtPath(
         widget.audioPaths,
         language,
       );
-      final AsrJobState? existing = await widget.service.existingState(
+      final AsrJobState? existing = await _service.existingState(
         widget.audioPaths,
         language,
       );
@@ -422,7 +438,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     int completedBytes = 0;
     String lastFile = '';
     int lastFileTotal = 0;
-    _downloadSub = widget.service
+    _downloadSub = _service
         .downloadModel(language: plan.language, variant: plan.variant)
         .listen(
       (ModelDownloadEvent e) {
@@ -457,7 +473,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
       _result = null;
     });
     try {
-      final AsrRunningTranscription running = await widget.service.start(
+      final AsrRunningTranscription running = await _service.start(
         audioPaths: widget.audioPaths,
         language: plan.language,
         variant: plan.variant,
@@ -535,16 +551,56 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     _refreshPlan();
   }
 
-  /// 这门语言当前能选哪些模型包（第一项 = 当前生效的那个）。
-  List<AsrModelPack> _modelChoices() =>
-      asrModelChoicesFor(_language, asrModelRegistry);
+  /// 这门语言当前能选哪些引擎（ONNX 包在前，系统语音在后）。
+  List<AsrEngineOption> _engineOptions() => asrEngineOptions(
+        language: _language,
+        registry: asrModelRegistry,
+        systemSpeechAvailable: _systemSpeechAvailable,
+        systemSpeechLabel: t.audiobook_transcribe_engine_system,
+      );
+
+  /// 当前选中的引擎 id。
+  String? _selectedEngineId() => selectedAsrEngineId(
+        language: _language,
+        catalog: widget.catalogGetter(),
+        options: _engineOptions(),
+      );
+
+  /// 按选中的引擎给出服务实例。ONNX 走注入进来的那份（生产是
+  /// `createAsrTranscriptionService()`，测试是 fake）；系统语音走另一份实现。
+  AsrTranscriptionService _serviceFor(String? engineId) {
+    if (engineId != kAppleSpeechEngineId) return widget.service;
+    final AsrTranscriptionService Function()? factory =
+        widget.systemSpeechService;
+    return factory != null ? factory() : AppleSpeechTranscriptionService();
+  }
+
+  /// 探本机有没有系统语音。探不到（非 Apple、OS < 26、原生侧没实现）就当没有——
+  /// 让一个点了必报错的选项出现在下拉里比不出现更糟。
+  Future<void> _probeSystemSpeech() async {
+    bool available = false;
+    try {
+      final AsrTranscriptionService probe = _serviceFor(kAppleSpeechEngineId);
+      if (probe is AppleSpeechTranscriptionService) {
+        available = await probe.isAvailable();
+      }
+    } catch (_) {
+      available = false;
+    }
+    if (!mounted || available == _systemSpeechAvailable) return;
+    setState(() => _systemSpeechAvailable = available);
+  }
 
   /// 下拉每项的副标题：平台适配度 + int8 全套大小。
   ///
   /// 「多大」用 int8 那套：它是手机与无 GPU 桌面实际会下的一套，也是两套里小的
   /// 那个——把大的报给用户会让「Omnilingual 在手机上要 4 GB」这种吓人的数字出现在
   /// 一个根本不会下 fp32 的设备上。
-  String _modelSubtitle(AsrModelPack pack) {
+  String _modelSubtitle(AsrEngineOption option) {
+    final AsrModelPack? pack = option.pack;
+    // 系统语音没有包、没有大小可报——说清它的真实代价（系统会下自己的语言资产），
+    // 别编一个字节数，也别吹成零下载。
+    if (pack == null) return t.audiobook_transcribe_engine_system_hint;
     final String fit = switch (asrModelFitFor(pack, mobile: _isMobile)) {
       AsrModelFit.light => t.audiobook_transcribe_model_fit_light,
       AsrModelFit.desktop => t.audiobook_transcribe_model_fit_desktop,
@@ -559,6 +615,19 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
     return '$fit · $size$badge';
   }
 
+  /// 当前选中的是不是系统语音引擎。
+  bool get _systemSpeech => _selectedEngineId() == kAppleSpeechEngineId;
+
+  /// 就绪行里那段「用哪个模型跑」的描述。
+  ///
+  /// 系统语音没有变体（fp32 / int8 是 ONNX 编码器的概念），报变体等于报一个假事实，
+  /// 所以只报引擎名。
+  String _readyEngineLabel(AsrTranscribePlan plan) {
+    if (_systemSpeech) return t.audiobook_transcribe_engine_system;
+    return '${asrModelPackFor(plan.language).displayName} · '
+        '${_variantLabel(plan.variant)}';
+  }
+
   bool get _isMobile =>
       defaultTargetPlatform == TargetPlatform.android ||
       defaultTargetPlatform == TargetPlatform.iOS;
@@ -567,11 +636,13 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
   ///
   /// 模型换了就是另一套磁盘目录与另一个任务哈希（任务 id 含包 id），所以进行中的
   /// 进度不会被顶掉，切回去还在。
-  Future<void> _changeModel(String packId) async {
-    final List<AsrModelPack> packs = _modelChoices();
-    if (packs.isEmpty || packs.first.id == packId) return;
+  Future<void> _changeEngine(String engineId) async {
+    if (_selectedEngineId() == engineId) return;
+    // 先换服务再重新规划：plan / 就绪判定 / 任务目录全由服务决定，顺序反了会用
+    // 旧引擎去查新引擎的任务。
+    setState(() => _service = _serviceFor(engineId));
     await _updateCatalog(
-      widget.catalogGetter().withChoice(_language, packId),
+      widget.catalogGetter().withChoice(_language, engineId),
     );
   }
 
@@ -635,7 +706,7 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
   }
 
   Future<void> _discard() async {
-    await widget.service.discard(widget.audioPaths, _language);
+    await _service.discard(widget.audioPaths, _language);
     if (!mounted) return;
     _result = null;
     _finishedSrt = null;
@@ -693,13 +764,17 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
         );
       case _Phase.ready:
       case _Phase.paused:
+        // 就绪行报的是**当前引擎**的名字。不能再直接问 `asrModelPackFor(language)`
+        // ——那只答得出 ONNX 包，选中系统语音时会报出一个根本没在跑的模型名。
         final String ready = t.audiobook_transcribe_model_ready(
-          variant: plan == null
-              ? ''
-              : '${asrModelPackFor(plan.language).displayName} · '
-                  '${_variantLabel(plan.variant)}',
+          variant: plan == null ? '' : _readyEngineLabel(plan),
         );
         final StringBuffer sb = StringBuffer(ready);
+        if (_systemSpeech) {
+          sb
+            ..writeln()
+            ..write(t.audiobook_transcribe_engine_system_no_pause);
+        }
         if (_phase == _Phase.paused) {
           sb
             ..writeln()
@@ -869,22 +944,22 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
           // 进度条），模型区多占一行会把「加速」整段挤出首屏。
           Builder(
             builder: (BuildContext ctx) {
-              final List<AsrModelPack> packs = _modelChoices();
+              final List<AsrEngineOption> options = _engineOptions();
               return Row(
                 children: <Widget>[
                   Expanded(
                     child: GamepadMenuDropdown<String>(
                       key: const ValueKey<String>('asr-transcribe-model'),
                       entries: <GamepadDropdownEntry<String>>[
-                        for (final AsrModelPack pack in packs)
-                          (value: pack.id, label: pack.displayName),
+                        for (final AsrEngineOption option in options)
+                          (value: option.id, label: option.label),
                       ],
-                      selected: packs.isEmpty ? null : packs.first.id,
-                      enabled: _canChangePreference && packs.length > 1,
+                      selected: _selectedEngineId(),
+                      enabled: _canChangePreference && options.length > 1,
                       entrySubtitle: (String id) => _modelSubtitle(
-                        packs.firstWhere((AsrModelPack p) => p.id == id),
+                        options.firstWhere((AsrEngineOption o) => o.id == id),
                       ),
-                      onChanged: _changeModel,
+                      onChanged: _changeEngine,
                     ),
                   ),
                   SizedBox(width: tokens.spacing.gap),
@@ -892,7 +967,12 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
                     key: const ValueKey<String>('asr-transcribe-model-add'),
                     tooltip: t.audiobook_transcribe_model_custom_add,
                     icon: const Icon(Icons.create_new_folder_outlined),
-                    onPressed: _canChangePreference ? _addLocalModel : null,
+                    // 选中系统语音时接入本地 ONNX 模型没有意义（那是另一个引擎的
+                    // 东西）——留着可点会让用户以为接进来就能给系统语音用。
+                    onPressed: _canChangePreference &&
+                            _selectedEngineId() != kAppleSpeechEngineId
+                        ? _addLocalModel
+                        : null,
                   ),
                 ],
               );

--- a/fushi/macos/Runner.xcodeproj/project.pbxproj
+++ b/fushi/macos/Runner.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */; };
 		FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000002001C0F02 /* FushiSystemOcr.swift */; };
+		FA171A002B000003001C0F01 /* FushiSpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
@@ -67,6 +68,7 @@
 /* Begin PBXFileReference section */
 		FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiChallengeBrowser.swift; path = ../../apple/FushiChallengeBrowser.swift; sourceTree = "<group>"; };
 		FA171A002B000002001C0F02 /* FushiSystemOcr.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSystemOcr.swift; path = ../../apple/FushiSystemOcr.swift; sourceTree = "<group>"; };
+		FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FushiSpeechTranscriber.swift; path = ../../apple/FushiSpeechTranscriber.swift; sourceTree = "<group>"; };
 		0B7C95E12A53CED1568D4414 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		112D242DE0B0F664C7BC49FA /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -185,6 +187,7 @@
 			children = (
 				FA171A002B000001001C0F02 /* FushiChallengeBrowser.swift */,
 				FA171A002B000002001C0F02 /* FushiSystemOcr.swift */,
+				FA171A002B000003001C0F02 /* FushiSpeechTranscriber.swift */,
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
@@ -496,6 +499,7 @@
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				FA171A002B000001001C0F01 /* FushiChallengeBrowser.swift in Sources */,
 				FA171A002B000002001C0F01 /* FushiSystemOcr.swift in Sources */,
+				FA171A002B000003001C0F01 /* FushiSpeechTranscriber.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/fushi/macos/Runner/AppDelegate.swift
+++ b/fushi/macos/Runner/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: FlutterAppDelegate {
       let controller = windowController.flutterViewController
       // 系统自带 OCR（Vision）。与 iOS 侧同一份实现（apple/FushiSystemOcr.swift）。
       FushiSystemOcr.register(binaryMessenger: controller.engine.binaryMessenger)
+      // 系统语音转录（macOS 26 的 SpeechAnalyzer）；与 iOS 同一份实现。
+      FushiSpeechTranscriber.register(
+        binaryMessenger: controller.engine.binaryMessenger)
       challengeBrowser = FushiChallengeBrowser(
         binaryMessenger: controller.engine.binaryMessenger
       ) { [weak self] in self?.mainFlutterWindow }

--- a/fushi/test/asr_host/apple_speech_test.dart
+++ b/fushi/test/asr_host/apple_speech_test.dart
@@ -1,0 +1,418 @@
+/// Apple 系统语音转录：平台契约解析、cue 拼装、引擎选项、以及服务产出的任务目录
+/// 与 ONNX 后端同构。
+///
+/// 原生侧一行 Dart 测试都碰不到（那是 Swift），所以这里守的是**两边约定的形状**：
+/// Swift 改一个字段名，这里立刻红，而不是等到真机上转出一份空字幕——那种失败在
+/// 设备上看起来和「这段没人说话」一模一样。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_asr_core/asr_core.dart';
+
+import 'package:fushi/src/asr_host/apple_speech_channel.dart';
+import 'package:fushi/src/asr_host/apple_speech_transcription_service.dart';
+import 'package:fushi/src/asr_host/asr_engine_options.dart';
+import 'package:fushi/src/asr_host/asr_model_catalog.dart';
+
+/// 可编程的假平台：不碰 method channel。
+class _FakePlatform implements AppleSpeechPlatform {
+  _FakePlatform({this.installed = const <String>['ja-JP']});
+
+  bool available = true;
+  List<String> installed;
+  List<String> supported = const <String>['ja-JP', 'en-US'];
+
+  int prepareCalls = 0;
+  int cancelCalls = 0;
+  final List<String> transcribedPaths = <String>[];
+
+  @override
+  Future<bool> isAvailable() async => available;
+
+  @override
+  Future<List<String>> installedLocales() async => installed;
+
+  @override
+  Future<List<String>> supportedLocales() async => supported;
+
+  @override
+  Future<void> prepare(String locale) async {
+    prepareCalls++;
+    installed = <String>[...installed, locale];
+  }
+
+  @override
+  Future<AppleSpeechResult> transcribe({
+    required String path,
+    required String locale,
+    void Function(int processedMs, int totalMs)? onProgress,
+  }) async {
+    transcribedPaths.add(path);
+    onProgress?.call(500, 1000);
+    return const AppleSpeechResult(
+      durationMs: 1000,
+      segments: <AppleSpeechSegment>[
+        AppleSpeechSegment(
+          text: '今日はいい天気。',
+          startMs: 100,
+          endMs: 900,
+          tokens: <String>['今日', 'は', 'いい', '天気'],
+          tokenOffsetsMs: <int>[100, 300, 500, 700],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<void> cancel() async => cancelCalls++;
+}
+
+void main() {
+  group('parseAppleSpeechPayload', () {
+    test('正常载荷：字段名与时间原样落地', () {
+      final AppleSpeechResult result =
+          parseAppleSpeechPayload(<Object?, Object?>{
+        'durationMs': 5000,
+        'segments': <Object?>[
+          <Object?, Object?>{
+            'text': 'hello',
+            'startMs': 100,
+            'endMs': 900,
+            'tokens': <Object?>[
+              <Object?, Object?>{'text': 'hel', 'startMs': 100},
+              <Object?, Object?>{'text': 'lo', 'startMs': 400},
+            ],
+          },
+        ],
+      });
+      expect(result.durationMs, 5000);
+      expect(result.segments.single.text, 'hello');
+      expect(result.segments.single.startMs, 100);
+      expect(result.segments.single.endMs, 900);
+      expect(result.segments.single.tokens, <String>['hel', 'lo']);
+      expect(result.segments.single.tokenOffsetsMs, <int>[100, 400]);
+    });
+
+    test('空文本与退化区间逐条丢弃，不毁掉整份', () {
+      final AppleSpeechResult result =
+          parseAppleSpeechPayload(<Object?, Object?>{
+        'durationMs': 1000,
+        'segments': <Object?>[
+          <Object?, Object?>{'text': '   ', 'startMs': 0, 'endMs': 100},
+          <Object?, Object?>{'text': 'bad', 'startMs': 500, 'endMs': 500},
+          <Object?, Object?>{'text': 'ok', 'startMs': 0, 'endMs': 100},
+        ],
+      });
+      expect(result.segments.map((AppleSpeechSegment s) => s.text), <String>[
+        'ok',
+      ]);
+    });
+
+    test('缺时长要抛：没有分母，进度和结尾都算不出来', () {
+      expect(
+        () => parseAppleSpeechPayload(
+            <Object?, Object?>{'segments': <Object?>[]}),
+        throwsA(isA<AppleSpeechUnavailable>()),
+      );
+    });
+
+    test('零段落是合法结果（整段没人说话），不抛', () {
+      final AppleSpeechResult result = parseAppleSpeechPayload(
+        <Object?, Object?>{'durationMs': 1000},
+      );
+      expect(result.segments, isEmpty);
+    });
+  });
+
+  group('appleSpeechCues', () {
+    test('多文件按拼接时间轴平移，逐词起点一起平移', () {
+      final List<AsrCue> cues = appleSpeechCues(
+        const <AppleSpeechSegment>[
+          AppleSpeechSegment(
+            text: 'second file',
+            startMs: 100,
+            endMs: 400,
+            tokens: <String>['second', 'file'],
+            tokenOffsetsMs: <int>[100, 250],
+          ),
+        ],
+        fileIndex: 1,
+        offsetMs: 60000,
+      );
+      final AsrCue cue = cues.single;
+      expect(cue.startMs, 60100);
+      expect(cue.endMs, 60400);
+      expect(cue.audioFileIndex, 1);
+      // 逐词起点不平移的话，跳播会整整差一个文件的时长。
+      expect(cue.tokenOffsetsMs, <int>[60100, 60250]);
+      // 下游 attachAsrCueTokenTiming 要求两者等长，不等长时一条都不挂。
+      expect(cue.tokens.length, cue.tokenOffsetsMs.length);
+    });
+  });
+
+  group('asrEngineOptions', () {
+    final AsrModelRegistry registry =
+        buildAsrModelRegistry(AsrModelCatalog.empty);
+
+    test('系统语音不可用时那一项整个不出现', () {
+      final List<AsrEngineOption> options = asrEngineOptions(
+        language: AsrLanguage.japanese,
+        registry: registry,
+        systemSpeechAvailable: false,
+        systemSpeechLabel: '系统语音',
+      );
+      expect(
+        options.map((AsrEngineOption o) => o.id),
+        isNot(contains(kAppleSpeechEngineId)),
+      );
+    });
+
+    test('可用时排在 ONNX 包之后——默认不能变', () {
+      final List<AsrEngineOption> options = asrEngineOptions(
+        language: AsrLanguage.japanese,
+        registry: registry,
+        systemSpeechAvailable: true,
+        systemSpeechLabel: '系统语音',
+      );
+      expect(options.first.id, kAsrJapanesePack.id);
+      expect(options.last.id, kAppleSpeechEngineId);
+      expect(options.last.isSystemSpeech, isTrue);
+      expect(options.first.isSystemSpeech, isFalse);
+    });
+
+    test('选中值：没记录取第一项，有记录取记录的', () {
+      final List<AsrEngineOption> options = asrEngineOptions(
+        language: AsrLanguage.japanese,
+        registry: registry,
+        systemSpeechAvailable: true,
+        systemSpeechLabel: '系统语音',
+      );
+      expect(
+        selectedAsrEngineId(
+          language: AsrLanguage.japanese,
+          catalog: AsrModelCatalog.empty,
+          options: options,
+        ),
+        kAsrJapanesePack.id,
+      );
+      expect(
+        selectedAsrEngineId(
+          language: AsrLanguage.japanese,
+          catalog: AsrModelCatalog.empty
+              .withChoice(AsrLanguage.japanese, kAppleSpeechEngineId),
+          options: options,
+        ),
+        kAppleSpeechEngineId,
+      );
+    });
+
+    test('记录的那项已经不在列表里（换了台没系统语音的机器）→ 回落第一项', () {
+      final List<AsrEngineOption> options = asrEngineOptions(
+        language: AsrLanguage.japanese,
+        registry: registry,
+        systemSpeechAvailable: false,
+        systemSpeechLabel: '系统语音',
+      );
+      expect(
+        selectedAsrEngineId(
+          language: AsrLanguage.japanese,
+          catalog: AsrModelCatalog.empty
+              .withChoice(AsrLanguage.japanese, kAppleSpeechEngineId),
+          options: options,
+        ),
+        kAsrJapanesePack.id,
+      );
+    });
+
+    test('保留 id 落进目录也不会污染 ONNX 注册表', () {
+      // buildAsrModelRegistry 找不到这个 id 就忽略这条选择——日语的默认包不变。
+      final AsrModelRegistry polluted = buildAsrModelRegistry(
+        AsrModelCatalog.empty
+            .withChoice(AsrLanguage.japanese, kAppleSpeechEngineId),
+      );
+      expect(
+        polluted.packForLanguage(AsrLanguage.japanese)?.id,
+        kAsrJapanesePack.id,
+      );
+    });
+  });
+
+  group('AppleSpeechTranscriptionService', () {
+    late Directory jobs;
+    late Directory audioDir;
+    late List<String> audioPaths;
+
+    setUp(() async {
+      jobs = await Directory.systemTemp.createTemp('apple_speech_jobs_');
+      audioDir = await Directory.systemTemp.createTemp('apple_speech_audio_');
+      audioPaths = <String>[
+        '${audioDir.path}${Platform.pathSeparator}a.m4a',
+        '${audioDir.path}${Platform.pathSeparator}b.m4a',
+      ];
+      for (final String path in audioPaths) {
+        File(path).writeAsBytesSync(<int>[1, 2, 3, 4]);
+      }
+    });
+    tearDown(() async {
+      if (jobs.existsSync()) await jobs.delete(recursive: true);
+      if (audioDir.existsSync()) await audioDir.delete(recursive: true);
+    });
+
+    AppleSpeechTranscriptionService build(_FakePlatform platform) =>
+        AppleSpeechTranscriptionService(
+          platform: platform,
+          jobsRoot: () async => jobs,
+        );
+
+    test('plan：语言资产装了才算就绪', () async {
+      final _FakePlatform platform = _FakePlatform(installed: <String>[]);
+      final AppleSpeechTranscriptionService service = build(platform);
+      AsrTranscribePlan plan = await service.plan(
+        language: AsrLanguage.japanese,
+        preference: AsrAccelerationPreference.auto,
+      );
+      expect(plan.modelReady, isFalse);
+
+      // 「下载模型」在这个引擎下 = 让系统装语言资产。
+      await service
+          .downloadModel(
+            language: AsrLanguage.japanese,
+            variant: AsrEncoderVariant.int8,
+          )
+          .drain<void>();
+      expect(platform.prepareCalls, 1);
+
+      plan = await service.plan(
+        language: AsrLanguage.japanese,
+        preference: AsrAccelerationPreference.auto,
+      );
+      expect(plan.modelReady, isTrue);
+    });
+
+    test('installed 用主子标签比：ja 命中 ja-JP', () async {
+      final AppleSpeechTranscriptionService service =
+          build(_FakePlatform(installed: <String>['ja-JP']));
+      final AsrTranscribePlan plan = await service.plan(
+        language: AsrLanguage.japanese,
+        preference: AsrAccelerationPreference.auto,
+      );
+      expect(plan.modelReady, isTrue);
+    });
+
+    test('跑完产出与 ONNX 后端同构的任务目录', () async {
+      final _FakePlatform platform = _FakePlatform();
+      final AppleSpeechTranscriptionService service = build(platform);
+      final AsrRunningTranscription running = await service.start(
+        audioPaths: audioPaths,
+        language: AsrLanguage.japanese,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.auto,
+      );
+      final List<AsrTranscribeEvent> events = await running.run().toList();
+      final AsrTranscribeFinishedEvent finished =
+          events.whereType<AsrTranscribeFinishedEvent>().single;
+
+      final Directory dir =
+          await service.jobDirFor(audioPaths, AsrLanguage.japanese);
+      // 三份产物齐、文件名与包里的常量一致——下游认「这是转录产物」靠的就是
+      // transcript.srt 旁边有没有 state.json。
+      expect(File('${dir.path}/${AsrJobFiles.srt}').existsSync(), isTrue);
+      expect(File('${dir.path}/${AsrJobFiles.state}').existsSync(), isTrue);
+      expect(File('${dir.path}/${AsrJobFiles.cueTokens}').existsSync(), isTrue);
+      expect(
+        AsrTranscriptionService.isAsrGeneratedSubtitlePath(
+            finished.result.srtPath),
+        isTrue,
+      );
+
+      // 两个文件都转了，时间轴是拼接的单轨。
+      expect(platform.transcribedPaths, audioPaths);
+      final String srt =
+          File('${dir.path}/${AsrJobFiles.srt}').readAsStringSync();
+      expect(srt, contains('今日はいい天気。'));
+      // 第二个文件的 cue 起点被平移到第一个文件之后（1000ms + 100ms）。
+      expect(srt, contains('00:00:01,100'));
+
+      // state.json 记的是本引擎的 id，且已完成。
+      final Map<String, Object?> state = jsonDecode(
+        File('${dir.path}/${AsrJobFiles.state}').readAsStringSync(),
+      ) as Map<String, Object?>;
+      expect(state['modelId'], kAppleSpeechEngineId);
+      expect(state['finished'], isTrue);
+
+      expect(
+        await service.finishedSrtPath(audioPaths, AsrLanguage.japanese),
+        finished.result.srtPath,
+      );
+    });
+
+    test('任务 id 与 ONNX 那条不同——换引擎不顶掉对方的进度', () {
+      final String appleId = AppleSpeechTranscriptionService.appleSpeechJobId(
+        audioPaths,
+        AsrLanguage.japanese,
+      );
+      final String onnxId = AsrTranscriptionService.jobIdFor(
+        audioPaths,
+        AsrLanguage.japanese,
+      );
+      expect(appleId, isNot(onnxId));
+    });
+
+    test('语言不同也是不同任务', () {
+      expect(
+        AppleSpeechTranscriptionService.appleSpeechJobId(
+          audioPaths,
+          AsrLanguage.japanese,
+        ),
+        isNot(
+          AppleSpeechTranscriptionService.appleSpeechJobId(
+            audioPaths,
+            AsrLanguage.english,
+          ),
+        ),
+      );
+    });
+
+    test('discard 清掉任务目录', () async {
+      final AppleSpeechTranscriptionService service = build(_FakePlatform());
+      final AsrRunningTranscription running = await service.start(
+        audioPaths: audioPaths,
+        language: AsrLanguage.japanese,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.auto,
+      );
+      await running.run().drain<void>();
+      final Directory dir =
+          await service.jobDirFor(audioPaths, AsrLanguage.japanese);
+      expect(dir.existsSync(), isTrue);
+      await service.discard(audioPaths, AsrLanguage.japanese);
+      expect(dir.existsSync(), isFalse);
+      expect(
+        await service.finishedSrtPath(audioPaths, AsrLanguage.japanese),
+        isNull,
+      );
+    });
+
+    test('requestPause 取消原生任务且不产出半份产物', () async {
+      final _FakePlatform platform = _FakePlatform();
+      final AppleSpeechTranscriptionService service = build(platform);
+      final AsrRunningTranscription running = await service.start(
+        audioPaths: audioPaths,
+        language: AsrLanguage.japanese,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.auto,
+      );
+      running.requestPause();
+      final List<AsrTranscribeEvent> events = await running.run().toList();
+      expect(platform.cancelCalls, greaterThan(0));
+      expect(events.whereType<AsrTranscribeFinishedEvent>(), isEmpty);
+      final Directory dir =
+          await service.jobDirFor(audioPaths, AsrLanguage.japanese);
+      // 半份 SRT 比没有更糟：下游会把它当成一份完整字幕去匹配。
+      expect(File('${dir.path}/${AsrJobFiles.srt}').existsSync(), isFalse);
+    });
+  });
+}

--- a/fushi/test/build/apple_speech_transcriber_guard_test.dart
+++ b/fushi/test/build/apple_speech_transcriber_guard_test.dart
@@ -1,0 +1,164 @@
+/// Apple 系统语音转录原生半边的静态守卫。
+///
+/// 与系统 OCR 那条同理：Swift 这边**没有任何 Dart 测试能碰到**，本机（Windows）连
+/// 编都编不了。这里钉的是那些**错了不会报错**、或者只在某一类机器上才炸的地方。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+void main() {
+  // 在**剥掉注释**的源码上判定。本仓注释极其详尽——这个文件的类文档里就逐字写着
+  // `#if compiler(>=6.2)` 之类的字面量，不剥的话把实现里那一行改掉，守卫照样绿
+  // （变异实测当场撞到过这条：3 个变异只红了 2 条）。
+  final String swift = maskComments(
+    File('apple/FushiSpeechTranscriber.swift').readAsStringSync(),
+  );
+  final String dart =
+      File('lib/src/asr_host/apple_speech_channel.dart').readAsStringSync();
+  final String iosDelegate =
+      File('ios/Runner/AppDelegate.swift').readAsStringSync();
+  final String macosDelegate =
+      File('macos/Runner/AppDelegate.swift').readAsStringSync();
+
+  test('channel 名与 Dart 侧常量逐字一致', () {
+    expect(dart, contains("MethodChannel('app.fushi.reader/apple_speech')"));
+    expect(swift, contains('"app.fushi.reader/apple_speech"'));
+  });
+
+  test('iOS 与 macOS 两侧都注册了', () {
+    expect(
+      iosDelegate,
+      contains('FushiSpeechTranscriber.register(binaryMessenger:'),
+    );
+    expect(
+      macosDelegate,
+      contains('FushiSpeechTranscriber.register('),
+    );
+  });
+
+  test('两个 Xcode 工程都登记了这份 Swift（四处齐全）', () {
+    for (final String path in <String>[
+      'ios/Runner.xcodeproj/project.pbxproj',
+      'macos/Runner.xcodeproj/project.pbxproj',
+    ]) {
+      final String pbx = File(path).readAsStringSync();
+      expect(
+        pbx,
+        contains('path = ../../apple/FushiSpeechTranscriber.swift;'),
+        reason: '$path 缺 PBXFileReference',
+      );
+      expect(
+        pbx,
+        contains(
+          '/* FushiSpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile;',
+        ),
+        reason: '$path 缺 PBXBuildFile',
+      );
+      expect(
+        '/* FushiSpeechTranscriber.swift */,'.allMatches(pbx).length,
+        1,
+        reason: '$path 的 PBXGroup children 应恰好登记一次',
+      );
+      expect(
+        '/* FushiSpeechTranscriber.swift in Sources */,'.allMatches(pbx).length,
+        1,
+        reason: '$path 的 Sources phase 应恰好登记一次',
+      );
+    }
+  });
+
+  test('两道版本闸门都在：编译期隔离 + 运行期可用性', () {
+    // 编译期：SpeechAnalyzer 这批符号只存在于 Xcode 26 的 SDK。不隔离的话，本仓
+    // Mac 开发机（Xcode 16.4）上整个工程编不过——而那台机器编不过是**本地**才发现
+    // 的，CI 用 Xcode 26 反而一路绿。
+    expect(swift, contains('#if compiler(>=6.2)'));
+    expect(swift, contains('#else'));
+    expect(swift, contains('#endif'));
+    // 运行期：部署目标是 iOS 15.1 / macOS 13.4，绝大多数机器上这套 API 不存在。
+    expect(swift, contains('#available(iOS 26.0, macOS 26.0, *)'));
+  });
+
+  test('老 SDK 分支把每个方法都兜住了，不留未定义符号', () {
+    final int elseAt = swift.lastIndexOf('#else');
+    final int endAt = swift.lastIndexOf('#endif');
+    expect(elseAt, greaterThan(-1));
+    expect(endAt, greaterThan(elseAt));
+    final String fallback = swift.substring(elseAt, endAt);
+    for (final String fn in <String>[
+      'isAvailable',
+      'localeList',
+      'prepare',
+      'transcribe',
+    ]) {
+      expect(
+        fallback,
+        contains(fn),
+        reason: '老 Xcode 分支缺 $fn，那边会编不过',
+      );
+    }
+    // 老分支必须回「不支持」，不能假装能跑。
+    expect(fallback, contains('unsupported('));
+  });
+
+  test('payload 键名与 Dart 解析器一致', () {
+    for (final String key in <String>[
+      '"durationMs"',
+      '"segments"',
+      '"text"',
+      '"startMs"',
+      '"endMs"',
+      '"tokens"',
+    ]) {
+      expect(swift, contains(key), reason: 'payload 缺键 $key');
+      expect(dart, contains(key.replaceAll('"', "'")), reason: 'Dart 侧缺键 $key');
+    }
+  });
+
+  test('句级时间来自 Result.range，词级来自 audioTimeRange', () {
+    // 两级都要：句级拼 SRT，词级喂 transcript.tokens.jsonl。少一级下游就少一半能力。
+    expect(swift, contains('value.range.start'));
+    expect(swift, contains('value.range.end'));
+    expect(swift, contains('.audioTimeRange'));
+    expect(swift, contains('run.audioTimeRange'));
+  });
+
+  test('只收 isFinal 的结果，不把 volatile 中间态写进字幕', () {
+    // 不过滤的话同一句会以逐步成形的形态重复出现在 SRT 里。
+    expect(swift, contains('value.isFinal'));
+  });
+
+  test('整份文件一次喂进去（finishAfterFile），不是麦克风流', () {
+    expect(
+        swift, contains('start(inputAudioFile: file, finishAfterFile: true)'));
+    expect(swift, contains('finalizeAndFinishThroughEndOfInput()'));
+    expect(swift, contains('AVAudioFile(forReading:'));
+  });
+
+  test('三类不可用与「这次失败」分开，Dart 侧据此换引擎', () {
+    for (final String code in <String>[
+      'UNSUPPORTED_OS',
+      'LOCALE_UNSUPPORTED',
+      'ASSET_INSTALL_FAILED',
+    ]) {
+      expect(swift, contains(code));
+      expect(dart, contains(code), reason: 'Dart 侧没把 $code 归到「不可用」');
+    }
+    expect(swift, contains('TRANSCRIBE_FAILED'));
+    expect(swift, contains('CANCELLED'));
+  });
+
+  test('语言资产要显式装并预留，不指望它自己就位', () {
+    expect(swift, contains('AssetInventory.assetInstallationRequest('));
+    expect(swift, contains('downloadAndInstall()'));
+    expect(swift, contains('AssetInventory.reserve(locale:'));
+  });
+
+  test('回调恰好一次：长任务有正常/抛错/取消三条出口', () {
+    expect(swift, contains('if replied { return }'));
+    expect(swift, contains('replied = true'));
+  });
+}

--- a/fushi/test/build/apple_system_ocr_guard_test.dart
+++ b/fushi/test/build/apple_system_ocr_guard_test.dart
@@ -11,8 +11,14 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 void main() {
-  final String swift = File('apple/FushiSystemOcr.swift').readAsStringSync();
+  // 剥注释后再判：本仓注释里往往留着与实现同样的字面量，不剥的话「改了实现、
+  // 守卫仍绿」（假绿形态④）。
+  final String swift = maskComments(
+    File('apple/FushiSystemOcr.swift').readAsStringSync(),
+  );
   final String dart =
       File('lib/src/ocr/system_ocr_channel.dart').readAsStringSync();
   final String iosDelegate =
@@ -51,7 +57,8 @@ void main() {
       );
       expect(
         pbx,
-        contains('/* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile;'),
+        contains(
+            '/* FushiSystemOcr.swift in Sources */ = {isa = PBXBuildFile;'),
         reason: '$path 缺 PBXBuildFile',
       );
       // group children + Sources phase：两处引用各一次，加上上面两条定义，共四处。


### PR DESCRIPTION
## 为什么

苹果侧那条「不用下我们的模型」的语音转录，此前 **Dart 与原生两侧都是零**；ASR 也没有多后端抽象（`createAsrTranscriptionService` 单入口 + `isAsrSupported` 布尔闸门）。

## 改了什么

- **`apple/FushiSpeechTranscriber.swift`**：用 iOS 26 / macOS 26 的 `SpeechAnalyzer` 直接转录**本地音频文件**（`start(inputAudioFile:finishAfterFile:)`，不是麦克风流，也没有旧 `SFSpeechRecognizer` 的 1 分钟上限），产出**句级区间**（`Result.range`）与**逐词时间戳**（`ResultAttributeOption.audioTimeRange`）。两侧 AppDelegate 各注册一次，两个 Xcode 工程各登记四处。
- **`AppleSpeechTranscriptionService extends AsrTranscriptionService`**：那个类的对外方法全是可覆写的实例方法（包里的 widget 测试早就在继承它做 fake），所以**转录弹层与设置页一行不用改**就能换引擎——不必给上游包抽接口。
- **产物与 ONNX 后端逐字节同构**：同一套 `serializeAsrCuesToSrt` / `serializeAsrCueTokens`，同样的 `state.json` / `transcript.srt` / `transcript.tokens.jsonl`。下游匹配、对齐、`isAsrGeneratedSubtitlePath` 判据零改动。任务 id 用自己的引擎名 → 换引擎不顶掉对方的进度。
- **「模型」下拉的值域**从「ONNX 包 id」扩成「包 id 或系统语音保留 id」。系统语音**不是**一个 `AsrModelPack`（没有文件、没有变体、大小未知），硬塞会在 `filesFor()` / `totalBytes()` 抛 `StateError`，所以引入窄类型 `AsrEngineOption` 表达这个和类型。ONNX 包排在前，**默认一个都没变**。

## 两道版本闸门，缺一不可

- **编译期 `#if compiler(>=6.2)`**：`SpeechAnalyzer` 只存在于 Xcode 26 的 SDK。本仓 Mac 开发机是 **Xcode 16.4**，不隔离那边**整个工程编不过**——而 CI 用的是 Xcode 26.6，反而一路绿，这种失败只会在本地出现。
- **运行期 `#available(iOS 26, macOS 26, *)`**：部署目标是 iOS 15.1 / macOS 13.4。

## 边界如实写，不吹「零下载」

不用下我们那 1 GB ONNX，但**系统的语言资产仍要下**（`AssetInventory.assetInstallationRequest(supporting:)` → `downloadAndInstall()`，还要 `reserve(locale:)`，有 `maximumReservedLocales` 上限）。区别是那份由**系统**保管、多 app 共享、不占我们的包体。UI 文案照此写。

行为差异也写进 UI：这个引擎在文件中途**没有可续跑的检查点**，暂停等于放弃当前文件的进度。

## 测试

- 新增 **17 条 Dart 用例**：契约解析（字段名/退化区间/缺时长）、多文件 cue 平移（含逐词起点，不平移会整整差一个文件时长）、引擎选项与选中回落、服务产出同构任务目录、任务 id 与 ONNX 隔离、取消不留半份产物。
- 新增 **12 条 Swift 静态守卫**，做过变异实测，并因此**修掉一个真问题**：判据被本文件自己的注释兜住（fast-workflow 记的假绿形态④），3 个变异只红 2 条；改用 `maskComments` 剥注释后 **3 个变异全红、还原全绿**。同一处隐患在已合入的 `apple_system_ocr_guard_test` 上一并修掉。
- `flutter analyze` 全量干净；`test/asr_host test/build test/media/audiobook test/settings test/i18n` 共 **2067 条绿**（退出码 0）。

## 未验证的部分（如实标注）

Swift 的**编译**由本 PR CI 的 ios / macos job 验证。**真机行为**——长音频离线转录、语言资产下载与预留、逐词时间戳的实际精度——本机是 Windows，无法验证，按 `implemented_unverified` 对待。需要一台 iOS 26 / macOS 26 设备实测「选系统语音 → 装语言 → 转一本 → 对齐是否正确」。

https://claude.ai/code/session_019JNKMR2aLamZinSPMcBw28
