### PR TITLE
fix(asr): 关掉声学调轴，转录不再被 985 MB 调轴模型挡住

### DIFF
--- a/fushi/integration_test/asr_transcribe_e2e_itest.dart
+++ b/fushi/integration_test/asr_transcribe_e2e_itest.dart
@@ -101,6 +101,8 @@ Future<
   required AsrEncoderVariant variant,
 }) async {
   final AsrTranscriptionService service = AsrTranscriptionService(
+    // 素材是干净朗读（TTS / 有声书），能量门限的双模态前提成立。
+    audioProfile: AsrAudioProfile.cleanSpeech,
     backend: fushiAsrBackend(),
     openStore: (AsrLanguage _) async => store,
     jobsRoot: () async => jobsRoot,

--- a/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
+++ b/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
@@ -44,6 +44,9 @@ class AppleSpeechTranscriptionService extends AsrTranscriptionService {
           // 父类构造要一个 backend，但本服务把每一个会用到它的方法都覆写了，
           // ONNX 那条路在这里结构上不可达（`buildFactory` 永远不会被调）。
           backend: const AsrIsolateBackend(buildFactory: _unusedOnnxFactory),
+          // 同理：Apple 原生引擎自己做端点检测，不经本仓的 VAD 切段。父类要求
+          // 显式声明素材属性（见 AsrAudioProfile），这里填一个不会被用到的值。
+          audioProfile: AsrAudioProfile.cleanSpeech,
         );
 
   final AppleSpeechPlatform _platform;
@@ -130,6 +133,8 @@ class AppleSpeechTranscriptionService extends AsrTranscriptionService {
   Stream<ModelDownloadEvent> downloadModel({
     required AsrLanguage language,
     required AsrEncoderVariant variant,
+    // 系统语音资产里没有「调轴模型」这回事，收下但忽略。
+    bool includeAlignment = false,
   }) async* {
     yield const ModelDownloadEvent(
       fileName: 'system speech assets',

--- a/fushi/lib/src/asr_host/asr_host.dart
+++ b/fushi/lib/src/asr_host/asr_host.dart
@@ -151,11 +151,26 @@ Future<void> saveAsrModelCatalog(AsrModelCatalog catalog) async {
 }
 
 /// 建一个装配好的转录服务。两个生产实例化点都调这里。
+///
+/// [alignGeneratedSubtitles] **默认关**。声学调轴是转录之后**再跑一遍**字符级
+/// CTC 模型、把每个 token 的时间重新按声学定位；它是精修不是必需——转录本身
+/// 已经产出完整 SRT（时间来自 VAD 段边界与 RNN-T 发射时刻）。
+///
+/// 打开它要付两笔账：日语包是 transducer 架构，调轴得另下 Omnilingual 1B
+/// （int8 约 985 MB），而识别模型才约 150 MB；整段音频还要多跑一遍推理。
+///
+/// 要重新打开，在调用点传 true 即可。上游已修掉「词表缺字直接抛异常炸掉整趟
+/// 转录」与「调轴模型缺失就不让转录」，再打开是安全的，但那 985 MB 与那一倍
+/// 推理时间仍旧要付。
 asr.AsrTranscriptionService createAsrTranscriptionService({
-  bool alignGeneratedSubtitles = true,
+  bool alignGeneratedSubtitles = false,
 }) =>
     asr.AsrTranscriptionService(
       alignGeneratedSubtitles: alignGeneratedSubtitles,
+      // 有声书是干净朗读：语音与静默能量差 30 dB 以上、双模态可分，能量门限
+      // 够用且免掉每 32 ms 一次 ONNX 前向。混音素材（动画/影视/带 BGM 的音源）
+      // 必须换 mixedAudio，见 AsrAudioProfile。
+      audioProfile: asr.AsrAudioProfile.cleanSpeech,
       backend: fushiAsrBackend(),
       pcm: asr.FfmpegAsrPcmSource(backend: const FushiAsrFfmpegBackend()),
       openStore: openAsrModelStore,

--- a/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
+++ b/fushi/lib/src/media/audiobook/asr_transcribe_sheet.dart
@@ -911,8 +911,10 @@ class _AsrTranscribeSheetState extends State<AsrTranscribeSheet> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Text(t.audiobook_transcribe_intro, style: tokens.type.metadata),
-          Text(t.audiobook_transcribe_alignment_hint,
-              style: tokens.type.metadata),
+          // 声学调轴已默认关闭（见 createAsrTranscriptionService）：转录本身就
+          // 产出完整 SRT，调轴只是精修，代价是另下约 985 MB 的 CTC 模型 + 一倍
+          // 推理时间。文案先不渲染，i18n key（audiobook_transcribe_alignment_hint）
+          // 保留 17 种语言的既有翻译，重新打开调轴时原位恢复即可。
           SizedBox(height: tokens.spacing.rowVertical),
           Text(
             t.audiobook_transcribe_language_label,

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
+      ref: 8820d3862297f42c99e1f0d9f440a9dddccee0ac
   # 字幕重定时（拿 ASR 转录当参照修好已有字幕的时间轴）。与 fushi_asr_core 同仓同 sha。
   #
   # 只依赖 fushi_asr_core，**不含** ONNX 后端：算法那半边住在 fushi_asr 包里的话会
@@ -28,7 +28,7 @@ dependencies:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_subtitles
-      ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
+      ref: 8820d3862297f42c99e1f0d9f440a9dddccee0ac
   archive: ^3.6.1
   async_zip: ^0.1.0
   basic_utils: ^5.7.0

--- a/fushi/test/asr/asr_host_ffmpeg_adapter_test.dart
+++ b/fushi/test/asr/asr_host_ffmpeg_adapter_test.dart
@@ -50,13 +50,25 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const FushiAsrFfmpegBackend adapter = FushiAsrFfmpegBackend();
 
-  test('generated subtitles use a second model pass by default', () {
-    expect(createAsrTranscriptionService().alignGeneratedSubtitles, isTrue);
+  test('声学调轴默认关：转录本身就产出完整 SRT，调轴是精修不是必需', () {
+    // 曾经默认开，代价是：日语包是 transducer 架构，调轴要另下 Omnilingual 1B
+    // （int8 约 985 MB），而识别模型才约 150 MB —— 于是「选个小模型」被要求先下
+    // 近 1 GB，不下就不让转录。转录出来的时间取自 VAD 段边界与 RNN-T 发射时刻，
+    // 已经是一份可用的 SRT；调轴只是把每个 token 的时间再按声学定位一遍。
+    expect(createAsrTranscriptionService().alignGeneratedSubtitles, isFalse);
+    // 能力还在，一个参数就能打开。
     expect(
-      createAsrTranscriptionService(alignGeneratedSubtitles: false)
+      createAsrTranscriptionService(alignGeneratedSubtitles: true)
           .alignGeneratedSubtitles,
-      isFalse,
+      isTrue,
     );
+  });
+
+  test('有声书路径显式声明素材是干净朗读', () {
+    // 能量门限是带前提的优化（语音与静默双模态可分），上游已把这个前提改成必填
+    // 声明。有声书成立；混音素材（动画/影视）必须换 mixedAudio。
+    expect(createAsrTranscriptionService().audioProfile,
+        asr.AsrAudioProfile.cleanSpeech);
   });
 
   tearDown(() => host.setFfmpegBackendForTesting(null));

--- a/fushi/test/asr/asr_transcription_service_test.dart
+++ b/fushi/test/asr/asr_transcription_service_test.dart
@@ -46,6 +46,7 @@ void main() {
 
   AsrTranscriptionService service(_ProbeFactory factory) =>
       AsrTranscriptionService(
+        audioProfile: AsrAudioProfile.cleanSpeech,
         backend: const AsrIsolateBackend(
           buildFactory: _unusedOnnxFactory,
         ),

--- a/fushi/test/media/audiobook/asr_models_settings_section_test.dart
+++ b/fushi/test/media/audiobook/asr_models_settings_section_test.dart
@@ -13,6 +13,7 @@ import 'package:path/path.dart' as p;
 class _FakeService extends AsrTranscriptionService {
   _FakeService({required this.root, required this.readyByLanguage})
       : super(
+        audioProfile: AsrAudioProfile.cleanSpeech,
         backend: const AsrIsolateBackend(
           buildFactory: _unusedOnnxFactory,
         ),
@@ -51,6 +52,7 @@ class _FakeService extends AsrTranscriptionService {
   Stream<ModelDownloadEvent> downloadModel({
     required AsrLanguage language,
     required AsrEncoderVariant variant,
+    bool includeAlignment = false,
   }) async* {
     downloadLanguages.add(language);
     yield const ModelDownloadEvent(

--- a/fushi/test/media/audiobook/asr_transcribe_sheet_test.dart
+++ b/fushi/test/media/audiobook/asr_transcribe_sheet_test.dart
@@ -79,6 +79,7 @@ class _FakeService extends AsrTranscriptionService {
     this.existingSrt,
     this.probeError,
   }) : super(
+          audioProfile: AsrAudioProfile.cleanSpeech,
           backend: const AsrIsolateBackend(
             buildFactory: _unusedOnnxFactory,
           ),
@@ -132,6 +133,7 @@ class _FakeService extends AsrTranscriptionService {
   Stream<ModelDownloadEvent> downloadModel({
     required AsrLanguage language,
     required AsrEncoderVariant variant,
+    bool includeAlignment = false,
   }) async* {
     downloadCalls++;
     lastDownloadLanguage = language;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,8 +885,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/asr_core"
-      ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
-      resolved-ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
+      ref: "8820d3862297f42c99e1f0d9f440a9dddccee0ac"
+      resolved-ref: "8820d3862297f42c99e1f0d9f440a9dddccee0ac"
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"
@@ -894,8 +894,8 @@ packages:
     dependency: transitive
     description:
       path: "packages/asr_subtitles"
-      ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
-      resolved-ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
+      ref: "8820d3862297f42c99e1f0d9f440a9dddccee0ac"
+      resolved-ref: "8820d3862297f42c99e1f0d9f440a9dddccee0ac"
       url: "https://github.com/hajisensai/fushi-subtitles.git"
     source: git
     version: "0.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,7 +145,7 @@ dependency_overrides:
     git:
       url: https://github.com/hajisensai/fushi-subtitles.git
       path: packages/asr_core
-      ref: e4dd0f882eb92230ad63a2a540fde273a67ca489
+      ref: 8820d3862297f42c99e1f0d9f440a9dddccee0ac
 
 # Melos 7 的配置位置就是这里（7.0 起 melos.yaml 被废弃）。包列表不再重复声明：
 # 成员由上面的 workspace: 决定，melos 直接读它。


### PR DESCRIPTION
## 现象

- 选日语小模型（ReazonSpeech k2-v2，约 150 MB）被要求先下 **985.1 MB**，不下不让转录
- 删掉大模型后小模型直接不能选；删光重下，下的还是约 1 GB
- 下完两个模型都转不出 SRT，日语小模型报 `Bad state: 字幕调轴模型词表不支持正文字符 U+75E9`（**痩**）

## 根因

调轴（转录之后**再跑一遍**字符级 CTC 模型、把每个 token 的时间按声学重新定位）是**精修不是必需**——转录本身已经产出完整 SRT，时间取自 VAD 段边界与 RNN-T 发射时刻。而日语包是 transducer 架构，调轴要另下 Omnilingual 1B（int8 约 985 MB）。**一个可选增强绑架了核心功能。**

## 改了什么

- `createAsrTranscriptionService` 的 `alignGeneratedSubtitles` **默认 false**。能力保留，传 `true` 就能重新打开。
- 转录弹层不再渲染「会再跑一遍模型校准时间 / 首次会下载调轴模型」那句提示。i18n key 保留（17 种语言的既有翻译不丢，重开时原位恢复；本仓没有未使用 key 的守卫）。
- 上游 sha `e4dd0f8` → `8820d38`（hajisensai/fushi-subtitles#12）。

### ⚠️ 三处 pin，少改一处就是假 bump

`fushi/pubspec.yaml` 两条 **+ 根 `pubspec.yaml` 的 `dependency_overrides` 一条**。只改前两条时 `pub get` 只换了 `fushi_asr_subtitles`，`fushi_asr_core` 因为是 `direct overridden` 仍停在旧 sha——那会变成「以为 bump 了、跑的还是旧代码」。已核 lockfile 里旧 sha 归零、新 sha 4 处。

## 顺带被上游修掉的

`8820d38` 里还有这次报错链上的另外两个根因，所以日后重新打开调轴也不会再撞：

- 词表缺字不再抛异常炸掉整趟转录（实测日语 transducer 能吐的 4823 个汉字里 **1302 个（27%）** 不在 Omnilingual 调轴词表里）
- 调轴模型缺失时降级成不调轴，而不是拒绝转录

## 被编译器拦下的连带改动

`AsrTranscriptionService.audioProfile` 在上游成了**必填**（能量门限的前提改为调用方显式声明），本仓四个构造点因此被逐一拦下并表态：有声书 / TTS 都是干净朗读 → `cleanSpeech`；Apple 原生引擎自己做端点检测 → 填一个不会被用到的值。`downloadModel` 的两个 override 补上 `includeAlignment`。

守卫 `generated subtitles use a second model pass by default` 原本钉的是「默认开」，跟着翻成「默认关 + 能力仍在」，并新增一条钉住有声书路径声明的是 `cleanSpeech`。

## 验证

`flutter analyze` 只剩 **3 条基底自带**的问题：`buildListeningDestination` / `SettingsDestinationId.listening` 被删但 `integration_test/` 仍在引用，加一条 `unnecessary_non_null_assertion` 的 warning。这三条在本分支起点 `754b00c9f0` 上就已存在（`git show HEAD:` 里那两个符号都不存在），与本次改动无关，我没碰那些文件 —— **develop 当前就是红的**。

定向测试 `test/asr` + `test/media/audiobook/asr_{models_settings_section,transcribe_sheet}_test.dart`：**71 通过 / 1 跳过 / 0 失败**，退出码 0。

未验证：真机跑一遍「音频 + EPUB → SRT」的原始路径。

https://claude.ai/code/session_01KEgBTAQYy6YP9ZZGinA8Q7