### PR TITLE
fix(video): 订阅面板默认打开「加入订阅」，集数默认填 1

### DIFF
--- a/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
+++ b/fushi/lib/src/pages/implementations/video_discovery_acquisition_dialogs.dart
@@ -643,7 +643,15 @@ class _VideoResourceSearchSurfaceState
   final TextEditingController _queryController = TextEditingController();
   final TextEditingController _manualIdController = TextEditingController();
   final TextEditingController _manualYearController = TextEditingController();
-  final TextEditingController _startAfterController = TextEditingController();
+
+  /// 订阅起始集号的默认值。新版（`organizationPolicy == 'library'`）订阅把
+  /// `startAfterEpisode` 按「从该集开始」解释（见
+  /// `video_download_subscription_service.dart` 的 `inclusiveStart`），所以默认
+  /// 第 1 集与「留空 = 不限」落到同一个窗口；显式填出来用户才看得见起点。
+  static const String _defaultStartEpisode = '1';
+
+  final TextEditingController _startAfterController =
+      TextEditingController(text: _defaultStartEpisode);
   VideoDiscoveryCategory _manualCategory = VideoDiscoveryCategory.anime;
   VideoMetadataMediaKind _manualMediaKind = VideoMetadataMediaKind.tv;
   String _manualProvider = 'anidb';
@@ -673,7 +681,11 @@ class _VideoResourceSearchSurfaceState
       VideoDownloadSubtitlePolicy.bestEffort;
   bool _loading = false;
   bool _submitting = false;
-  bool _strictConfirmed = false;
+
+  /// 「加入订阅」开关（追踪当前 release 的字幕组 + 分辨率）。默认打开：进这个
+  /// 面板本来就是为了订阅，再要求用户手工确认一次只是多一步（提交按钮此前一直
+  /// 因为它是 false 而禁用）。用户显式关掉后不再被换候选/重新搜索拉回来。
+  bool _strictConfirmed = true;
   int _generation = 0;
 
   @override
@@ -735,7 +747,6 @@ class _VideoResourceSearchSurfaceState
       _loading = false;
       _result = null;
       _selectedCandidates.clear();
-      _strictConfirmed = false;
     });
   }
 
@@ -786,7 +797,6 @@ class _VideoResourceSearchSurfaceState
     setState(() {
       _loading = true;
       _selectedCandidates.clear();
-      _strictConfirmed = false;
     });
     final ProviderBatchResult<VideoResourceCandidate> result =
         await widget.registry.search(
@@ -804,7 +814,6 @@ class _VideoResourceSearchSurfaceState
 
   void _select(VideoResourceCandidate candidate) {
     setState(() {
-      _strictConfirmed = false;
       if (widget.subscription) {
         // 订阅只跟一条模板：选新的直接替换，不累积。
         _selectedCandidates
@@ -812,8 +821,7 @@ class _VideoResourceSearchSurfaceState
           ..add(candidate);
       } else if (!_selectedCandidates.remove(
         _selectedCandidates.firstWhereOrNull(
-          (VideoResourceCandidate c) =>
-              c.identityKey == candidate.identityKey,
+          (VideoResourceCandidate c) => c.identityKey == candidate.identityKey,
         ),
       )) {
         _selectedCandidates.add(candidate);
@@ -821,10 +829,9 @@ class _VideoResourceSearchSurfaceState
       // 起始集号只对订阅有意义，且要跟着「当前这一条」走；下载模式多选时用最后
       // 点的那条填，反正提交时不读它。
       final VideoResourceCandidate? current = _selected;
-      final int? episode = current == null
-          ? null
-          : episodeNumberFromReleaseTitle(current.title);
-      _startAfterController.text = episode?.toString() ?? '';
+      final int? episode =
+          current == null ? null : episodeNumberFromReleaseTitle(current.title);
+      _startAfterController.text = episode?.toString() ?? _defaultStartEpisode;
     });
   }
 
@@ -1104,7 +1111,6 @@ class _VideoResourceSearchSurfaceState
                     _manualMediaKind = value;
                     _result = null;
                     _selectedCandidates.clear();
-                    _strictConfirmed = false;
                   });
                 },
               ),
@@ -1508,7 +1514,7 @@ class _VideoResourceSearchSurfaceState
                 labelText: t.video_jimaku_episode,
                 helperText: t.download_subscription_start_episode(
                   episode: _startAfterController.text.trim().isEmpty
-                      ? '1'
+                      ? _defaultStartEpisode
                       : _startAfterController.text.trim(),
                 ),
               ),

--- a/fushi/test/pages/video_subscription_defaults_test.dart
+++ b/fushi/test/pages/video_subscription_defaults_test.dart
@@ -1,0 +1,176 @@
+// 订阅面板默认值契约：
+// ① 「加入订阅」开关默认打开——进这个页面本来就是为了订阅，提交按钮不该因为一
+//    个没人点的确认开关而一直禁用；
+// ② 集数框默认「1」——release 标题里解析不出集号时也不留空，否则 helper 写着
+//    「从第 1 集开始」而框里空着，用户看不出起点在哪。
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/external_provider.dart';
+import 'package:fushi/src/media/torrent/torrent_backend.dart'
+    show TorrentAddPayload;
+import 'package:fushi/src/media/torrent/video_resource_provider.dart';
+import 'package:fushi/src/media/video/discovery/video_discovery_provider.dart';
+import 'package:fushi/src/media/video/download/video_resource_registry.dart';
+import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi/src/pages/implementations/video_discovery_acquisition_dialogs.dart';
+import 'package:fushi/src/utils/components/settings_shared.dart';
+import 'package:fushi_core/fushi_core.dart' show MediaSourceRow;
+
+class _FakeResource extends VideoResourceCandidate {
+  /// 字幕组 + 清晰度必须齐（`deriveStrictVideoSubscriptionFilter` 缺一个就返回
+  /// null，开关行会换成「无法订阅」警告），所以在这里写死而不留参数。
+  _FakeResource({required super.title})
+      : super(
+          remoteId: 'r1',
+          providerId: 'nyaa',
+          providerInstanceId: 'nyaa',
+          providerPriority: 100,
+          releaseGroup: 'SubsPlease',
+          resolution: '1080p',
+          seeders: 30,
+        );
+}
+
+class _SeededProvider implements VideoResourceProvider {
+  _SeededProvider(this.items);
+
+  final List<VideoResourceCandidate> items;
+
+  @override
+  String get id => 'nyaa';
+
+  @override
+  Set<VideoDiscoveryCategory> get categories =>
+      const <VideoDiscoveryCategory>{};
+
+  @override
+  int get priority => 10;
+
+  @override
+  Future<ProviderBatchResult<VideoResourceCandidate>> search(
+    VideoResourceSearchRequest request,
+  ) async =>
+      ProviderBatchResult<VideoResourceCandidate>.success(items);
+
+  @override
+  Future<TorrentAddPayload> resolve(VideoResourceCandidate candidate) async =>
+      throw UnimplementedError();
+
+  @override
+  void close() {}
+}
+
+VideoDiscoveryItem _item() => VideoDiscoveryItem(
+      reference: VideoMediaReference(
+        providerId: 'anilist',
+        mediaId: '42',
+        mediaKind: VideoMetadataMediaKind.tv,
+        discoveryCategory: VideoDiscoveryCategory.anime,
+        title: 'Show',
+        anilistId: 42,
+      ),
+    );
+
+void main() {
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  /// 订阅面板 + 单条候选（单条组点卡直选，不必展开）。
+  Future<void> pumpSubscription(
+    WidgetTester tester,
+    VideoResourceCandidate candidate,
+  ) async {
+    tester.view.physicalSize = const Size(1100, 1400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: VideoDiscoverySubscriptionPage(
+            item: _item(),
+            registry: VideoResourceRegistry(<VideoResourceProvider>[
+              _SeededProvider(<VideoResourceCandidate>[candidate]),
+            ]),
+            sources: const <MediaSourceRow>[
+              MediaSourceRow(
+                videoGroupingMode: 'series',
+                id: 1,
+                label: 'videos',
+                mediaKind: 'video',
+                transport: 'local',
+                rootPath: r'D:\media',
+                mediaCount: 0,
+                recursive: true,
+                sortOrder: 0,
+                createdAt: 1,
+              ),
+            ],
+            defaultSourceId: 1,
+            onSubmit: (VideoDiscoverySubscriptionSelection selection) async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    // 订阅模式恒用平铺列表（见 `_buildFlatResults` 的文档），行 key 按候选身份。
+    await tester.tap(
+      find.byKey(ValueKey<String>('video-resource-${candidate.identityKey}')),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  String startAfterText(WidgetTester tester) => tester
+      .widget<TextField>(
+        find.byKey(const ValueKey<String>('video-subscription-start-after')),
+      )
+      .controller!
+      .text;
+
+  bool strictConfirmed(WidgetTester tester) => tester
+      .widget<AdaptiveSettingsSwitchRow>(
+        find.byKey(
+          const ValueKey<String>('video-subscription-strict-confirm'),
+        ),
+      )
+      .value;
+
+  testWidgets('选中候选后「加入订阅」默认打开，提交按钮直接可用', (
+    WidgetTester tester,
+  ) async {
+    await pumpSubscription(
+      tester,
+      _FakeResource(title: '[SubsPlease] Show - 05 (1080p)'),
+    );
+    expect(strictConfirmed(tester), isTrue, reason: '默认打开，不必手动确认一次');
+    final FilledButton submit = tester.widget<FilledButton>(
+      find.byKey(const ValueKey<String>('video-subscription-submit')),
+    );
+    expect(
+      submit.onPressed,
+      isNotNull,
+      reason: '开关默认关时按钮恒禁用，用户只能看着一个能点的开关猜',
+    );
+  });
+
+  testWidgets('集数用选中 release 解析出的集号', (WidgetTester tester) async {
+    await pumpSubscription(
+      tester,
+      _FakeResource(title: '[SubsPlease] Show - 05 (1080p)'),
+    );
+    expect(startAfterText(tester), '5', reason: '选中的 release 集号优先');
+  });
+
+  testWidgets('标题无集号时集数框仍是 1，不留空', (WidgetTester tester) async {
+    await pumpSubscription(
+      tester,
+      _FakeResource(title: '[SubsPlease] Show (1080p)'),
+    );
+    expect(
+      startAfterText(tester),
+      '1',
+      reason: 'helper 写着「从第 1 集开始」，框里就不该是空的',
+    );
+  });
+}


### PR DESCRIPTION
## 问题

视频「加入订阅」面板（`VideoResourceSearchSurface`，subscription 模式）两个默认值都不对：

1. **「加入订阅」开关默认关**。`_strictConfirmed` 初值 `false`，而提交按钮的门禁（`_canSubmit`）正是它 —— 用户进订阅页、选好 release 之后按钮仍是灰的，唯一线索是那句「将追踪 X · 1080p，有新的单集发布时自动加入下载。」的开关文案。更糟的是它在四处被按回 `false`（换候选、重新搜索、切换类型、清空手动身份），点开了再换一条又灰回去。
2. **集数框在解析不出集号时留空**，而它下方的 helper 恒写着「从第 1 集开始」—— 显示和输入对不上，用户看不出起点。

## 改动

- `_strictConfirmed` 初值改 `true`，并删掉那四处重置：值只由初值和用户决定，用户显式关掉后不再被换候选拉回来。
- 集数默认 `1`（新增 `_defaultStartEpisode` 常量，controller 初值 / 解析失败回退 / helper 三处同源）。新版 `library` 订阅的 `startAfterEpisode` 按「从该集开始」inclusive 解释（`video_download_subscription_service.dart` 的 `inclusiveStart`），所以填 1 与留空落到同一个下载窗口，只是把起点写出来了 —— 不改任何下载行为。

## 测试

新增 `fushi/test/pages/video_subscription_defaults_test.dart`（3 例）：开关默认打开且提交按钮直接可用、集号能解析时用解析值、解析不到时仍是 1。

- 定向：`flutter test` 52 例绿（新增 3 + 订阅/资源面板既有 49）
- `flutter analyze lib test`：零 issue
- 目录枚举型守卫整批 51 条：368 例绿（215 + 153 两批，与 fast-workflow.md 当前基线 368 一致）

> 顺带报一个与本 PR 无关的 develop 既有红：`fushi/integration_test/module_gating_test.dart:98` 调用的 `buildListeningDestination` 全仓没有定义，`flutter analyze` 上是一条 error（引入于 `318f9feeeb`）。本 PR 没碰它。

https://claude.ai/code/session_01GYm39abrCo6nhueqFSu4VH
