### PR TITLE
feat(collections): 删除合集可选连原始视频文件一起删

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 78693 (4629 per locale)
 ///
-/// Built on 2026-09-10 at 10:05 UTC
+/// Built on 2026-09-10 at 10:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1381,8 +1381,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get delete_choices_remember => 'Remember these choices';
   String get delete_collection => 'Delete collection';
   String get delete_collection_also_books => 'Also delete the books in it';
-  String get delete_collection_also_videos =>
-      'Also delete the videos (keeps your original video files)';
+  String get delete_collection_also_videos => 'Also delete the videos';
   String get delete_collection_confirm =>
       'Only the grouping is removed. The items in it are kept.';
   String get delete_custom_theme => 'Delete theme';
@@ -8497,8 +8496,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get delete_collection_also_books => 'حذف الكتب الموجودة فيها أيضاً';
   @override
-  String get delete_collection_also_videos =>
-      'حذف الفيديوهات أيضاً (يحتفظ بملفات الفيديو الأصلية)';
+  String get delete_collection_also_videos => 'حذف الفيديوهات أيضاً';
   @override
   String get delete_collection_confirm =>
       'سيتم إزالة التجميع فقط. العناصر الموجودة فيه ستبقى.';
@@ -19420,8 +19418,7 @@ class _StringsDe extends _StringsEn {
   String get delete_collection_also_books =>
       'Auch die enthaltenen Bücher löschen';
   @override
-  String get delete_collection_also_videos =>
-      'Auch die Videos löschen (deine originalen Videodateien bleiben erhalten)';
+  String get delete_collection_also_videos => 'Auch die Videos löschen';
   @override
   String get delete_collection_confirm =>
       'Nur die Gruppierung wird entfernt. Die enthaltenen Einträge bleiben erhalten.';
@@ -30539,8 +30536,7 @@ class _StringsEs extends _StringsEn {
   String get delete_collection_also_books =>
       'También eliminar los libros que contiene';
   @override
-  String get delete_collection_also_videos =>
-      'También eliminar los vídeos (conserva sus archivos de vídeo originales)';
+  String get delete_collection_also_videos => 'También eliminar los vídeos';
   @override
   String get delete_collection_confirm =>
       'Solo se elimina la agrupación. Los elementos que contiene se conservan.';
@@ -41717,8 +41713,7 @@ class _StringsFr extends _StringsEn {
   String get delete_collection_also_books =>
       'Supprimer aussi les livres qu\'elle contient';
   @override
-  String get delete_collection_also_videos =>
-      'Supprimer aussi les vidéos (conserve vos fichiers vidéo originaux)';
+  String get delete_collection_also_videos => 'Supprimer aussi les vidéos';
   @override
   String get delete_collection_confirm =>
       'Seul le regroupement est supprimé. Les éléments qu\'elle contient sont conservés.';
@@ -52882,8 +52877,7 @@ class _StringsId extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Hapus juga buku di dalamnya';
   @override
-  String get delete_collection_also_videos =>
-      'Hapus juga video (file video asli Anda tetap ada)';
+  String get delete_collection_also_videos => 'Hapus juga video';
   @override
   String get delete_collection_confirm =>
       'Hanya pengelompokan yang dihapus. Item di dalamnya dipertahankan.';
@@ -63898,8 +63892,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Elimina anche i libri contenuti';
   @override
-  String get delete_collection_also_videos =>
-      'Elimina anche i video (mantiene i file video originali)';
+  String get delete_collection_also_videos => 'Elimina anche i video';
   @override
   String get delete_collection_confirm =>
       'Solo il raggruppamento viene rimosso. Gli elementi vengono mantenuti.';
@@ -74897,7 +74890,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get delete_collection_also_books => '中の書籍も削除';
   @override
-  String get delete_collection_also_videos => '動画も削除（元の動画ファイルは保持されます）';
+  String get delete_collection_also_videos => '動画も削除';
   @override
   String get delete_collection_confirm => 'グループのみ削除されます。中のアイテムは保持されます。';
   @override
@@ -85367,7 +85360,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get delete_collection_also_books => '포함된 도서도 삭제';
   @override
-  String get delete_collection_also_videos => '동영상도 삭제 (원본 동영상 파일은 유지)';
+  String get delete_collection_also_videos => '동영상도 삭제';
   @override
   String get delete_collection_confirm => '그룹만 제거됩니다. 포함된 항목은 유지됩니다.';
   @override
@@ -95941,8 +95934,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Ook de boeken erin verwijderen';
   @override
-  String get delete_collection_also_videos =>
-      'Ook de video\'s verwijderen (behoudt je originele videobestanden)';
+  String get delete_collection_also_videos => 'Ook de video\'s verwijderen';
   @override
   String get delete_collection_confirm =>
       'Alleen de groepering wordt verwijderd. De items erin worden bewaard.';
@@ -107006,8 +106998,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Também excluir os livros nela';
   @override
-  String get delete_collection_also_videos =>
-      'Também excluir os vídeos (mantém seus arquivos de vídeo originais)';
+  String get delete_collection_also_videos => 'Também excluir os vídeos';
   @override
   String get delete_collection_confirm =>
       'Apenas o agrupamento é removido. Os itens nele são mantidos.';
@@ -118099,8 +118090,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Также удалить книги из неё';
   @override
-  String get delete_collection_also_videos =>
-      'Также удалить видео (исходные видеофайлы сохранятся)';
+  String get delete_collection_also_videos => 'Также удалить видео';
   @override
   String get delete_collection_confirm =>
       'Удаляется только группировка. Элементы в ней сохраняются.';
@@ -129149,8 +129139,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get delete_collection_also_books => 'ลบหนังสือในนั้นด้วย';
   @override
-  String get delete_collection_also_videos =>
-      'ลบวิดีโอด้วย (เก็บไฟล์วิดีโอต้นฉบับไว้)';
+  String get delete_collection_also_videos => 'ลบวิดีโอด้วย';
   @override
   String get delete_collection_confirm =>
       'เฉพาะการจัดกลุ่มเท่านั้นที่จะถูกลบ รายการภายในจะยังคงอยู่';
@@ -140059,8 +140048,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get delete_collection_also_books => 'İçindeki kitapları da sil';
   @override
-  String get delete_collection_also_videos =>
-      'Videoları da sil (orijinal video dosyalarınız korunur)';
+  String get delete_collection_also_videos => 'Videoları da sil';
   @override
   String get delete_collection_confirm =>
       'Yalnızca gruplama kaldırılır. İçindeki öğeler korunur.';
@@ -151055,8 +151043,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get delete_collection_also_books => 'Đồng thời xóa sách trong đó';
   @override
-  String get delete_collection_also_videos =>
-      'Đồng thời xóa video (giữ lại tệp video gốc)';
+  String get delete_collection_also_videos => 'Đồng thời xóa video';
   @override
   String get delete_collection_confirm =>
       'Chỉ xóa nhóm. Các mục trong đó vẫn được giữ lại.';
@@ -161863,7 +161850,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get delete_collection_also_books => '同时删除其中的书';
   @override
-  String get delete_collection_also_videos => '同时删除其中的视频（保留你的原始视频文件）';
+  String get delete_collection_also_videos => '同时删除其中的视频';
   @override
   String get delete_collection_confirm => '只解除分组，其中的条目会保留。';
   @override
@@ -171949,7 +171936,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get delete_collection_also_books => '同時刪除其中的書';
   @override
-  String get delete_collection_also_videos => '同時刪除其中的影片（保留你的原始影片檔案）';
+  String get delete_collection_also_videos => '同時刪除其中的影片';
   @override
   String get delete_collection_confirm => '只解除分組，其中的條目會保留。';
   @override
@@ -181952,7 +181939,7 @@ extension on _StringsEn {
       case 'delete_collection_also_books':
         return 'Also delete the books in it';
       case 'delete_collection_also_videos':
-        return 'Also delete the videos (keeps your original video files)';
+        return 'Also delete the videos';
       case 'delete_collection_confirm':
         return 'Only the grouping is removed. The items in it are kept.';
       case 'delete_custom_theme':
@@ -191480,7 +191467,7 @@ extension on _StringsAr {
       case 'delete_collection_also_books':
         return 'حذف الكتب الموجودة فيها أيضاً';
       case 'delete_collection_also_videos':
-        return 'حذف الفيديوهات أيضاً (يحتفظ بملفات الفيديو الأصلية)';
+        return 'حذف الفيديوهات أيضاً';
       case 'delete_collection_confirm':
         return 'سيتم إزالة التجميع فقط. العناصر الموجودة فيه ستبقى.';
       case 'delete_custom_theme':
@@ -201015,7 +201002,7 @@ extension on _StringsDe {
       case 'delete_collection_also_books':
         return 'Auch die enthaltenen Bücher löschen';
       case 'delete_collection_also_videos':
-        return 'Auch die Videos löschen (deine originalen Videodateien bleiben erhalten)';
+        return 'Auch die Videos löschen';
       case 'delete_collection_confirm':
         return 'Nur die Gruppierung wird entfernt. Die enthaltenen Einträge bleiben erhalten.';
       case 'delete_custom_theme':
@@ -210579,7 +210566,7 @@ extension on _StringsEs {
       case 'delete_collection_also_books':
         return 'También eliminar los libros que contiene';
       case 'delete_collection_also_videos':
-        return 'También eliminar los vídeos (conserva sus archivos de vídeo originales)';
+        return 'También eliminar los vídeos';
       case 'delete_collection_confirm':
         return 'Solo se elimina la agrupación. Los elementos que contiene se conservan.';
       case 'delete_custom_theme':
@@ -220140,7 +220127,7 @@ extension on _StringsFr {
       case 'delete_collection_also_books':
         return 'Supprimer aussi les livres qu\'elle contient';
       case 'delete_collection_also_videos':
-        return 'Supprimer aussi les vidéos (conserve vos fichiers vidéo originaux)';
+        return 'Supprimer aussi les vidéos';
       case 'delete_collection_confirm':
         return 'Seul le regroupement est supprimé. Les éléments qu\'elle contient sont conservés.';
       case 'delete_custom_theme':
@@ -229704,7 +229691,7 @@ extension on _StringsId {
       case 'delete_collection_also_books':
         return 'Hapus juga buku di dalamnya';
       case 'delete_collection_also_videos':
-        return 'Hapus juga video (file video asli Anda tetap ada)';
+        return 'Hapus juga video';
       case 'delete_collection_confirm':
         return 'Hanya pengelompokan yang dihapus. Item di dalamnya dipertahankan.';
       case 'delete_custom_theme':
@@ -239244,7 +239231,7 @@ extension on _StringsIt {
       case 'delete_collection_also_books':
         return 'Elimina anche i libri contenuti';
       case 'delete_collection_also_videos':
-        return 'Elimina anche i video (mantiene i file video originali)';
+        return 'Elimina anche i video';
       case 'delete_collection_confirm':
         return 'Solo il raggruppamento viene rimosso. Gli elementi vengono mantenuti.';
       case 'delete_custom_theme':
@@ -248789,7 +248776,7 @@ extension on _StringsJa {
       case 'delete_collection_also_books':
         return '中の書籍も削除';
       case 'delete_collection_also_videos':
-        return '動画も削除（元の動画ファイルは保持されます）';
+        return '動画も削除';
       case 'delete_collection_confirm':
         return 'グループのみ削除されます。中のアイテムは保持されます。';
       case 'delete_custom_theme':
@@ -258277,7 +258264,7 @@ extension on _StringsKo {
       case 'delete_collection_also_books':
         return '포함된 도서도 삭제';
       case 'delete_collection_also_videos':
-        return '동영상도 삭제 (원본 동영상 파일은 유지)';
+        return '동영상도 삭제';
       case 'delete_collection_confirm':
         return '그룹만 제거됩니다. 포함된 항목은 유지됩니다.';
       case 'delete_custom_theme':
@@ -267785,7 +267772,7 @@ extension on _StringsNl {
       case 'delete_collection_also_books':
         return 'Ook de boeken erin verwijderen';
       case 'delete_collection_also_videos':
-        return 'Ook de video\'s verwijderen (behoudt je originele videobestanden)';
+        return 'Ook de video\'s verwijderen';
       case 'delete_collection_confirm':
         return 'Alleen de groepering wordt verwijderd. De items erin worden bewaard.';
       case 'delete_custom_theme':
@@ -277340,7 +277327,7 @@ extension on _StringsPtBr {
       case 'delete_collection_also_books':
         return 'Também excluir os livros nela';
       case 'delete_collection_also_videos':
-        return 'Também excluir os vídeos (mantém seus arquivos de vídeo originais)';
+        return 'Também excluir os vídeos';
       case 'delete_collection_confirm':
         return 'Apenas o agrupamento é removido. Os itens nele são mantidos.';
       case 'delete_custom_theme':
@@ -286893,7 +286880,7 @@ extension on _StringsRu {
       case 'delete_collection_also_books':
         return 'Также удалить книги из неё';
       case 'delete_collection_also_videos':
-        return 'Также удалить видео (исходные видеофайлы сохранятся)';
+        return 'Также удалить видео';
       case 'delete_collection_confirm':
         return 'Удаляется только группировка. Элементы в ней сохраняются.';
       case 'delete_custom_theme':
@@ -296437,7 +296424,7 @@ extension on _StringsTh {
       case 'delete_collection_also_books':
         return 'ลบหนังสือในนั้นด้วย';
       case 'delete_collection_also_videos':
-        return 'ลบวิดีโอด้วย (เก็บไฟล์วิดีโอต้นฉบับไว้)';
+        return 'ลบวิดีโอด้วย';
       case 'delete_collection_confirm':
         return 'เฉพาะการจัดกลุ่มเท่านั้นที่จะถูกลบ รายการภายในจะยังคงอยู่';
       case 'delete_custom_theme':
@@ -305974,7 +305961,7 @@ extension on _StringsTr {
       case 'delete_collection_also_books':
         return 'İçindeki kitapları da sil';
       case 'delete_collection_also_videos':
-        return 'Videoları da sil (orijinal video dosyalarınız korunur)';
+        return 'Videoları da sil';
       case 'delete_collection_confirm':
         return 'Yalnızca gruplama kaldırılır. İçindeki öğeler korunur.';
       case 'delete_custom_theme':
@@ -315511,7 +315498,7 @@ extension on _StringsVi {
       case 'delete_collection_also_books':
         return 'Đồng thời xóa sách trong đó';
       case 'delete_collection_also_videos':
-        return 'Đồng thời xóa video (giữ lại tệp video gốc)';
+        return 'Đồng thời xóa video';
       case 'delete_collection_confirm':
         return 'Chỉ xóa nhóm. Các mục trong đó vẫn được giữ lại.';
       case 'delete_custom_theme':
@@ -325025,7 +325012,7 @@ extension on _StringsZhCn {
       case 'delete_collection_also_books':
         return '同时删除其中的书';
       case 'delete_collection_also_videos':
-        return '同时删除其中的视频（保留你的原始视频文件）';
+        return '同时删除其中的视频';
       case 'delete_collection_confirm':
         return '只解除分组，其中的条目会保留。';
       case 'delete_custom_theme':
@@ -334483,7 +334470,7 @@ extension on _StringsZhHk {
       case 'delete_collection_also_books':
         return '同時刪除其中的書';
       case 'delete_collection_also_videos':
-        return '同時刪除其中的影片（保留你的原始影片檔案）';
+        return '同時刪除其中的影片';
       case 'delete_collection_confirm':
         return '只解除分組，其中的條目會保留。';
       case 'delete_custom_theme':

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Remember these choices",
   "delete_collection": "Delete collection",
   "delete_collection_also_books": "Also delete the books in it",
-  "delete_collection_also_videos": "Also delete the videos (keeps your original video files)",
+  "delete_collection_also_videos": "Also delete the videos",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
   "delete_custom_theme": "Delete theme",
   "delete_custom_theme_confirm": "Delete this custom theme? This cannot be undone.",

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "تذكّر هذه الخيارات",
   "delete_collection": "حذف المجموعة",
   "delete_collection_also_books": "حذف الكتب الموجودة فيها أيضاً",
-  "delete_collection_also_videos": "حذف الفيديوهات أيضاً (يحتفظ بملفات الفيديو الأصلية)",
+  "delete_collection_also_videos": "حذف الفيديوهات أيضاً",
   "delete_collection_confirm": "سيتم إزالة التجميع فقط. العناصر الموجودة فيه ستبقى.",
   "delete_custom_theme": "حذف السمة",
   "delete_custom_theme_confirm": "حذف هذه السمة المخصصة؟ لا يمكن التراجع عن هذا.",

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Diese Auswahl merken",
   "delete_collection": "Sammlung löschen",
   "delete_collection_also_books": "Auch die enthaltenen Bücher löschen",
-  "delete_collection_also_videos": "Auch die Videos löschen (deine originalen Videodateien bleiben erhalten)",
+  "delete_collection_also_videos": "Auch die Videos löschen",
   "delete_collection_confirm": "Nur die Gruppierung wird entfernt. Die enthaltenen Einträge bleiben erhalten.",
   "delete_custom_theme": "Theme löschen",
   "delete_custom_theme_confirm": "Dieses benutzerdefinierte Theme löschen? Dies kann nicht rückgängig gemacht werden.",

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Recordar estas opciones",
   "delete_collection": "Eliminar colección",
   "delete_collection_also_books": "También eliminar los libros que contiene",
-  "delete_collection_also_videos": "También eliminar los vídeos (conserva sus archivos de vídeo originales)",
+  "delete_collection_also_videos": "También eliminar los vídeos",
   "delete_collection_confirm": "Solo se elimina la agrupación. Los elementos que contiene se conservan.",
   "delete_custom_theme": "Eliminar tema",
   "delete_custom_theme_confirm": "¿Eliminar este tema personalizado? Esto no se puede deshacer.",

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Mémoriser ces choix",
   "delete_collection": "Supprimer la collection",
   "delete_collection_also_books": "Supprimer aussi les livres qu'elle contient",
-  "delete_collection_also_videos": "Supprimer aussi les vidéos (conserve vos fichiers vidéo originaux)",
+  "delete_collection_also_videos": "Supprimer aussi les vidéos",
   "delete_collection_confirm": "Seul le regroupement est supprimé. Les éléments qu'elle contient sont conservés.",
   "delete_custom_theme": "Supprimer le thème",
   "delete_custom_theme_confirm": "Supprimer ce thème personnalisé ? Cette action est irréversible.",

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Ingat pilihan ini",
   "delete_collection": "Hapus koleksi",
   "delete_collection_also_books": "Hapus juga buku di dalamnya",
-  "delete_collection_also_videos": "Hapus juga video (file video asli Anda tetap ada)",
+  "delete_collection_also_videos": "Hapus juga video",
   "delete_collection_confirm": "Hanya pengelompokan yang dihapus. Item di dalamnya dipertahankan.",
   "delete_custom_theme": "Hapus tema",
   "delete_custom_theme_confirm": "Hapus tema kustom ini? Ini tidak bisa dibatalkan.",

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Ricorda queste scelte",
   "delete_collection": "Elimina raccolta",
   "delete_collection_also_books": "Elimina anche i libri contenuti",
-  "delete_collection_also_videos": "Elimina anche i video (mantiene i file video originali)",
+  "delete_collection_also_videos": "Elimina anche i video",
   "delete_collection_confirm": "Solo il raggruppamento viene rimosso. Gli elementi vengono mantenuti.",
   "delete_custom_theme": "Elimina tema",
   "delete_custom_theme_confirm": "Eliminare questo tema personalizzato? Non può essere annullato.",

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "この選択を記憶する",
   "delete_collection": "コレクションを削除",
   "delete_collection_also_books": "中の書籍も削除",
-  "delete_collection_also_videos": "動画も削除（元の動画ファイルは保持されます）",
+  "delete_collection_also_videos": "動画も削除",
   "delete_collection_confirm": "グループのみ削除されます。中のアイテムは保持されます。",
   "delete_custom_theme": "テーマを削除",
   "delete_custom_theme_confirm": "このカスタムテーマを削除しますか？元に戻せません。",

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "이 선택 기억하기",
   "delete_collection": "컬렉션 삭제",
   "delete_collection_also_books": "포함된 도서도 삭제",
-  "delete_collection_also_videos": "동영상도 삭제 (원본 동영상 파일은 유지)",
+  "delete_collection_also_videos": "동영상도 삭제",
   "delete_collection_confirm": "그룹만 제거됩니다. 포함된 항목은 유지됩니다.",
   "delete_custom_theme": "테마 삭제",
   "delete_custom_theme_confirm": "이 사용자 정의 테마를 삭제하시겠습니까? 되돌릴 수 없습니다.",

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Deze keuzes onthouden",
   "delete_collection": "Collectie verwijderen",
   "delete_collection_also_books": "Ook de boeken erin verwijderen",
-  "delete_collection_also_videos": "Ook de video's verwijderen (behoudt je originele videobestanden)",
+  "delete_collection_also_videos": "Ook de video's verwijderen",
   "delete_collection_confirm": "Alleen de groepering wordt verwijderd. De items erin worden bewaard.",
   "delete_custom_theme": "Thema verwijderen",
   "delete_custom_theme_confirm": "Dit aangepaste thema verwijderen? Dit kan niet ongedaan worden gemaakt.",

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Lembrar estas escolhas",
   "delete_collection": "Excluir coleção",
   "delete_collection_also_books": "Também excluir os livros nela",
-  "delete_collection_also_videos": "Também excluir os vídeos (mantém seus arquivos de vídeo originais)",
+  "delete_collection_also_videos": "Também excluir os vídeos",
   "delete_collection_confirm": "Apenas o agrupamento é removido. Os itens nele são mantidos.",
   "delete_custom_theme": "Excluir tema",
   "delete_custom_theme_confirm": "Excluir este tema personalizado? Isso não pode ser desfeito.",

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Запомнить этот выбор",
   "delete_collection": "Удалить коллекцию",
   "delete_collection_also_books": "Также удалить книги из неё",
-  "delete_collection_also_videos": "Также удалить видео (исходные видеофайлы сохранятся)",
+  "delete_collection_also_videos": "Также удалить видео",
   "delete_collection_confirm": "Удаляется только группировка. Элементы в ней сохраняются.",
   "delete_custom_theme": "Удалить тему",
   "delete_custom_theme_confirm": "Удалить эту пользовательскую тему? Это действие нельзя отменить.",

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "จดจำตัวเลือกเหล่านี้",
   "delete_collection": "ลบคอลเลกชัน",
   "delete_collection_also_books": "ลบหนังสือในนั้นด้วย",
-  "delete_collection_also_videos": "ลบวิดีโอด้วย (เก็บไฟล์วิดีโอต้นฉบับไว้)",
+  "delete_collection_also_videos": "ลบวิดีโอด้วย",
   "delete_collection_confirm": "เฉพาะการจัดกลุ่มเท่านั้นที่จะถูกลบ รายการภายในจะยังคงอยู่",
   "delete_custom_theme": "ลบธีม",
   "delete_custom_theme_confirm": "ลบธีมที่กำหนดเองนี้? ไม่สามารถยกเลิกได้",

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Bu seçimleri hatırla",
   "delete_collection": "Koleksiyonu sil",
   "delete_collection_also_books": "İçindeki kitapları da sil",
-  "delete_collection_also_videos": "Videoları da sil (orijinal video dosyalarınız korunur)",
+  "delete_collection_also_videos": "Videoları da sil",
   "delete_collection_confirm": "Yalnızca gruplama kaldırılır. İçindeki öğeler korunur.",
   "delete_custom_theme": "Temayı sil",
   "delete_custom_theme_confirm": "Bu özel tema silinsin mi? Bu işlem geri alınamaz.",

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "Ghi nhớ các lựa chọn này",
   "delete_collection": "Xóa bộ sưu tập",
   "delete_collection_also_books": "Đồng thời xóa sách trong đó",
-  "delete_collection_also_videos": "Đồng thời xóa video (giữ lại tệp video gốc)",
+  "delete_collection_also_videos": "Đồng thời xóa video",
   "delete_collection_confirm": "Chỉ xóa nhóm. Các mục trong đó vẫn được giữ lại.",
   "delete_custom_theme": "Xóa giao diện",
   "delete_custom_theme_confirm": "Xóa giao diện tùy chỉnh này? Thao tác này không thể hoàn tác.",

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "记住这些选择",
   "delete_collection": "删除合集",
   "delete_collection_also_books": "同时删除其中的书",
-  "delete_collection_also_videos": "同时删除其中的视频（保留你的原始视频文件）",
+  "delete_collection_also_videos": "同时删除其中的视频",
   "delete_collection_confirm": "只解除分组，其中的条目会保留。",
   "delete_custom_theme": "删除主题",
   "delete_custom_theme_confirm": "删除这个自定义主题？此操作不可撤销。",

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -843,7 +843,7 @@
   "delete_choices_remember": "記住這些選擇",
   "delete_collection": "刪除合集",
   "delete_collection_also_books": "同時刪除其中的書",
-  "delete_collection_also_videos": "同時刪除其中的影片（保留你的原始影片檔案）",
+  "delete_collection_also_videos": "同時刪除其中的影片",
   "delete_collection_confirm": "只解除分組，其中的條目會保留。",
   "delete_custom_theme": "刪除主題",
   "delete_custom_theme_confirm": "刪除這個自定義主題？此操作不可撤銷。",

--- a/fushi/lib/src/media/collections/collection_context_dialog.dart
+++ b/fushi/lib/src/media/collections/collection_context_dialog.dart
@@ -27,6 +27,10 @@ import 'package:fushi_core/fushi_core.dart';
 /// [onDeleteMembersMedia] 非 null 且合集有成员时，删除确认框提供
 /// [deleteMembersCheckboxLabel] 勾选行（调用方按媒体域传
 /// `delete_collection_also_books` / `delete_collection_also_videos` 等文案）。
+/// [deleteMembersLocalFilesSubtitle] 非 null 时，勾了上面那行还会再出现二级
+/// 「同时删除本地文件」勾选行，其状态经 `deleteLocalFiles` 参数交给
+/// [onDeleteMembersMedia]——库里的条目删不删、磁盘上的原件删不删是两个决定，
+/// 调用方按媒体域决定是否提供后者（视频合集提供；书 / 游戏合集传 null）。
 /// [extraListActions] 由调用方注入媒体特有行（视频页：在线匹配封面 / 为合集
 /// 获取字幕），本对话框统一负责「先关自身再执行」，回调里不要再 pop。
 /// 排序两项内建（[applyCollectionOneKeySort]，与详情页 AppBar 排序菜单同源），
@@ -37,9 +41,12 @@ Future<void> showCollectionContextDialog({
   required MediaCollectionRow collection,
   required VoidCallback onOpenDetail,
   required VoidCallback onChanged,
-  Future<void> Function(List<MediaCollectionItemRow> members)?
-      onDeleteMembersMedia,
+  Future<void> Function(
+    List<MediaCollectionItemRow> members,
+    bool deleteLocalFiles,
+  )? onDeleteMembersMedia,
   String? deleteMembersCheckboxLabel,
+  String? deleteMembersLocalFilesSubtitle,
   DeletionDisclosure? deleteMembersDisclosure,
   List<DialogListAction> extraListActions = const <DialogListAction>[],
   Widget? cover,
@@ -127,6 +134,8 @@ Future<void> showCollectionContextDialog({
                 onChanged: onChanged,
                 onDeleteMembersMedia: onDeleteMembersMedia,
                 deleteMembersCheckboxLabel: deleteMembersCheckboxLabel,
+                deleteMembersLocalFilesSubtitle:
+                    deleteMembersLocalFilesSubtitle,
                 deleteMembersDisclosure: deleteMembersDisclosure,
               ),
             ),
@@ -187,8 +196,9 @@ Future<void> _sortCollection({
   onChanged();
 }
 
-/// 删除合集：确认（可选「连同成员本体一起删」勾选）→ 先删成员本体（调用方注入，
-/// 按媒体域删 DB 行 + 磁盘副本）→ [deleteMediaCollectionWithAssets] 解散容器
+/// 删除合集：确认（可选「连同成员本体一起删」勾选，及其下的「同时删除本地文件」
+/// 二级勾选）→ 先删成员本体（调用方注入，按媒体域删 DB 行 + 磁盘副本，勾了二级
+/// 就连原始文件一起删）→ [deleteMediaCollectionWithAssets] 解散容器
 /// （清引用行 + 写合集级墓碑 + 回收合集自有封面）。与两个合集详情页的 `_delete`
 /// 同一顺序、同一入口（BUG-1319：回收必须挂在删除动作上，不能各入口各写一遍）。
 Future<void> _deleteCollection({
@@ -196,9 +206,12 @@ Future<void> _deleteCollection({
   required FushiDatabase db,
   required MediaCollectionRow collection,
   required VoidCallback onChanged,
-  required Future<void> Function(List<MediaCollectionItemRow> members)?
-      onDeleteMembersMedia,
+  required Future<void> Function(
+    List<MediaCollectionItemRow> members,
+    bool deleteLocalFiles,
+  )? onDeleteMembersMedia,
   required String? deleteMembersCheckboxLabel,
+  required String? deleteMembersLocalFilesSubtitle,
   required DeletionDisclosure? deleteMembersDisclosure,
 }) async {
   final List<MediaCollectionItemRow> members =
@@ -214,12 +227,17 @@ Future<void> _deleteCollection({
       message: t.delete_collection_confirm,
       confirmLabel: t.delete_collection,
       checkboxLabel: canDeleteMembers ? deleteMembersCheckboxLabel : null,
+      localFilesSubtitle:
+          canDeleteMembers ? deleteMembersLocalFilesSubtitle : null,
       checkedDisclosure: canDeleteMembers ? deleteMembersDisclosure : null,
     ),
   );
   if (result == null || !context.mounted) return;
   if (result.checked && onDeleteMembersMedia != null) {
-    await onDeleteMembersMedia(List<MediaCollectionItemRow>.of(members));
+    await onDeleteMembersMedia(
+      List<MediaCollectionItemRow>.of(members),
+      result.deleteLocalFiles,
+    );
   }
   await deleteMediaCollectionWithAssets(db, collection.id);
   onChanged();

--- a/fushi/lib/src/pages/implementations/collection_detail_shared.dart
+++ b/fushi/lib/src/pages/implementations/collection_detail_shared.dart
@@ -140,6 +140,7 @@ mixin CollectionDetailShared<T extends StatefulWidget> on State<T> {
   /// 返回 null = 取消。
   Future<FushiDestructiveConfirmResult?> confirmDetailCollectionDelete({
     String? checkboxLabel,
+    String? localFilesSubtitle,
     DeletionDisclosure? checkedDisclosure,
   }) {
     return showAppDialog<FushiDestructiveConfirmResult>(
@@ -149,6 +150,7 @@ mixin CollectionDetailShared<T extends StatefulWidget> on State<T> {
         message: t.delete_collection_confirm,
         confirmLabel: t.delete_collection,
         checkboxLabel: checkboxLabel,
+        localFilesSubtitle: localFilesSubtitle,
         checkedDisclosure: checkedDisclosure,
       ),
     );

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -6322,9 +6322,22 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 合集封面卡长按/右键菜单（统一三库页合集菜单）：打开/重命名/标签/删除，动作
   /// 语义与合集详情页 AppBar 同源；删除支持「连同视频一起删」勾选（与详情页
   /// `onDeleteMembersMedia` 同一删除纪律）。
-  Future<void> _showCollectionContextMenu(MediaCollectionRow collection) {
+  Future<void> _showCollectionContextMenu(MediaCollectionRow collection) async {
     final VideoBookRepository repo = widget.repo;
-    final FushiDatabase db = ref.read(appProvider).database;
+    final AppModel appModel = ref.read(appProvider);
+    final FushiDatabase db = appModel.database;
+    // 「同时删除本地文件」二级勾选只在这个合集真有本机原件时才摆出来（成员全是
+    // 远端流就没有文件可删，与单删 / 批删同一条「兑现不了就不显示」纪律）。判据
+    // [videoBookHasLocalFiles] 要的是视频行本身，成员引用行只有 uid，故先取一遍库。
+    final Set<String> memberUids = <String>{
+      for (final MediaCollectionItemRow m
+          in await db.getCollectionItems(collection.id))
+        if (MediaKind.tryParse(m.mediaType) == MediaKind.video) m.entryKey,
+    };
+    final bool anyLocalFile = memberUids.isNotEmpty &&
+        (await repo.listAll()).any((VideoBookRow b) =>
+            memberUids.contains(b.bookUid) && videoBookHasLocalFiles(b));
+    if (!mounted) return;
     return showCollectionContextDialog(
       context: context,
       db: db,
@@ -6335,22 +6348,39 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ref.invalidate(filteredCollectionIdsProvider);
         _refresh();
       },
-      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async {
-        bool anyVideo = false;
-        for (final MediaCollectionItemRow m in members) {
-          // 视频合集理论上只含 video 成员；混入的未知/跨域成员跳过不误删。
-          if (MediaKind.tryParse(m.mediaType) != MediaKind.video) continue;
-          await repo.deleteVideoBookAndReclaimAssets(
-            m.entryKey,
-            compactDatabase: false,
-          );
-          anyVideo = true;
-        }
-        if (anyVideo) {
-          await repo.compactAfterVideoDeleteBestEffort();
-        }
+      onDeleteMembersMedia: (
+        List<MediaCollectionItemRow> members,
+        bool deleteLocalFiles,
+      ) async {
+        final List<String> uids = <String>[
+          for (final MediaCollectionItemRow m in members)
+            // 视频合集理论上只含 video 成员；混入的未知/跨域成员跳过不误删。
+            if (MediaKind.tryParse(m.mediaType) == MediaKind.video) m.entryKey,
+        ];
+        if (uids.isEmpty) return;
+        // 必须走 [deleteVideoBooksWithDecision] 而不是裸仓库调用：勾了「删本地
+        // 文件」时，删盘前要先让播放器放句柄（Windows 上不放就是 errno 32，
+        // 用户看到「删除成功」而盘上一个文件没少）、把还在做种的文件在下载后端
+        // 标 skip，删完再对账下载任务。这条纪律只存在于那一层。
+        final VideoLibraryDeleteResult result =
+            await deleteVideoBooksWithDecision(
+          repo: repo,
+          database: db,
+          pipeline: appModel.videoDownloadPipelineService,
+          bookUids: uids,
+          decision: DeleteDecision(
+            scope: DeleteScope.keepLocalOnly,
+            deleteLocalFiles: deleteLocalFiles,
+          ),
+        );
+        reportLocalFileDeleteFailures(
+          result.localFiles,
+          source: 'HomeVideoPage.deleteCollectionMembers',
+        );
       },
       deleteMembersCheckboxLabel: t.delete_collection_also_videos,
+      deleteMembersLocalFilesSubtitle:
+          anyLocalFile ? t.delete_local_files_video_desc : null,
       // 视频合集特有项：封面 / 重刮 / 批量字幕。
       //
       // 封面两项只给视频合集：书架与游戏库的合集入口是横排行头，根本没有封面槽，
@@ -6571,17 +6601,29 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           workRef: VideoWorkRef.collection(collection.id),
           onChanged: _refresh,
           remote: remote,
-          onDeleteMembersMedia: (List<VideoBookRow> members) async {
-            for (final VideoBookRow member in members) {
-              await repo.deleteVideoBookAndReclaimAssets(
-                member.bookUid,
-                compactDatabase: false,
-              );
-            }
-            if (members.isNotEmpty) {
-              await repo.compactAfterVideoDeleteBestEffort();
-            }
+          onDeleteMembersMedia: (
+            List<VideoBookRow> members,
+            bool deleteLocalFiles,
+          ) async {
+            if (members.isEmpty) return;
+            // 与库页右键同一条删除纪律（先放句柄 / 标 skip，再删盘，删完对账）。
+            final VideoLibraryDeleteResult result =
+                await deleteVideoBooksWithDecision(
+              repo: repo,
+              database: db,
+              pipeline: ref.read(appProvider).videoDownloadPipelineService,
+              bookUids: members.map((VideoBookRow m) => m.bookUid),
+              decision: DeleteDecision(
+                scope: DeleteScope.keepLocalOnly,
+                deleteLocalFiles: deleteLocalFiles,
+              ),
+            );
+            reportLocalFileDeleteFailures(
+              result.localFiles,
+              source: 'VideoWorkDetailPage.deleteCollectionMembers',
+            );
           },
+          deleteMembersLocalFilesSubtitle: t.delete_local_files_video_desc,
           // 详情页的「重新刮削资料与封面」：controller 归 HomePage，注入库页同一
           // 条实现，合集语境下的重刮不再是断头路（BUG-1662 入口的 canonical 复位）。
           onRescrapeCollection:

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -31,6 +31,8 @@ import 'package:fushi/src/media/video/metadata/video_metadata_lock_dialog.dart';
 import 'package:fushi/src/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi/src/media/video/metadata/video_source_metadata_indexer.dart';
 import 'package:fushi/src/media/video/stream_video_launch.dart';
+import 'package:fushi/src/media/video/video_local_files.dart'
+    show videoBookHasLocalFiles;
 import 'package:fushi/src/media/video/scraper/episode_rename.dart';
 import 'package:fushi/src/media/video/scraper/scraper_types.dart';
 import 'package:fushi/src/media/video/video_book_repository.dart';
@@ -70,6 +72,7 @@ class MediaCollectionDetailPage extends StatefulWidget {
     this.remote,
     required this.onChanged,
     this.onDeleteMembersMedia,
+    this.deleteMembersLocalFilesSubtitle,
     this.onRescrapeCollection,
     super.key,
   });
@@ -103,7 +106,15 @@ class MediaCollectionDetailPage extends StatefulWidget {
   /// 调用方（持 [VideoBookRepository]）注入：按 [VideoBookRow] 删视频 DB 行 +
   /// app 拥有副本（封面/字幕），**保留用户原始视频文件**（导入时只存路径从不复制）。
   /// null = 详情页不提供该选项（确认框不显示复选框），退回纯解链删除。
-  final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
+  final Future<void> Function(
+    List<VideoBookRow> members,
+    bool deleteLocalFiles,
+  )? onDeleteMembersMedia;
+
+  /// 非 null 时，「同时删除其中的视频」勾选下再给一行「同时删除本地文件」二级
+  /// 勾选，其状态经 [onDeleteMembersMedia] 的 `deleteLocalFiles` 参数落地。
+  /// null = 该合集没有可删的本机原件（如全是远端流），不摆这一行。
+  final String? deleteMembersLocalFilesSubtitle;
 
   /// 「重新刮削资料与封面」：由库页注入（刮削 controller 的生命周期归 HomePage，
   /// 详情页不自己造）。null = 当前装配拿不到 controller，菜单项整条不渲染。
@@ -1162,6 +1173,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     final FushiDestructiveConfirmResult? result =
         await confirmDetailCollectionDelete(
       checkboxLabel: canDeleteMembers ? t.delete_collection_also_videos : null,
+      // 成员全是远端流时不摆「同时删除本地文件」——盘上没有文件可删，摆了就是
+      // 一个兑现不了的开关（与单删 / 批删同一纪律）。
+      localFilesSubtitle:
+          canDeleteMembers && _members.any(videoBookHasLocalFiles)
+              ? widget.deleteMembersLocalFilesSubtitle
+              : null,
     );
     if (result == null || !mounted) return;
     // 先删各集视频本体（DB 行 + 封面/字幕副本），再解散容器。删视频会连带清各合集
@@ -1169,7 +1186,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     // [deleteMediaCollectionWithAssets]：裸 deleteMediaCollection 只删 DB 行，合集
     // 自有封面会永久留在磁盘上（BUG-1319）。
     if (result.checked && widget.onDeleteMembersMedia != null) {
-      await widget.onDeleteMembersMedia!(List<VideoBookRow>.of(_members));
+      await widget.onDeleteMembersMedia!(
+        List<VideoBookRow>.of(_members),
+        result.deleteLocalFiles,
+      );
     }
     await deleteMediaCollectionWithAssets(
         widget.database, widget.collection.id);

--- a/fushi/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -60,8 +60,14 @@ class MediaCollectionGridDetailPage extends StatefulWidget {
   /// （持 AppModel + [ReaderFushiSource] / [VideoBookRepository]）注入：按每个成员
   /// (mediaType, entryKey) 删底层书/有声书/视频本体 + 磁盘副本，并释放空间。
   /// null = 详情页不提供该选项（确认框不显示复选框），退回纯解链删除。
-  final Future<void> Function(List<MediaCollectionItemRow> members)?
-      onDeleteMembersMedia;
+  ///
+  /// 第二个参数 `deleteLocalFiles` 与视频侧共用同一回调形状；书架合集不提供
+  /// 「同时删除本地文件」二级勾选（书的原件删除由 [ReaderFushiSource.deleteBook]
+  /// 自己的纪律决定），故这里恒传 false。
+  final Future<void> Function(
+    List<MediaCollectionItemRow> members,
+    bool deleteLocalFiles,
+  )? onDeleteMembersMedia;
 
   @override
   State<MediaCollectionGridDetailPage> createState() =>
@@ -159,8 +165,10 @@ class _MediaCollectionGridDetailPageState
     // 行，故随后的解散负责清掉残留引用 + 写合集级墓碑 + 回收合集自有封面
     // （[deleteMediaCollectionWithAssets]，BUG-1319）。
     if (result.checked && widget.onDeleteMembersMedia != null) {
-      await widget
-          .onDeleteMembersMedia!(List<MediaCollectionItemRow>.of(_rows));
+      await widget.onDeleteMembersMedia!(
+        List<MediaCollectionItemRow>.of(_rows),
+        false,
+      );
     }
     await deleteMediaCollectionWithAssets(
         widget.database, widget.collection.id);

--- a/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_history_page.dart
@@ -1907,8 +1907,12 @@ class _ReaderFushiHistoryPageState<T extends HistoryReaderPage>
   /// 「删除合集」时连同成员本体一起删：按 (mediaType, entryKey) 分派到删书/删视频。
   /// 复用批量删除同一分派纪律（[_batchDeleteConfirm]）——epub 直接删；srt 先 findByUid
   /// 拿 bookKey 删本体再删 srt 行；video 逐个删并末尾一次 compact。删书本身各自 VACUUM。
+  /// [deleteLocalFiles] 与视频侧共用同一回调形状。书架合集不提供「同时删除本地
+  /// 文件」二级勾选（书的原件删除自有纪律，走 [ReaderFushiSource.deleteBook]），
+  /// 故这里恒收到 false；混入的视频成员照旧只删 DB 行 + app 副本、保留原始文件。
   Future<void> _deleteCollectionMembersMedia(
     List<MediaCollectionItemRow> members,
+    bool deleteLocalFiles,
   ) async {
     bool anyVideo = false;
     for (final MediaCollectionItemRow m in members) {

--- a/fushi/lib/src/pages/implementations/video_work_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/video_work_detail_page.dart
@@ -38,6 +38,7 @@ class VideoWorkDetailPage extends StatefulWidget {
     required this.onChanged,
     this.remote,
     this.onDeleteMembersMedia,
+    this.deleteMembersLocalFilesSubtitle,
     this.onRescrapeCollection,
     super.key,
   });
@@ -55,7 +56,14 @@ class VideoWorkDetailPage extends StatefulWidget {
   /// 视图（调用方没有互联 client），与远端支持引入前逐字节相同。
   final CollectionRemoteContext? remote;
 
-  final Future<void> Function(List<VideoBookRow> members)? onDeleteMembersMedia;
+  final Future<void> Function(
+    List<VideoBookRow> members,
+    bool deleteLocalFiles,
+  )? onDeleteMembersMedia;
+
+  /// 透传给 [MediaCollectionDetailPage.deleteMembersLocalFilesSubtitle]：
+  /// 「同时删除其中的视频」之下的二级「同时删除本地文件」勾选说明。
+  final String? deleteMembersLocalFilesSubtitle;
 
   /// 透传给合集详情页的「重新刮削资料与封面」（刮削 controller 归 HomePage，
   /// 由库页注入）。null = 不渲染该菜单项。
@@ -151,6 +159,8 @@ class _VideoWorkDetailPageState extends State<VideoWorkDetailPage> {
             },
             onChanged: widget.onChanged,
             onDeleteMembersMedia: widget.onDeleteMembersMedia,
+            deleteMembersLocalFilesSubtitle:
+                widget.deleteMembersLocalFilesSubtitle,
             onRescrapeCollection: widget.onRescrapeCollection,
           );
         },

--- a/fushi/lib/src/utils/components/fushi_destructive_confirm_dialog.dart
+++ b/fushi/lib/src/utils/components/fushi_destructive_confirm_dialog.dart
@@ -9,11 +9,19 @@ import 'package:fushi/src/utils/components/fushi_material_components.dart';
 ///
 /// pop `null` = 取消；非 null = 已确认，[checked] 携带可选勾选项状态
 /// （无 [FushiDestructiveConfirmDialog.checkboxLabel] 时恒为 false）。
+/// [deleteLocalFiles] 是挂在 [checked] 之下的二级勾选（无
+/// [FushiDestructiveConfirmDialog.localFilesSubtitle] 或主勾选未勾时恒为 false）。
 @immutable
 class FushiDestructiveConfirmResult {
-  const FushiDestructiveConfirmResult({required this.checked});
+  const FushiDestructiveConfirmResult({
+    required this.checked,
+    this.deleteLocalFiles = false,
+  });
 
   final bool checked;
+
+  /// 用户是否要求连磁盘上的原始文件一起删（仅在 [checked] 为真时可能为真）。
+  final bool deleteLocalFiles;
 }
 
 /// 全 app 统一的「确认销毁」对话框。
@@ -34,6 +42,7 @@ class FushiDestructiveConfirmDialog extends StatefulWidget {
     this.leadingIcon = Icons.delete_outline,
     this.checkboxLabel,
     this.checkboxInitialValue = false,
+    this.localFilesSubtitle,
     this.checkedDisclosure,
     super.key,
   });
@@ -51,6 +60,19 @@ class FushiDestructiveConfirmDialog extends StatefulWidget {
 
   final bool checkboxInitialValue;
 
+  /// 非 null 时，在主勾选被勾上后追加渲染二级勾选行「同时删除本地文件」
+  /// （[DeleteLocalFilesRow]，与单条删除确认框同一行组件、同一文案）。
+  ///
+  /// 语义分层是这两行的全部理由：主勾选决定「库里的条目删不删」，二级勾选决定
+  /// 「磁盘上的原件删不删」。把两件事压进一行文案（旧实现的「同时删除其中的视频
+  /// （保留你的原始视频文件）」）等于替用户把后一个决定定死。null = 这个入口没有
+  /// 可删的本机原件（书 / 游戏合集），此时结果里的 [
+  /// FushiDestructiveConfirmResult.deleteLocalFiles] 恒 false。
+  ///
+  /// 二级行只在主勾选为真时可见，主勾选取消时其状态一并复位——隐藏着的 true
+  /// 会在用户下次勾主选时静默删掉磁盘原件。
+  final String? localFilesSubtitle;
+
   /// 勾选框被勾上后追加渲染的「会被删除 / 会被保留」逐项披露。
   ///
   /// 根因（BUG-1305）：本对话框的正文 [message] 与勾选行是两个静态节点，勾选翻转
@@ -67,6 +89,7 @@ class FushiDestructiveConfirmDialog extends StatefulWidget {
 class _FushiDestructiveConfirmDialogState
     extends State<FushiDestructiveConfirmDialog> {
   late bool _checked = widget.checkboxInitialValue;
+  bool _deleteLocalFiles = false;
 
   @override
   Widget build(BuildContext context) {
@@ -119,12 +142,27 @@ class _FushiDestructiveConfirmDialogState
                     ),
                   ),
                 ),
-                onTap: () => setState(() => _checked = !_checked),
+                onTap: () => setState(() {
+                  _checked = !_checked;
+                  // 主勾选取消 = 连成员都不删，磁盘原件更无从谈起；不复位就会留下
+                  // 一个看不见的 true。
+                  if (!_checked) _deleteLocalFiles = false;
+                }),
               ),
+              if (_checked && widget.localFilesSubtitle != null)
+                DeleteLocalFilesRow(
+                  value: _deleteLocalFiles,
+                  subtitle: widget.localFilesSubtitle!,
+                  onChanged: (bool v) => setState(() => _deleteLocalFiles = v),
+                ),
               if (_checked && widget.checkedDisclosure != null) ...<Widget>[
                 SizedBox(height: tokens.spacing.gap),
                 DeletionDisclosureView(
-                  disclosure: widget.checkedDisclosure!,
+                  // 勾了「同时删除本地文件」时披露必须跟着翻面，否则又回到
+                  // BUG-1305 那种「正文说保留、代码在删」的说反话状态。
+                  disclosure: _deleteLocalFiles
+                      ? widget.checkedDisclosure!.withLocalFilesDeleted()
+                      : widget.checkedDisclosure!,
                 ),
               ],
             ],
@@ -145,7 +183,12 @@ class _FushiDestructiveConfirmDialogState
               isDestructiveAction: true,
               onPressed: () => Navigator.pop(
                 context,
-                FushiDestructiveConfirmResult(checked: _checked),
+                FushiDestructiveConfirmResult(
+                  checked: _checked,
+                  deleteLocalFiles: _checked &&
+                      widget.localFilesSubtitle != null &&
+                      _deleteLocalFiles,
+                ),
               ),
               child: Text(widget.confirmLabel ?? t.dialog_delete),
             ),

--- a/fushi/test/media/collection_context_dialog_test.dart
+++ b/fushi/test/media/collection_context_dialog_test.dart
@@ -45,6 +45,7 @@ void main() {
     required FushiDatabase db,
     required MediaCollectionRow collection,
     required bool injectDeleteMembers,
+    String? localFilesSubtitle,
     List<DialogListAction> extraListActions = const <DialogListAction>[],
   }) async {
     final _Probe probe = _Probe();
@@ -64,15 +65,20 @@ void main() {
                   onOpenDetail: () => probe.openedDetail = true,
                   onChanged: () => probe.changedCount++,
                   onDeleteMembersMedia: injectDeleteMembers
-                      ? (List<MediaCollectionItemRow> members) async {
+                      ? (
+                          List<MediaCollectionItemRow> members,
+                          bool deleteLocalFiles,
+                        ) async {
                           probe.deletedMembers = members
                               .map((MediaCollectionItemRow m) => m.entryKey)
                               .toList();
+                          probe.deleteLocalFiles = deleteLocalFiles;
                         }
                       : null,
                   deleteMembersCheckboxLabel: injectDeleteMembers
                       ? t.delete_collection_also_books
                       : null,
+                  deleteMembersLocalFilesSubtitle: localFilesSubtitle,
                   extraListActions: extraListActions,
                 ),
                 child: const Text('open'),
@@ -147,6 +153,99 @@ void main() {
     expect(probe.deletedMembers, <String>['book-1', 'book-2']);
     expect(await db.getAllMediaCollections(), isEmpty);
     expect(probe.changedCount, 1);
+  });
+
+  // ── 二级勾选「同时删除本地文件」：删库里的条目 ≠ 删磁盘上的原件 ─────────────
+  // 这两个决定必须分开落地。压成一行文案（旧实现「同时删除其中的视频（保留你的
+  // 原始视频文件）」）等于替用户把后一个决定定死，用户没有任何入口删原件。
+
+  testWidgets('二级勾选未提供：勾主选也不出现「同时删除本地文件」，回调收到 false',
+      (WidgetTester tester) async {
+    final (FushiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+    );
+
+    await tapDeleteAction(tester);
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(t.delete_local_files),
+      findsNothing,
+      reason: '调用方没给本机原件文案 = 该域没有可删的原件，不许摆兑现不了的开关。',
+    );
+
+    await tapConfirm(tester);
+    expect(probe.deleteLocalFiles, isFalse);
+  });
+
+  testWidgets('二级勾选只在主勾选之下出现，勾上后回调收到 deleteLocalFiles=true',
+      (WidgetTester tester) async {
+    final (FushiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+      localFilesSubtitle: t.delete_local_files_video_desc,
+    );
+
+    await tapDeleteAction(tester);
+    expect(
+      find.text(t.delete_local_files),
+      findsNothing,
+      reason: '主勾选没勾 = 成员本体都不删，磁盘原件更无从谈起。',
+    );
+
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    expect(find.text(t.delete_local_files), findsOneWidget);
+    await tester.tap(find.text(t.delete_local_files));
+    await tester.pumpAndSettle();
+    await tapConfirm(tester);
+
+    expect(probe.deletedMembers, <String>['book-1', 'book-2']);
+    expect(
+      probe.deleteLocalFiles,
+      isTrue,
+      reason: '勾了「同时删除本地文件」就必须把这个判据交给调用方，否则原件永远删不掉。',
+    );
+  });
+
+  testWidgets('取消主勾选会复位二级勾选：重新勾主选时不得留着看不见的 true', (WidgetTester tester) async {
+    final (FushiDatabase db, MediaCollectionRow collection) =
+        await buildCollection();
+    final _Probe probe = await pumpAndOpen(
+      tester,
+      db: db,
+      collection: collection,
+      injectDeleteMembers: true,
+      localFilesSubtitle: t.delete_local_files_video_desc,
+    );
+
+    await tapDeleteAction(tester);
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.delete_local_files));
+    await tester.pumpAndSettle();
+    // 反悔：取消主勾选（二级行随之消失），再勾回来。
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(t.delete_collection_also_books));
+    await tester.pumpAndSettle();
+    await tapConfirm(tester);
+
+    expect(probe.deletedMembers, <String>['book-1', 'book-2']);
+    expect(
+      probe.deleteLocalFiles,
+      isFalse,
+      reason: '隐藏着的 true 会在用户下次勾主选时静默删掉磁盘原件。',
+    );
   });
 
   testWidgets('取消确认框：合集与成员都不动，页面也不刷新', (WidgetTester tester) async {
@@ -314,6 +413,24 @@ void main() {
       });
     });
 
+    test('home_video_page：删成员走 deleteVideoBooksWithDecision 并给出删本地文件二级勾选', () {
+      final String src = File(
+        'lib/src/pages/implementations/home_video_page.dart',
+      ).readAsStringSync();
+      expect(
+        src,
+        contains('deleteMembersLocalFilesSubtitle:'),
+        reason: '不注入本机原件文案 = 用户删合集时永远没有删原始视频文件的入口。',
+      );
+      expect(
+        src,
+        isNot(contains('repo.deleteVideoBookAndReclaimAssets(')),
+        reason: '合集删成员必须走 deleteVideoBooksWithDecision：勾了「删本地文件」时'
+            '要先让播放器放句柄（Windows 上不放就是 errno 32，盘上文件一个没少）、'
+            '把做种文件标 skip，删完再对账下载任务。裸仓库调用绕过这整条纪律。',
+      );
+    });
+
     test('games_library_page 走统一合集菜单且**不**注入删成员本体（纯解散语义）', () {
       final String src = File(
         'lib/src/pages/implementations/games_library_page.dart',
@@ -339,4 +456,7 @@ class _Probe {
   bool openedDetail = false;
   int changedCount = 0;
   List<String>? deletedMembers;
+
+  /// 删成员回调收到的「连磁盘原件一起删」判据。null = 回调没被调过。
+  bool? deleteLocalFiles;
 }

--- a/fushi/test/pages/media_collection_grid_detail_page_test.dart
+++ b/fushi/test/pages/media_collection_grid_detail_page_test.dart
@@ -246,8 +246,10 @@ void main() {
   Widget wrapPageWithDelete(
     MediaCollectionRow col,
     FushiDatabase db, {
-    Future<void> Function(List<MediaCollectionItemRow> members)?
-        onDeleteMembersMedia,
+    Future<void> Function(
+      List<MediaCollectionItemRow> members,
+      bool deleteLocalFiles,
+    )? onDeleteMembersMedia,
   }) =>
       TranslationProvider(
         child: MaterialApp(
@@ -284,7 +286,10 @@ void main() {
     await tester.pumpWidget(wrapPageWithDelete(
       s.col,
       s.db,
-      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async =>
+      onDeleteMembersMedia: (
+        List<MediaCollectionItemRow> members,
+        bool deleteLocalFiles,
+      ) async =>
           passed.addAll(members),
     ));
     await tester.pumpAndSettle();
@@ -306,7 +311,10 @@ void main() {
     await tester.pumpWidget(wrapPageWithDelete(
       s.col,
       s.db,
-      onDeleteMembersMedia: (List<MediaCollectionItemRow> members) async =>
+      onDeleteMembersMedia: (
+        List<MediaCollectionItemRow> members,
+        bool deleteLocalFiles,
+      ) async =>
           passed.addAll(members.map(
               (MediaCollectionItemRow r) => '${r.mediaType}|${r.entryKey}')),
     ));


### PR DESCRIPTION
## 问题

「删除合集」确认框只有一行「同时删除其中的视频（保留你的原始视频文件）」——把「磁盘上的原件删不删」替用户定死了，用户没有任何入口连原始文件一起删。

## 改动

- `FushiDestructiveConfirmDialog` 加二级勾选 `localFilesSubtitle`（复用 `DeleteLocalFilesRow`，与单删 / 批删同一文案），只在主勾选为真时出现；主勾选取消时状态一并复位（隐藏着的 true 会在下次勾主选时静默删盘）。勾上后 `checkedDisclosure` 走 `withLocalFilesDeleted()`，披露不再和实际行为说反话（BUG-1305 同类）。
- `onDeleteMembersMedia` 回调加 `deleteLocalFiles` 参数，三库页 + 两个合集详情页同步；书 / 游戏合集不提供该二级勾选（恒 false）。
- 视频合集删成员改走 `deleteVideoBooksWithDecision`，不再裸调仓库：勾了删本地文件时先让播放器放句柄（Windows 上不放就是 errno 32，用户看到「删除成功」而盘上一个文件没少）、把做种文件在下载后端标 skip，删完再对账下载任务。
- 二级勾选只在合集真有本机原件时出现（`videoBookHasLocalFiles`），成员全是远端流就不摆这个兑现不了的开关。
- `delete_collection_also_videos` 17 语言去掉「保留你的原始视频文件」括号承诺。

## 验证

- `flutter analyze`（含 test）：只剩 develop 既有的一条 `integration_test/module_gating_test.dart:98` `buildListeningDestination` 未定义（PR #1376「听书并入阅读」删了该 builder 没跟着改测试），与本 PR 无关。
- 定向测试 95 条全绿（rebase 到最新 develop 后复跑）：`collection_context_dialog` / `media_collection_grid_detail_page` / `fushi_destructive_confirm_dialog` / `deletion_disclosure` / `test/i18n` / `video_delete_reclaim_entry_guard` / `unified_collections_architecture_guard` / `reader_history_source_corpus` / `sync/delete_local_files_dialog`。
- 新增 3 条行为守卫（二级勾选未提供 / 勾上后回调收到 true / 取消主勾选复位）+ 1 条 home_video_page 接线对账（禁止回到裸 `repo.deleteVideoBookAndReclaimAssets`）。

https://claude.ai/code/session_01TAMnok9WcXj1f4ZTJiiqW4