### PR TITLE
fix(video): 合集重刮按成员归属定位作品单元，消除单成员/无集号合集的死胡同 (BUG-2433)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2241 条。点号进各自文件。
+> 共 2242 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2433](bugs/BUG-2433-collection-rescrape-dead-end.md) | ✅ | ✅ | 合集右键重新刮削对单成员/无集号合集必然死胡同 |
 | [BUG-2431](bugs/BUG-2431-discovery-hero-backdrop-cropped.md) | ✅ | ✅ | 发现页详情顶部 backdrop 被上下裁掉六成 |
 | [BUG-2430](bugs/BUG-2430-discovery-failure-shows-raw-provider-id.md) | ✅ | ✅ | 发现页失败横幅印原始 provider id 且不分失败类型 |
 | [BUG-2429](bugs/BUG-2429-opensubtitles-builtin-shown-disabled.md) | ✅ | ✅ | OpenSubtitles 内置密钥却显示已停用 |

--- a/docs/bugs/BUG-2433-collection-rescrape-dead-end.md
+++ b/docs/bugs/BUG-2433-collection-rescrape-dead-end.md
@@ -1,0 +1,20 @@
+## BUG-2433 · 合集右键重新刮削对单成员/无集号合集必然死胡同
+- **报告**：2026-09-10（用户：截图——视频库页合集卡上弹出「这个合集不在任何本地视频来源的刮削计划里」）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/metadata/video_library_scrape_sweep.dart:50`（旧 `planScrapeWorkForCollection` 只按 `work.stableKey == 'collection:<id>'` 字面匹配）。
+
+  计划器 `VideoSourceWorkPlanner.plan`（`fushi/lib/src/media/video/metadata/video_source_work_planner.dart:57`）对同一个合集有**两种同样合法**的表示：成员数 ≥2（`collection_member_policy.dart:41` 的 `multiMemberCollectionIdByVideoUid`）**且**文件名解析出集号（`video_source_work_planner.dart:88`）时，整个合集是一个 `collection:<id>` 单元；否则每个成员各自是一个 `book:<uid>` 单元。单成员合集、剧场版合集、目录合集（`sourceFolderPath != null`）全部落在后者。
+
+  旧查询只认前者，于是对后者一律返回 null，调用方 `_rescrapeCollection`（`fushi/lib/src/pages/implementations/home_video_page.dart:6443`）弹一句 toast 就 return——**而且这句提示是假话**：成员明明在刮削计划里，只是以 book 单元的形式。用户拿到的是一条无出路的死胡同。
+
+  用户真实数据（读 `D:/APP/HIBIKI_date/support/fushi.db` 快照实测）：合集 68「Kimi no Na wa 播放列表」`playlist`，**成员恰好 1 个** `video/Kimi no Na wa - S00E01`（`source_id=3`，video/local/`series` 模式，路径 `D:\video\Kimi no Na wa\Season 00\Kimi no Na wa - S00E01.mkv`）；`video_metadata_works` 里 `collection_id=68` 无行，该成员有一条 `book_uid` 锚定行。单成员 → 被 ≥2 判据剔除 → 计划里只有 `book:video/Kimi no Na wa - S00E01`。
+
+  **不能用「放宽计划器判据、让合集始终成为作品单元」来修**（调查结论，三条独立的破坏性）：
+  1. `video_metadata_works` 的 `collectionId` / `bookUid` 是互斥锚定（`packages/fushi_core/lib/src/database/tables.dart:1601` 的 `CHECK`），而 `_hasCanonicalIdentity`（`video_library_scrape_sweep.dart:179`）只按 `work.collection != null` 二选一、无回退 → 历史已刮的单成员合集会被判「从未刮过」重新补刮；落库时 `_removeBookOwnedWorksForCollection`（`video_metadata_database_store.dart:166`）按成员 bookUid 物理 DELETE 旧行（identities/seasons/episodes cascade），且 `existingWork` 查不到导致**用户字段锁失效**。
+  2. `collection != null` 会把 `kind` 强制成 tv（`video_source_scrape_coordinator.dart:798`），而 resolver 有硬类型门（`video_metadata_resolver.dart:458/475`）→ 剧场版按电视剧搜，movie 条目全被拒 → notFound。
+  3. 无集号成员在合集单元下会被静默跳过、不写任何 `VideoScrapeMeta`（`video_metadata_database_store.dart:986`、`:924`），比原先作为独立 movie 单元时更差；海报归属还会与 `collection_member_policy.dart` 的「单成员合集不受影响」口径打架。
+
+  另有既有测试 `fushi/test/media/video/video_source_work_planner_test.dart:96`「任意多片 m3u 合集不会被误判为电视剧作品」明确钉死了这条设计意图。所以根因在**查询的定位方式**，不在计划器。
+
+- **[x] ① 已修复** — `planScrapeWorkForCollection` → `planScrapeWorksForCollection`，改按**成员归属**定位并返回候选列表：存在合集级单元就只返回它（既有行为一字不变），否则返回该合集成员对应的全部 `book:<uid>` 单元。调用方三分支：0 个 → 保留提示（此时才是真话）；1 个 → 直接走原绑定 + 重刮；N 个 → 弹选择列表（新增 `collection_rescrape_pick_work`），不再默选第一个也不再死胡同。搜索种子在「整个合集就是这一个作品」时改用合集名（成员标题可能是 `S00E01` 这种纯集号标签）。计划器、stableKey、canonical 锚定、封面归属**一律未动** → 零数据迁移、零回归。提交 `<commit>`
+- **[x] ② 已加自动化测试** — `fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart`：单成员合集回落 book 单元（按用户真实数据形状构造）、多片无集号合集返回全部候选、合集级单元存在时只返回它、非 local 来源返回空、以及既有三条改成列表口径。共 16 条全绿。
+- **备注**：多候选的选择列表是同一条路径的另一半死胡同（多片播放列表、目录合集右键重刮原本同样只能拿到那句 toast），一并修掉。

--- a/docs/bugs/BUG-2433-collection-rescrape-dead-end.md
+++ b/docs/bugs/BUG-2433-collection-rescrape-dead-end.md
@@ -15,6 +15,6 @@
 
   另有既有测试 `fushi/test/media/video/video_source_work_planner_test.dart:96`「任意多片 m3u 合集不会被误判为电视剧作品」明确钉死了这条设计意图。所以根因在**查询的定位方式**，不在计划器。
 
-- **[x] ① 已修复** — `planScrapeWorkForCollection` → `planScrapeWorksForCollection`，改按**成员归属**定位并返回候选列表：存在合集级单元就只返回它（既有行为一字不变），否则返回该合集成员对应的全部 `book:<uid>` 单元。调用方三分支：0 个 → 保留提示（此时才是真话）；1 个 → 直接走原绑定 + 重刮；N 个 → 弹选择列表（新增 `collection_rescrape_pick_work`），不再默选第一个也不再死胡同。搜索种子在「整个合集就是这一个作品」时改用合集名（成员标题可能是 `S00E01` 这种纯集号标签）。计划器、stableKey、canonical 锚定、封面归属**一律未动** → 零数据迁移、零回归。提交 `<commit>`
+- **[x] ① 已修复** — `planScrapeWorkForCollection` → `planScrapeWorksForCollection`，改按**成员归属**定位并返回候选列表：存在合集级单元就只返回它（既有行为一字不变），否则返回该合集成员对应的全部 `book:<uid>` 单元。调用方三分支：0 个 → 保留提示（此时才是真话）；1 个 → 直接走原绑定 + 重刮；N 个 → 弹选择列表（新增 `collection_rescrape_pick_work`），不再默选第一个也不再死胡同。搜索种子在「整个合集就是这一个作品」时改用合集名（成员标题可能是 `S00E01` 这种纯集号标签）。计划器、stableKey、canonical 锚定、封面归属**一律未动** → 零数据迁移、零回归。提交 `c81ba126bc`
 - **[x] ② 已加自动化测试** — `fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart`：单成员合集回落 book 单元（按用户真实数据形状构造）、多片无集号合集返回全部候选、合集级单元存在时只返回它、非 local 来源返回空、以及既有三条改成列表口径。共 16 条全绿。
 - **备注**：多候选的选择列表是同一条路径的另一半死胡同（多片播放列表、目录合集右键重刮原本同样只能拿到那句 toast），一并修掉。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 78829 (4637 per locale)
+/// Strings: 78846 (4638 per locale)
 ///
-/// Built on 2026-09-10 at 10:51 UTC
+/// Built on 2026-09-10 at 10:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6439,6 +6439,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Some sources are rate limited; showing the rest';
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -17342,6 +17343,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -28473,6 +28476,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -39658,6 +39663,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -50877,6 +50884,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -61898,6 +61907,8 @@ class _StringsId extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -73012,6 +73023,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -83502,6 +83515,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -94002,6 +94017,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -105072,6 +105089,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -116196,6 +116215,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -127297,6 +127318,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -138197,6 +138220,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -149213,6 +149238,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -160200,6 +160227,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 // Path: <root>
@@ -170280,6 +170309,8 @@ class _StringsZhCn extends _StringsEn {
   String get video_discovery_provider_rate_limited => '部分来源请求过于频繁，已显示其余结果';
   @override
   String get video_discovery_provider_failed => '部分来源暂时请求失败，已显示其余结果';
+  @override
+  String get collection_rescrape_pick_work => '选择要重新刮削的作品';
 }
 
 // Path: <root>
@@ -180452,6 +180483,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_discovery_provider_failed =>
       'Some sources failed temporarily; showing the rest';
+  @override
+  String get collection_rescrape_pick_work => 'Pick a work to rescrape';
 }
 
 /// Flat map(s) containing all translations.
@@ -189996,6 +190029,8 @@ extension on _StringsEn {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -199535,6 +199570,8 @@ extension on _StringsAr {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -209119,6 +209156,8 @@ extension on _StringsDe {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -218694,6 +218733,8 @@ extension on _StringsEs {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -228278,6 +228319,8 @@ extension on _StringsFr {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -237833,6 +237876,8 @@ extension on _StringsId {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -247410,6 +247455,8 @@ extension on _StringsIt {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -256914,6 +256961,8 @@ extension on _StringsJa {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -266422,6 +266471,8 @@ extension on _StringsKo {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -275992,6 +276043,8 @@ extension on _StringsNl {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -285557,6 +285610,8 @@ extension on _StringsPtBr {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -295129,6 +295184,8 @@ extension on _StringsRu {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -304673,6 +304730,8 @@ extension on _StringsTh {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -314232,6 +314291,8 @@ extension on _StringsTr {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -323785,6 +323846,8 @@ extension on _StringsVi {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }
@@ -333255,6 +333318,8 @@ extension on _StringsZhCn {
         return '部分来源请求过于频繁，已显示其余结果';
       case 'video_discovery_provider_failed':
         return '部分来源暂时请求失败，已显示其余结果';
+      case 'collection_rescrape_pick_work':
+        return '选择要重新刮削的作品';
       default:
         return null;
     }
@@ -342737,6 +342802,8 @@ extension on _StringsZhHk {
         return 'Some sources are rate limited; showing the rest';
       case 'video_discovery_provider_failed':
         return 'Some sources failed temporarily; showing the rest';
+      case 'collection_rescrape_pick_work':
+        return 'Pick a work to rescrape';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "前面に出して辞書検索ページを開く",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "Dictionary name",
   "shortcut_action_global_external_open_lookup_page": "Bring to front and open lookup page",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "词典名称",
   "shortcut_action_global_external_open_lookup_page": "唤起主窗并打开查词页",
   "video_discovery_provider_rate_limited": "部分来源请求过于频繁，已显示其余结果",
-  "video_discovery_provider_failed": "部分来源暂时请求失败，已显示其余结果"
+  "video_discovery_provider_failed": "部分来源暂时请求失败，已显示其余结果",
+  "collection_rescrape_pick_work": "选择要重新刮削的作品"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4635,5 +4635,6 @@
   "dict_rename_label": "詞典名稱",
   "shortcut_action_global_external_open_lookup_page": "喚起主視窗並開啟查詞頁",
   "video_discovery_provider_rate_limited": "Some sources are rate limited; showing the rest",
-  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest"
+  "video_discovery_provider_failed": "Some sources failed temporarily; showing the rest",
+  "collection_rescrape_pick_work": "Pick a work to rescrape"
 }

--- a/fushi/lib/src/media/video/metadata/video_library_scrape_sweep.dart
+++ b/fushi/lib/src/media/video/metadata/video_library_scrape_sweep.dart
@@ -37,35 +37,55 @@ class VideoPendingScrapeWork {
 /// 在所有本地视频来源的刮削计划里定位某个合集对应的作品单元。
 ///
 /// 「重新刮削这个合集」需要的三样东西——来源行、作品标题、稳定键——只有计划器
-/// 知道：合集本身不记 sourceId（成员才记），而作品单元是计划器按「合集 = 一个
-/// 剧集作品」现推出来的。所以入口不是「查一张表」，而是「问计划器要同一份计划」，
-/// 与自动补刮、待确认队列、批次刮削看到的作品定义**逐字节同源**。
+/// 知道：合集本身不记 sourceId（成员才记），而作品单元是计划器按来源现推出来的。
+/// 所以入口不是「查一张表」，而是「问计划器要同一份计划」，与自动补刮、待确认
+/// 队列、批次刮削看到的作品定义**逐字节同源**。
 ///
-/// 按 [VideoSourceScrapeWork.stableKey]（`collection:<id>`）匹配而不是按标题：
-/// 同名合集、改过名的合集都不会认错，也不会撞
-/// [VideoSourceScrapeWorkAmbiguous]。
+/// 关键点（BUG-2433）：计划器对同一个合集有**两种同样合法**的表示。成员数 >=2
+/// 且文件名解析出集号时，整个合集是一个 `collection:<id>` 单元；否则每个成员各
+/// 自是一个 `book:<uid>` 单元——单成员合集、剧场版合集、目录合集都落在后者。
+/// 旧实现只按 `collection:<id>` 字面匹配，于是对后者一律报「不在刮削计划里」，
+/// 而成员明明就在计划里，用户拿到的是一句假话 + 死胡同。
 ///
-/// 找不到返回 null——合集成员全是远端占位、来源已删、或该来源是目录分组模式
-/// （计划器对它返回空计划）时都会这样，调用方需要给出可见提示而不是静默失败。
-Future<VideoPendingScrapeWork?> planScrapeWorkForCollection(
+/// 所以定位判据是**成员归属**而不是 key 字面：
+/// * 存在合集级单元 -> 只返回它（既有行为一字不变，且它已覆盖全部有集号成员）；
+/// * 否则返回该合集成员对应的全部 book 级单元。
+///
+/// 返回空列表才是真的无从下手——成员全是远端占位、来源已删、成员被特典分类器
+/// 判为非正片、或该来源是目录分组模式（计划器对它返回空计划）。调用方据此给可
+/// 见提示；返回多个时调用方须让用户选，不得默选第一个（合集里是 N 个独立作品，
+/// 猜哪个都可能把身份写错）。
+Future<List<VideoPendingScrapeWork>> planScrapeWorksForCollection(
   FushiDatabase database,
   int collectionId,
 ) async {
   final String stableKey = 'collection:$collectionId';
+  final Set<String> memberUids = <String>{
+    for (final MediaCollectionItemRow item
+        in await database.getCollectionItems(collectionId))
+      if (item.mediaType == MediaKind.video.dbValue) item.entryKey,
+  };
   final List<SourceLibraryRow> sources =
       (await database.getMediaSourcesByKind('video'))
           .where((SourceLibraryRow source) => source.transport == 'local')
           .toList(growable: false);
+  final List<VideoPendingScrapeWork> memberWorks = <VideoPendingScrapeWork>[];
   for (final SourceLibraryRow source in sources) {
     final List<VideoSourceScrapeWork> works =
         await VideoSourceWorkPlanner(database).plan(source);
     for (final VideoSourceScrapeWork work in works) {
       if (work.stableKey == stableKey) {
-        return VideoPendingScrapeWork(source: source, work: work);
+        return <VideoPendingScrapeWork>[
+          VideoPendingScrapeWork(source: source, work: work),
+        ];
+      }
+      if (work.collection == null &&
+          memberUids.contains(work.members.single.bookUid)) {
+        memberWorks.add(VideoPendingScrapeWork(source: source, work: work));
       }
     }
   }
-  return null;
+  return List<VideoPendingScrapeWork>.unmodifiable(memberWorks);
 }
 
 /// 自动补刮调度器。生命周期跟随 HomePage 的刮削 controller。

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -6432,23 +6432,32 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         widget.scrapeTaskController;
     if (controller == null) return;
     final FushiDatabase db = ref.read(appProvider).database;
-    final VideoPendingScrapeWork? planned =
-        await planScrapeWorkForCollection(db, collection.id);
+    final List<VideoPendingScrapeWork> planned =
+        await planScrapeWorksForCollection(db, collection.id);
     if (!mounted) return;
-    if (planned == null) {
+    if (planned.isEmpty) {
       FushiToast.show(
         msg: t.collection_rescrape_not_planned,
         severity: ToastSeverity.info,
       );
       return;
     }
+    // 合集在计划里对应多个独立作品（无集号的多片播放列表、目录合集）时不能默选
+    // 第一个——猜错就把身份写到别的作品上。让用户选，而不是再给一句死胡同提示。
+    final VideoPendingScrapeWork? chosen = planned.length == 1
+        ? planned.single
+        : await _pickCollectionScrapeWork(planned);
+    if (chosen == null || !mounted) return;
+    // 搜索种子：整个合集就是这一个作品时用合集名（成员标题可能是「S00E01」这种
+    // 纯集号标签，拿它当种子等于让用户对着无意义的词搜）；合集里有多个作品时合
+    // 集名描述的是整个播放列表，反而是选中成员自己的标题更贴。
     final VideoSourceScrapeConfirmationCandidate? candidate =
         await showVideoSourceScrapeManualBindingDialog(
       context: context,
       controller: controller,
-      source: planned.source,
-      workTitle: planned.work.title,
-      workStableKey: planned.work.stableKey,
+      source: chosen.source,
+      workTitle: planned.length == 1 ? collection.name : chosen.work.title,
+      workStableKey: chosen.work.stableKey,
     );
     if (candidate == null || !mounted) return;
     FushiToast.show(
@@ -6457,9 +6466,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     try {
       await controller.rescrapeWorkWithLookup(
-        source: planned.source,
-        workTitle: planned.work.title,
-        workStableKey: planned.work.stableKey,
+        source: chosen.source,
+        workTitle: chosen.work.title,
+        workStableKey: chosen.work.stableKey,
         lookup: candidate.lookup,
       );
     } on VideoSourceScrapeCancelled {
@@ -6477,6 +6486,27 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (!mounted) return;
     _refresh();
   }
+
+  /// 合集在刮削计划里对应多个独立作品时，让用户选一个重刮（BUG-2433）。
+  ///
+  /// 取消返回 null。列表项标题就是计划器给出的作品标题，与待确认队列、批次刮削
+  /// 里看到的是同一份作品定义——用户在这里选的和系统在别处认的是同一个东西。
+  Future<VideoPendingScrapeWork?> _pickCollectionScrapeWork(
+    List<VideoPendingScrapeWork> works,
+  ) =>
+      showAppDialog<VideoPendingScrapeWork>(
+        context: context,
+        builder: (BuildContext context) => SimpleDialog(
+          title: Text(t.collection_rescrape_pick_work),
+          children: <Widget>[
+            for (final VideoPendingScrapeWork entry in works)
+              SimpleDialogOption(
+                onPressed: () => Navigator.of(context).pop(entry),
+                child: Text(entry.work.title),
+              ),
+          ],
+        ),
+      );
 
   /// 合集右键「为合集获取字幕」：与合集详情页 AppBar 同一 [SubtitleWorkbenchPage]
   /// （合集作用域：绑定 AniList 系列 → 统一来源 → 逐集拉最佳字幕）。collection 行重取一次拿最新

--- a/fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart
+++ b/fushi/test/media/video/metadata/video_library_scrape_sweep_test.dart
@@ -282,7 +282,7 @@ void main() {
     );
   });
 
-  group('planScrapeWorkForCollection（「重刮这一个合集」的定位入口）', () {
+  group('planScrapeWorksForCollection（「重刮这一个合集」的定位入口）', () {
     /// 建一个多成员合集并返回 id —— 计划器只把**多成员**合集当剧集作品单元。
     Future<int> addCollection(String name, int sourceId,
         {required List<String> uids}) async {
@@ -301,13 +301,13 @@ void main() {
       final int id =
           await addCollection('Show', sourceId, uids: <String>['s-e1', 's-e2']);
 
-      final VideoPendingScrapeWork? planned =
-          await planScrapeWorkForCollection(db, id);
+      final List<VideoPendingScrapeWork> planned =
+          await planScrapeWorksForCollection(db, id);
 
-      expect(planned, isNotNull);
-      expect(planned!.source.id, sourceId);
-      expect(planned.work.stableKey, 'collection:$id');
-      expect(planned.work.collection?.id, id);
+      expect(planned, hasLength(1));
+      expect(planned.single.source.id, sourceId);
+      expect(planned.single.work.stableKey, 'collection:$id');
+      expect(planned.single.work.collection?.id, id);
     });
 
     test('同名合集不会认错——匹配的是 stableKey 不是标题', () async {
@@ -318,16 +318,111 @@ void main() {
           await addCollection('Show', sourceId, uids: <String>['b-e1', 'b-e2']);
 
       expect(
-          (await planScrapeWorkForCollection(db, first))!.work.collection?.id,
+          (await planScrapeWorksForCollection(db, first))
+              .single
+              .work
+              .collection
+              ?.id,
           first);
       expect(
-          (await planScrapeWorkForCollection(db, second))!.work.collection?.id,
+          (await planScrapeWorksForCollection(db, second))
+              .single
+              .work
+              .collection
+              ?.id,
           second);
     });
 
-    test('合集不在任何本地来源的计划里时返回 null（调用方据此给可见提示）', () async {
+    test('合集不在任何本地来源的计划里时返回空列表（调用方据此给可见提示）', () async {
       final int orphan = await db.createMediaCollection('No members');
-      expect(await planScrapeWorkForCollection(db, orphan), isNull);
+      expect(await planScrapeWorksForCollection(db, orphan), isEmpty);
+    });
+
+    test('单成员合集回落到成员的 book 单元，而不是报「不在刮削计划里」（BUG-2433）',
+        () async {
+      // 用户真实数据形状：合集「<名> 播放列表」只有一个成员，成员标题是纯集号
+      // 标签 S00E01。单成员被 multiMemberCollectionIdByVideoUid 的 >=2 判据剔除，
+      // 计划里它是 book 单元；旧实现只认 collection:<id>，于是必然死胡同。
+      final int sourceId = await addSource('D:/video');
+      await addVideo(
+        'video/Kimi no Na wa - S00E01',
+        'D:/video/Kimi no Na wa/Season 00/Kimi no Na wa - S00E01.mkv',
+        sourceId,
+        title: 'S00E01',
+      );
+      final int id = await db.createMediaCollection(
+        'Kimi no Na wa 播放列表',
+        collectionType: 'playlist',
+      );
+      await db.addToCollection(
+          id, MediaKind.video, 'video/Kimi no Na wa - S00E01');
+
+      final List<VideoPendingScrapeWork> planned =
+          await planScrapeWorksForCollection(db, id);
+
+      expect(planned, hasLength(1));
+      expect(planned.single.source.id, sourceId);
+      expect(planned.single.work.collection, isNull);
+      expect(planned.single.work.stableKey,
+          'book:video/Kimi no Na wa - S00E01');
+    });
+
+    test('多片无集号合集返回全部候选，调用方须让用户选而不是默选第一个', () async {
+      final int sourceId = await addSource('/movies');
+      await addVideo('movie-a', '/movies/A Movie (2020).mkv', sourceId,
+          title: 'A Movie');
+      await addVideo('movie-b', '/movies/B Movie (2021).mkv', sourceId,
+          title: 'B Movie');
+      final int id = await db.createMediaCollection(
+        'Weekend playlist',
+        collectionType: 'playlist',
+      );
+      await db.addToCollection(id, MediaKind.video, 'movie-a');
+      await db.addToCollection(id, MediaKind.video, 'movie-b');
+
+      final List<VideoPendingScrapeWork> planned =
+          await planScrapeWorksForCollection(db, id);
+
+      expect(planned, hasLength(2));
+      expect(
+        planned.map((VideoPendingScrapeWork entry) => entry.work.stableKey),
+        containsAll(<String>['book:movie-a', 'book:movie-b']),
+      );
+    });
+
+    test('合集级单元存在时只返回它，不把并存的无集号成员一起带出来', () async {
+      // 同一合集里有集号的成员进合集级单元、无集号的成员各自成 book 单元；此时
+      // 「重刮这个合集」的答案仍是合集级单元（既有行为一字不变）。
+      final int sourceId = await addSource('D:/A');
+      final int id =
+          await addCollection('Show', sourceId, uids: <String>['s-e1', 's-e2']);
+      await addVideo('bonus', 'D:/A/Bonus Feature.mkv', sourceId,
+          title: 'Bonus Feature');
+      await db.addToCollection(id, MediaKind.video, 'bonus');
+
+      final List<VideoPendingScrapeWork> planned =
+          await planScrapeWorksForCollection(db, id);
+
+      expect(planned, hasLength(1));
+      expect(planned.single.work.stableKey, 'collection:$id');
+    });
+
+    test('成员只存在于非 local 来源时返回空列表', () async {
+      final int remoteId = await db.insertMediaSource(
+        MediaSourcesCompanion.insert(
+          label: 'remote',
+          mediaKind: 'video',
+          rootPath: 'remote://lib',
+          createdAt: 1,
+          transport: const Value<String>('interconnect'),
+        ),
+      );
+      await addVideo('remote-1', 'remote://lib/Movie.mkv', remoteId,
+          title: 'Movie');
+      final int id = await db.createMediaCollection('Remote only');
+      await db.addToCollection(id, MediaKind.video, 'remote-1');
+
+      expect(await planScrapeWorksForCollection(db, id), isEmpty);
     });
   });
 }


### PR DESCRIPTION
## 症状（BUG-2433）

视频库页右键合集 →「重新刮削资料与封面」，对**单成员合集 / 剧场版合集 / 目录合集**必然只弹一句「这个合集不在任何本地视频来源的刮削计划里」就 return，没有任何出路。

而且**这句提示是假话**：成员明明在刮削计划里，只是计划器把它表示成 `book:<uid>` 单元而不是 `collection:<id>` 单元。

用户真实数据（读 DB 快照实测）：合集 68「Kimi no Na wa 播放列表」`playlist`，成员恰好 1 个 `video/Kimi no Na wa - S00E01`（`source_id=3`，video/local/`series`）；`video_metadata_works` 里 `collection_id=68` 无行，该成员有一条 `book_uid` 锚定行。

## 根因

`VideoSourceWorkPlanner.plan` 对同一个合集有**两种同样合法**的表示：

- 成员数 ≥2（`multiMemberCollectionIdByVideoUid` 的判据）**且**文件名解析出集号 → 整个合集是一个 `collection:<id>` 单元；
- 否则每个成员各自是一个 `book:<uid>` 单元。

而 `planScrapeWorkForCollection` 只按 `stableKey == 'collection:<id>'` **字面匹配**，看不见后者。根因在**查询的定位方式**，不在计划器。

## 为什么不放宽计划器判据

调查过「让合集始终成为作品单元」这条路，它有三条独立的破坏性，全部否掉：

1. `video_metadata_works` 的 `collectionId` / `bookUid` 是互斥锚定（`CHECK`），`_hasCanonicalIdentity` 只按 `work.collection != null` 二选一且无回退 → 历史已刮的单成员合集会被判「从未刮过」重新补刮；落库时 `_removeBookOwnedWorksForCollection` 按成员 bookUid 物理 DELETE 旧行（cascade 带走 identities/seasons/episodes），且 `existingWork` 查不到导致**用户字段锁失效**。
2. `collection != null` 会把 `kind` 强制成 tv，而 resolver 有硬类型门 → **剧场版按电视剧搜，movie 条目全被拒** → notFound。
3. 无集号成员在合集单元下会被静默跳过、不写任何 `VideoScrapeMeta`，比原先作为独立 movie 单元更差；海报归属还会与 `collection_member_policy.dart`「单成员合集不受影响」的口径打架。

既有测试 `video_source_work_planner_test.dart` 的「任意多片 m3u 合集不会被误判为电视剧作品」也明确钉死了这条设计意图。

## 改法

`planScrapeWorkForCollection` → `planScrapeWorksForCollection`，改按**成员归属**定位并返回候选列表：

- 存在合集级单元 → 只返回它（**既有行为一字不变**）；
- 否则返回该合集成员对应的全部 `book:<uid>` 单元。

调用方 `_rescrapeCollection` 三分支：

- **0 个** → 保留原提示（此时它才是真话）；
- **1 个** → 直接走原绑定 + 重刮（覆盖截图那个 case 与所有单片/剧场版合集）；
- **N 个** → 弹选择列表（新增 i18n `collection_rescrape_pick_work`），不默选第一个——猜错会把身份写到别的作品上。这是同一条路径的另一半死胡同（多片播放列表、目录合集右键重刮原本同样只能拿到那句 toast），一并修掉。

搜索种子在「整个合集就是这一个作品」时改用**合集名**：成员标题可能是 `S00E01` 这种纯集号标签，拿它当种子等于让用户对着无意义的词搜；而合集级单元的 `work.title` 本来就等于合集名，所以对既有路径零变化。

**计划器、stableKey、canonical 锚定、封面归属一律未动 → 零数据迁移、零回归。**

## 验证

- `flutter analyze`（含 test 目录）：`No issues found`，退出码 0。
- 定向测试 86 条全绿、退出码 0：`video_library_scrape_sweep_test` / `video_source_work_planner_test` / `collection_member_policy_test` / `video_source_scrape_coordinator_test` / `video_metadata_database_store_test` / `test/i18n`。
- 更早在 rebase 前跑过 `test/i18n test/pages test/media/video` 整批 7329 条，唯一一条红是 `anidb_udp_file_client_test` 的 real UDP 用例（并发抢端口），**单跑复验全绿、退出码 0、执行 16 条**，与本改动无关。
- **变异实测**：把定位逻辑退回旧的「只认 `collection:<id>`」，恰好两条新用例变红（单成员合集回落、多候选），其余 14 条照绿 —— 新用例确实钉住了这个 bug，不是空壳断言。
- 真机复测未做（按既有决定跳过这一步）。

https://claude.ai/code/session_01ACiTqP65zHt4dBbJbYGxE1
