### PR TITLE
fix(dictionary): 源文本条点字换下方结果，不再叠一层查词浮层（BUG-2424）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,12 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2235 条。点号进各自文件。
+> 共 2236 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-2427](bugs/BUG-2427-desktop-library-header-top-gap.md) | ✅ | ✅ | 桌面端库页页头顶部留白过大（手机端修复未同步） |
 | [BUG-2426](bugs/BUG-2426-side-panel-embed-self-attested.md) | ✅ | ✅ | 扩展 side-panel 的「是否被嵌入」由 URL 参数自证，省略参数即可绕过 #1295 全部加固 |
+| [BUG-2424](bugs/BUG-2424-dict-scan-inline-results.md) | ✅ | ✅ | 查词页源文本条点字压嵌套浮层，没有换下方的查词结果 |
 | [BUG-2423](bugs/BUG-2423-sync-conflict-title-truncated.md) | ✅ | ✅ | 同步冲突卡片书名单行省略，同系列多条冲突只剩同一前缀无法分辨 |
 | [BUG-2422](bugs/BUG-2422-settings-surface-ladder-flat.md) | ✅ | ✅ | 设置页页面底/导航窗格/卡片三层对比度仅1.05糊成一片（M3阶梯最挤段+全局关阴影） |
 | [BUG-2421](bugs/BUG-2421-favorite-words-cross-device-gaps.md) | 🚧 | 🚧 | 收藏的单词跨端看不到：wire 丢归属 + 云同步绑死统计开关 + 备份按统计表删除 |

--- a/docs/bugs/BUG-2424-dict-scan-inline-results.md
+++ b/docs/bugs/BUG-2424-dict-scan-inline-results.md
@@ -1,0 +1,40 @@
+## BUG-2424 · 查词页源文本条点字压嵌套浮层，没有换下方的查词结果
+- **报告**：2026-09-10（用户：源文本条的 Yomitan 式点选查词「还是选中往后扫描、在此基础上嵌套查词，实际上要做的是改变下面的词典查询结果而不是嵌套查」）
+- **真实性**：✅ 真 bug。两个宿主各错一半，合起来正好是「扫描没落到那份结果上」：
+  - 首页词典 tab：`home_dictionary_page.dart` 的 `_lookupFromSourceStrip` 走
+    `_pushNestedPopup(query, screenRect, reuseWarmSlot: true)`——点一个字压一张**浮在
+    那个字上的查词卡**。页面本体那份结果（`DictionaryPopupWebView(result: _result!)`）
+    与弹窗栈是两棵独立子树，卡片起来了，下方那份结果仍停在上一个词上：同一次查词
+    裂成两个可见面，条上的高亮指着 A、页面下半屏还写着 B。
+  - Android 独立查词窗：`popup_dictionary_page.dart` 的 `_pushSearch` 每次都
+    `_sourceLookupText = trimmed` / `_searchController.text = trimmed`，把条上与框里的
+    整句换成「被点字起的后缀」。在「と言いつつ」上点「つ」，条上只剩「つつ」——被点字
+    左边的上下文当场消失，用户再想点回「言」已经没得点。Yomitan 的扫描是整句不动、
+    只挪高亮。
+- **[x] ① 已修复** — 源文本条点字改走**主查词管线**：条上的整句与搜索框里的整句都不动，
+  换的是下方那份结果 + 条上的高亮跨度。
+  - `home_dictionary_page.dart`：`_search` 新增 `scanAnchor`（`SourceLookupScan`），
+    它同时表示「本次不接管搜索框/源文本条」与「高亮锚在哪个字素簇」；`_pushNestedPopup`
+    从源文本条这条入口摘除（结果 WebView 内部选词/点链仍走弹窗栈，未动）。
+  - 顺带三处根因，都是这次改动才暴露出来的既有耦合：
+    - `_searchWithGeneration` 的过期守卫原本比 `trimmed != _controller.text`，对
+      「查询串恒等于输入框」的老路径成立，对扫描查词（框里整句、查询串后缀）恒不成立，
+      会把自己的结果全丢掉 → 改比**派发那一刻**的输入框内容（`inputTextAtDispatch`）。
+    - 朗读原本写在 `if (writeHistory)` 里，等于拿「要不要记历史」代答「要不要读」。
+      扫描查词要读、又不该把用户点过的每个字灌进历史 → 拆成独立的 `autoReadResult`。
+    - `_loadMore` 原本拿 `_controller.text` 去加载更多，扫描查词后那是整句而非眼下这份
+      结果的查询串，滚到底会把结果**掉包**成另一个词的 → 改用当前查询串。
+  - `popup_dictionary_page.dart`：`_pushSearch` 新增 `scan` 参数，非空时不接管条与框，
+    高亮锚改成被点的那个字素簇（此前恒 0）。
+  - `clipboard_lookup_text_panel.dart`：新增 `SourceLookupScan`（查询串 + 高亮锚的绑定）
+    与 `SourceLookupScan.fromSuffix`（把串首空白折进锚——查词管线一律 `trim`，锚不右移
+    就会框在空白上）。
+  - 提交见本分支 `pr/dict-scan-inline-results`。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_dictionary_source_scan_test.dart`
+  （4 条：点字后引擎吃后缀而条与框留整句、栈深恒 0；扫描后「加载更多」不掉包；点回条首；
+  源码守卫钉住 onLookup 不再压浮层）+ `fushi/test/pages/popup_dictionary_page_test.dart`
+  的「点第 3 个字后条与搜索框仍是 `abcdef`、高亮锚 = 2」+
+  `fushi/test/widgets/clipboard_lookup_text_panel_test.dart` 的
+  `SourceLookupScan.fromSuffix` 4 条纯逻辑。
+- **备注**：与 BUG-1478（查词是「从被点字到串尾」的后缀交给引擎最长匹配）同一条链路的
+  下游；那条决定「查什么」，这条决定「查出来的落在哪」。

--- a/fushi/integration_test/dict_source_scan_inline_itest.dart
+++ b/fushi/integration_test/dict_source_scan_inline_itest.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/home_dictionary_page.dart';
+import 'package:fushi/src/pages/implementations/home_page.dart'
+    show HomePage, HomeTab;
+import 'package:fushi/src/utils/components/clipboard_lookup_text_panel.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart' show Dictionary;
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'helpers/library_fixture.dart' show readyAppModel;
+import 'helpers/observe_capture.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+/// BUG-2424 真机复测：查词页源文本条点字 = Yomitan 式扫描，**换的是下方那份结果**。
+///
+/// 原始失败路径：在「と言いつつ」上点第 2 个字「言」。此前那会压一张浮在「言」上的
+/// 查词卡（`_pushNestedPopup`），页面本体那份结果仍停在上一个词上；条上的高亮与卡片
+/// 各说各话。现在必须是：条上整句不动、搜索框整句不动、栈深恒 0、下方结果换成从
+/// 「言」起的最长匹配，条上的高亮跨度由**真引擎**回报的匹配长度撑开。
+///
+/// 高亮长度是本用例的核心证据：它不是页面自己编的，是 `lookupHighlightCharCount`
+/// 从真实 `DictionarySearchResult.bestLength` 换算来的。高亮框住「言い」两个字 ⇔
+/// 真的用后缀「言いつつ」查到了「言い」这条词。
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('源文本条点字换下方结果、不压浮层（BUG-2424）', (WidgetTester tester) async {
+    await launchFushiTestApp();
+    expect(await waitForHome(tester), isTrue, reason: '主页应在 90s 内出现');
+    await tester.pump(const Duration(seconds: 2));
+
+    final AppModel appModel = await readyAppModel(tester);
+    expect(await _seedScanDictionary(tester, appModel), isTrue,
+        reason: '本用例需要一本含「と言い/言い/言う/つつ」的真词典');
+
+    expect(HomePage.debugSelectTab, isNotNull,
+        reason:
+            'HomePage.debugSelectTab hook must be registered (debug build)');
+    HomePage.debugSelectTab!(HomeTab.dictionaries);
+    await tester.pump(const Duration(seconds: 2));
+
+    final HomeDictionarySearchDebug page = tester
+        .state(find.byType(HomeDictionaryPage)) as HomeDictionarySearchDebug;
+
+    // ① 主查词：整句进条、命中段锚在条首。
+    await page.debugSearch('と言いつつ');
+    for (int i = 0; i < 20 && page.debugIsSearching; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    await tester.pump(const Duration(seconds: 1));
+
+    SourceLookupTextPanel panel = _panel(tester);
+    expect(panel.text, 'と言いつつ');
+    expect(panel.highlight?.start, 0);
+    final int mainLength = panel.highlight?.length ?? 0;
+    debugPrint('[scan-probe] 主查词 highlight=${panel.highlight}');
+    ObserveShot shot = await captureFlutterFrame(tester, '01-main-search');
+    expect(shot.saved, isTrue);
+
+    // ② 源文本条点第 2 个字「言」。焦点驱动纪律禁坐标点击，这里直接驱动本条对外的
+    // 生产回调（`onLookup` 就是逐字 GestureDetector 唯一的出口，手势本身由
+    // clipboard_lookup_text_panel_test 的 widget 用例覆盖）。
+    panel.onLookup('言いつつ', Rect.zero, 1);
+    await tester.pump(const Duration(milliseconds: 200));
+    for (int i = 0; i < 20 && page.debugIsSearching; i++) {
+      await tester.pump(const Duration(milliseconds: 500));
+    }
+    await tester.pump(const Duration(seconds: 1));
+
+    panel = _panel(tester);
+    debugPrint('[scan-probe] 点「言」后 highlight=${panel.highlight} '
+        'panel="${panel.text}" box="${_searchBoxText(tester)}" '
+        'stack=${page.debugPopupStackShape}');
+    shot = await captureFlutterFrame(tester, '02-scan-from-index-1');
+    expect(shot.saved, isTrue);
+
+    expect(panel.text, 'と言いつつ', reason: '条上必须留着整句，换成后缀就把被点字左边的上下文丢了');
+    expect(_searchBoxText(tester), 'と言いつつ', reason: '搜索框是用户输入的整句，扫描查词不接管它');
+    expect(panel.highlight?.start, 1, reason: '高亮锚在被点的那个字素簇上');
+    expect(page.debugPopupStackShape.depth, 0,
+        reason: '扫描换的是下方那份结果，不再压一张浮在字上的查词卡');
+    expect(panel.highlight?.length, 2,
+        reason: '真引擎用后缀「言いつつ」查到「言い」，高亮据此撑成两个字'
+            '（主查词那次是 $mainLength）');
+  });
+}
+
+SourceLookupTextPanel _panel(WidgetTester tester) =>
+    tester.widget(find.byType(SourceLookupTextPanel));
+
+String _searchBoxText(WidgetTester tester) {
+  final FushiSearchField field = tester.widget(find.byType(FushiSearchField));
+  return field.controller.text;
+}
+
+/// 造一本只为本用例服务的 yomitan 词典（四条词头，覆盖扫描要用到的每个起点），
+/// 经真实 [AppModel.importDictionary] FFI 导入隔离根。
+Future<bool> _seedScanDictionary(
+  WidgetTester tester,
+  AppModel appModel,
+) async {
+  final Directory cacheDir = await getTemporaryDirectory();
+  final File dictFile = File('${cacheDir.path}/scan_dict.zip');
+  final Map<String, dynamic> index = <String, dynamic>{
+    'title': 'FushiScanProbeDict',
+    'format': 3,
+    'revision': 'scan-probe-1',
+    'sequenced': false,
+  };
+  List<dynamic> term(String word, String reading, String gloss) => <dynamic>[
+        word,
+        reading,
+        '',
+        '',
+        0,
+        <String>[gloss],
+        0,
+        '',
+      ];
+  final List<List<dynamic>> termBank = <List<dynamic>>[
+    term('と言い', 'といい', 'scan probe: と言い'),
+    term('言い', 'いい', 'scan probe: 言い'),
+    term('言う', 'いう', 'scan probe: 言う'),
+    term('つつ', 'つつ', 'scan probe: つつ'),
+  ].cast<List<dynamic>>();
+
+  final Archive archive = Archive()
+    ..addFile(_jsonFile('index.json', index))
+    ..addFile(_jsonFile('term_bank_1.json', termBank));
+  final List<int> zipBytes = ZipEncoder().encode(archive)!;
+  dictFile.parent.createSync(recursive: true);
+  await dictFile.writeAsBytes(zipBytes, flush: true);
+
+  final ValueNotifier<String> progress = ValueNotifier<String>('');
+  bool ok = false;
+  try {
+    await appModel.importDictionary(
+      file: dictFile,
+      progressNotifier: progress,
+      onImportSuccess: () => ok = true,
+    );
+  } catch (e, stack) {
+    debugPrint('[scan-probe] dictionary import failed: $e\n$stack');
+  } finally {
+    progress.dispose();
+  }
+  await tester.pump(const Duration(seconds: 1));
+  final bool installed = ok ||
+      appModel.dictionaries
+          .any((Dictionary d) => d.name == 'FushiScanProbeDict');
+  debugPrint('[scan-probe] dictionary seed success=$installed');
+  return installed;
+}
+
+ArchiveFile _jsonFile(String name, Object json) {
+  final List<int> bytes = utf8.encode(jsonEncode(json));
+  return ArchiveFile(name, bytes.length, bytes);
+}

--- a/fushi/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/home_dictionary_page.dart
@@ -154,13 +154,11 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
   ///
   /// 查词是「从被点的字到串尾」的整段后缀交给引擎最长匹配（BUG-1478），所以查询串
   /// 本身看不出命中了多长；不标出来，用户在「と言いつつ」上点第一个字，根本无从
-  /// 判断结果是「と言い」还是「と」。跨度长度只能等引擎回报，故本页持有它、由
-  /// [_sourceHighlightGeneration] 把迟到的回报挡在门外。
+  /// 判断结果是「と言い」还是「と」。跨度长度只能等引擎回报，故本页持有它。
+  ///
+  /// 迟到回报由 [_searchGeneration] 一并挡住：高亮现在与下方结果同源于一次主查词，
+  /// 结果被判过期，长度也就到不了这里，不再需要第二个发号器（那正是它被摘掉的原因）。
   SourceLookupHighlight? _sourceHighlight;
-
-  /// 高亮的发号器：主查词与源文本条点字都会 ++ 它。异步匹配长度回来时若号已变
-  /// （用户又点了别的字 / 又发起了新查询），这次回报直接丢弃，不去盖新的高亮。
-  int _sourceHighlightGeneration = 0;
 
   bool _historyWritten = false;
 
@@ -347,7 +345,6 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     _allLoaded = false;
     _sourceLookupText = '';
     _sourceHighlight = null;
-    _sourceHighlightGeneration++;
     _historyWritten = false;
     setState(() {});
     if (_searchFocusNode.canRequestFocus) {
@@ -686,7 +683,10 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
       _sourceLookupText = _lastQuery;
       // 缓存结果同样带 bestLength，扫描高亮按同一条换算落到句首命中段——否则从
       // 历史点回一条旧查询，原文条上会是一片没有任何标记的裸文本。
-      _applyMainSearchHighlight(_lastQuery, cached);
+      _applyScanHighlight(
+        SourceLookupScan(query: _lastQuery, charIndex: 0),
+        cached,
+      );
       // TODO-931：保留常驻热槽。
       _popup.pruneToWarmSlot();
     });
@@ -701,10 +701,22 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     // DesktopLookupService 排队时已做过时间窗去重判定（同词超窗口 = 用户显式重查），
     // 页面这层若再叠加一次永久内容去重，用户第二次复制同一个词依旧查不了。
     bool force = false,
+    // 源文本条点字发起的「扫描查词」（Yomitan 式）：查询串是被点字起的后缀，但
+    // 条上的整句、搜索框里的整句都**不动**——变的只是下方的结果和条上的高亮跨度。
+    // 非空即表示本次查词由该锚点发起，同时充当高亮的坐标锚。
+    SourceLookupScan? scanAnchor,
   }) {
     final String trimmed = query.trim();
     if (trimmed.isEmpty) return;
-    final bool replaceSourceLookupText = overrideMaximumTerms == null;
+    // 「接管搜索框与源文本条」的顶层查词：只有既不是「加载更多」、也不是扫描查词
+    // 的那一类。加载更多只是把同一个查询串的词头上限调大；扫描查词则要把整句留在
+    // 条上和搜索框里，被点的字只是句中的一段。
+    final bool replaceSourceLookupText =
+        overrideMaximumTerms == null && scanAnchor == null;
+    // 朗读与写历史解耦：旧实现把朗读写在 writeHistory 分支里，等于拿「要不要记
+    // 历史」代答「要不要读」。输入框防抖查词（writeHistory=false）确实不该读，但
+    // 扫描查词要读、又不该把用户点过的每个字都灌进历史，两者不能再共用一个开关。
+    final bool autoReadResult = writeHistory || scanAnchor != null;
 
     if (!force && _lastQuery == trimmed && overrideMaximumTerms == null) {
       if (_sourceLookupText != trimmed && mounted) {
@@ -715,9 +727,11 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
           final DictionarySearchResult? current = _result;
           if (current == null) {
             _sourceHighlight = null;
-            _sourceHighlightGeneration++;
           } else {
-            _applyMainSearchHighlight(trimmed, current);
+            _applyScanHighlight(
+              SourceLookupScan(query: trimmed, charIndex: 0),
+              current,
+            );
           }
         });
       }
@@ -737,7 +751,10 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     _lastQuery = trimmed;
     overrideMaximumTerms ??= appModel.maximumTerms;
 
-    if (_controller.text != trimmed) {
+    // 只有接管搜索框的顶层查词才把输入框同步成查询串。扫描查词的查询串是句中后缀，
+    // 同步过去会把用户眼前的整句换成半截；「加载更多」的查询串与框内本就一致，这条
+    // 守卫对它是恒真的空操作。
+    if (replaceSourceLookupText && _controller.text != trimmed) {
       _controller.text = trimmed;
       _controller.selection = TextSelection.collapsed(offset: trimmed.length);
     }
@@ -755,11 +772,23 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
         overrideMaximumTerms: overrideMaximumTerms,
         writeHistory: writeHistory,
         autoRead: autoRead,
+        autoReadResult: autoReadResult,
         searchGeneration: searchGeneration,
+        // 派发那一刻搜索框里是什么，结果落地时就得还是什么，否则这次结果已被用户
+        // 改写的输入作废。此前这里直接拿 `trimmed` 与输入框比——对「查询串恒等于
+        // 输入框」的老路径成立，对扫描查词（框里是整句、查询串是后缀）恒不成立，
+        // 结果会被自己的守卫全部丢掉。
+        inputTextAtDispatch: _controller.text,
         // 「加载更多」（overrideMaximumTerms 非空）不换源文本，也就不该动扫描高亮：
         // 它只是把同一个查询串的词头上限调大，命中段没变，而用户此刻的高亮可能已经
-        // 是他点出来的某个词，重设会把它弹回句首。
-        resetHighlight: replaceSourceLookupText,
+        // 是他点出来的某个词，重设会把它弹回句首。扫描查词则按被点字的下标重定位。
+        // 这里不能再判 `overrideMaximumTerms == null`：它上面已被 `??=` 补过默认值，
+        // 那个判空恒假，主查词会一路拿到 null 锚点、高亮再也不落。用入口处算好的
+        // 标志，它记的正是「本次是不是接管搜索框与源文本条的顶层查词」。
+        highlightAnchor: scanAnchor ??
+            (replaceSourceLookupText
+                ? SourceLookupScan(query: trimmed, charIndex: 0)
+                : null),
       );
       _lastDispatchedSearch = dispatched;
       unawaited(dispatched);
@@ -774,7 +803,9 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     required bool writeHistory,
     required bool? autoRead,
     required int searchGeneration,
-    required bool resetHighlight,
+    required bool autoReadResult,
+    required String inputTextAtDispatch,
+    required SourceLookupScan? highlightAnchor,
   }) async {
     // 用 try/finally 守卫整条失败路径：searchDictionary 走远程网络查询 +
     // fushidicts C++ FFI，任一环节抛异常都不能让 _isSearching 永久为 true
@@ -788,13 +819,13 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
       );
       if (!mounted ||
           searchGeneration != _searchGeneration ||
-          trimmed != _controller.text) {
+          _controller.text != inputTextAtDispatch) {
         return;
       }
 
       _result = result;
       _allLoaded = !result.truncated;
-      if (resetHighlight) _applyMainSearchHighlight(trimmed, result);
+      if (highlightAnchor != null) _applyScanHighlight(highlightAnchor, result);
 
       if (writeHistory) {
         _historyWritten = true;
@@ -804,16 +835,18 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
         );
         if (result.entries.isNotEmpty) {
           appModel.addToDictionaryHistory(result: result);
-          // autoRead 覆盖：null 沿用全局 autoReadOnLookup（正常输入查词不变），
-          // 桌面剪贴板/热键路径显式传 false 抑制朗读。
-          final bool shouldAutoRead =
-              autoRead ?? ReaderFushiSource.instance.autoReadOnLookup;
-          if (shouldAutoRead) {
-            final entry = result.entries.first;
-            if (entry.word.isNotEmpty) {
-              autoReadWord(entry.word, entry.reading,
-                  popupState: _resultWebViewKey.currentState);
-            }
+        }
+      }
+      if (autoReadResult && result.entries.isNotEmpty) {
+        // autoRead 覆盖：null 沿用全局 autoReadOnLookup（正常输入查词不变），
+        // 桌面剪贴板/热键路径显式传 false 抑制朗读。
+        final bool shouldAutoRead =
+            autoRead ?? ReaderFushiSource.instance.autoReadOnLookup;
+        if (shouldAutoRead) {
+          final entry = result.entries.first;
+          if (entry.word.isNotEmpty) {
+            autoReadWord(entry.word, entry.reading,
+                popupState: _resultWebViewKey.currentState);
           }
         }
       }
@@ -832,9 +865,14 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     if (_isSearching || _allLoaded || _result == null) return;
     // BUG-1478：按词头递增（见 base_source_page 同处注释）。
     final int current = _result!.headwordCount;
+    // 「更多」要更多的是**眼下这份结果**的查询串。扫描查词之后它是句中的一段后缀，
+    // 而搜索框里仍是整句——照旧拿 `_controller.text` 去加载更多，会把结果整个换成
+    // 另一个词的，用户只是滚到底就看见结果被掉包。
+    final String activeQuery =
+        _lastQuery.isNotEmpty ? _lastQuery : _controller.text;
     _lastQuery = '';
     _search(
-      _controller.text,
+      activeQuery,
       overrideMaximumTerms: current + appModel.maximumTerms,
       writeHistory: false,
     );
@@ -913,15 +951,14 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
         if (_sourceLookupText.trim().isNotEmpty)
           SourceLookupTextPanel(
             text: _sourceLookupText,
-            // TODO-617：弹窗已提到根 Overlay（全窗、净缩放=1），源文本条点字必须回报屏幕
-            // （global）坐标与之同系；不再用结果子区域 [_resultStackKey] 局部坐标。
-            globalCoordinates: true,
             dictionaryHeadwordScale: appModel.dictionaryFontSize /
                 appModel.defaultDictionaryFontSize,
             highlight: _sourceHighlight,
-            onLookup: (String query, Rect screenRect, int charIndex) {
-              unawaited(_lookupFromSourceStrip(query, screenRect, charIndex));
-            },
+            // 点字换的是下方那份结果（Yomitan 式扫描），不再压一张浮在字上的查词卡，
+            // 所以本条不再需要回报任何弹窗坐标系的 rect——rect 与 globalCoordinates
+            // 都随之退场。结果卡内部选词 / 点链才继续走弹窗栈（见下方 WebView）。
+            onLookup: (String query, Rect _, int charIndex) =>
+                _lookupFromSourceStrip(query, charIndex),
           ),
         // 根因修复（BUG-054）：结果区 WebView 仍整块在中和器下渲染（净缩放=1），否则被全局
         // 「界面大小」FittedBox 拉糊。源文本条是普通 app UI，留在中和器外继续吃界面大小。
@@ -1077,52 +1114,61 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     );
   }
 
-  /// 源文本条点字（或 Shift 悬停）：压查词浮层，并把 Yomitan 式扫描高亮落到真正被
-  /// 匹配的那几个字上。
+  /// 源文本条点字（或 Shift 悬停）：把**下方那份查词结果**换成从该字起的最长匹配，
+  /// 并把 Yomitan 式扫描高亮落到真正被匹配的那几个字上。
+  ///
+  /// 此前这里压的是一张浮在被点字上的查词卡（`_pushNestedPopup`）。那让同一次查词
+  /// 裂成两个可见面：条上的高亮挪了、卡片盖在条下面另起一套结果，而页面本体那份
+  /// 结果还停在上一个词上；再点一个字又是一张卡。Yomitan 的扫描没有这一层——挪的
+  /// 始终是同一份结果。所以这里改走主查词管线（[_search]），条上的整句与搜索框里的
+  /// 整句都留着不动，变的只有下方结果和高亮跨度。
   ///
   /// 分两拍：先立刻框住被点的那个字（点下去就有反馈，不用干等查词往返），引擎回报
-  /// 匹配长度后再扩成整词。中途用户又点了别的字就换号，这次的回报直接丢弃。
-  Future<void> _lookupFromSourceStrip(
-    String query,
-    Rect screenRect,
-    int charIndex,
-  ) async {
-    final int generation = ++_sourceHighlightGeneration;
+  /// 匹配长度后再由 [_applyScanHighlight] 扩成整词；中途用户又点了别的字，迟到的那
+  /// 次回报会被 `_searchGeneration` 挡在门外。
+  void _lookupFromSourceStrip(String query, int charIndex) {
+    final SourceLookupScan scan = SourceLookupScan.fromSuffix(
+      suffix: query,
+      charIndex: charIndex,
+    );
+    if (scan.query.isEmpty) return;
     setState(() {
-      _sourceHighlight = SourceLookupHighlight(start: charIndex, length: 1);
-    });
-    final int matchedUnits =
-        await _pushNestedPopup(query, screenRect, reuseWarmSlot: true);
-    if (!mounted || generation != _sourceHighlightGeneration) return;
-    setState(() {
-      _sourceHighlight = resolveSourceLookupHighlight(
-        query: query,
-        tappedGraphemeIndex: charIndex,
-        matchedUnits: matchedUnits,
-        leadingStripUnits: appModel.lookupLeadingStripUnits(query),
+      _sourceHighlight = SourceLookupHighlight(
+        start: scan.charIndex,
+        length: 1,
       );
     });
+    _search(
+      scan.query,
+      // 点同一个字两次仍要重查：与桌面取词同理（BUG-1025），显式手势不该被「与上次
+      // 查询相同即不重查」的内容去重吞掉。
+      force: true,
+      // 用户点过的每个字都灌进查词历史会把历史刷成噪声；朗读由 scanAnchor 单独开
+      // （见 [_search] 里的 autoReadResult）。
+      writeHistory: false,
+      scanAnchor: scan,
+    );
   }
 
-  /// 主查词（搜索框提交 / 桌面取词 / 深链 / 点回历史）落地后的扫描高亮。
+  /// 把一次查词的引擎命中长度落成源文本条上的扫描高亮。
   ///
   /// 引擎的候选串**全部是查询串的前缀**（`scan_candidates` 只从串首锚定、由长到短
-  /// 地截），所以主结果的命中段起点恒为 0 —— 与源文本条点第 0 个字是同一件事，直接
-  /// 复用同一个换算。
-  void _applyMainSearchHighlight(
-    String panelText,
+  /// 地截），所以命中段的起点恒为查询串的串首；[SourceLookupScan.charIndex] 给出那个
+  /// 串首落在条上的位置——主查词（搜索框提交 / 桌面取词 / 深链 / 点回历史）是条首
+  /// 0，源文本条点字是被点的那个字。两者是同一个换算的两种锚。
+  void _applyScanHighlight(
+    SourceLookupScan anchor,
     DictionarySearchResult result,
   ) {
-    _sourceHighlightGeneration++;
     _sourceHighlight = resolveSourceLookupHighlight(
-      query: panelText,
-      tappedGraphemeIndex: 0,
+      query: anchor.query,
+      tappedGraphemeIndex: anchor.charIndex,
       matchedUnits: lookupHighlightCharCount(
         result: result,
-        searchTerm: panelText,
+        searchTerm: anchor.query,
         language: JapaneseLanguage.instance,
       ),
-      leadingStripUnits: appModel.lookupLeadingStripUnits(panelText),
+      leadingStripUnits: appModel.lookupLeadingStripUnits(anchor.query),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -71,8 +71,9 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
 
   /// 源文本条上「这次查的是哪几个字」的扫描高亮，与首页词典 tab 同一口径。
   ///
-  /// 本页每次查词都把 [_sourceLookupText] 换成被点字起的后缀（见 [_pushSearch]），
-  /// 所以命中段的起点恒为条首（0）；长度仍要等引擎回报。
+  /// 顶层查词（宿主推来新词 / 搜索栏提交 / 开页自动查词）会把 [_sourceLookupText]
+  /// 换成查询串本身，命中段起点即条首（0）；源文本条点字则整句不动、起点是被点的
+  /// 那个字素簇（见 [_pushSearch] 的 `scan`）。长度两种情形都要等引擎回报。
   SourceLookupHighlight? _sourceHighlight;
 
   /// 迟到匹配长度的发号器（见首页词典 tab 的同名字段）。
@@ -171,10 +172,17 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     String query,
     Rect selectionRect, {
     bool reuseWarmSlot = false,
+    // 源文本条点字发起的「扫描查词」（Yomitan 式）。非空时本条与搜索框都**不动**：
+    // 变的只有下方那份结果和条上的高亮跨度，锚点就是被点的那个字素簇。
+    SourceLookupScan? scan,
   }) async {
     final String trimmed = query.trim();
     if (trimmed.isEmpty) return;
-    if (_searchController.text != trimmed) {
+    // 此前每次点字都把条上的整句换成「被点字起的后缀」，被点字左边的上下文就此丢
+    // 失：在「と言いつつ」上点「つ」，条上只剩「つつ」，再想点回「言」已经没得点。
+    // Yomitan 的扫描是整句不动、只挪高亮，所以扫描查词不再接管这两处。
+    final int anchorIndex = scan?.charIndex ?? 0;
+    if (scan == null && _searchController.text != trimmed) {
       _searchController.text = trimmed;
       _searchController.selection = TextSelection.collapsed(
         offset: trimmed.length,
@@ -183,9 +191,12 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     final int highlightGeneration = ++_sourceHighlightGeneration;
     if (mounted) {
       setState(() {
-        _sourceLookupText = trimmed;
-        // 先框住条首那个字给即时反馈，引擎回报匹配长度后再扩成整词。
-        _sourceHighlight = const SourceLookupHighlight(start: 0, length: 1);
+        if (scan == null) _sourceLookupText = trimmed;
+        // 先框住被点的那个字给即时反馈，引擎回报匹配长度后再扩成整词。
+        _sourceHighlight = SourceLookupHighlight(
+          start: anchorIndex,
+          length: 1,
+        );
       });
     }
     final int matchedUnits = await pushNestedPopup(
@@ -203,8 +214,9 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     setState(() {
       _sourceHighlight = resolveSourceLookupHighlight(
         query: trimmed,
-        // 本页源文本条渲染的就是 trimmed 本身，条首即被查的那个字。
-        tappedGraphemeIndex: 0,
+        // 顶层查词时条上渲染的就是 trimmed 本身，条首即被查的那个字（锚点 0）；
+        // 扫描查词时条上是整句，锚点是被点的那个字。
+        tappedGraphemeIndex: anchorIndex,
         matchedUnits: matchedUnits,
         leadingStripUnits: appModel.lookupLeadingStripUnits(trimmed),
       );
@@ -386,11 +398,17 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
               coordinateSpaceKey: _resultStackKey,
               dictionaryHeadwordScale: _dictionaryHeadwordScale,
               highlight: _sourceHighlight,
-              // 源文本面板点选 = 顶层新词，复用常驻热槽（TODO-951 症状C）。
-              // charIndex 在本页恒被 _pushSearch 归零：条上的文本随即换成从该字起
-              // 的后缀，被点的字就落回条首。
-              onLookup: (String query, Rect rect, int _) =>
-                  _pushSearch(query, rect, reuseWarmSlot: true),
+              // 源文本面板点选 = 扫描查词：复用常驻热槽原地换结果（TODO-951 症状C），
+              // 条上的整句与搜索框里的整句都留着，只有高亮跨度跟着挪。
+              onLookup: (String query, Rect rect, int charIndex) => _pushSearch(
+                query,
+                rect,
+                reuseWarmSlot: true,
+                scan: SourceLookupScan.fromSuffix(
+                  suffix: query,
+                  charIndex: charIndex,
+                ),
+              ),
             ),
           Expanded(child: _buildStack(context)),
         ],

--- a/fushi/lib/src/utils/components/clipboard_lookup_text_panel.dart
+++ b/fushi/lib/src/utils/components/clipboard_lookup_text_panel.dart
@@ -98,6 +98,55 @@ SourceLookupHighlight resolveSourceLookupHighlight({
   );
 }
 
+/// 一次「扫描查词」的发起点：交给引擎的那段串，以及它在源文本条上的起始字素簇。
+///
+/// 源文本条上点第 n 个字，查的是「从该字到串尾」的后缀（[SourceLookupTextPanel]
+/// 的 `onLookup`）。引擎的候选串全部是查询串的**前缀**，所以命中段的起点恒为
+/// [query] 的串首，而 [charIndex] 就是那个串首落在条上的位置——把两者绑成一个值，
+/// 异步结果回来时才能把匹配长度还给**发起那一次**的位置（见
+/// [resolveSourceLookupHighlight]）。主查词是同一件事的退化情形：整条就是查询串，
+/// [charIndex] = 0。
+@immutable
+class SourceLookupScan {
+  const SourceLookupScan({required this.query, required this.charIndex});
+
+  /// 从源文本条回报的原始后缀构造，把串首空白折进 [charIndex]。
+  ///
+  /// 查词管线一律 `trim()` 查询串，而 [SourceLookupTextPanel] 回报的下标指的是**未
+  /// trim** 的那个字。用户点在词与词之间的空白上时两者就错开一位，高亮会框住那个
+  /// 空白、而不是引擎真正吃下去的第一个字。
+  factory SourceLookupScan.fromSuffix({
+    required String suffix,
+    required int charIndex,
+  }) {
+    final int leadingBlank = suffix.characters
+        .takeWhile((String grapheme) => grapheme.trim().isEmpty)
+        .length;
+    return SourceLookupScan(
+      query: suffix.trim(),
+      charIndex: charIndex + leadingBlank,
+    );
+  }
+
+  /// 交给引擎的串（源文本条从 [charIndex] 起的后缀 / 主查词的整个查询串）。
+  final String query;
+
+  /// [query] 的串首在源文本条渲染序列里的字素簇下标。
+  final int charIndex;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SourceLookupScan &&
+      other.query == query &&
+      other.charIndex == charIndex;
+
+  @override
+  int get hashCode => Object.hash(query, charIndex);
+
+  @override
+  String toString() => 'SourceLookupScan(query: $query, charIndex: $charIndex)';
+}
+
 class SourceLookupTextPanel extends StatefulWidget {
   const SourceLookupTextPanel({
     required this.text,

--- a/fushi/test/pages/home_dictionary_popup_overlay_test.dart
+++ b/fushi/test/pages/home_dictionary_popup_overlay_test.dart
@@ -226,8 +226,12 @@ void main() {
     expect(page.contains('popupWordScreenRect('), isTrue,
         reason:
             'top-level result-WebView lookup maps localRect to screen coords');
-    expect(page.contains('globalCoordinates: true'), isTrue,
-        reason: 'source-text panel reports screen coords for the overlay');
+    // 源文本条曾经也往这个 overlay 里压卡（故此处曾断言它回报屏幕坐标）。它现在改走
+    // 主查词管线、整份换掉下方结果，不再产出任何弹窗坐标——那条断言的前提没了。
+    // 「点字不压浮层」的不变量由 home_dictionary_source_scan_test 的源码守卫接管；
+    // 这里只继续守住**结果 WebView 内部**取词那条仍在用 overlay 的入口。
+    expect(page.contains('onTextSelected:'), isTrue,
+        reason: 'result WebView selection still feeds the overlay popup stack');
   });
 
   test(

--- a/fushi/test/pages/home_dictionary_source_scan_test.dart
+++ b/fushi/test/pages/home_dictionary_source_scan_test.dart
@@ -1,0 +1,262 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/models/audio_source_config.dart';
+import 'package:fushi/src/pages/implementations/home_dictionary_page.dart';
+import 'package:fushi/src/sync/desktop_lookup_service.dart';
+import 'package:fushi/src/utils/components/clipboard_lookup_text_panel.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+import '../helpers/fake_inappwebview_platform.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 源文本条点字 = Yomitan 式**扫描**：整句留在条上、留在搜索框里，变的只有下方那份
+/// 查词结果和条上的高亮跨度。
+///
+/// 之前这里是「往后扫描 + 在此基础上嵌套查词」：点一个字压一张浮在字上的查词卡
+/// （`_pushNestedPopup`），同一次查词裂成两个可见面——条上的高亮挪了，卡片盖在条下面
+/// 另起一套结果，而页面本体那份结果还停在上一个词上；再点一个字又是一张卡。本组
+/// 测试钉住改回同一份结果之后的不变量：**引擎吃后缀、条与框吃整句、栈不长高**。
+class _ScanAppModel extends AppModel {
+  _ScanAppModel() : super(testPlatformServices());
+
+  final List<String> searchedTerms = <String>[];
+  final List<int?> searchedLimits = <int?>[];
+
+  @override
+  List<DictionarySearchResult> get dictionaryHistory =>
+      <DictionarySearchResult>[];
+
+  @override
+  List<Dictionary> get dictionaries => <Dictionary>[
+        Dictionary(name: 'Test', formatKey: 'test', order: 0),
+      ];
+
+  @override
+  int get maximumTerms => 10;
+
+  @override
+  bool get autoSearchEnabled => false;
+
+  @override
+  double get defaultDictionaryFontSize => 26;
+
+  @override
+  double get dictionaryFontSize => 26;
+
+  @override
+  double get appUiScale => 1.0;
+
+  @override
+  List<String> get enabledAudioSources => const <String>[];
+
+  // 扫描查词会走朗读（与它取代的浮层路径同行为），朗读要读音频源配置，而那条读的是
+  // 未初始化的 prefsRepo → 空断言炸。配一份空音频源让朗读原地无声返回，测的仍是
+  // 查词状态机本身。
+  @override
+  List<AudioSourceConfig> get audioSourceConfigs => const <AudioSourceConfig>[];
+
+  @override
+  void addToSearchHistory({
+    required String historyKey,
+    required String searchTerm,
+  }) {}
+
+  @override
+  void addToDictionaryHistory({required DictionarySearchResult result}) {}
+
+  @override
+  Future<DictionarySearchResult> searchDictionary({
+    required String searchTerm,
+    required bool searchWithWildcards,
+    int? overrideMaximumTerms,
+    bool useCache = true,
+    bool allowRemoteLookup = true,
+  }) async {
+    searchedTerms.add(searchTerm);
+    searchedLimits.add(overrideMaximumTerms);
+    return DictionarySearchResult(
+      searchTerm: searchTerm,
+      entries: List<DictionaryEntry>.generate(
+        10,
+        (int i) => DictionaryEntry(word: '$searchTerm$i'),
+      ),
+      headwordCount: 10,
+      truncated: true,
+    );
+  }
+}
+
+Widget _wrap(_ScanAppModel appModel) {
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+    child: TranslationProvider(
+      child: MaterialApp(
+        navigatorKey: appModel.navigatorKey,
+        builder: (BuildContext context, Widget? child) =>
+            child ?? const SizedBox.shrink(),
+        home: const Scaffold(body: HomeDictionaryPage()),
+      ),
+    ),
+  );
+}
+
+HomeDictionarySearchDebug _debug(WidgetTester tester) =>
+    tester.state(find.byType(HomeDictionaryPage)) as HomeDictionarySearchDebug;
+
+SourceLookupTextPanel _panel(WidgetTester tester) =>
+    tester.widget(find.byType(SourceLookupTextPanel));
+
+String _searchBoxText(WidgetTester tester) {
+  final FushiSearchField field = tester.widget(find.byType(FushiSearchField));
+  return field.controller.text;
+}
+
+/// 派发一次查词并把 microtask 排空（假 AppModel 立即返回，无需真实时钟）。
+Future<void> _settle(WidgetTester tester, [Future<void>? dispatched]) async {
+  await tester.runAsync(() async {
+    if (dispatched != null) await dispatched;
+  });
+  await tester.pump();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(installFakeInAppWebViewPlatform);
+
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+    DesktopLookupService.instance.debugReset();
+  });
+
+  tearDown(() {
+    DesktopLookupService.instance.debugReset();
+  });
+
+  testWidgets('点源文本条的字：引擎吃「从该字起的后缀」，条上与搜索框里的整句都不动',
+      (WidgetTester tester) async {
+    final _ScanAppModel appModel = _ScanAppModel();
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    await _settle(tester, _debug(tester).debugSearch('と言いつつ'));
+
+    expect(_panel(tester).text, 'と言いつつ');
+    expect(_searchBoxText(tester), 'と言いつつ');
+    expect(_panel(tester).highlight?.start, 0, reason: '主查词的命中段锚在条首。');
+    expect(appModel.searchedTerms, <String>['と言いつつ']);
+
+    // 点第 2 个字「言」（字素簇下标 1）。
+    await tester.tap(find.text('言'));
+    await _settle(tester);
+    await _settle(tester);
+
+    expect(
+      appModel.searchedTerms.last,
+      '言いつつ',
+      reason: '扫描查词交给引擎的是从被点字起的后缀。',
+    );
+    expect(
+      _panel(tester).text,
+      'と言いつつ',
+      reason: '条上必须留着整句：换成后缀就把被点字左边的上下文丢了，'
+          '再想点回「と」已经没得点。',
+    );
+    expect(
+      _searchBoxText(tester),
+      'と言いつつ',
+      reason: '搜索框是用户输入的整句，扫描查词不接管它。',
+    );
+    expect(
+      _panel(tester).highlight?.start,
+      1,
+      reason: '高亮锚在被点的那个字素簇上（Yomitan 的扫描高亮）。',
+    );
+    expect(
+      _debug(tester).debugPopupStackShape.depth,
+      0,
+      reason: '扫描换的是下方那份结果，不再压一张浮在字上的查词卡。',
+    );
+  });
+
+  testWidgets('扫描查词后「加载更多」加载的是眼下这份结果的查询串，不是搜索框里的整句',
+      (WidgetTester tester) async {
+    final _ScanAppModel appModel = _ScanAppModel();
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    await _settle(tester, _debug(tester).debugSearch('と言いつつ'));
+    await tester.tap(find.text('言'));
+    await _settle(tester);
+    await _settle(tester);
+    expect(appModel.searchedTerms.last, '言いつつ');
+
+    await _settle(tester, _debug(tester).debugLoadMore());
+
+    expect(
+      appModel.searchedTerms.last,
+      '言いつつ',
+      reason: '滚到底只该要更多同一个词的词头；拿搜索框里的整句去加载更多，'
+          '用户会看见结果被悄悄掉包成另一个词的。',
+    );
+    expect(appModel.searchedLimits.last, greaterThan(10),
+        reason: '加载更多必须把词头上限调大。');
+    expect(_panel(tester).highlight?.start, 1,
+        reason: '加载更多不换源文本，也就不该把高亮弹回句首。');
+  });
+
+  testWidgets('点回条首那个字：整句与搜索框仍不动，高亮回到 0', (WidgetTester tester) async {
+    final _ScanAppModel appModel = _ScanAppModel();
+    await tester.pumpWidget(_wrap(appModel));
+    await tester.pump();
+
+    await _settle(tester, _debug(tester).debugSearch('と言いつつ'));
+    await tester.tap(find.text('言'));
+    await _settle(tester);
+    await _settle(tester);
+    expect(_panel(tester).highlight?.start, 1);
+
+    await tester.tap(find.text('と'));
+    await _settle(tester);
+    await _settle(tester);
+
+    expect(appModel.searchedTerms.last, 'と言いつつ');
+    expect(_panel(tester).text, 'と言いつつ');
+    expect(_searchBoxText(tester), 'と言いつつ');
+    expect(_panel(tester).highlight?.start, 0);
+    expect(_debug(tester).debugPopupStackShape.depth, 0);
+  });
+
+  test('源码守卫：源文本条的 onLookup 走主查词管线，不再压嵌套浮层', () {
+    final String page = File(
+      'lib/src/pages/implementations/home_dictionary_page.dart',
+    ).readAsStringSync();
+
+    final int panelStart = page.indexOf('SourceLookupTextPanel(');
+    expect(panelStart, greaterThan(0), reason: '首页词典 tab 必须挂源文本条。');
+    final int panelEnd = page.indexOf('Expanded(', panelStart);
+    expect(panelEnd, greaterThan(panelStart));
+    final String wiring = page.substring(panelStart, panelEnd);
+
+    expect(
+      wiring.contains('_lookupFromSourceStrip('),
+      isTrue,
+      reason: '点字必须走主查词管线，把下方那份结果整份换掉。',
+    );
+    expect(
+      wiring.contains('_pushNestedPopup('),
+      isFalse,
+      reason: '点字压浮层会让同一次查词裂成两个可见面：条上高亮挪了、卡片另起一套'
+          '结果，而页面本体那份结果还停在上一个词上。',
+    );
+    // 结果卡内部选词 / 点链是另一条入口，仍然走弹窗栈——别把它一起摘了。
+    expect(page.contains('Future<int> _pushNestedPopup('), isTrue,
+        reason: '结果 WebView 内部取词仍需嵌套浮层。');
+  });
+}

--- a/fushi/test/pages/home_dictionary_source_scan_test.dart
+++ b/fushi/test/pages/home_dictionary_source_scan_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/models.dart';
-import 'package:fushi/src/models/audio_source_config.dart';
 import 'package:fushi/src/pages/implementations/home_dictionary_page.dart';
 import 'package:fushi/src/sync/desktop_lookup_service.dart';
 import 'package:fushi/src/utils/components/clipboard_lookup_text_panel.dart';

--- a/fushi/test/pages/popup_dictionary_page_test.dart
+++ b/fushi/test/pages/popup_dictionary_page_test.dart
@@ -362,10 +362,20 @@ void main() {
     await tester.tap(find.text('c'));
     await tester.pump();
 
+    // Yomitan 式扫描：点第 3 个字查的是后缀 'cdef'，但条上的整句与搜索框里的整句都
+    // 留着不动，只有高亮跨度挪到被点的那个字上。此前这里两处都会被换成 'cdef'——
+    // 被点字左边的 'ab' 就此从条上消失，用户再想点回去已经没得点。
     final PopupDictionarySearchBar searchBar = tester.widget(
       find.byType(PopupDictionarySearchBar),
     );
-    expect(searchBar.controller.text, 'cdef');
+    expect(searchBar.controller.text, 'abcdef');
+
+    final SourceLookupTextPanel panel = tester.widget(
+      find.byType(SourceLookupTextPanel),
+    );
+    expect(panel.text, 'abcdef');
+    expect(panel.highlight?.start, 2,
+        reason: '高亮锚在被点的那个字素簇上，不再恒归零。');
   });
 
   test('source guard: popup dictionary consumes layer visibility',

--- a/fushi/test/widgets/clipboard_lookup_text_panel_test.dart
+++ b/fushi/test/widgets/clipboard_lookup_text_panel_test.dart
@@ -429,6 +429,43 @@ void main() {
     expect(allHighlightBoxes(), findsNothing);
   });
 
+  group('SourceLookupScan.fromSuffix（后缀 → 查询串 + 高亮锚）', () {
+    test('普通后缀原样带过，锚就是被点的那个字', () {
+      final SourceLookupScan scan = SourceLookupScan.fromSuffix(
+        suffix: '言いつつ',
+        charIndex: 1,
+      );
+      expect(scan.query, '言いつつ');
+      expect(scan.charIndex, 1);
+    });
+
+    test('串首空白折进锚：查词管线会 trim，锚不跟着右移就框在空白上', () {
+      final SourceLookupScan scan = SourceLookupScan.fromSuffix(
+        suffix: '  hello world',
+        charIndex: 5,
+      );
+      expect(scan.query, 'hello world');
+      expect(scan.charIndex, 7, reason: '5 + 两个空白字素簇');
+    });
+
+    test('全空白后缀不产出查询串（宿主据此早退，不发空查询）', () {
+      final SourceLookupScan scan = SourceLookupScan.fromSuffix(
+        suffix: '   ',
+        charIndex: 3,
+      );
+      expect(scan.query, isEmpty);
+    });
+
+    test('串尾空白只影响查询串，不影响锚', () {
+      final SourceLookupScan scan = SourceLookupScan.fromSuffix(
+        suffix: 'あい  ',
+        charIndex: 2,
+      );
+      expect(scan.query, 'あい');
+      expect(scan.charIndex, 2);
+    });
+  });
+
   group('resolveSourceLookupHighlight（UTF-16 匹配长度 → 字素簇跨度）', () {
     test('从被点的字起，按引擎匹配长度框住整词', () {
       // 「と言いつつ」上点第 0 个字：查询串是整条，引擎命中「と言い」(3 unit)。


### PR DESCRIPTION
查词页顶部那条原文是 Yomitan 式的「扫描」：点第几个字，就把从该字到串尾的后缀交给引擎最长匹配。**落地却落错了地方**——扫描的结果没有落到那份结果上。

## 症状（BUG-2424）

两个宿主各错一半：

**首页词典 tab**（`home_dictionary_page`）：点字走 `_pushNestedPopup(...)`，压一张**浮在那个字上的查词卡**。页面本体那份结果（`DictionaryPopupWebView(result: _result!)`）与弹窗栈是两棵独立子树，卡片起来了、下方那份结果仍停在上一个词上——同一次查词裂成两个可见面，条上的高亮指着 A、页面下半屏还写着 B；再点一个字又是一张卡。

**Android 独立查词窗**（`popup_dictionary_page`）：`_pushSearch` 每次都把 `_sourceLookupText` 和搜索框换成「被点字起的后缀」。在「と言いつつ」上点「つ」，条上只剩「つつ」——被点字左边的上下文当场消失，再想点回「言」已经没得点。

Yomitan 的扫描没有这一层：整句留在条上，挪的是同一份结果。

## 改法

两个宿主统一到一个口径：**条上的整句与搜索框里的整句都不动，变的只有下方那份结果和高亮跨度。**

- `home_dictionary_page`：`_search` 新增 `scanAnchor`（`SourceLookupScan`）。一个值同时表示「本次不接管搜索框 / 源文本条」与「高亮锚在哪个字素簇」。源文本条这条入口不再调 `_pushNestedPopup`；**结果 WebView 内部选词 / 点链仍走弹窗栈，未动**（那是另一条入口，嵌套下钻是它应有的语义）。
- `popup_dictionary_page`：`_pushSearch` 新增 `scan`，非空时不接管条与框，高亮锚改成被点的那个字素簇（此前恒 0）。
- `clipboard_lookup_text_panel`：新增 `SourceLookupScan`（查询串 + 高亮锚的绑定）与 `SourceLookupScan.fromSuffix`——查词管线一律 `trim`，串首空白不折进锚就会框在空白上。

### 三处随之暴露的既有耦合，一并修根因

它们都是「扫描查词」第一次让其前提不成立才浮出来的：

1. `_searchWithGeneration` 的过期守卫原本比 `trimmed != _controller.text`。对「查询串恒等于输入框」的老路径成立，对扫描查词（框里整句、查询串后缀）**恒不成立**，会把自己的结果全丢掉 → 改比**派发那一刻**的输入框内容（`inputTextAtDispatch`）。
2. 朗读原本写在 `if (writeHistory)` 里，等于拿「要不要记历史」代答「要不要读」。扫描查词要读、又不该把用户点过的每个字都灌进历史 → 拆成独立的 `autoReadResult`（既有各路径的取值逐一对齐，行为不变）。
3. `_loadMore` 原本拿 `_controller.text` 去加载更多。扫描查词后那是整句而不是眼下这份结果的查询串，滚到底会把结果**掉包**成另一个词的 → 改用当前查询串。

另外摘掉首页那个已成死码的 `_sourceHighlightGeneration`：高亮现在与下方结果同源于一次主查词，迟到回报由 `_searchGeneration` 一并挡住，第二个发号器没有存在理由了（analyzer 也报了 `unused_field`）。

## 验证

- `dart analyze lib test integration_test` 全绿。
- 新增 `fushi/test/pages/home_dictionary_source_scan_test.dart`（4 条）：点字后引擎吃后缀而条与框留整句、**栈深恒 0**；扫描后「加载更多」不掉包；点回条首；源码守卫钉住 `onLookup` 不再压浮层。
- 改写 `popup_dictionary_page_test` 里钉旧契约那条（原断言「点第 3 个字后搜索框变成 `cdef`」→ 现在断言条与框仍是 `abcdef`、高亮锚 = 2）。
- 新增 `SourceLookupScan.fromSuffix` 4 条纯逻辑；`home_dictionary_popup_overlay_test` 里那条「源文本条回报屏幕坐标供 overlay 用」的断言前提已消失，换成守住仍在用 overlay 的结果 WebView 入口。
- 定向 59 条退出码 0；**目录枚举型守卫整批 51 条 368 tests 全绿**（与 `docs/agent/fast-workflow.md` 记的当前基线 368 一致，零漂移）。
- 真机复测见下。

修复档：`docs/bugs/BUG-2424-dict-scan-inline-results.md`。

## 真机复测（Windows 离屏 itest）

新增 `fushi/integration_test/dict_source_scan_inline_itest.dart`：造一本含「と言い/言い/言う/つつ」四条词头的 yomitan 词典经真实 `AppModel.importDictionary` FFI 导入隔离根，再走原始失败路径——查「と言いつつ」，然后从源文本条第 2 个字「言」发起扫描。

```
[scan-probe] 主查词   highlight=SourceLookupHighlight(start: 0, length: 3)
[scan-probe] 点「言」后 highlight=SourceLookupHighlight(start: 1, length: 2)
             panel="と言いつつ" box="と言いつつ" stack=(depth: 0, parkedRealms: 0)
```

条上整句不动、搜索框整句不动、**栈深恒 0**（没有浮在字上的查词卡），高亮从「と言い」挪到「言い」。高亮长度是核心证据：它不是页面自己编的，是 `lookupHighlightCharCount` 从真实 `DictionarySearchResult.bestLength` 换算来的——只有下方那份结果真换成了用后缀「言いつつ」查到的「言い」，它才可能是 2。

结果区在 observe 帧里是黑的（WebView 原生纹理，`captureFlutterFrame` 抓不到，文档已注明），所以「结果确实换了」由上面那条 Dart 侧证据接管，不靠截图。操作走本条对外的生产回调 `onLookup`，不做坐标点击 / `tester.tap`。

https://claude.ai/code/session_01CCGE5Z99i794xEAGFUiy6G
