### PR TITLE
fix(asr): 修 Apple 系统语音转录的三处缺陷（逐词时间基准 / 暂停报错 / 进度丢失）

### DIFF
--- a/fushi/lib/src/asr_host/apple_speech_channel.dart
+++ b/fushi/lib/src/asr_host/apple_speech_channel.dart
@@ -23,7 +23,7 @@ class AppleSpeechSegment {
     required this.startMs,
     required this.endMs,
     this.tokens = const <String>[],
-    this.tokenOffsetsMs = const <int>[],
+    this.tokenStartsMs = const <int>[],
   });
 
   final String text;
@@ -31,8 +31,14 @@ class AppleSpeechSegment {
   final int endMs;
 
   /// 逐词文本与起点（毫秒）。两者等长；原生没给词级时间时同为空。
+  ///
+  /// **是「起点」不是「偏移」**：与 [startMs] / [endMs] 同一把尺子，都是这个音频
+  /// 文件内的绝对毫秒（原生那边来自 `run.audioTimeRange.start`）。而下游
+  /// [AsrCue.tokenOffsetsMs] 要的是**相对 cue 起点**的偏移——两者差一个 cue 起点，
+  /// 换算在 [appleSpeechCues] 里做。这两个词曾经共用一个名字，代价是逐词时间整体
+  /// 偏掉一个 cue 起点、而 SRT 与行数全对得上，谁都看不出来。
   final List<String> tokens;
-  final List<int> tokenOffsetsMs;
+  final List<int> tokenStartsMs;
 }
 
 /// 一次转录的结果。
@@ -221,7 +227,7 @@ AppleSpeechResult parseAppleSpeechPayload(Map<Object?, Object?> raw) {
       // 退化区间：留着会在 SRT 里变成一条零长甚至倒挂的字幕。
       if (endMs <= startMs) continue;
       final List<String> tokens = <String>[];
-      final List<int> offsets = <int>[];
+      final List<int> starts = <int>[];
       final Object? rawTokens = map['tokens'];
       if (rawTokens is List) {
         for (final Object? token in rawTokens) {
@@ -230,7 +236,7 @@ AppleSpeechResult parseAppleSpeechPayload(Map<Object?, Object?> raw) {
           final String piece = (t['text'] ?? '').toString();
           if (piece.isEmpty) continue;
           tokens.add(piece);
-          offsets.add(_asInt(t['startMs']));
+          starts.add(_asInt(t['startMs']));
         }
       }
       segments.add(
@@ -239,7 +245,7 @@ AppleSpeechResult parseAppleSpeechPayload(Map<Object?, Object?> raw) {
           startMs: startMs,
           endMs: endMs,
           tokens: tokens,
-          tokenOffsetsMs: offsets,
+          tokenStartsMs: starts,
         ),
       );
     }
@@ -253,8 +259,20 @@ AppleSpeechResult parseAppleSpeechPayload(Map<Object?, Object?> raw) {
 /// 多文件有声书转出来的是**单时间轴** SRT（与 ONNX 后端一致），所以每个文件的时间
 /// 都要加上前面所有文件的时长。
 ///
-/// 逐词起点同样要平移；词数与 [AsrCue.tokens] 不等长会让下游一条都不挂
-/// （`attachAsrCueTokenTiming` 的纪律），所以两个列表在这里就保持等长。
+/// 逐词时间要**换基准**，不是跟着平移：原生给的
+/// [AppleSpeechSegment.tokenStartsMs] 是文件内绝对毫秒，而 [AsrCue.tokenOffsetsMs]
+/// 的契约是**相对该 cue 起点**的偏移（上游 `serializeAsrCueTokens` 写进
+/// `transcript.tokens.jsonl` 的 `o`，消费端一律按 `cue.startMs + o` 还原绝对时刻，
+/// 见 `cue_sentence_resegmenter.dart`）。所以这里减掉 `segment.startMs`——拼接偏移
+/// `offsetMs` 在减法里自己抵消掉了，**不该再加一次**。
+///
+/// 加错基准是**静默**的：SRT 逐行正确、cue 数与 sidecar 行数一致，
+/// `attachAsrCueTokenTiming` 照挂不误，只有逐词跳播会整体偏掉一个 cue 起点
+/// （有声书里就是几十分钟到几小时）。
+///
+/// 负偏移会被夹到 0：原生偶尔把词的起点报得比句子起点早一点点，夹住比丢弃好——
+/// 词数与 [AsrCue.tokens] 不等长会让下游一条都不挂（`attachAsrCueTokenTiming` 的
+/// 纪律），所以两个列表在这里必须保持等长。
 List<AsrCue> appleSpeechCues(
   List<AppleSpeechSegment> segments, {
   required int fileIndex,
@@ -269,7 +287,8 @@ List<AsrCue> appleSpeechCues(
         audioFileIndex: fileIndex,
         tokens: segment.tokens,
         tokenOffsetsMs: <int>[
-          for (final int offset in segment.tokenOffsetsMs) offset + offsetMs,
+          for (final int start in segment.tokenStartsMs)
+            if (start < segment.startMs) 0 else start - segment.startMs,
         ],
       ),
   ];

--- a/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
+++ b/fushi/lib/src/asr_host/apple_speech_transcription_service.dart
@@ -225,9 +225,13 @@ class AppleSpeechTranscriptionService extends AsrTranscriptionService {
 /// 一次正在跑的系统语音转录。
 ///
 /// 与 ONNX 那条的**行为差异必须说清**：系统 API 是「喂一个文件、等它转完」，中途
-/// **没有可续跑的检查点**。所以 [requestPause] 只能是取消——本类不发
-/// `AsrTranscribePausedEvent`，弹层的「暂停」在这个引擎下等于放弃当前文件的进度
-/// （已转完的文件仍然留在任务目录里，下次从下一个文件接着来）。
+/// **没有可续跑的检查点**。产物只在**整趟跑完**之后才落盘（SRT / sidecar /
+/// `state.json` 一次写齐），所以 [requestPause] 实际上是放弃**整趟**——不是「从下
+/// 一个文件接着来」，重开就是从第一个文件重跑。
+///
+/// 即便如此也**必须发** `AsrTranscribePausedEvent`：弹层按下暂停后停在
+/// `_Phase.pausing`，只认这个事件落到「已暂停」。不发它（或改发 error）会让界面
+/// 卡在「正在暂停…」或报出一条 `PlatformException(CANCELLED)` 当失败。
 class AppleSpeechRunningTranscription implements AsrRunningTranscription {
   AppleSpeechRunningTranscription({
     required AppleSpeechPlatform platform,
@@ -261,90 +265,128 @@ class AppleSpeechRunningTranscription implements AsrRunningTranscription {
   @override
   AsrDecodeStats? get decodeStats => null;
 
+  /// 事件流。真正的活在 [_drive] 里，**不能用 `async*`**：原生的文件内进度是从
+  /// 回调里来的，而回调里 `yield` 不了。早先那版在回调里往一个没人订阅的
+  /// `StreamController` 里塞进度，等于把长文件唯一会动的那个进度整份丢掉——
+  /// 转一个几小时的音频，进度条要到整个文件转完才第一次动。
+  ///
+  /// 起跑挂在 `onListen` 上：`run()` 被调用但没人订阅时不该已经在转。
   @override
-  Stream<AsrTranscribeEvent> run() async* {
+  Stream<AsrTranscribeEvent> run() {
+    final StreamController<AsrTranscribeEvent> events =
+        StreamController<AsrTranscribeEvent>();
+    events.onListen = () => unawaited(_drive(events));
+    return events.stream;
+  }
+
+  Future<void> _drive(StreamController<AsrTranscribeEvent> events) async {
     final Stopwatch clock = Stopwatch()..start();
     final List<AsrCue> cues = <AsrCue>[];
     final List<int> fileDurationsMs = <int>[];
     int offsetMs = 0;
+    int currentIndex = 0;
 
-    for (int index = 0; index < audioPaths.length; index++) {
-      if (_cancelled) break;
-      final StreamController<AsrTranscribeProgress> ticks =
-          StreamController<AsrTranscribeProgress>();
-      final int fileIndex = index;
-      final int base = offsetMs;
-      final AppleSpeechResult result = await _platform.transcribe(
-        path: audioPaths[index],
-        locale: language.tag,
-        onProgress: (int processedMs, int totalMs) {
-          if (ticks.isClosed) return;
-          ticks.add(
-            AsrTranscribeProgress(
-              fileIndex: fileIndex,
-              filesTotal: audioPaths.length,
-              processedMs: base + processedMs,
-              totalMs: base + totalMs,
-              speechMs: base + processedMs,
-              segmentsDone: cues.length,
-              elapsed: clock.elapsed,
-            ),
-          );
-        },
-      );
-      unawaited(ticks.close());
-      cues.addAll(
-        appleSpeechCues(
-          result.segments,
-          fileIndex: index,
-          offsetMs: offsetMs,
-        ),
-      );
-      offsetMs += result.durationMs;
-      fileDurationsMs.add(result.durationMs);
-      yield AsrTranscribeProgressEvent(
+    AsrTranscribeProgress progressAt(
+      int fileIndex,
+      int processedMs,
+      int totalMs,
+    ) =>
         AsrTranscribeProgress(
-          fileIndex: index,
+          fileIndex: fileIndex,
           filesTotal: audioPaths.length,
-          processedMs: offsetMs,
-          totalMs: offsetMs,
-          speechMs: offsetMs,
+          processedMs: processedMs,
+          totalMs: totalMs,
+          speechMs: processedMs,
           segmentsDone: cues.length,
           elapsed: clock.elapsed,
-        ),
-      );
+        );
+
+    void emit(AsrTranscribeEvent event) {
+      if (!events.isClosed) events.add(event);
     }
 
-    if (_cancelled) return;
+    try {
+      for (int index = 0; index < audioPaths.length; index++) {
+        if (_cancelled) break;
+        currentIndex = index;
+        final int base = offsetMs;
+        final AppleSpeechResult result;
+        try {
+          result = await _platform.transcribe(
+            path: audioPaths[index],
+            locale: language.tag,
+            onProgress: (int processedMs, int totalMs) => emit(
+              AsrTranscribeProgressEvent(
+                progressAt(index, base + processedMs, base + totalMs),
+              ),
+            ),
+          );
+        } on Object {
+          // 取消是我们自己发下去的，原生会以 `CANCELLED` 应答；那不是失败，
+          // 不能报成错误态（见 [requestPause]）。只有**没在取消**时才是真失败。
+          if (_cancelled) break;
+          rethrow;
+        }
+        cues.addAll(
+          appleSpeechCues(
+            result.segments,
+            fileIndex: index,
+            offsetMs: offsetMs,
+          ),
+        );
+        offsetMs += result.durationMs;
+        fileDurationsMs.add(result.durationMs);
+        emit(
+          AsrTranscribeProgressEvent(progressAt(index, offsetMs, offsetMs)),
+        );
+      }
 
-    // 产物与 ONNX 后端同构：同一套序列化函数、同样的文件名。
-    final File srt = File(p.join(jobDir.path, AsrJobFiles.srt));
-    final File tokens = File(p.join(jobDir.path, AsrJobFiles.cueTokens));
-    await srt.writeAsString(serializeAsrCuesToSrt(cues), flush: true);
-    await tokens.writeAsString(serializeAsrCueTokens(cues), flush: true);
-    await File(p.join(jobDir.path, AsrJobFiles.state)).writeAsString(
-      jsonEncode(
-        AsrJobState(
-          audioPaths: audioPaths,
-          modelId: kAppleSpeechEngineId,
-          fileDurationsMs: fileDurationsMs,
-          resumeSamples: List<int>.filled(audioPaths.length, 0),
-          finished: true,
-        ).toJson(),
-      ),
-      flush: true,
-    );
+      if (_cancelled) {
+        // 必须给一个终局事件：弹层按下暂停后停在 `_Phase.pausing`，收不到
+        // Paused 就一直显示「正在暂停…」且没有任何按钮可按。
+        emit(
+          AsrTranscribePausedEvent(
+            progressAt(currentIndex, offsetMs, offsetMs),
+          ),
+        );
+        return;
+      }
 
-    yield AsrTranscribeFinishedEvent(
-      AsrTranscribeResult(
-        srtPath: srt.path,
-        segmentsPath: p.join(jobDir.path, AsrJobFiles.segments),
-        cueCount: cues.length,
-        segmentCount: cues.length,
-        totalMs: offsetMs,
-        fileDurationsMs: fileDurationsMs,
-      ),
-    );
+      // 产物与 ONNX 后端同构：同一套序列化函数、同样的文件名。
+      final File srt = File(p.join(jobDir.path, AsrJobFiles.srt));
+      final File tokens = File(p.join(jobDir.path, AsrJobFiles.cueTokens));
+      await srt.writeAsString(serializeAsrCuesToSrt(cues), flush: true);
+      await tokens.writeAsString(serializeAsrCueTokens(cues), flush: true);
+      await File(p.join(jobDir.path, AsrJobFiles.state)).writeAsString(
+        jsonEncode(
+          AsrJobState(
+            audioPaths: audioPaths,
+            modelId: kAppleSpeechEngineId,
+            fileDurationsMs: fileDurationsMs,
+            resumeSamples: List<int>.filled(audioPaths.length, 0),
+            finished: true,
+          ).toJson(),
+        ),
+        flush: true,
+      );
+
+      emit(
+        AsrTranscribeFinishedEvent(
+          AsrTranscribeResult(
+            srtPath: srt.path,
+            segmentsPath: p.join(jobDir.path, AsrJobFiles.segments),
+            cueCount: cues.length,
+            segmentCount: cues.length,
+            totalMs: offsetMs,
+            fileDurationsMs: fileDurationsMs,
+          ),
+        ),
+      );
+    } catch (error, stack) {
+      if (!events.isClosed) events.addError(error, stack);
+    } finally {
+      await events.close();
+    }
   }
 
   @override
@@ -356,6 +398,10 @@ class AppleSpeechRunningTranscription implements AsrRunningTranscription {
 
   @override
   Future<void> dispose() async {
-    if (!_cancelled) await _platform.cancel();
+    // 先立旗再取消：在跑的那次 `transcribe` 会以 `CANCELLED` 抛回来，[_drive]
+    // 靠这面旗把它认成「我们要求的停」而不是转录失败。
+    final bool wasRunning = !_cancelled;
+    _cancelled = true;
+    if (wasRunning) await _platform.cancel();
   }
 }

--- a/fushi/test/asr_host/apple_speech_test.dart
+++ b/fushi/test/asr_host/apple_speech_test.dart
@@ -6,9 +6,11 @@
 /// 设备上看起来和「这段没人说话」一模一样。
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_asr_core/asr_core.dart';
 
@@ -60,7 +62,7 @@ class _FakePlatform implements AppleSpeechPlatform {
           startMs: 100,
           endMs: 900,
           tokens: <String>['今日', 'は', 'いい', '天気'],
-          tokenOffsetsMs: <int>[100, 300, 500, 700],
+          tokenStartsMs: <int>[100, 300, 500, 700],
         ),
       ],
     );
@@ -68,6 +70,53 @@ class _FakePlatform implements AppleSpeechPlatform {
 
   @override
   Future<void> cancel() async => cancelCalls++;
+}
+
+/// 停在半路的假平台：转录**不返回**，直到 [cancel] 把它以原生的 `CANCELLED`
+/// 抛回来——这正是真机上按下暂停时发生的事。
+///
+/// [_FakePlatform] 的 transcribe 立刻返回，`requestPause()` 只能在 `run()` 之前调，
+/// 于是循环在第一行就 break、根本走不到「有一次转录正在飞」的那条路径。
+class _CancellingPlatform implements AppleSpeechPlatform {
+  final Completer<AppleSpeechResult> _inFlight = Completer<AppleSpeechResult>();
+
+  /// 原生已经开转（用来确保暂停发生在转录中途，而不是开跑之前）。
+  final Completer<void> started = Completer<void>();
+
+  int cancelCalls = 0;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<List<String>> installedLocales() async => const <String>['ja-JP'];
+
+  @override
+  Future<List<String>> supportedLocales() async => const <String>['ja-JP'];
+
+  @override
+  Future<void> prepare(String locale) async {}
+
+  @override
+  Future<AppleSpeechResult> transcribe({
+    required String path,
+    required String locale,
+    void Function(int processedMs, int totalMs)? onProgress,
+  }) {
+    onProgress?.call(300, 1000);
+    if (!started.isCompleted) started.complete();
+    return _inFlight.future;
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
+    if (!_inFlight.isCompleted) {
+      _inFlight.completeError(
+        PlatformException(code: 'CANCELLED', message: 'cancelled'),
+      );
+    }
+  }
 }
 
 void main() {
@@ -93,7 +142,7 @@ void main() {
       expect(result.segments.single.startMs, 100);
       expect(result.segments.single.endMs, 900);
       expect(result.segments.single.tokens, <String>['hel', 'lo']);
-      expect(result.segments.single.tokenOffsetsMs, <int>[100, 400]);
+      expect(result.segments.single.tokenStartsMs, <int>[100, 400]);
     });
 
     test('空文本与退化区间逐条丢弃，不毁掉整份', () {
@@ -128,7 +177,7 @@ void main() {
   });
 
   group('appleSpeechCues', () {
-    test('多文件按拼接时间轴平移，逐词起点一起平移', () {
+    test('cue 时间按拼接时间轴平移，逐词偏移改以 cue 起点为基准', () {
       final List<AsrCue> cues = appleSpeechCues(
         const <AppleSpeechSegment>[
           AppleSpeechSegment(
@@ -136,7 +185,7 @@ void main() {
             startMs: 100,
             endMs: 400,
             tokens: <String>['second', 'file'],
-            tokenOffsetsMs: <int>[100, 250],
+            tokenStartsMs: <int>[100, 250],
           ),
         ],
         fileIndex: 1,
@@ -146,10 +195,30 @@ void main() {
       expect(cue.startMs, 60100);
       expect(cue.endMs, 60400);
       expect(cue.audioFileIndex, 1);
-      // 逐词起点不平移的话，跳播会整整差一个文件的时长。
-      expect(cue.tokenOffsetsMs, <int>[60100, 60250]);
+      // 上游 sidecar 的 `o` 是**相对 cue 起点**的偏移，消费端一律按
+      // `cue.startMs + o` 还原。塞绝对时间（60100/60250）会让每个词多算一整个
+      // cue 起点，而 SRT 与行数全对得上——静默偏移，只有跳播看得出来。
+      expect(cue.tokenOffsetsMs, <int>[0, 150]);
       // 下游 attachAsrCueTokenTiming 要求两者等长，不等长时一条都不挂。
       expect(cue.tokens.length, cue.tokenOffsetsMs.length);
+    });
+
+    test('词起点早于句起点时夹到 0，不丢词（丢了就长度不等，一条都挂不上）', () {
+      final List<AsrCue> cues = appleSpeechCues(
+        const <AppleSpeechSegment>[
+          AppleSpeechSegment(
+            text: 'early token',
+            startMs: 500,
+            endMs: 900,
+            tokens: <String>['early', 'token'],
+            tokenStartsMs: <int>[480, 700],
+          ),
+        ],
+        fileIndex: 0,
+        offsetMs: 0,
+      );
+      expect(cues.single.tokenOffsetsMs, <int>[0, 200]);
+      expect(cues.single.tokens.length, cues.single.tokenOffsetsMs.length);
     });
   });
 
@@ -261,7 +330,7 @@ void main() {
       if (audioDir.existsSync()) await audioDir.delete(recursive: true);
     });
 
-    AppleSpeechTranscriptionService build(_FakePlatform platform) =>
+    AppleSpeechTranscriptionService build(AppleSpeechPlatform platform) =>
         AppleSpeechTranscriptionService(
           platform: platform,
           jobsRoot: () async => jobs,
@@ -413,6 +482,60 @@ void main() {
           await service.jobDirFor(audioPaths, AsrLanguage.japanese);
       // 半份 SRT 比没有更糟：下游会把它当成一份完整字幕去匹配。
       expect(File('${dir.path}/${AsrJobFiles.srt}').existsSync(), isFalse);
+    });
+
+    test('转录中途暂停：原生的 CANCELLED 要落成「已暂停」，不是转录失败', () async {
+      final _CancellingPlatform platform = _CancellingPlatform();
+      final AppleSpeechTranscriptionService service = build(platform);
+      final AsrRunningTranscription running = await service.start(
+        audioPaths: audioPaths,
+        language: AsrLanguage.japanese,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.auto,
+      );
+
+      final List<AsrTranscribeEvent> events = <AsrTranscribeEvent>[];
+      final Completer<void> closed = Completer<void>();
+      Object? failure;
+      final StreamSubscription<AsrTranscribeEvent> sub = running.run().listen(
+            events.add,
+            onError: (Object error, StackTrace _) => failure = error,
+            onDone: closed.complete,
+          );
+
+      await platform.started.future;
+      running.requestPause();
+      await closed.future;
+      await sub.cancel();
+
+      expect(platform.cancelCalls, greaterThan(0));
+      // 取消是我们自己要求的，不该冒充失败——弹层会把它显示成「转录失败」并
+      // 甩出一条 PlatformException 原文。
+      expect(failure, isNull);
+      // 弹层按下暂停后停在 pausing，只认这个事件才落到「已暂停」。
+      expect(events.whereType<AsrTranscribePausedEvent>(), hasLength(1));
+      expect(events.whereType<AsrTranscribeFinishedEvent>(), isEmpty);
+    });
+
+    test('原生的文件内进度要并进产出流（长文件唯一会动的那个）', () async {
+      final _FakePlatform platform = _FakePlatform();
+      final AppleSpeechTranscriptionService service = build(platform);
+      final AsrRunningTranscription running = await service.start(
+        audioPaths: audioPaths,
+        language: AsrLanguage.japanese,
+        variant: AsrEncoderVariant.int8,
+        preference: AsrAccelerationPreference.auto,
+      );
+      final List<AsrTranscribeEvent> events = await running.run().toList();
+      final List<int> processed = events
+          .whereType<AsrTranscribeProgressEvent>()
+          .map((AsrTranscribeProgressEvent e) => e.progress.processedMs)
+          .toList();
+
+      // 假平台每个文件在半路报一次 500/1000；第二个文件要加上第一个的时长。
+      // 缺了它们，几小时的音频在整份转完前进度条一动不动。
+      expect(processed, contains(500));
+      expect(processed, contains(1500));
     });
   });
 }


### PR DESCRIPTION
`5bfa9c2407` 把 SpeechAnalyzer 接进转录弹层之后，Dart 装配侧留下三处缺陷。三处的共同点是**在单测与 CI 里都看不见**，只在真机跑长音频时才显形。

## 1. 逐词时间基准错位（静默，危害最大）

`AsrCue.tokenOffsetsMs` 的契约是**相对该 cue 起点**的偏移：

- 上游产的是 `seg.tokenTimesMs[i] - start`（`asr_cue_builder.dart:229/264`），`serializeAsrCueTokens` 的注释写死「`o` = 相对 cue 起点的毫秒」；
- 消费端一律按 `cue.startMs + o` 还原绝对时刻（`packages/fushi_audio/.../cue_sentence_resegmenter.dart:352`，字段注释见 `audiobook_model.dart:62`）。

而 `appleSpeechCues()` 写进去的是 `原生绝对起点 + 拼接偏移`——原生给的 `run.audioTimeRange.start` 本来就是文件内绝对毫秒。结果每个词的时刻都多算一整个 cue 起点。

失败形态之所以难发现：SRT 逐行正确、cue 数与 sidecar 行数一致、`attachAsrCueTokenTiming` 的行数校验照样通过、整条链路照跑照落库——**只有逐词跳播整体偏掉**，有声书里就是几十分钟到几小时。

顺带把 `AppleSpeechSegment.tokenOffsetsMs` 改名为 `tokenStartsMs`：这个 bug 的根源就是「起点」和「相对偏移」共用了一个词。

## 2. 转录中途暂停被报成「转录失败」

原生对我们自己发出的取消以 `FlutterError(CANCELLED)` 应答，通道层按设计原样抛出（只有三类 unavailable 才转成 `AppleSpeechUnavailable`），异常穿过 `run()` 落到弹层 `onError` → `_failWith` → 显示「转录失败」加一条 `PlatformException(CANCELLED, ...)` 原文。

现在：取消时不当失败，改为补发 `AsrTranscribePausedEvent`。弹层按下暂停后停在 `_Phase.pausing`，**只认这个事件**才落到「已暂停」；既不发它又不报错的话，界面会永远卡在「正在暂停…」且没有任何按钮可按。

原有那条 pause 测试是在 `run()` **之前**调 `requestPause()`，循环在第一行就 break，从来没走到「有一次转录正在飞」的路径——所以这个 bug 漏了过去。新测试用一个转录不返回、直到 cancel 才以 `CANCELLED` 抛回的假平台补上。

## 3. 文件内进度整份丢失

`run()` 把原生反向发来的进度 `add` 进一个 `StreamController`，而那个 controller **没有任何订阅者、也从未并进产出流**——进度全丢。长文件唯一会动的就是它，转一个几小时的音频，进度条要到整份转完才第一次动。

`async*` 结构上做不到这件事（回调里没法 `yield`），所以改成显式 controller，起跑挂在 `onListen` 上（`run()` 被调用但没人订阅时不该已经在转）。

## 附带

改正与实现矛盾的类文档：产物只在**整趟跑完**后一次写齐（SRT / sidecar / `state.json`），所以暂停是放弃**整趟**、重开从第一个文件重跑，不是原文写的「已转完的文件留在任务目录里，下次从下一个文件接着来」。

## 验证

- 三条新增/修正的用例各做了**变异检验**：把原来的错误逻辑逐个注回去，确认每次只打红对应的那一条（分别 2 红 / 1 红 / 1 红），排除「测试写了但抓不住」。
- `flutter analyze` 全仓 **No issues found**。
- `test/asr_host/` + `test/asr/` + `test/build/apple_speech_transcriber_guard_test.dart` 共 **109 条**全绿；`asr_transcribe_sheet` / `asr_models_settings_section` / `subtitle_retiming_service` 共 **37 条**全绿。
- 三个文件均按上游该文件原有的短格式（`dart format --language-version=3.6`）校验 clean，未引入格式噪音。

## 两处**没有**动、但建议复核的风险

我在 Windows 上无法编译或运行 Swift，所以这两条只报告、不改，避免把无法验证的原生改动塞进来：

1. **`NSSpeechRecognitionUsageDescription` 缺失**。`fushi/ios/Runner/Info.plist` 与 `fushi/macos/Runner/Info.plist` 都只有 `NSMicrophoneUsageDescription`。新的 `SpeechAnalyzer` 路径是否触发语音识别的 TCC 授权，我没有真机可证；若触发，缺这个 key 是进程级硬崩，需要在真机上确认一次。
2. **`AssetInventory.reserve(locale:)` 有 `maximumReservedLocales` 上限**。`prepare` 里 reserve 抛出会被统一压成 `ASSET_INSTALL_FAILED`，用户侧表现是「资产明明装好了却报装不上」。多语言反复切换后是否真会撞上限，同样需要真机确认。

另：这三条是我审这份刚合入的实现时发现的，不是用户报障，所以没走 `docs/bugs/` 的一 bug 一文件流程；如果希望补记录，我可以另起一条。

https://claude.ai/code/session_01TB5XVTAAfvSRNURdAHtXhy
