### PR TITLE
fix(lookup): 查词弹窗墨水屏适配的三处失效 + 全宽展示

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2235 条。点号进各自文件。
+> 共 2238 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2432](bugs/BUG-2432-eink-popup-body-opacity-not-flattened.md) | ✅ | ✅ | 墨水屏弹窗只压了按钮 opacity，正文侧十几处静息半透明与亚像素位移漏网 |
+| [BUG-2431](bugs/BUG-2431-dict-style-preview-missing-eink.md) | ✅ | ✅ | 词典样式预览不注入 eink class，墨水屏下预览与真弹窗不同源 |
+| [BUG-2430](bugs/BUG-2430-reader-lookup-popup-loses-eink-theme.md) | ✅ | ✅ | 书内查词弹窗丢失墨水屏主题扩展，整个 html.eink 覆盖块失效 |
 | [BUG-2427](bugs/BUG-2427-desktop-library-header-top-gap.md) | ✅ | ✅ | 桌面端库页页头顶部留白过大（手机端修复未同步） |
 | [BUG-2426](bugs/BUG-2426-side-panel-embed-self-attested.md) | ✅ | ✅ | 扩展 side-panel 的「是否被嵌入」由 URL 参数自证，省略参数即可绕过 #1295 全部加固 |
 | [BUG-2423](bugs/BUG-2423-sync-conflict-title-truncated.md) | ✅ | ✅ | 同步冲突卡片书名单行省略，同系列多条冲突只剩同一前缀无法分辨 |

--- a/docs/bugs/BUG-2430-reader-lookup-popup-loses-eink-theme.md
+++ b/docs/bugs/BUG-2430-reader-lookup-popup-loses-eink-theme.md
@@ -1,0 +1,57 @@
+## BUG-2430 · 书内查词弹窗丢失墨水屏主题扩展，整个 html.eink 覆盖块失效
+- **报告**：2026-09-10（用户：对比 Hoshi Reader Android 的查词框墨水屏适配，「现在查词框显示发虚，而且词典字体页发虚」）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart` 的
+  `_syncDictionaryTheme()`：它手工 `ThemeData(useMaterial3: true, colorScheme: ...)` 拼出查词弹窗的
+  覆盖主题，**没有 `extensions:`**。
+  `FushiEinkTheme` 全仓只在 `ThemeNotifier._buildThemeData`（`theme_notifier.dart:1347-1350`）挂一次，
+  任何不经它构造的 ThemeData 都会丢掉这个扩展。而这份覆盖主题经 `base_source_page.dart:634` 的
+  `Theme(data: appModel.overrideDictionaryTheme ?? theme, ...)` 罩住**整个查词浮层子树**，
+  `dictionary_popup_webview` 再用 `Theme.of(context)` 喂 `buildPopupStaticSettingsJs` →
+  `popup_settings_injection.dart:110` 的 eink 判定恒 `false`。
+  于是**只要是在书里查词**，`popup.css` 的整个 `html.eink` 覆盖块（纯黑白变量 / 去阴影 / 去
+  text-shadow / 杀掉半透明亚克力卡底 / 方角 / 线式高亮 / 顶部按钮 opacity 压平）一行都不生效，
+  `dictionary_popup_layer.dart:500` 的入场淡入归零也一并失效。app 外全局查词与视频字幕查词不设
+  override，反而一直是对的——书内查词是最高频路径，却恰恰是唯一坏的那条，这也是它能长期潜伏的原因。
+  **第二重根因**：即便把扩展补上，原实现仍会用 `deriveSurfaceRolesFrom(阅读器纸色)` 把
+  `buildColorScheme()` 在墨水屏下本该纯黑白的 surface 角色整套覆盖回纸色派生的灰阶梯度
+  （`onSurface` / `outline` / `surfaceContainer*` 全被换掉）。而正文 CSS 在 eink 下已被
+  `reader_content_styles.dart:215-223` 强制成纯黑白 —— 结果就是「正文纯白底 + 弹窗纸色灰阶底」，
+  而灰阶正是墨水屏上的抖动噪点。用户报的「发虚」在这两重下是叠加的。
+- **[x] ① 已修复** —— 把覆盖主题的全部决策抽成纯函数 `resolveDictionaryPopupTheme()`
+  （新文件 `fushi/lib/src/pages/implementations/dictionary_popup_theme.dart`），`_syncDictionaryTheme()`
+  只负责把 AppModel / 阅读器主题的当前取值喂进去。两条不变式在同一处收口：
+  - **必须挂 `FushiEinkTheme`**（`extensions: <ThemeExtension<dynamic>>[FushiEinkTheme(eink)]`）。
+    非墨水屏时也挂、值为 `false`——弹窗要靠它把 `html.eink` **摘除**，只在开启时挂会让关掉墨水屏后
+    卡在黑白方角态。
+  - **墨水屏下跳过纸色派生**：`bg`/`fg` 取纯黑白，`brightness` 取 `appModel.isDarkMode`（与正文 CSS
+    的 `einkDark` 同一真值，同样不读阅读器自己的 theme key），`ColorScheme` 直接用
+    `buildColorScheme()` 的纯黑白结果，不再 `copyWith` 纸色梯度。
+  - 非墨水屏下的语义**逐字节不变**（同一套 `deriveSurfaceRolesFrom` 梯度 + 同样保留 app 真实主题色）。
+- **[x] ② 已加自动化测试** —— `fushi/test/dictionary/dictionary_popup_theme_test.dart` 共 5 条，直接
+  断言纯函数返回值而不是扫源码（扫源码只能证明「写了这行字」，证明不了颜色真的没被覆盖）：
+  浅色 / 深色墨水屏各断言「扩展为 true」+「surface/onSurface/surfaceContainerHigh 是纯黑白」+
+  「纸色一点都渗不进来」（`isNot(paperBg)`）；非墨水屏断言纸色梯度、`onSurface`、`outline`、
+  主题色 `primary` 全部原样保留，且扩展仍挂着只是值为 false。
+  判别力验证：临时摘掉 `extensions:` 那一行 → 正好 3 条（两条 eink + 一条「扩展仍挂着」）当场红，
+  其余 2 条仍绿；恢复后 5/5 绿。
+  另在 `test/settings/md3_design_system_static_test.dart` 的两张豁免表登记新文件（理由：那段
+  `ColorScheme.copyWith` 是逐字搬运自已豁免的 `chrome.part.dart`），并按同一条「不留死豁免」纪律
+  删掉 `chrome.part.dart` 上已不再命中的 `surfaceContainerHighest/Low/Lowest` 三个 token。
+- **备注**：
+  - 与 [BUG-2431](BUG-2431-dict-style-preview-missing-eink.md)（词典样式预览不注入 eink）、
+    [BUG-2432](BUG-2432-eink-popup-body-opacity-not-flattened.md)（正文侧半透明漏网）是同一条用户
+    报告下的三个独立根因：本条管「书内查词弹窗根本没进过墨水屏模式」，2431 管「用户调样式时看的
+    那份预览也没进」，2432 管「进了之后仍有十几处灰没压平」。
+  - `FushiDesignSystemTheme` 在这份覆盖主题里**同样是丢失的**（`_buildThemeData` 挂了两个扩展，
+    这里只补了 eink 那个）。默认 `auto` 下五平台统一 Material 3，丢它没有可见后果，故本轮不动以
+    控制爆炸半径；真要补需连带复核隐藏的 Cupertino 渲染路径。
+  - **验证边界（如实记录）**：整条链路已由单测闭环——「覆盖主题必须带 FushiEinkTheme」
+    （`dictionary_popup_theme_test.dart`，含摘掉 extensions 就红的判别力验证）→「拿到扩展后注入串
+    真的 toggle 出 `eink`」（`popup_settings_injection_memo_test.dart` 新增 group，含「丢了扩展恒
+    false」这条正是本 bug 失效形态的用例）→「popup.css 里 html.eink 块存在且含新规则」
+    （`popup_css_eink_guard_test.dart`）。剩下未被单测覆盖的只有「WebView 执行这段 JS」这一段，
+    属既有行为（app 外全局查词一直走同一条注入、一直正常）。
+    另在本机 Windows Release 真 app 上跑过启动冒烟（正常常驻、无早退）。
+    **未做**：墨水屏设备目视复测（本机没有 Android 墨水屏），以及 headless 像素对照
+    （本机 Chrome/Edge 的 `--screenshot` 开关已不产出文件、CDP 侧 Chrome 又立即退出，两条路都没走通）。
+    观感层面的「锐利了多少」因此没有像素证据，待有设备时补。

--- a/docs/bugs/BUG-2431-dict-style-preview-missing-eink.md
+++ b/docs/bugs/BUG-2431-dict-style-preview-missing-eink.md
@@ -1,0 +1,27 @@
+## BUG-2431 · 词典样式预览不注入 eink class，墨水屏下预览与真弹窗不同源
+- **报告**：2026-09-10（用户：「而且词典字体页发虚」，与 [BUG-2430](BUG-2430-reader-lookup-popup-loses-eink-theme.md) 同一条报告）
+- **真实性**：✅ 真 bug —— 根因 `fushi/lib/src/pages/implementations/dict_style_preview.dart` 的
+  `_bootstrap()`：它只 `document.documentElement.setAttribute('data-theme', ...)`，**从不 toggle
+  `eink` class**。
+  该文件开头明写「不自绘近似渲染……这里渲染路径与真弹窗同源」——预览跑的确实是**真的**
+  `popup.html` + `popup.js`。但真弹窗的 eink class 由 `popup_settings_injection.dart:110-112` 的主题
+  变量段 toggle，而 popup.css 的整个 `html.eink` 覆盖块挂的就是这个 class。预览少了这一段，于是
+  墨水屏下**用户是照着一份灰阶 + 圆角 + 阴影 + 半透明卡底的预览去调词典字体/字号/配色，而真弹窗
+  是另一个样子**——正好是那句「近似的东西必然失真」要避免的情形，只是失真来自缺一个 class 而不是
+  自绘。
+  第二个缺口：即便首帧补上，`_bootstrap()` 是一次性的，开着预览去翻墨水屏开关不会有任何反应。
+- **[x] ① 已修复** —— 抽出 `_pushTheme()`：从 `Theme.of(context)` 读 `FushiEinkTheme`，一并下发
+  `data-theme` 与 `classList.toggle('eink', <bool>)`。
+  - 用 `toggle` 而非 `add`，与真弹窗同款——`add` 摘不掉，关掉墨水屏后预览会卡在黑白方角态。
+  - 在 `didChangeDependencies` 里调用，主题切换（含墨水屏开关）当场补推；用 `_pushedDark` /
+    `_pushedEink` 记住上次真正推下去的值，避免每次依赖变化都重复 `evaluateJavascript`。
+  - `_bootstrap()` 在 `_ready = true` 之后先 `_pushTheme()` 再 `_pushStyles()`，保证首帧就带上。
+- **[x] ② 已加自动化测试** —— `fushi/test/dictionary/dict_style_preview_eink_guard_test.dart` 共 4 条
+  源码守卫：读得到 `FushiEinkTheme`、真的 `classList.toggle('eink'`、**不**用 `classList.add('eink'`
+  （摘不掉的反向断言）、以及存在 `didChangeDependencies`（只在 bootstrap 推一次会让开关无反应）。
+  只能做源码守卫的原因与既有 `popup_instant_scroll_guard_test` 同处境：预览的渲染发生在真 WebView
+  里，单元测试环境没有 WebView，断言不到最终像素，故钉的是「注入链路上每一段载荷位都还在」。
+- **备注**：
+  - 预览的 `InAppWebView` 是 `transparentBackground: false`（真弹窗是 `true`），本轮未动。
+  - 真机复测状态见 [BUG-2430](BUG-2430-reader-lookup-popup-loses-eink-theme.md) 的「验证」一节
+    （同一次真 app 复测覆盖两条）。

--- a/docs/bugs/BUG-2432-eink-popup-body-opacity-not-flattened.md
+++ b/docs/bugs/BUG-2432-eink-popup-body-opacity-not-flattened.md
@@ -1,0 +1,44 @@
+## BUG-2432 · 墨水屏弹窗只压了按钮 opacity，正文侧十几处静息半透明与亚像素位移漏网
+- **报告**：2026-09-10（用户：「查词框显示发虚」，与 [BUG-2430](BUG-2430-reader-lookup-popup-loses-eink-theme.md) 同一条报告）
+- **真实性**：✅ 真 bug —— 根因 `fushi/assets/popup/popup.css` 的 `html.eink` 覆盖块：它的通配压平
+  规则只覆盖 `border-radius` / `box-shadow` / `text-shadow` / `transition` / `animation`，opacity 那条
+  单独规则**只列了顶部四个动作按钮**（`.audio-button` / `.favorite-button` / `.open-anki-button` /
+  `.mine-button`，注释写的是「静息态 0.5 opacity 在墨水屏上是抖动灰」）。
+  但同一份 CSS 里，**正文与标签**上还有十几处同性质的静息半透明，全部漏网：
+  `.dict-label`（词典名，10px + `opacity: 0.7`，最糊的一处）、`.glossary-group > summary::before`
+  （折叠三角 0.5）、`.deinflection-tag::before`（`«` 分隔符 0.55）、`.pitch-entries > li::after`（0.6）、
+  `.pitch-transcription-tag`（0.85）、`.no-results` / `.no-results-icon`（0.7 / 0.5）、
+  `.kanji-card-dict`（0.6）、`.ctx-adjust-button`（0.85）、`.mined-action-subtitle`（0.75）、
+  `.sentence-context-picker` 的 label / stepper / count（0.6 / 0.55 / 0.5）、`.clear-draft-button`（0.45）。
+  **半透明黑字 = 灰字**，而墨水屏没有足够灰阶去表现，只能抖动——这正是「发虚」的直接形态，与那条
+  已有规则的注释是同一个理由，只是当初没扫全。
+  另有一处亚像素位移 `.mine-button.duplicate { transform: translateY(0.5px); }`：0.5px 把字形推到半个
+  物理像素上，同样只能糊成两行。`html.eink` 的通配块关了 `transition`/`animation`，**没关 `transform`**。
+- **[x] ① 已修复** —— 在 `html.eink` 块里补两条规则（三镜像逐字节同步：`assets/popup/`、
+  `assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`，并重跑
+  `generate-content-css.mjs` 重建两份 `content.css`）：
+  - 上列 14 个正文/标签选择器统一 `opacity: 1`，层次改由字号 / 描边 / 位置承担——这正是 Hoshi
+    Reader Android 弹窗的做法（它的正文一律零 opacity、纯 `#000`/`#fff`，21:1，清晰度全靠「不制造
+    灰」而不是任何增锐手段；见下方对照结论）。
+  - `html.eink .mine-button.duplicate { transform: none; }` 只归零这一条亚像素位移；整数位移
+    （`.audio-button` 的 1px）落点仍是整像素，不受影响。
+  - **刻意不动三类**：`:active`/`:hover` 的即时反馈、`:disabled` 与 `.audio-unavailable` 的失效态
+    （弱化本身就是它要传达的信息）、`.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。
+    因此没有用通配 `html.eink * { opacity: 1 }`——那会把这三类一起连坐。
+- **[x] ② 已加自动化测试** —— `fushi/test/build/popup_css_eink_guard_test.dart` 新增一条
+  `html.eink flattens resting body opacity and subpixel transforms`，对三份 popup.css 镜像逐一断言：
+  存在 `.dict-label` 与 `.glossary-group > summary::before` 的 eink 压平、存在
+  `.mine-button.duplicate` 的位移归零，以及**反向**断言不存在通配 `html.eink * { opacity`
+  （防止将来有人图省事一把连坐 disabled / 隐藏态）。
+- **备注**：
+  - 与 Hoshi 的对照结论：该仓库**没有任何**墨水屏 / 灰阶 / 增锐代码（无 `-webkit-font-smoothing`、
+    无 `text-rendering`、无 `setLayerType`、无 `textZoom`/`initialScale`、弹窗零动画零缩放）。它清晰
+    的原因只有三条减分项清单：三层不透明纯色背景、自管深色方案绕开 WebView 的 algorithmic
+    darkening、正文颜色不带任何 opacity。本条修的就是第三条。
+  - 未采纳的一条：Fushi 弹窗 WebView 是 `transparentBackground: true`（`dictionary_popup_webview.dart:1694`），
+    而 Hoshi 是三层不透明纯色底。透明合成层会让 Chromium 从 LCD subpixel AA 退回灰阶 AA，理论上
+    也会让文字变淡——但 Fushi 的 body 在 eink 下本就是不透明纯白/纯黑，是否真触发需要真机像素比对，
+    且透明底是弹窗圆角透出所依赖的，改动爆炸半径大，故本轮不动，留作后续单独验证。
+  - 同理未动的还有：内容缩放走的 CSS `zoom` 是 `toStringAsFixed(4)` 的任意小数
+    （`popup_settings_injection.dart:808`，`zoom = appUiScale × 字号/16`），会让 1px 边框/下划线落在
+    分数像素上。这条跨平台且改动面大（会动到所有平台的弹窗尺寸表现），需要真机测量后单独处理。

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -1961,6 +1961,37 @@
     opacity: 1;
 }
 
+/* 正文侧的静息半透明：半透明黑字在墨水屏上就是抖动灰，10px 的 `.dict-label`
+   （词典名）尤其糊。与上面顶部动作按钮同一处理，统一压到全不透明；层次改由
+   字号 / 描边 / 位置承担（对齐 Hoshi 弹窗——它的正文一律零 opacity、纯 #000/#fff，
+   清晰度全靠「不制造灰」而非任何增锐手段）。
+   刻意**不**动三类：`:active` / `:hover` 的即时反馈、`:disabled` 与
+   `.audio-unavailable` 的失效态（弱化本身就是它要传达的信息）、以及
+   `.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。 */
+:where(#entries-container).eink .sentence-context-picker .context-label,
+:where(#entries-container).eink .sentence-context-picker .context-stepper-btn,
+:where(#entries-container).eink .sentence-context-picker .context-count,
+:where(#entries-container).eink .clear-draft-button,
+:where(#entries-container).eink .deinflection-tag:not(:first-child)::before,
+:where(#entries-container).eink .glossary-group > summary::before,
+:where(#entries-container).eink .dict-label,
+:where(#entries-container).eink .pitch-entries > li:not(:last-child)::after,
+:where(#entries-container).eink .pitch-transcription-tag,
+:where(#entries-container).eink .no-results,
+:where(#entries-container).eink .no-results-icon,
+:where(#entries-container).eink .kanji-card-dict,
+:where(#entries-container).eink .ctx-adjust-button,
+:where(#entries-container).eink .mined-action-subtitle {
+    opacity: 1;
+}
+
+/* 亚像素位移：0.5px 把该按钮的字形推到半个物理像素上，墨水屏没有灰阶去表现，
+   只能糊成两行。整数位移（`.audio-button` 的 1px）落点仍是整像素，不受影响，
+   故只归零这一条。 */
+:where(#entries-container).eink .mine-button.duplicate {
+    transform: none;
+}
+
 /* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
 :where(#entries-container).eink .favorite-button.favorited,
 :where(#entries-container).eink .mine-button.latest {

--- a/fushi/assets/browser_extension/vendor/popup.css
+++ b/fushi/assets/browser_extension/vendor/popup.css
@@ -2073,6 +2073,37 @@ html.eink .mine-button {
     opacity: 1;
 }
 
+/* 正文侧的静息半透明：半透明黑字在墨水屏上就是抖动灰，10px 的 `.dict-label`
+   （词典名）尤其糊。与上面顶部动作按钮同一处理，统一压到全不透明；层次改由
+   字号 / 描边 / 位置承担（对齐 Hoshi 弹窗——它的正文一律零 opacity、纯 #000/#fff，
+   清晰度全靠「不制造灰」而非任何增锐手段）。
+   刻意**不**动三类：`:active` / `:hover` 的即时反馈、`:disabled` 与
+   `.audio-unavailable` 的失效态（弱化本身就是它要传达的信息）、以及
+   `.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。 */
+html.eink .sentence-context-picker .context-label,
+html.eink .sentence-context-picker .context-stepper-btn,
+html.eink .sentence-context-picker .context-count,
+html.eink .clear-draft-button,
+html.eink .deinflection-tag:not(:first-child)::before,
+html.eink .glossary-group > summary::before,
+html.eink .dict-label,
+html.eink .pitch-entries > li:not(:last-child)::after,
+html.eink .pitch-transcription-tag,
+html.eink .no-results,
+html.eink .no-results-icon,
+html.eink .kanji-card-dict,
+html.eink .ctx-adjust-button,
+html.eink .mined-action-subtitle {
+    opacity: 1;
+}
+
+/* 亚像素位移：0.5px 把该按钮的字形推到半个物理像素上，墨水屏没有灰阶去表现，
+   只能糊成两行。整数位移（`.audio-button` 的 1px）落点仍是整像素，不受影响，
+   故只归零这一条。 */
+html.eink .mine-button.duplicate {
+    transform: none;
+}
+
 /* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
 html.eink .favorite-button.favorited,
 html.eink .mine-button.latest {

--- a/fushi/assets/popup/popup.css
+++ b/fushi/assets/popup/popup.css
@@ -2073,6 +2073,37 @@ html.eink .mine-button {
     opacity: 1;
 }
 
+/* 正文侧的静息半透明：半透明黑字在墨水屏上就是抖动灰，10px 的 `.dict-label`
+   （词典名）尤其糊。与上面顶部动作按钮同一处理，统一压到全不透明；层次改由
+   字号 / 描边 / 位置承担（对齐 Hoshi 弹窗——它的正文一律零 opacity、纯 #000/#fff，
+   清晰度全靠「不制造灰」而非任何增锐手段）。
+   刻意**不**动三类：`:active` / `:hover` 的即时反馈、`:disabled` 与
+   `.audio-unavailable` 的失效态（弱化本身就是它要传达的信息）、以及
+   `.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。 */
+html.eink .sentence-context-picker .context-label,
+html.eink .sentence-context-picker .context-stepper-btn,
+html.eink .sentence-context-picker .context-count,
+html.eink .clear-draft-button,
+html.eink .deinflection-tag:not(:first-child)::before,
+html.eink .glossary-group > summary::before,
+html.eink .dict-label,
+html.eink .pitch-entries > li:not(:last-child)::after,
+html.eink .pitch-transcription-tag,
+html.eink .no-results,
+html.eink .no-results-icon,
+html.eink .kanji-card-dict,
+html.eink .ctx-adjust-button,
+html.eink .mined-action-subtitle {
+    opacity: 1;
+}
+
+/* 亚像素位移：0.5px 把该按钮的字形推到半个物理像素上，墨水屏没有灰阶去表现，
+   只能糊成两行。整数位移（`.audio-button` 的 1px）落点仍是整像素，不受影响，
+   故只归零这一条。 */
+html.eink .mine-button.duplicate {
+    transform: none;
+}
+
 /* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
 html.eink .favorite-button.favorited,
 html.eink .mine-button.latest {

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,7 +1,7 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 78557 (4621 per locale)
+/// Strings: 78591 (4623 per locale)
 ///
 /// Built on 2026-09-10 at 08:08 UTC
 
@@ -3887,6 +3887,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Auto-fills up to this many dictionary columns per row; narrower screens use fewer';
   String get popup_font_size_decrease => 'Smaller dictionary text';
   String get popup_font_size_increase => 'Larger dictionary text';
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Instant popup scroll';
   String get popup_instant_scroll_hint =>
       'Jump the lookup popup by fixed distances without animated scrolling for e-ink screens.';
@@ -12838,6 +12841,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get popup_font_size_increase => 'تكبير نص القاموس';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'تمرير فوري للنافذة المنبثقة';
   @override
   String get popup_instant_scroll_hint =>
@@ -23844,6 +23850,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Wörterbuchtext vergrößern';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Sofortiges Popup-Scrollen';
   @override
   String get popup_instant_scroll_hint =>
@@ -34957,6 +34966,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Texto de diccionario más grande';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Desplazamiento instantáneo de la ventana';
   @override
   String get popup_instant_scroll_hint =>
@@ -46127,6 +46139,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Agrandir le texte du dictionnaire';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Défilement instantané de la fenêtre';
   @override
   String get popup_instant_scroll_hint =>
@@ -57194,6 +57209,9 @@ class _StringsId extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Perbesar teks kamus';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Gulir popup seketika';
   @override
   String get popup_instant_scroll_hint =>
@@ -68231,6 +68249,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Testo dizionario più grande';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Scorrimento istantaneo del popup';
   @override
   String get popup_instant_scroll_hint =>
@@ -78946,6 +78967,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get popup_font_size_increase => '辞書テキストを大きく';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'ポップアップを瞬時にスクロール';
   @override
   String get popup_instant_scroll_hint =>
@@ -89403,6 +89427,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get popup_font_size_increase => '사전 텍스트 확대';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => '팝업 즉시 스크롤';
   @override
   String get popup_instant_scroll_hint =>
@@ -100199,6 +100226,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Grotere woordenboektekst';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Direct scrollen in pop-up';
   @override
   String get popup_instant_scroll_hint =>
@@ -111265,6 +111295,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Texto do dicionário maior';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Rolagem instantânea do pop-up';
   @override
   String get popup_instant_scroll_hint =>
@@ -122333,6 +122366,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Увеличить текст словаря';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Мгновенная прокрутка окна поиска';
   @override
   String get popup_instant_scroll_hint =>
@@ -133281,6 +133317,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get popup_font_size_increase => 'เพิ่มขนาดตัวอักษรพจนานุกรม';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'เลื่อนหน้าต่างค้นคำแบบทันที';
   @override
   String get popup_instant_scroll_hint =>
@@ -144220,6 +144259,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Sözlük metnini büyüt';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Anında açılır pencere kaydırma';
   @override
   String get popup_instant_scroll_hint =>
@@ -155187,6 +155229,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get popup_font_size_increase => 'Phóng to chữ từ điển';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => 'Cuộn tức thì cửa sổ tra';
   @override
   String get popup_instant_scroll_hint =>
@@ -165591,6 +165636,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get popup_font_size_increase => '放大查词字号';
   @override
+  String get popup_full_width => '弹窗全宽';
+  String get popup_full_width_hint => '忽略最大宽度，让弹窗横向铺满可用宽度；位置仍跟随选中的词。';
   String get popup_instant_scroll => '查词弹窗瞬时滚动';
   @override
   String get popup_instant_scroll_hint => '为墨水屏使用：查词弹窗按固定距离瞬时跳动，不播放滚动动画。';
@@ -175686,6 +175733,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get popup_font_size_increase => '放大查詞字號';
   @override
+  String get popup_full_width => 'Full-width popup';
+  String get popup_full_width_hint =>
+      'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
   String get popup_instant_scroll => '查詞彈窗即時捲動';
   @override
   String get popup_instant_scroll_hint => '供電子墨水屏使用：查詞彈窗按固定距離即時跳動，不播放捲動動畫。';
@@ -185426,6 +185476,10 @@ extension on _StringsEn {
         return 'Smaller dictionary text';
       case 'popup_font_size_increase':
         return 'Larger dictionary text';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Instant popup scroll';
       case 'popup_instant_scroll_hint':
@@ -194936,6 +194990,10 @@ extension on _StringsAr {
         return 'تصغير نص القاموس';
       case 'popup_font_size_increase':
         return 'تكبير نص القاموس';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'تمرير فوري للنافذة المنبثقة';
       case 'popup_instant_scroll_hint':
@@ -204472,6 +204530,10 @@ extension on _StringsDe {
         return 'Wörterbuchtext verkleinern';
       case 'popup_font_size_increase':
         return 'Wörterbuchtext vergrößern';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Sofortiges Popup-Scrollen';
       case 'popup_instant_scroll_hint':
@@ -214016,6 +214078,10 @@ extension on _StringsEs {
         return 'Texto de diccionario más pequeño';
       case 'popup_font_size_increase':
         return 'Texto de diccionario más grande';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Desplazamiento instantáneo de la ventana';
       case 'popup_instant_scroll_hint':
@@ -223566,6 +223632,10 @@ extension on _StringsFr {
         return 'Réduire le texte du dictionnaire';
       case 'popup_font_size_increase':
         return 'Agrandir le texte du dictionnaire';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Défilement instantané de la fenêtre';
       case 'popup_instant_scroll_hint':
@@ -233100,6 +233170,10 @@ extension on _StringsId {
         return 'Perkecil teks kamus';
       case 'popup_font_size_increase':
         return 'Perbesar teks kamus';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Gulir popup seketika';
       case 'popup_instant_scroll_hint':
@@ -242632,6 +242706,10 @@ extension on _StringsIt {
         return 'Testo dizionario più piccolo';
       case 'popup_font_size_increase':
         return 'Testo dizionario più grande';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Scorrimento istantaneo del popup';
       case 'popup_instant_scroll_hint':
@@ -252142,6 +252220,10 @@ extension on _StringsJa {
         return '辞書テキストを小さく';
       case 'popup_font_size_increase':
         return '辞書テキストを大きく';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'ポップアップを瞬時にスクロール';
       case 'popup_instant_scroll_hint':
@@ -261615,6 +261697,10 @@ extension on _StringsKo {
         return '사전 텍스트 축소';
       case 'popup_font_size_increase':
         return '사전 텍스트 확대';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return '팝업 즉시 스크롤';
       case 'popup_instant_scroll_hint':
@@ -271124,6 +271210,10 @@ extension on _StringsNl {
         return 'Kleinere woordenboektekst';
       case 'popup_font_size_increase':
         return 'Grotere woordenboektekst';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Direct scrollen in pop-up';
       case 'popup_instant_scroll_hint':
@@ -280661,6 +280751,10 @@ extension on _StringsPtBr {
         return 'Texto do dicionário menor';
       case 'popup_font_size_increase':
         return 'Texto do dicionário maior';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Rolagem instantânea do pop-up';
       case 'popup_instant_scroll_hint':
@@ -290201,6 +290295,10 @@ extension on _StringsRu {
         return 'Уменьшить текст словаря';
       case 'popup_font_size_increase':
         return 'Увеличить текст словаря';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Мгновенная прокрутка окна поиска';
       case 'popup_instant_scroll_hint':
@@ -299720,6 +299818,10 @@ extension on _StringsTh {
         return 'ลดขนาดตัวอักษรพจนานุกรม';
       case 'popup_font_size_increase':
         return 'เพิ่มขนาดตัวอักษรพจนานุกรม';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'เลื่อนหน้าต่างค้นคำแบบทันที';
       case 'popup_instant_scroll_hint':
@@ -309242,6 +309344,10 @@ extension on _StringsTr {
         return 'Sözlük metnini küçült';
       case 'popup_font_size_increase':
         return 'Sözlük metnini büyüt';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Anında açılır pencere kaydırma';
       case 'popup_instant_scroll_hint':
@@ -318765,6 +318871,10 @@ extension on _StringsVi {
         return 'Thu nhỏ chữ từ điển';
       case 'popup_font_size_increase':
         return 'Phóng to chữ từ điển';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return 'Cuộn tức thì cửa sổ tra';
       case 'popup_instant_scroll_hint':
@@ -328243,6 +328353,10 @@ extension on _StringsZhCn {
         return '缩小查词字号';
       case 'popup_font_size_increase':
         return '放大查词字号';
+      case 'popup_full_width':
+        return '弹窗全宽';
+      case 'popup_full_width_hint':
+        return '忽略最大宽度，让弹窗横向铺满可用宽度；位置仍跟随选中的词。';
       case 'popup_instant_scroll':
         return '查词弹窗瞬时滚动';
       case 'popup_instant_scroll_hint':
@@ -337688,6 +337802,10 @@ extension on _StringsZhHk {
         return '縮小查詞字號';
       case 'popup_font_size_increase':
         return '放大查詞字號';
+      case 'popup_full_width':
+        return 'Full-width popup';
+      case 'popup_full_width_hint':
+        return 'Ignore the maximum width and let the popup span the available width. Its position still follows the selected word.';
       case 'popup_instant_scroll':
         return '查詞彈窗即時捲動';
       case 'popup_instant_scroll_hint':

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "用系统自带的语音模型，不下载我们那 1 GB 模型。首次使用时系统仍会下载它自己的语言资产，那份资产由系统保管、多个 app 共用。",
   "audiobook_transcribe_engine_system_install": "安装语言",
   "audiobook_transcribe_engine_system_installing": "正在让系统安装该语言…",
-  "audiobook_transcribe_engine_system_no_pause": "这个引擎在文件中途无法暂停，停止会丢掉当前文件的进度。"
+  "audiobook_transcribe_engine_system_no_pause": "这个引擎在文件中途无法暂停，停止会丢掉当前文件的进度。",
+  "popup_full_width": "弹窗全宽",
+  "popup_full_width_hint": "忽略最大宽度，让弹窗横向铺满可用宽度；位置仍跟随选中的词。"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4619,5 +4619,7 @@
   "audiobook_transcribe_engine_system_hint": "Uses the built-in speech model — no 1 GB download from us. The system still fetches its own language assets the first time, and keeps them shared across apps.",
   "audiobook_transcribe_engine_system_install": "Install language",
   "audiobook_transcribe_engine_system_installing": "Asking the system to install the language…",
-  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress."
+  "audiobook_transcribe_engine_system_no_pause": "This engine can't pause mid-file — stopping discards the current file's progress.",
+  "popup_full_width": "Full-width popup",
+  "popup_full_width_hint": "Ignore the maximum width and let the popup span the available width. Its position still follows the selected word."
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -6398,6 +6398,11 @@ class AppModel with ChangeNotifier {
   double get popupMaxWidth => prefsRepo.popupMaxWidth;
   void setPopupMaxWidth(double width) => prefsRepo.setPopupMaxWidth(width);
 
+  /// 全宽展示：忽略 [popupMaxWidth]，弹窗横向铺满（位置仍跟随选区）。
+  bool get popupFullWidth => prefsRepo.popupFullWidth;
+  Future<void> setPopupFullWidth(bool value) =>
+      prefsRepo.setPopupFullWidth(value);
+
   double get defaultPopupMaxHeight => prefsRepo.defaultPopupMaxHeight;
   double get popupMaxHeight => prefsRepo.popupMaxHeight;
   void setPopupMaxHeight(double height) => prefsRepo.setPopupMaxHeight(height);

--- a/fushi/lib/src/models/preference_keys.dart
+++ b/fushi/lib/src/models/preference_keys.dart
@@ -177,6 +177,8 @@ const Set<String> kKnownPreferenceKeys = <String>{
   // "Compact Glossaries"）。默认 false。
   'popup_compact_glossaries',
   'popup_dictionary_columns',
+  // bool：查词弹窗全宽展示（忽略最大宽度，横向铺满；位置仍跟随选区）。默认 false。
+  'popup_full_width',
   'popup_instant_scroll',
   'popup_max_height',
   'popup_max_width',

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -577,6 +577,20 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 查词弹窗「全宽展示」：忽略上面的最大宽度，横向铺满可用宽度（左右仍留同一条
+  /// 边距）。位置仍跟随选区——与「底部固定」正交：底部固定本来就是屏幕底部的一条
+  /// 全宽面板，本项管的是**贴词定位下**也占满宽度。
+  ///
+  /// 存在的理由是「最大宽度」是绝对逻辑像素：换设备、旋屏、改界面缩放后都得重调，
+  /// 而墨水屏这类窄屏上用户要的恒定是「占满」。默认 false = 保持既有手感。
+  bool get popupFullWidth =>
+      getPref('popup_full_width', defaultValue: false) as bool;
+
+  Future<void> setPopupFullWidth(bool value) async {
+    await setPref('popup_full_width', value);
+    notifyListeners();
+  }
+
   final double defaultPopupMaxHeight = 360;
 
   double get popupMaxHeight =>

--- a/fushi/lib/src/pages/base_source_page.dart
+++ b/fushi/lib/src/pages/base_source_page.dart
@@ -1181,6 +1181,7 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       selectionRect: sel,
       screen: screen,
       bottomDocked: appModel.popupBottomDocked,
+      fullWidth: appModel.popupFullWidth,
       maxWidth: popupMaxWidth,
       maxHeight: popupMaxHeight,
       padding: popupPadding,

--- a/fushi/lib/src/pages/implementations/dict_style_preview.dart
+++ b/fushi/lib/src/pages/implementations/dict_style_preview.dart
@@ -6,6 +6,8 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:fushi/src/dictionary/dict_style_preview_sample.dart';
 import 'package:fushi/src/dictionary/dict_style_rules.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
+    show FushiEinkTheme;
 import 'package:fushi/src/utils/misc/webview_asset_url.dart';
 import 'package:fushi/src/webview/webview_death_guard.dart';
 
@@ -56,6 +58,42 @@ class _DictStylePreviewState extends State<DictStylePreview> {
       WebViewDeathGuard(surface: 'dict-style-preview');
   bool _ready = false;
 
+  /// 上一次真正推给 WebView 的主题标识，避免每次依赖变化都重复 evaluateJavascript。
+  bool? _pushedDark;
+  bool? _pushedEink;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    unawaited(_pushTheme());
+  }
+
+  /// 预览与真弹窗同源，`eink` class 就也必须同源。
+  ///
+  /// 真弹窗由 popup_settings_injection 的主题变量段 toggle 这个 class，而
+  /// popup.css 的整个 `html.eink` 覆盖块（纯黑白变量 / 去阴影 / 去半透明卡底 /
+  /// 方角 / 线式高亮）全挂在它上面。预览此前只设 `data-theme`、从不设 eink：
+  /// 墨水屏下用户是照着一份灰阶 + 圆角 + 阴影的预览去调样式，而真弹窗是另一个
+  /// 样子——正是本文件开头「不自绘近似渲染」要避免的那种失真。
+  ///
+  /// 用 `toggle` 而非 `add`：主题来回切时要能摘除（与真弹窗同款）。
+  Future<void> _pushTheme() async {
+    final InAppWebViewController? controller = _controller;
+    if (controller == null || !_ready) return;
+    final ThemeData theme = Theme.of(context);
+    final bool dark = theme.brightness == Brightness.dark;
+    final bool eink = theme.extension<FushiEinkTheme>()?.einkMode ?? false;
+    if (_pushedDark == dark && _pushedEink == eink) return;
+    _pushedDark = dark;
+    _pushedEink = eink;
+    await controller.evaluateJavascript(
+      source: '''
+        document.documentElement.setAttribute('data-theme', '${dark ? 'dark' : 'light'}');
+        document.documentElement.classList.toggle('eink', $eink);
+      ''',
+    );
+  }
+
   @override
   void didUpdateWidget(DictStylePreview oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -105,6 +143,7 @@ class _DictStylePreviewState extends State<DictStylePreview> {
       ''',
     );
     _ready = true;
+    await _pushTheme();
     await _pushStyles();
   }
 

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -274,6 +274,7 @@ mixin DictionaryPageMixin {
       selectionRect: layerSelection,
       screen: screen,
       bottomDocked: mixinAppModel.popupBottomDocked,
+      fullWidth: mixinAppModel.popupFullWidth,
       maxWidth: (_popupResizePreview?.width ?? mixinAppModel.popupMaxWidth) *
           mixinAppModel.appUiScale,
       maxHeight: effectiveMaxHeight,

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -220,6 +220,14 @@ Rect resolvePopupRect({
   double bottomReserve = 0.0,
   double topReserve = 0.0,
   bool verticalWriting = false,
+
+  /// 全宽展示：忽略 [maxWidth]，让弹窗横向铺满可用宽度（左右仍各留 [padding]）。
+  /// 只作用于跟随选区这一支——[bottomDocked] 的 dock 面板本来就是全宽的。
+  ///
+  /// 之所以是「把 maxWidth 换成屏宽」而不是另起一套几何：[calcPopupPosition] 的
+  /// `availableWidth` 本就是 `(screen.width - padding * 2).clamp(0, maxWidth)`，
+  /// 传屏宽即让 clamp 失去约束力，避让 / 边界 / 竖排回退全部沿用同一条既有路径。
+  bool fullWidth = false,
 }) {
   if (bottomDocked) {
     return dockedPopupRect(
@@ -234,7 +242,7 @@ Rect resolvePopupRect({
     selectionRect: selectionRect,
     screen: screen,
     padding: padding,
-    maxWidth: maxWidth,
+    maxWidth: fullWidth ? screen.width : maxWidth,
     maxHeight: maxHeight,
     bottomReserve: bottomReserve,
     topReserve: topReserve,

--- a/fushi/lib/src/pages/implementations/dictionary_popup_theme.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_theme.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:fushi/src/models/theme_notifier.dart'
+    show SurfaceRoles, deriveSurfaceRolesFrom;
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
+    show FushiEinkTheme;
+
+/// 查词弹窗覆盖主题的解析结果：罩住整个查词浮层的 [theme]，以及弹窗外壳的
+/// [fillColor]。两者必须同源——外壳填充色与主题的 surface 一旦差一个色阶，
+/// 弹窗边缘就会出现一圈色带。
+@immutable
+class DictionaryPopupTheme {
+  const DictionaryPopupTheme({required this.theme, required this.fillColor});
+
+  /// 罩住查词浮层子树的覆盖主题（`base_source_page.buildDictionary` 用它包住
+  /// 整棵浮层树，`dictionary_popup_webview` 再从中读出注入 WebView 的主题变量）。
+  final ThemeData theme;
+
+  /// 弹窗外壳（Flutter 侧 Material）的填充色。
+  final Color fillColor;
+}
+
+/// 书内查词弹窗覆盖主题的**单一决策点**。
+///
+/// 抽成纯函数是为了让两条不变式能被直接断言，而不是只能靠源码扫描间接钉：
+///
+/// **① 必须挂 [FushiEinkTheme]。** 这份 ThemeData 不经
+/// `ThemeNotifier._buildThemeData` 构造，主题扩展不会自动跟过来。而
+/// `popup_settings_injection` 判定墨水屏读的正是这个扩展：丢了它，判定恒 false，
+/// popup.css 的整个 `html.eink` 覆盖块（纯黑白变量 / 去阴影 / 去半透明卡底 /
+/// 方角 / 线式高亮）在**书内查词**这条最高频路径上一行都不生效，弹窗入场淡入
+/// 也不归零。后果不是「少一点动画」，而是墨水屏适配整体失效。
+///
+/// **② 墨水屏下不做纸色覆盖。** 正文在 eink 下已被 `ReaderContentStyles.css`
+/// 强制成纯黑白，而阅读器主题解析出的 `readerBackground` / `readerForeground`
+/// 走的是主题 preset 手调底色、完全不看 eink。照常派生中性梯度就会出现「正文
+/// 纯白底 + 弹窗纸色灰阶底」的割裂，而灰阶正是墨水屏上的抖动噪点。
+///
+/// [einkDark] 取 app 的明暗模式，与正文 CSS 的 `einkDark` 同一真值（同样**不**读
+/// 阅读器自己的 theme key）。[buildColorScheme] 传 `AppModel.buildColorScheme`，
+/// 它在墨水屏下本就返回纯黑白 ColorScheme。
+DictionaryPopupTheme resolveDictionaryPopupTheme({
+  required bool eink,
+  required bool einkDark,
+  required Color readerBackground,
+  required Color readerForeground,
+  required bool readerDark,
+  required ColorScheme Function(Brightness brightness) buildColorScheme,
+}) {
+  final Color bg =
+      eink ? (einkDark ? Colors.black : Colors.white) : readerBackground;
+  final Color fg =
+      eink ? (einkDark ? Colors.white : Colors.black) : readerForeground;
+  final Brightness brightness = eink
+      ? (einkDark ? Brightness.dark : Brightness.light)
+      : (readerDark ? Brightness.dark : Brightness.light);
+  final ColorScheme scheme = buildColorScheme(brightness);
+
+  // 非墨水屏：弹窗配色 = app 真实 ColorScheme（主题色 / 高亮 / 描边跟用户主题）
+  // + 纸色与字色盖上去的中性角色，与编辑页预览共用 [deriveSurfaceRolesFrom]。
+  ColorScheme dictionaryScheme = scheme;
+  if (!eink) {
+    final SurfaceRoles paper = deriveSurfaceRolesFrom(bg);
+    dictionaryScheme = scheme.copyWith(
+      surface: paper.surface,
+      surfaceDim: paper.surfaceDim,
+      surfaceBright: paper.surfaceBright,
+      surfaceContainerLowest: paper.surfaceContainerLowest,
+      surfaceContainerLow: paper.surfaceContainerLow,
+      surfaceContainer: paper.surfaceContainer,
+      surfaceContainerHigh: paper.surfaceContainerHigh,
+      surfaceContainerHighest: paper.surfaceContainerHighest,
+      onSurface: fg,
+      onSurfaceVariant: paper.onSurfaceVariant,
+      outline: paper.outline,
+      outlineVariant: paper.outlineVariant,
+      inverseSurface: paper.inverseSurface,
+      onInverseSurface: paper.onInverseSurface,
+      surfaceTint: Colors.transparent,
+    );
+  }
+
+  return DictionaryPopupTheme(
+    theme: ThemeData(
+      useMaterial3: true,
+      extensions: <ThemeExtension<dynamic>>[FushiEinkTheme(eink)],
+      colorScheme: dictionaryScheme,
+    ),
+    fillColor: bg,
+  );
+}

--- a/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/chrome.part.dart
@@ -2786,40 +2786,28 @@ extension _ReaderChrome on _ReaderFushiPageState {
     if (mounted) _rebuild(() {});
   }
 
-  /// 词典弹窗配色 = app 真实 ColorScheme（主题色 / 高亮 / 描边跟用户主题）+ 纸色
-  /// 与字色盖上去的中性角色。以前是拿纸色当 seed 重造整套 ColorScheme，弹窗里的
-  /// 按钮、查到词高亮全由纸色派生，与用户设的主题色完全脱钩（改了主题色最高频的
-  /// 查词面不变色）。中性梯度与编辑页预览 / ColorScheme 用同一个
+  /// 把当前取值喂给 [resolveDictionaryPopupTheme]——弹窗覆盖主题的全部决策
+  /// （含墨水屏两条不变式）都在那个纯函数里，本方法不再自己拼 ThemeData。
+  ///
+  /// 非墨水屏下的语义不变：app 真实 ColorScheme（主题色 / 高亮 / 描边跟用户主题）
+  /// + 纸色与字色盖上去的中性角色。以前是拿纸色当 seed 重造整套 ColorScheme，
+  /// 弹窗里的按钮、查到词高亮全由纸色派生，与用户设的主题色完全脱钩（改了主题色
+  /// 最高频的查词面不变色）。中性梯度与编辑页预览 / ColorScheme 用同一个
   /// [deriveSurfaceRolesFrom]，所见即所得。
   void _syncDictionaryTheme() {
-    final Color bg = _themeBackgroundColor();
-    final Color textColor = _themeTextColor();
-    final Brightness brightness =
-        _isReaderThemeDark ? Brightness.dark : Brightness.light;
-    final SurfaceRoles paper = deriveSurfaceRolesFrom(bg);
-    appModel.setOverrideDictionaryColor(bg);
-    appModel.setOverrideDictionaryTheme(
-      ThemeData(
-        useMaterial3: true,
-        colorScheme: appModel.buildColorScheme(brightness).copyWith(
-              surface: paper.surface,
-              surfaceDim: paper.surfaceDim,
-              surfaceBright: paper.surfaceBright,
-              surfaceContainerLowest: paper.surfaceContainerLowest,
-              surfaceContainerLow: paper.surfaceContainerLow,
-              surfaceContainer: paper.surfaceContainer,
-              surfaceContainerHigh: paper.surfaceContainerHigh,
-              surfaceContainerHighest: paper.surfaceContainerHighest,
-              onSurface: textColor,
-              onSurfaceVariant: paper.onSurfaceVariant,
-              outline: paper.outline,
-              outlineVariant: paper.outlineVariant,
-              inverseSurface: paper.inverseSurface,
-              onInverseSurface: paper.onInverseSurface,
-              surfaceTint: Colors.transparent,
-            ),
-      ),
+    // 决策全在 [resolveDictionaryPopupTheme]（纯函数、可直接断言）：它保证覆盖
+    // 主题带上 FushiEinkTheme 扩展，并在墨水屏下跳过纸色派生。这里只负责把
+    // AppModel / 阅读器主题的当前取值喂进去。
+    final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+      eink: appModel.einkMode,
+      einkDark: appModel.isDarkMode,
+      readerBackground: _themeBackgroundColor(),
+      readerForeground: _themeTextColor(),
+      readerDark: _isReaderThemeDark,
+      buildColorScheme: appModel.buildColorScheme,
     );
+    appModel.setOverrideDictionaryColor(resolved.fillColor);
+    appModel.setOverrideDictionaryTheme(resolved.theme);
   }
 
   // ── JS result helpers (evaluateJavascript returns dynamic) ────────

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -17,8 +17,9 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:fushi/pages.dart';
 import 'package:fushi/src/models/app_model.dart';
 import 'package:fushi/src/models/theme_notifier.dart'
-    show SurfaceRoles, ThemeNotifier, deriveSurfaceRolesFrom;
+    show ThemeNotifier, deriveSurfaceRolesFrom;
 import 'package:fushi/src/models/content_font_chain.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_theme.dart';
 import 'package:fushi/src/utils/adaptive/adaptive_widgets.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/epub/epub_book.dart';

--- a/fushi/lib/src/settings/settings_schema_lookup.dart
+++ b/fushi/lib/src/settings/settings_schema_lookup.dart
@@ -490,9 +490,26 @@ SettingsDestination buildLookupDestination() {
         presentation: SettingsSectionPresentation.collapsed,
         title: t.settings_section_lookup_popup_window,
         items: <SettingsItem>[
+          // 全宽展示（对齐 Hoshi Reader Android 的 "Full Width" 弹窗开关）。放在
+          // 宽度滑杆之前：它一旦打开，下面那条滑杆就不再决定任何东西，故同时隐藏，
+          // 避免留一条「拖了没反应」的死控件。
+          SettingsSwitchItem(
+            id: 'lookup.popup_full_width',
+            title: t.popup_full_width,
+            subtitle: t.popup_full_width_hint,
+            icon: Icons.fit_screen_outlined,
+            value: (SettingsContext settingsContext) =>
+                settingsContext.appModel.popupFullWidth,
+            onChanged: (SettingsContext settingsContext, bool value) async {
+              await settingsContext.appModel.setPopupFullWidth(value);
+              settingsContext.refresh();
+            },
+          ),
           SettingsSliderItem(
             id: 'lookup.popup_max_width',
             titleReadout: true,
+            visible: (SettingsContext settingsContext) =>
+                !settingsContext.appModel.popupFullWidth,
             // TODO-1352: 放宽查词弹窗最大宽度的强制上限（1000→2000），让宽屏 / 4K 下
             // 弹窗能拉到接近占满（实际宽度仍由 resolvePopupRect 按当前屏宽 clamp，
             // 绝不会超出屏幕）。divisions 保持 10px 步进（1750/175）。

--- a/fushi/test/build/popup_css_eink_guard_test.dart
+++ b/fushi/test/build/popup_css_eink_guard_test.dart
@@ -39,6 +39,34 @@ void main() {
     expect(css, contains('html.eink ::selection'));
   });
 
+  // BUG-2430 ②：墨水屏块此前只压了圆角 / 阴影 / 过渡 / 顶部按钮那几个 opacity，
+  // **正文侧**十几处静息 opacity（0.4~0.9）与一处亚像素 transform 全部漏网。
+  // 半透明黑字在墨水屏上就是抖动灰——10px 的 `.dict-label` 尤其糊；0.5px 位移则把
+  // 字形推到半个物理像素上，墨水屏没有灰阶去表现，只能糊成两行。这两条都是「看起来
+  // 只是不够锐利」的静默失效，没有任何报错，故用守卫钉死。
+  test('html.eink flattens resting body opacity and subpixel transforms', () {
+    for (final String path in <String>[
+      popupCssPath,
+      'assets/browser_extension/vendor/popup.css',
+      '../tools/browser-extension/vendor/popup.css',
+    ]) {
+      final String css = File(path).readAsStringSync();
+      // 正文/标签的静息半透明压平（抽查两条最典型的：10px 词典名标签、
+      // 折叠三角伪元素）。
+      expect(css, contains('html.eink .dict-label'),
+          reason: '$path 缺少词典名标签的 eink opacity 压平');
+      expect(css, contains('html.eink .glossary-group > summary::before'),
+          reason: '$path 缺少折叠三角的 eink opacity 压平');
+      // 亚像素位移归零。
+      expect(css, contains('html.eink .mine-button.duplicate'),
+          reason: '$path 缺少 0.5px 亚像素位移的 eink 归零');
+      // 状态反馈刻意不压平：:disabled 的弱化本身就是它要传达的信息，
+      // 若哪天被一条通配 opacity 规则连坐，这里应当有人重新审。
+      expect(css, isNot(contains('html.eink * { opacity')),
+          reason: '$path 不应用通配规则压平 opacity（会连坐 disabled / 隐藏态）');
+    }
+  });
+
   test('generated content.css re-roots html.eink for the extension', () {
     final String css = File(contentCssPath).readAsStringSync();
     expect(css, contains(':where(#entries-container).eink'));

--- a/fushi/test/dictionary/dict_style_preview_eink_guard_test.dart
+++ b/fushi/test/dictionary/dict_style_preview_eink_guard_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2430 ②：词典样式预览（设置 › 词典样式，用户在这里调词典字体/字号/配色）
+/// 跑的是**真的** `popup.html` + `popup.js`，文件开头明写「渲染路径与真弹窗同源」
+/// ——但它此前只设 `data-theme`，从不设 `eink` class。
+///
+/// 真弹窗的 eink class 由 `popup_settings_injection` 的主题变量段 toggle，而
+/// popup.css 的整个 `html.eink` 覆盖块（纯黑白变量 / 去阴影 / 去半透明卡底 / 方角 /
+/// 线式高亮）全挂在它上面。少了它，墨水屏下用户是照着一份灰阶 + 圆角 + 阴影的预览
+/// 去调样式，真弹窗却是另一个样子——正是那句「不自绘近似渲染」要避免的失真。
+///
+/// 这条只能做源码守卫：预览的渲染发生在真 WebView 里，单元测试环境没有 WebView，
+/// 断言不到最终像素（与既有 `popup_instant_scroll_guard_test` 同处境）。故钉的是
+/// 「注入链路上每一段载荷位都还在」。
+void main() {
+  const String previewPath =
+      'lib/src/pages/implementations/dict_style_preview.dart';
+
+  late String source;
+
+  setUpAll(() {
+    source = File(previewPath).readAsStringSync();
+  });
+
+  test('预览读得到墨水屏主题扩展', () {
+    expect(
+      source,
+      contains('FushiEinkTheme'),
+      reason: '预览必须从 Theme 读出墨水屏标志，否则永远按普通主题渲染',
+    );
+  });
+
+  test('预览把 eink class toggle 到 documentElement 上', () {
+    expect(
+      source,
+      contains("classList.toggle('eink'"),
+      reason: 'popup.css 的 html.eink 覆盖块挂在这个 class 上；'
+          '少了它整块样式在预览里不生效',
+    );
+  });
+
+  test('用 toggle 而非 add：主题来回切要能摘除（与真弹窗同款）', () {
+    expect(
+      source,
+      isNot(contains("classList.add('eink'")),
+      reason: 'add 摘不掉——关掉墨水屏后预览会一直卡在黑白方角态',
+    );
+  });
+
+  test('主题变化时会补推，而不是只在首次 bootstrap 推一次', () {
+    expect(
+      source,
+      contains('didChangeDependencies'),
+      reason: '只在 bootstrap 推一次的话，开着预览去翻墨水屏开关不会有任何反应',
+    );
+  });
+}

--- a/fushi/test/dictionary/dictionary_popup_theme_test.dart
+++ b/fushi/test/dictionary/dictionary_popup_theme_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_theme.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart';
+
+/// BUG-2430：书内查词弹窗的覆盖主题此前手工 `new ThemeData(...)` 却不带
+/// `extensions`，[FushiEinkTheme] 当场丢失 —— 而 `popup_settings_injection` 判定
+/// 墨水屏读的正是这个扩展，恒 false 让 popup.css 的整个 `html.eink` 覆盖块在书内
+/// 查词这条路径上完全不生效。第二条不变式是墨水屏下不得再叠纸色派生的中性梯度
+/// （正文已是纯黑白，弹窗叠灰阶就割裂）。
+///
+/// 两条不变式都在 [resolveDictionaryPopupTheme] 里，故直接断言它的返回值，而不是
+/// 扫源码——扫源码只能证明「写了这行字」，证明不了颜色真的没被覆盖。
+void main() {
+  // 阅读器 sepia 预设那类「手调纸色」：墨水屏下绝不允许出现在弹窗上。
+  const Color paperBg = Color(0xFFF5EFE0);
+  const Color paperFg = Color(0xFF3B3229);
+
+  ColorScheme plainScheme(Brightness brightness) =>
+      ColorScheme.fromSeed(seedColor: const Color(0xFF1F4959),
+          brightness: brightness);
+
+  group('墨水屏：覆盖主题必须带 FushiEinkTheme 且不叠纸色', () {
+    test('浅色墨水屏 = 纯白底，扩展为 true，纸色一点都渗不进来', () {
+      final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+        eink: true,
+        einkDark: false,
+        readerBackground: paperBg,
+        readerForeground: paperFg,
+        readerDark: false,
+        buildColorScheme: buildEinkColorScheme,
+      );
+
+      // ① 扩展必须在——丢了它 popup.css 的 html.eink 块整块失效。
+      expect(resolved.theme.extension<FushiEinkTheme>()?.einkMode, isTrue);
+
+      // ② 纸色不得覆盖纯黑白。
+      expect(resolved.fillColor, Colors.white);
+      expect(resolved.theme.colorScheme.surface, Colors.white);
+      expect(resolved.theme.colorScheme.onSurface, Colors.black);
+      expect(resolved.theme.colorScheme.surfaceContainerHigh, Colors.white);
+      expect(resolved.fillColor, isNot(paperBg));
+      expect(resolved.theme.colorScheme.onSurface, isNot(paperFg));
+    });
+
+    test('深色墨水屏 = 纯黑底白字', () {
+      final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+        eink: true,
+        einkDark: true,
+        readerBackground: paperBg,
+        readerForeground: paperFg,
+        // 阅读器自己的明暗刻意与 einkDark 相反：墨水屏取的是 app 明暗模式，
+        // 不读阅读器 theme key（与正文 CSS 的 einkDark 同一真值）。
+        readerDark: false,
+        buildColorScheme: buildEinkColorScheme,
+      );
+
+      expect(resolved.theme.extension<FushiEinkTheme>()?.einkMode, isTrue);
+      expect(resolved.fillColor, Colors.black);
+      expect(resolved.theme.colorScheme.surface, Colors.black);
+      expect(resolved.theme.colorScheme.onSurface, Colors.white);
+    });
+  });
+
+  group('非墨水屏：既有的纸色派生行为原样保留', () {
+    test('填充色仍是阅读器纸色，中性梯度仍由 deriveSurfaceRolesFrom 派生', () {
+      final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+        eink: false,
+        einkDark: false,
+        readerBackground: paperBg,
+        readerForeground: paperFg,
+        readerDark: false,
+        buildColorScheme: plainScheme,
+      );
+
+      final SurfaceRoles paper = deriveSurfaceRolesFrom(paperBg);
+      expect(resolved.fillColor, paperBg);
+      expect(resolved.theme.colorScheme.surface, paper.surface);
+      expect(resolved.theme.colorScheme.onSurface, paperFg);
+      expect(resolved.theme.colorScheme.outline, paper.outline);
+      expect(resolved.theme.colorScheme.surfaceTint, Colors.transparent);
+      // 主题色仍来自 app 的真实 ColorScheme（不被纸色重造）。
+      expect(
+        resolved.theme.colorScheme.primary,
+        plainScheme(Brightness.light).primary,
+      );
+    });
+
+    test('扩展仍挂着，只是值为 false（弹窗才能在关掉墨水屏后摘除 html.eink）', () {
+      final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+        eink: false,
+        einkDark: false,
+        readerBackground: paperBg,
+        readerForeground: paperFg,
+        readerDark: false,
+        buildColorScheme: plainScheme,
+      );
+
+      expect(resolved.theme.extension<FushiEinkTheme>(), isNotNull);
+      expect(resolved.theme.extension<FushiEinkTheme>()?.einkMode, isFalse);
+    });
+
+    test('阅读器深色主题走深色 ColorScheme', () {
+      final DictionaryPopupTheme resolved = resolveDictionaryPopupTheme(
+        eink: false,
+        einkDark: false,
+        readerBackground: const Color(0xFF1A1A1A),
+        readerForeground: const Color(0xFFE0E0E0),
+        readerDark: true,
+        buildColorScheme: plainScheme,
+      );
+
+      expect(resolved.theme.colorScheme.brightness, Brightness.dark);
+    });
+  });
+}

--- a/fushi/test/pages/popup_full_width_test.dart
+++ b/fushi/test/pages/popup_full_width_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_layer.dart';
+
+/// 「弹窗全宽」（对齐 Hoshi Reader Android 的 Full Width 开关）：忽略用户设的最大
+/// 宽度，让跟随选区的弹窗横向铺满可用宽度，左右仍各留一条 `padding`。
+///
+/// 存在的理由是「最大宽度」是绝对逻辑像素——换设备、旋屏、改界面缩放后都得重调，
+/// 而窄屏（尤其墨水屏阅读器）上用户要的恒定是「占满」。
+///
+/// 判别力要点：断言必须同时钉住「开了真的变宽」和「关了仍按 maxWidth」，否则把
+/// 实现改成恒 true / 恒 false 都能骗过单边断言。
+void main() {
+  const Size screen = Size(800, 600);
+  const Rect sel = Rect.fromLTWH(100, 200, 50, 20);
+  const double padding = 6.0;
+
+  group('resolvePopupRect 的 fullWidth', () {
+    test('开启后宽度 = 屏宽减两侧 padding，且左缘贴在 padding 上', () {
+      final Rect rect = resolvePopupRect(
+        selectionRect: sel,
+        screen: screen,
+        bottomDocked: false,
+        fullWidth: true,
+        maxWidth: 360,
+        maxHeight: 300,
+        padding: padding,
+      );
+
+      expect(rect.width, screen.width - padding * 2);
+      expect(rect.left, padding);
+    });
+
+    test('关闭时仍然只有 maxWidth 那么宽（同一组入参，结果必须不同）', () {
+      Rect at({required bool fullWidth}) => resolvePopupRect(
+            selectionRect: sel,
+            screen: screen,
+            bottomDocked: false,
+            fullWidth: fullWidth,
+            maxWidth: 360,
+            maxHeight: 300,
+            padding: padding,
+          );
+
+      expect(at(fullWidth: false).width, 360);
+      expect(at(fullWidth: true).width, greaterThan(at(fullWidth: false).width));
+    });
+
+    test('默认值为关闭：不传 fullWidth 与显式传 false 逐字节同结果', () {
+      expect(
+        resolvePopupRect(
+          selectionRect: sel,
+          screen: screen,
+          bottomDocked: false,
+          maxWidth: 360,
+          maxHeight: 300,
+          padding: padding,
+        ),
+        resolvePopupRect(
+          selectionRect: sel,
+          screen: screen,
+          bottomDocked: false,
+          fullWidth: false,
+          maxWidth: 360,
+          maxHeight: 300,
+          padding: padding,
+        ),
+      );
+    });
+
+    test('底部固定不受影响：dock 面板本来就是全宽，开关不改变它', () {
+      Rect docked({required bool fullWidth}) => resolvePopupRect(
+            selectionRect: sel,
+            screen: screen,
+            bottomDocked: true,
+            fullWidth: fullWidth,
+            maxWidth: 360,
+            maxHeight: 300,
+            padding: padding,
+          );
+
+      expect(docked(fullWidth: true), docked(fullWidth: false));
+      expect(docked(fullWidth: false).width, screen.width - padding * 2);
+    });
+
+    test('全宽不会溢出屏幕：右缘仍在 padding 之内', () {
+      final Rect rect = resolvePopupRect(
+        // 选区贴着右缘，最容易把弹窗推出屏外。
+        selectionRect: const Rect.fromLTWH(780, 200, 15, 20),
+        screen: screen,
+        bottomDocked: false,
+        fullWidth: true,
+        maxWidth: 360,
+        maxHeight: 300,
+        padding: padding,
+      );
+
+      expect(rect.left, greaterThanOrEqualTo(padding));
+      expect(rect.right, lessThanOrEqualTo(screen.width - padding));
+    });
+
+    test('全宽时 maxWidth 已不再决定任何东西（设成极小值也一样宽）', () {
+      Rect withMax(double maxWidth) => resolvePopupRect(
+            selectionRect: sel,
+            screen: screen,
+            bottomDocked: false,
+            fullWidth: true,
+            maxWidth: maxWidth,
+            maxHeight: 300,
+            padding: padding,
+          );
+
+      expect(withMax(250), withMax(2000));
+    });
+  });
+}

--- a/fushi/test/pages/popup_settings_injection_memo_test.dart
+++ b/fushi/test/pages/popup_settings_injection_memo_test.dart
@@ -15,6 +15,8 @@ import 'package:fushi/src/pages/implementations/popup_settings_injection.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/utils/adaptive/adaptive_platform.dart'
+    show FushiEinkTheme;
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
 
@@ -248,6 +250,45 @@ void main() {
         expect(hot.script, contains('"renderJs"'));
       },
     );
+  });
+
+  // BUG-2430：这条是墨水屏适配链路的**后半段**。前半段（覆盖主题必须带
+  // FushiEinkTheme）由 test/dictionary/dictionary_popup_theme_test.dart 钉住；
+  // 这里钉「拿到扩展之后，注入串里真的会 toggle eink class」——popup.css 的整个
+  // html.eink 覆盖块挂在这个 class 上，少了它整块样式静默失效、无任何报错。
+  group('eink class 注入', () {
+    test('主题带 FushiEinkTheme(true) → 注入 toggle 成 true', () {
+      final MemoAppModel appModel = MemoAppModel();
+      final PopupStaticSettingsJs js = build(
+        appModel,
+        theme: ThemeData(
+          brightness: Brightness.light,
+          extensions: <ThemeExtension<dynamic>>[const FushiEinkTheme(true)],
+        ),
+      );
+      expect(js.head, contains("classList.toggle('eink', true)"));
+    });
+
+    test('扩展为 false → toggle 成 false（要能摘除，不是只加不减）', () {
+      final MemoAppModel appModel = MemoAppModel();
+      final PopupStaticSettingsJs js = build(
+        appModel,
+        theme: ThemeData(
+          brightness: Brightness.light,
+          extensions: <ThemeExtension<dynamic>>[const FushiEinkTheme(false)],
+        ),
+      );
+      expect(js.head, contains("classList.toggle('eink', false)"));
+    });
+
+    test('主题丢了扩展 → 恒 false（这正是 BUG-2430 的失效形态）', () {
+      final MemoAppModel appModel = MemoAppModel();
+      final PopupStaticSettingsJs js = build(
+        appModel,
+        theme: ThemeData(brightness: Brightness.light),
+      );
+      expect(js.head, contains("classList.toggle('eink', false)"));
+    });
   });
 
   group('memo invalidation', () {

--- a/fushi/test/settings/md3_design_system_static_test.dart
+++ b/fushi/test/settings/md3_design_system_static_test.dart
@@ -779,6 +779,15 @@ void main() {
           'image context-menu font size are reader content / chrome, '
           'same rationale as the parent reader_fushi_page.dart allowlist '
           '(extracted verbatim).',
+      // BUG-2430：书内查词弹窗的覆盖主题决策从 chrome.part.dart 抽成纯函数
+      // （抽出来才能对「墨水屏下不叠纸色」「必须挂 FushiEinkTheme」直接写断言，
+      // 而不是只能扫源码）。那段 ColorScheme.copyWith 是逐字搬运的，豁免随之
+      // 延伸，理由与父条目 reader_fushi/chrome.part.dart 同一类。
+      'lib/src/pages/implementations/dictionary_popup_theme.dart':
+          'The dictionary popup override theme derives its neutral container '
+          'ladder from the reader paper color (deriveSurfaceRolesFrom) — it is '
+          'reader content chrome, same rationale as the parent '
+          'reader_fushi/chrome.part.dart allowlist (extracted verbatim).',
       // BUG-1425：reader_fushi/webview.part.dart 的豁免已删除。它的理由写的是
       // 「shellScript 收到 fontSize: s.fontSize.round()」，但该文件如今一个禁用
       // token 都不剩（`shellScript` 这个符号在整个 lib/src 里也已不存在），豁免早与
@@ -1305,6 +1314,12 @@ void main() {
             'surfaceContainerHighest',
             'fontSize:',
           },
+      'lib/src/pages/implementations/dictionary_popup_theme.dart': <String>{
+        'surfaceContainerHigh',
+        'surfaceContainerHighest',
+        'surfaceContainerLow',
+        'surfaceContainerLowest',
+      },
       'lib/src/pages/implementations/popup_settings_injection.dart': <String>{
         'surfaceContainerHigh',
       },
@@ -1314,10 +1329,9 @@ void main() {
         // lib/src/reader/reader_statistics_dialog.dart，本文件已无此 token，
         // 留着就是死豁免（会给它无声开着回来的门）。
         'surfaceContainerHigh',
-        'surfaceContainerHighest',
-        // BUG-2166 批：桌面 chrome 的抽屉/状态行底色用到低阶 tonal 面。
-        'surfaceContainerLow',
-        'surfaceContainerLowest',
+        // BUG-2430：查词弹窗覆盖主题的中性梯度（surfaceContainerHighest /
+        // Low / Lowest）已搬到 dictionary_popup_theme.dart，本文件不再命中，
+        // 按同一条「不留死豁免」纪律删除，范围随代码走。
         'fontSize:',
       },
       'lib/src/reader/reader_desktop_chrome.dart': <String>{'fontSize:'},

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -324,6 +324,11 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   // charOffset 不变/spread 优先由专项纯函数测试守住，渲染效果需真机验。
   'reading/Merge illustration pages into text':
       'test/epub/epub_spread_map_test.dart: mergeImagePages absorb/spread-priority/charOffset (reader layout effect needs live WebView, DEVICE for render)',
+  // BUG-2430 批：「弹窗全宽」（对齐 Hoshi 的 Full Width）。焦点遍历能切到开关并
+  // 写穿 DB，但生效点是 resolvePopupRect 算出的矩形宽度——纯几何，harness 没有
+  // 适用的 T4 渲染探针，故与兄弟行 Popup max width / max height 同款登记，行为由
+  // 专项纯函数测试钉住（含「开/关同一组入参结果必须不同」的判别力用例）。
+  'lookup/Full-width popup': 'test/pages/popup_full_width_test.dart',
   'lookup/Popup max width': 'test/pages/dictionary_popup_layer_test.dart',
   'lookup/Popup max height': 'test/pages/dictionary_popup_layer_test.dart',
   // TODO-776: 查词弹窗「词典最多列数（自动填充）」（实验性）。PR#83 语义收敛后文案

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -1961,6 +1961,37 @@
     opacity: 1;
 }
 
+/* 正文侧的静息半透明：半透明黑字在墨水屏上就是抖动灰，10px 的 `.dict-label`
+   （词典名）尤其糊。与上面顶部动作按钮同一处理，统一压到全不透明；层次改由
+   字号 / 描边 / 位置承担（对齐 Hoshi 弹窗——它的正文一律零 opacity、纯 #000/#fff，
+   清晰度全靠「不制造灰」而非任何增锐手段）。
+   刻意**不**动三类：`:active` / `:hover` 的即时反馈、`:disabled` 与
+   `.audio-unavailable` 的失效态（弱化本身就是它要传达的信息）、以及
+   `.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。 */
+:where(#entries-container).eink .sentence-context-picker .context-label,
+:where(#entries-container).eink .sentence-context-picker .context-stepper-btn,
+:where(#entries-container).eink .sentence-context-picker .context-count,
+:where(#entries-container).eink .clear-draft-button,
+:where(#entries-container).eink .deinflection-tag:not(:first-child)::before,
+:where(#entries-container).eink .glossary-group > summary::before,
+:where(#entries-container).eink .dict-label,
+:where(#entries-container).eink .pitch-entries > li:not(:last-child)::after,
+:where(#entries-container).eink .pitch-transcription-tag,
+:where(#entries-container).eink .no-results,
+:where(#entries-container).eink .no-results-icon,
+:where(#entries-container).eink .kanji-card-dict,
+:where(#entries-container).eink .ctx-adjust-button,
+:where(#entries-container).eink .mined-action-subtitle {
+    opacity: 1;
+}
+
+/* 亚像素位移：0.5px 把该按钮的字形推到半个物理像素上，墨水屏没有灰阶去表现，
+   只能糊成两行。整数位移（`.audio-button` 的 1px）落点仍是整像素，不受影响，
+   故只归零这一条。 */
+:where(#entries-container).eink .mine-button.duplicate {
+    transform: none;
+}
+
 /* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
 :where(#entries-container).eink .favorite-button.favorited,
 :where(#entries-container).eink .mine-button.latest {

--- a/tools/browser-extension/vendor/popup.css
+++ b/tools/browser-extension/vendor/popup.css
@@ -2073,6 +2073,37 @@ html.eink .mine-button {
     opacity: 1;
 }
 
+/* 正文侧的静息半透明：半透明黑字在墨水屏上就是抖动灰，10px 的 `.dict-label`
+   （词典名）尤其糊。与上面顶部动作按钮同一处理，统一压到全不透明；层次改由
+   字号 / 描边 / 位置承担（对齐 Hoshi 弹窗——它的正文一律零 opacity、纯 #000/#fff，
+   清晰度全靠「不制造灰」而非任何增锐手段）。
+   刻意**不**动三类：`:active` / `:hover` 的即时反馈、`:disabled` 与
+   `.audio-unavailable` 的失效态（弱化本身就是它要传达的信息）、以及
+   `.audio-hint` 那种 `opacity: 0` 的隐藏态（压平会让提示常驻）。 */
+html.eink .sentence-context-picker .context-label,
+html.eink .sentence-context-picker .context-stepper-btn,
+html.eink .sentence-context-picker .context-count,
+html.eink .clear-draft-button,
+html.eink .deinflection-tag:not(:first-child)::before,
+html.eink .glossary-group > summary::before,
+html.eink .dict-label,
+html.eink .pitch-entries > li:not(:last-child)::after,
+html.eink .pitch-transcription-tag,
+html.eink .no-results,
+html.eink .no-results-icon,
+html.eink .kanji-card-dict,
+html.eink .ctx-adjust-button,
+html.eink .mined-action-subtitle {
+    opacity: 1;
+}
+
+/* 亚像素位移：0.5px 把该按钮的字形推到半个物理像素上，墨水屏没有灰阶去表现，
+   只能糊成两行。整数位移（`.audio-button` 的 1px）落点仍是整像素，不受影响，
+   故只归零这一条。 */
+html.eink .mine-button.duplicate {
+    transform: none;
+}
+
 /* 特例态的彩色（收藏金 / 最新可改绿）在灰阶屏上失义，回归前景色。 */
 html.eink .favorite-button.favorited,
 html.eink .mine-button.latest {


### PR DESCRIPTION
用户报告：对比 Hoshi Reader Android 的查词框墨水屏适配，**「查词框显示发虚，而且词典字体页发虚」**；另提「查词弹窗好像还没有全宽展示」。

沿真实代码路径查下来，「发虚」不是观感问题，是**墨水屏适配在最高频路径上整体没生效**。三个根因彼此独立，各自建档、各自一个 commit。

---

## ① BUG-2430 · 书内查词弹窗从未进入过墨水屏模式

`reader_fushi/chrome.part.dart` 的 `_syncDictionaryTheme()` 手工拼覆盖 `ThemeData` 时**没有 `extensions:`**，`FushiEinkTheme` 当场丢失。

`FushiEinkTheme` 全仓只在 `ThemeNotifier._buildThemeData` 挂一次，任何不经它构造的 ThemeData 都丢。而这份覆盖主题经 `base_source_page.dart:634` 罩住**整个查词浮层子树**，`popup_settings_injection.dart:110` 的墨水屏判定读的正是它 —— 恒 `false` 意味着 `popup.css` 的整个 `html.eink` 覆盖块（纯黑白变量 / 去阴影 / 去半透明亚克力卡底 / 方角 / 线式高亮）**在书里查词时一行都不生效**，入场淡入归零也失效。

app 外全局查词与视频字幕查词不设 override，反而一直是对的 —— 书内查词是最高频路径，却恰恰是唯一坏的那条，这是它能长期潜伏的原因。

**第二重**：即便补上扩展，原实现仍用 `deriveSurfaceRolesFrom(阅读器纸色)` 把墨水屏下本该纯黑白的 surface 角色整套覆盖回灰阶梯度，而正文 CSS 早已被强制成纯黑白 —— 于是「正文纯白底 + 弹窗纸色灰阶底」，灰阶正是墨水屏上的抖动噪点。

修法：决策抽成纯函数 `resolveDictionaryPopupTheme()`（新文件），两条不变式一处收口且可直接断言。非墨水屏语义逐字节不变。

## ② BUG-2431 · 词典样式预览不注入 eink，与真弹窗不同源

`dict_style_preview.dart` 跑的是**真的** `popup.html` + `popup.js`，文件开头明写「渲染路径与真弹窗同源」，但 `_bootstrap()` 只设 `data-theme`、从不 toggle `eink`。墨水屏下用户是照着一份灰阶 + 圆角 + 阴影的预览去调词典字体/字号/配色 —— 这正是用户说的第二个「发虚」的地方。

修法：抽出 `_pushTheme()`，用 `toggle`（不是 `add`，`add` 摘不掉）并挂在 `didChangeDependencies` 上，开着预览翻开关也当场生效。

## ③ BUG-2432 · 墨水屏块只压了按钮 opacity，正文侧十几处漏网

`html.eink` 的 opacity 规则只列了顶部四个动作按钮。同一份 CSS 里正文与标签上还有十几处同性质的静息半透明全部漏网 —— `.dict-label`（10px 词典名，0.7，最糊的一处）、折叠三角、去屈折分隔符、音调标签、无结果提示、汉字卡词典名、上下文调整按钮、已制卡副标题、句子上下文三件套、清空草稿按钮。**半透明黑字就是灰字**，而墨水屏没有足够灰阶去表现。另有一处 `.mine-button.duplicate` 的 `translateY(0.5px)`：半个物理像素只能糊成两行（通配块关了 transition/animation，没关 transform）。

**刻意不动三类**：`:active`/`:hover` 的即时反馈、`:disabled` 与 `.audio-unavailable` 的失效态、`.audio-hint` 的 `opacity: 0` 隐藏态 —— 所以没有用通配 `html.eink * { opacity: 1 }`。

三镜像逐字节同步 + 重跑 `generate-content-css.mjs`。

## ④ 新增：查词弹窗全宽展示（对齐 Hoshi 的 Full Width）

Hoshi 有 `popupFullWidth` 开关，Fushi 一直没有：想占满只能把「最大宽度」滑杆手动拉到 2000，而那是绝对逻辑像素 —— 换设备、旋屏、改界面缩放都得重调，可窄屏（尤其墨水屏阅读器）上用户要的恒定是「占满」。

新增偏好 `popup_full_width`（默认 **false**，保持既有手感）+ 设置项「弹窗全宽」；开启后宽度滑杆不再决定任何东西，故同时隐藏，不留死控件。与「底部固定」正交 —— dock 面板本来就是全宽，本项管的是**贴词定位下**也占满。

实现是把 `resolvePopupRect` 的 `maxWidth` 换成屏宽而非另起几何：`availableWidth` 本就是 `(screen.width - padding*2).clamp(0, maxWidth)`，传屏宽即让 clamp 失去约束力，避让/边界/竖排回退全部沿用同一条既有路径。

---

## 与 Hoshi 的逐项对照结论

浅克隆比对后：**Hoshi 没有任何墨水屏 / 灰阶 / 增锐代码** —— 没有 `-webkit-font-smoothing`、没有 `text-rendering`、没有 `setLayerType`、没有 `textZoom`/`initialScale`，弹窗零动画零缩放。它清晰的原因只有三条「减分项清单」：

1. **三层不透明纯色背景**（Compose Surface 纯白/纯黑 + WebView `setBackgroundColor` + CSS `!important` 底），文字永不与背后正文做 alpha 混合；
2. **自管深色方案**，绕开 WebView 的 algorithmic darkening（系统算法反色会把 `#fff` 压成灰）；
3. **正文颜色零 opacity**，纯 `#000`/`#fff`，21:1。

③ 修的就是第三条。弹窗设置项方面 Fushi 已全面超过它（它没有拖动、置顶、resize、独立字号、弹窗字体选择，`font-family` 还被 `!important` 锁死在两个 iOS 字体上）。

## 有意未做（附理由，供后续单独处理）

- **弹窗 WebView 是 `transparentBackground: true`**（Hoshi 是三层不透明）。透明合成层会让 Chromium 从 LCD subpixel AA 退回灰阶 AA，理论上也让文字变淡；但 Fushi 的 body 在 eink 下本就是不透明纯白/纯黑，是否真触发**需要真机像素比对**，且透明底是弹窗圆角透出所依赖的，爆炸半径大。
- **内容缩放走 CSS `zoom`**，且是 `toStringAsFixed(4)` 的任意小数（`zoom = appUiScale × 字号/16`），会让 1px 边框/下划线落在分数像素上。跨平台且会动到所有平台的弹窗尺寸表现，需真机测量后单独处理。
- `FushiDesignSystemTheme` 在该覆盖主题里同样丢失（只补了 eink 那个）。默认 `auto` 下五平台统一 MD3，丢它无可见后果，补它需连带复核隐藏的 Cupertino 路径。

## 验证

- `flutter analyze` 零问题。
- 新增/改动测试：`dictionary_popup_theme_test`（5）、`popup_full_width_test`（6）、`dict_style_preview_eink_guard_test`（4）、`popup_css_eink_guard_test`（+1）、`popup_settings_injection_memo_test`（+3 条 eink 注入 group）。
- **判别力已验证**：摘掉 `extensions:` → 正好 3 条钉扩展的用例红、其余绿；把 `fullWidth` 改成恒用 `maxWidth` → 正好 3 条红。
- `test/settings` 447 条绿（`stillUnaccounted=0`）、`md3_design_system_static_test` 66 条绿、目录枚举型守卫整批 50 suites / 295 条绿。
- Windows Release 真 app 启动冒烟通过。

**验证边界（如实记录）**：链路已由单测闭环到「注入串真的 toggle 出 `eink`」，剩下只有「WebView 执行这段 JS」属既有行为。但**墨水屏设备目视复测未做**（本机无 Android 墨水屏），headless 像素对照也没走通（本机 Chrome/Edge 的 `--screenshot` 已不产出文件，CDP 侧 Chrome 立即退出）。因此「锐利了多少」这一层**没有像素证据**，已记在 BUG-2430 备注里待补。

https://claude.ai/code/session_01QuGPuNoQLgefkk9tYRbmVg
