### PR TITLE
fix(lookup): 关掉弹窗关闭动画=拖动直接关，dock 面板真正铺满左右（BUG-2439）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2238 条。点号进各自文件。
+> 共 2239 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2439](bugs/BUG-2439-popup-dismiss-instant-and-dock-full-width.md) | ✅ | ✅ | 关掉弹窗关闭动画后拖动仍跟手；底部停靠面板左右各缺 6px 不铺满 |
 | [BUG-2428](bugs/BUG-2428-dict-scan-inline-results.md) | ✅ | ✅ | 查词页源文本条点字压嵌套浮层，没有换下方的查词结果 |
 | [BUG-2427](bugs/BUG-2427-desktop-library-header-top-gap.md) | ✅ | ✅ | 桌面端库页页头顶部留白过大（手机端修复未同步） |
 | [BUG-2426](bugs/BUG-2426-side-panel-embed-self-attested.md) | ✅ | ✅ | 扩展 side-panel 的「是否被嵌入」由 URL 参数自证，省略参数即可绕过 #1295 全部加固 |

--- a/docs/bugs/BUG-2439-popup-dismiss-instant-and-dock-full-width.md
+++ b/docs/bugs/BUG-2439-popup-dismiss-instant-and-dock-full-width.md
@@ -1,0 +1,34 @@
+## BUG-2439 · 关掉弹窗关闭动画后拖动仍跟手；底部停靠面板左右各缺 6px 不铺满
+- **报告**：2026-09-10（用户：hajisensai）
+- **真实性**：✅ 真 bug（两条独立症状，同一次报告）
+  - ① 滑关跟手：`fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart:199`（`Transform.translate` 无条件跟手）与
+    `fushi/lib/src/pages/implementations/dictionary_popup_layer.dart:1541`（正文横拖同款）。BUG-2405 只把**松手后**的
+    补间时长归零（`popupDismissAnimationDuration`），跟手期的实时位移 + 淡出原样留着，于是「弹窗关闭动画」关掉后
+    拖动仍看得见弹窗跟着手指滑一段才消失——与该开关副标题「关掉则瞬间关闭」不符。
+  - ② dock 不铺满：`dictionary_popup_layer.dart:189`（`horizontalInset = inset.clamp(...)`，横纵共用一个 inset）
+    + `:227`（`resolvePopupRect` 的 dock 分支 `inset: padding` 转发）。两个收口点传的都是**跟随模式**的贴边避让
+    padding=6（`base_source_page.dart:559` / `dictionary_page_mixin.dart` 吃默认值），语义是「别贴着屏幕边缘弹出」，
+    与 dock 的「整宽面板」相反，于是底部停靠面板左右各缺 6px。矩形铺满后卡片圆角（令牌 10）的四段弧仍会在屏幕
+    左右缘露出背景，观感上还是没铺满。
+- **[x] ① 已修复** — 提交见分支 `pr/popup-dismiss-instant`
+  - 滑关：新增 `popupSwipeDismissIsInstant()` 收口（与 `popupDismissAnimationDuration` 同文件）。为真时两处滑关
+    实现跟手期都不重绘、不挂 `Transform`/`Opacity`，抬手当帧按累计横向位移判阈值：过了直接 `onDismiss`，没过原地
+    不动（没位移过，也就没有 spring-back 可弹）。判定时机仍在抬手，与 Hoshi Reader Android 一致（`LookupPopupHtml.kt`
+    只监听 `touchstart`/`touchend`、不听 `touchmove`，全链路无补间）。墨水屏那条来源不变，仍只压补间时长、保留
+    跟手方向反馈——两条来源正交。
+  - dock：`dockedPopupRect` 把内边距**分轴**（新增 `horizontalInset`，默认 0；`inset` 只管纵向），`resolvePopupRect`
+    的 dock 分支不再把 `padding` 转发进横向。`FushiPopupSurface` 新增 `borderRadius` 覆写（内圈半径逐角内缩描边、
+    夹在 0），`DictionaryPopupLayer` 新增 `bottomDocked`，dock 态把圆角摊平；两个宿主传 `popupBottomDocked`。
+- **[x] ② 已加自动化测试** — 10 条新用例，摘掉修复正好全红（判别力已验证）
+  - `fushi/test/widgets/swipe_dismiss_wrapper_test.dart` — 新组「关掉动画后跟手期零位移」4 条：开着位移 200 /
+    关掉恒 0 / 同一条拖动的对照 / 关掉时子树里一个 `Transform`·`Opacity` 都没有（不是靠 offset 0 假装不动）。
+    另修既有「未过阈值」用例的断言（不再有 `Transform` 可取）。
+  - `fushi/test/pages/dictionary_popup_layer_body_swipe_close_test.dart` — 正文横拖同款 4 条（与顶栏是两套独立
+    实现，只测一边另一边回归时全绿）。
+  - `fushi/test/pages/dictionary_popup_layer_test.dart` — dock 几何：左缘 0 / 宽 = 屏宽 / 右缘 = 屏宽；
+    `resolvePopupRect` 传 padding=6 时横向仍铺满而纵向保留 6；横向 inset 显式给出仍生效（分轴而非删掉）。
+  - `fushi/test/pages/dictionary_popup_dock_full_width_test.dart`（新文件）— dock 圆角摊平 / 跟随模式圆角不动 /
+    两者确实不同 + 两条源码守卫（负半径夹取、两个宿主都传 dock 偏好）。
+- **备注**：判定时机**没有**改成「越过阈值即刻关」——那会在拖到一半时误关，且与既有阈值语义（松手判定）冲突；
+  hoshi 也是抬手才判。app 外查词窗的 JS 滑关（`popup_swipe_close_script.dart`）与桌面 barrier 横拖
+  （`lookup_dismiss_barrier.dart`）本来就是纯判定、零跟手，不受本次改动影响。

--- a/fushi/lib/src/pages/base_source_page.dart
+++ b/fushi/lib/src/pages/base_source_page.dart
@@ -798,6 +798,8 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
         hasChildPopup: index < stack.length - 1,
         isDark: isDark,
         overrideFillColor: appModel.overrideDictionaryColor,
+        // dock 面板铺满屏幕左右缘时把圆角摊平，否则边缘露出背景（BUG-2439）。
+        bottomDocked: appModel.popupBottomDocked,
         onDismiss: () => _dismissPopupAt(index),
         // TODO-407②：平台/偏好级"滑动关闭"开关（Windows/Linux 默认 false）。
         enableSwipeToClose: ReaderFushiSource.instance.enableSwipeToClose,

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -733,6 +733,8 @@ mixin DictionaryPageMixin {
         hasChildPopup: index < controller.entries.length - 1,
         isDark: isDark,
         overrideFillColor: mixinAppModel.overrideDictionaryColor,
+        // dock 面板铺满屏幕左右缘时把圆角摊平，否则边缘露出背景（BUG-2439）。
+        bottomDocked: mixinAppModel.popupBottomDocked,
         onDismiss: () => onPop(index),
         // BUG-1269：弹窗是原生 WebView，指针落上去后宿主收不到键盘/鼠标——把宿主
         // 声明的那些输入交回来（表由注册表当前绑定实时导出，改键立即跟随）。

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -173,13 +173,21 @@ Rect computeFloatingLyricPopupRect({
 }
 
 /// TODO-108：底部固定（dock）模式下的弹窗矩形——忽略选区位置，把弹窗放成屏幕底部
-/// 一条全宽面板。[screen] 是可用区域大小；[inset] 是左右及离屏底的内边距；[dockedHeight]
-/// 是面板目标高度（会按可用高度 clamp）；[bottomReserve]/[topReserve] 与跟随模式同义
-/// （底栏/状态栏等预留），保证 dock 面板不被这些区域遮住。纯函数，reader 与 video 两个
-/// 收口点共用同一实现，保证两表面 dock 行为一致。
+/// 一条全宽面板。[screen] 是可用区域大小；[dockedHeight] 是面板目标高度（会按可用高度
+/// clamp）；[bottomReserve]/[topReserve] 与跟随模式同义（底栏/状态栏等预留），保证 dock
+/// 面板不被这些区域遮住。纯函数，reader 与 video 两个收口点共用同一实现，保证两表面
+/// dock 行为一致。
+///
+/// 两个内边距**分轴**（BUG-2439）：
+///   * [horizontalInset] 默认 **0** —— 「整宽面板」就该从屏幕最左铺到最右。此前它与
+///     纵向共用一个 [inset]，而两个收口点都把跟随模式的贴边避让 padding（6）转发进来，
+///     于是 dock 面板左右各缺 6px，怎么调设置都补不上。跟随模式的 padding 是「别贴着
+///     屏幕边缘弹出」，与 dock 的「铺满」诉求相反，不该共用同一个数。
+///   * [inset] 只管纵向：面板与屏幕底（或 [bottomReserve] 上沿）之间的留白。
 Rect dockedPopupRect({
   required Size screen,
   double inset = 6.0,
+  double horizontalInset = 0.0,
   double dockedHeight = 360.0,
   double bottomReserve = 0.0,
   double topReserve = 0.0,
@@ -187,18 +195,17 @@ Rect dockedPopupRect({
   final double reserve = bottomReserve.clamp(0, screen.height);
   final double effectiveTop = topReserve.clamp(0, screen.height);
   final double effectiveBottom = screen.height - reserve;
-  final double horizontalInset = inset.clamp(0, screen.width / 2);
+  final double sideInset = horizontalInset.clamp(0, screen.width / 2);
   final double verticalInset =
       inset.clamp(0, (effectiveBottom).clamp(0, screen.height) / 2);
-  final double width =
-      (screen.width - horizontalInset * 2).clamp(0, screen.width);
+  final double width = (screen.width - sideInset * 2).clamp(0, screen.width);
   final double maxAvail = (effectiveBottom - effectiveTop - verticalInset * 2)
       .clamp(0, screen.height);
   final double height = dockedHeight.clamp(0, maxAvail);
   final double top = (effectiveBottom - verticalInset - height)
       .clamp(effectiveTop + verticalInset, effectiveBottom)
       .toDouble();
-  return Rect.fromLTWH(horizontalInset, top, width, height);
+  return Rect.fromLTWH(sideInset, top, width, height);
 }
 
 /// 查词弹窗位置分流的单一收口：[bottomDocked] 时忽略选区返回屏幕底部全宽 dock 面板
@@ -224,6 +231,7 @@ Rect resolvePopupRect({
   if (bottomDocked) {
     return dockedPopupRect(
       screen: screen,
+      // [padding] 只喂纵向。横向留默认 0：dock 面板铺满屏幕最左到最右（BUG-2439）。
       inset: padding,
       dockedHeight: maxHeight,
       bottomReserve: bottomReserve,
@@ -639,6 +647,7 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.isDark = false,
     this.overrideFillColor,
     this.showBorder = true,
+    this.bottomDocked = false,
     this.swipeDismissible = true,
     this.enableSwipeToClose = true,
     this.onClose,
@@ -807,6 +816,14 @@ class DictionaryPopupLayer extends StatelessWidget {
   static const Key resizeGripKey =
       ValueKey<String>('dictionary-popup-resize-grip');
 
+  /// 本层是否是「底部停靠」的整宽面板（`popup_bottom_docked`）。
+  ///
+  /// 只影响**贴边处的观感**：dock 面板的矩形铺满屏幕最左到最右（见 [dockedPopupRect]
+  /// 的 `horizontalInset`），此时卡片圆角的四段弧会在屏幕左右缘露出背景色，看起来就是
+  /// 「全宽没铺满」。为真时把圆角摊平成直角，让 surface 真正边到边（BUG-2439）。跟随
+  /// 选区的普通弹窗四周都有留白，保持既有圆角。
+  final bool bottomDocked;
+
   /// TODO-406/407：滑动关闭是否生效——平台/偏好开关（[enableSwipeToClose]）与调用方
   /// 层级开关（[swipeDismissible]）同时为真才挂 [SwipeDismissWrapper]。
   bool get _swipeActive => swipeDismissible && enableSwipeToClose;
@@ -861,6 +878,8 @@ class DictionaryPopupLayer extends StatelessWidget {
     final Widget surface = FushiPopupSurface(
       color: fillColor,
       showBorder: showBorder,
+      // dock 面板贴着屏幕左右缘，圆角摊平才是真正的「整宽」（BUG-2439）。
+      borderRadius: bottomDocked ? BorderRadius.zero : null,
       clipBehavior: showBorder ? Clip.antiAlias : Clip.none,
       // BUG-1692：本 surface 里装的是原生 WebView（平台视图）。描边默认走
       // foregroundPainter、画在 WebView **之后**且 bounds 覆盖整个浮层，macOS engine
@@ -1348,6 +1367,10 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
         ReaderFushiSource.instance.dismissSwipeSensitivity,
       );
 
+  /// 用户关掉「弹窗关闭动画」= 整条滑关不画（[popupSwipeDismissIsInstant]）：跟手期
+  /// 不重绘、不位移，抬手过阈值当帧关。**用时取值**，理由同 [_applyDismissDuration]。
+  bool get _instant => popupSwipeDismissIsInstant();
+
   @override
   void initState() {
     super.initState();
@@ -1437,6 +1460,9 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
       _pointerIsHorizontal = delta.dx.abs() > delta.dy.abs() * 1.5;
     }
     if (_pointerIsHorizontal != true) return;
+    // instant：跟手期一帧都不重画（[build] 也不挂 Transform/Opacity），弹窗按住不动；
+    // 判定所需的累计位移在抬手时由 [_onPointerUp] 从指针位置重算，不依赖 [_dragX]。
+    if (_instant) return;
     setState(() => _dragX = delta.dx);
   }
 
@@ -1444,10 +1470,17 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
     _activePointers.remove(event.pointer);
     if (event.pointer != _trackedPointer) return;
     final bool shouldFinish = _pointerIsHorizontal == true;
+    // instant 下 [_dragX] 恒 0（跟手期不更新），累计位移只能从起点重算。
+    final double accumulated =
+        _pointerStart == null ? _dragX : event.position.dx - _pointerStart!.dx;
     _clearTrackedPointer();
-    if (shouldFinish) {
-      _finishHorizontalDrag();
+    if (!shouldFinish) return;
+    if (_instant) {
+      // 抬手当帧判定：过阈值直接关（无滑出补间），没过什么都不用做（弹窗没动过）。
+      if (accumulated.abs() > _threshold) widget.onDismiss();
+      return;
     }
+    _finishHorizontalDrag();
   }
 
   void _onPointerCancel(PointerCancelEvent event) {
@@ -1486,6 +1519,11 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
   }
 
   void _springBack() {
+    // instant：跟手期没位移过，没有可弹回的距离，也不该起一次 0→0 的补间。
+    if (_instant) {
+      if (_dragX != 0 && mounted) setState(() => _dragX = 0);
+      return;
+    }
     _applyDismissDuration();
     _dragStartX = _dragX;
     _dragTargetX = 0;
@@ -1503,7 +1541,7 @@ class _BodySwipeDismissDetectorState extends State<_BodySwipeDismissDetector>
       onPointerMove: _onPointerMove,
       onPointerUp: _onPointerUp,
       onPointerCancel: _onPointerCancel,
-      child: widget.enableSwipeToClose
+      child: widget.enableSwipeToClose && !_instant
           ? LayoutBuilder(
               builder: (BuildContext context, BoxConstraints constraints) {
                 if (constraints.maxWidth.isFinite) {

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -3215,6 +3215,7 @@ class FushiPopupSurface extends StatelessWidget {
     this.showBorder = true,
     this.clipBehavior = Clip.antiAlias,
     this.borderOnForeground = true,
+    this.borderRadius,
   });
 
   final Widget child;
@@ -3223,6 +3224,13 @@ class FushiPopupSurface extends StatelessWidget {
   final double elevation;
   final bool showBorder;
   final Clip clipBehavior;
+
+  /// 圆角覆写。默认 null = 走设计令牌的卡片圆角（10）。
+  ///
+  /// 唯一的现实用途是**贴边的 surface**：查词弹窗的底部 dock 面板铺满屏幕最左到最右
+  /// （BUG-2439），此时左右两侧的圆角弧会在屏幕边缘露出背景，看起来就是「没铺满」。
+  /// 贴哪条边就把那两个角摊平，别整块改令牌——其余 surface 的圆角是全局一致的。
+  final BorderRadius? borderRadius;
 
   /// BUG-1692：描边画在子节点**之前**还是**之后**。
   ///
@@ -3260,11 +3268,26 @@ class FushiPopupSurface extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(_borderWidth),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(
-          math.max(0, tokens.radii.card - _borderWidth),
-        ),
+        borderRadius: _deflate(_outerRadius(tokens)),
         child: content,
       ),
+    );
+  }
+
+  BorderRadius _outerRadius(FushiDesignTokens tokens) =>
+      borderRadius ?? tokens.radii.cardRadius;
+
+  /// 内圈半径 = 外圈逐角减一个笔宽（摊平的角保持摊平，不会被减成负数）。
+  static BorderRadius _deflate(BorderRadius outer) {
+    Radius shrink(Radius r) => Radius.elliptical(
+          math.max(0, r.x - _borderWidth),
+          math.max(0, r.y - _borderWidth),
+        );
+    return BorderRadius.only(
+      topLeft: shrink(outer.topLeft),
+      topRight: shrink(outer.topRight),
+      bottomLeft: shrink(outer.bottomLeft),
+      bottomRight: shrink(outer.bottomRight),
     );
   }
 
@@ -3275,7 +3298,7 @@ class FushiPopupSurface extends StatelessWidget {
       color: color ?? tokens.surfaces.card,
       elevation: elevation,
       shape: RoundedRectangleBorder(
-        borderRadius: tokens.radii.cardRadius,
+        borderRadius: _outerRadius(tokens),
         side: showBorder
             ? BorderSide(color: tokens.surfaces.outline, width: _borderWidth)
             : BorderSide.none,

--- a/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
+++ b/fushi/lib/src/utils/misc/swipe_dismiss_wrapper.dart
@@ -24,8 +24,10 @@ double swipeDismissThreshold(double sensitivity) =>
 ///     残影，此前是唯一的关闭途径。
 ///
 /// [Duration.zero] 的 `animateTo` 当帧就 complete，`onDismiss` 仍在完成回调里触发，
-/// 关窗时序不变，只是不再画中间帧。跟手期的 `Transform.translate` 不受影响——手指
-/// 按住时的实时跟随不是补间动画，去掉会让滑关失去方向反馈（BUG-2283 备注）。
+/// 关窗时序不变，只是不再画中间帧。
+///
+/// 墨水屏那条**只归零补间**：跟手期的 `Transform.translate` 保留，手指按住时仍有方向
+/// 反馈（BUG-2283 备注）。用户显式关掉开关那条更强，见 [popupSwipeDismissIsInstant]。
 Duration popupDismissAnimationDuration(
   BuildContext context,
   Duration duration,
@@ -35,6 +37,22 @@ Duration popupDismissAnimationDuration(
   }
   return einkSafeDuration(context, duration);
 }
+
+/// 用户显式关掉「弹窗关闭动画」（`popup_dismiss_animation`）时，滑关**整条**都不画：
+///
+///   * 跟手期不再 `Transform.translate` + 淡出——手指按住拖动时弹窗一动不动；
+///   * 抬手那一刻按累计横向位移判 [swipeDismissThreshold]：过了当帧 `onDismiss`，
+///     没过就原地留着（无 spring-back 补间可弹——本来就没动过）。
+///
+/// 判定时机仍在**抬手**，与 Hoshi Reader Android 一致：那边的滑关只监听
+/// `touchstart`/`touchend`、不听 `touchmove`（`LookupPopupHtml.kt`），拖动期间弹窗零
+/// 位移，抬手过阈值就直接 `dismiss()`，全链路无补间、无 exit transition。
+///
+/// BUG-2405 只把松手后的补间归零，跟手位移原样留着，于是开关关掉后拖动仍看得见弹窗
+/// 跟着手指滑一段才消失——与「弹窗关闭动画」这个名字和「关掉则瞬间关闭」的副标题
+/// 不符（BUG-2439）。
+bool popupSwipeDismissIsInstant() =>
+    !ReaderFushiSource.instance.popupDismissAnimation;
 
 // BUG-1757：`BarrierSwipeDismissTracker` 已迁到 `lookup_dismiss_barrier.dart`，
 // 并入唯一的 barrier 构造入口 [LookupDismissBarrier]。页面不再自己持有 tracker、
@@ -84,6 +102,11 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
 
   double get _threshold => swipeDismissThreshold(widget.sensitivity);
   double get _decisionDistance => 10 + (1.0 - widget.sensitivity) * 20;
+
+  /// 用户关掉「弹窗关闭动画」= 整条滑关不画（[popupSwipeDismissIsInstant]）：跟手期
+  /// 不重绘、不位移，抬手过阈值当帧关。**用时取值**，与补间时长同理（在设置里翻开关
+  /// 只触发 rebuild，缓存到字段会留着上一次的值）。
+  bool get _instant => popupSwipeDismissIsInstant();
 
   @override
   void initState() {
@@ -172,12 +195,23 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
       _decided = true;
       _isHorizontal = _dragX.abs() > _dragY.abs() * 2.5;
     }
-    if (_decided && _isHorizontal && mounted) {
+    // instant：跟手期一帧都不重画（[build] 也不会挂 Transform/Opacity），弹窗按住不动。
+    if (_decided && _isHorizontal && mounted && !_instant) {
       setState(() {});
     }
   }
 
   void _finishDrag() {
+    if (_instant) {
+      // 抬手当帧判定：过阈值直接关（无滑出补间），没过就复位（没动过，无 spring-back）。
+      final bool passed =
+          _decided && _isHorizontal && _dragX.abs() > _threshold;
+      // 不置 [_dismissing]：instant 没有「已滑出、等宿主移除」的退场帧要保住，留着它
+      // 反而会在宿主复用同一 child 时把 [_beginDrag] 永久锁死（那条复位靠 child 换身份）。
+      _reset();
+      if (passed) widget.onDismiss();
+      return;
+    }
     _applyDismissDuration();
     if (_decided && _isHorizontal && _dragX.abs() > _threshold) {
       // TODO-890：过阈值后不再 opacity 瞬灭，而是朝拖动方向补间滑出屏外（卡片宽 +
@@ -206,7 +240,8 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
 
   @override
   Widget build(BuildContext context) {
-    final bool active = (_decided && _isHorizontal) || _dismissing;
+    final bool active =
+        !_instant && ((_decided && _isHorizontal) || _dismissing);
     return Listener(
       behavior: HitTestBehavior.translucent,
       onPointerDown: (_) => _beginDrag(),
@@ -221,6 +256,9 @@ class _SwipeDismissWrapperState extends State<SwipeDismissWrapper>
           if (constraints.maxWidth.isFinite) {
             _layerWidth = constraints.maxWidth;
           }
+          // instant：没有跟手位移也没有退场补间，[Transform]/[Opacity] 一层都不套——
+          // 弹窗要么原样在，要么当帧消失。
+          if (_instant) return widget.child;
           // 退场期随位移淡出（对齐 _BodySwipeDismissDetector）：补间把 _dragX 推向
           // 「卡片宽 + 边距」屏外，opacity 同步从当前值趋近 0；中段卡片仍可见（介于
           // 0 与 1），朝屏外滑走而非瞬灭。归一分母用真实卡片宽 + 边距，无宽度回退 300。

--- a/fushi/test/pages/dictionary_popup_dock_full_width_test.dart
+++ b/fushi/test/pages/dictionary_popup_dock_full_width_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart';
+
+/// BUG-2439：「底部停靠查词弹窗」= 屏幕底部一条**整宽**面板，必须从屏幕最左铺到最右。
+///
+/// 几何那半（[dockedPopupRect] 的横向 inset 归 0、[resolvePopupRect] 不再把跟随模式的
+/// 贴边 padding 转发进横向）锁在 `dictionary_popup_layer_test.dart`。本文件锁**观感**
+/// 那半：矩形铺满之后，卡片圆角的四段弧仍会在屏幕左右缘露出背景色，用户看到的还是
+/// 「没铺满」。dock 态因此把圆角摊平，跟随模式（四周有留白）保持既有圆角。
+DictionaryPopupLayer _layer({required bool bottomDocked}) {
+  return DictionaryPopupLayer(
+    result: DictionarySearchResult(searchTerm: 'x'),
+    webViewKey: GlobalKey<DictionaryPopupWebViewState>(),
+    onDismiss: () {},
+    onTextSelected: (String _, Rect __) {},
+    onLinkClick: (String _, Rect __) {},
+    onMineEntry: (Map<String, String> _) async => const MinePopupResult(),
+    onDuplicateCheck: (String _, String __) async => false,
+    bottomDocked: bottomDocked,
+  );
+}
+
+Widget _host(Widget layer) {
+  return TranslationProvider(
+    child: MaterialApp(
+      builder: (context, child) => child ?? const SizedBox.shrink(),
+      home: Scaffold(
+        body: Center(child: SizedBox(width: 360, height: 360, child: layer)),
+      ),
+    ),
+  );
+}
+
+BorderRadius? _surfaceRadius(WidgetTester tester) {
+  return tester
+      .widget<FushiPopupSurface>(find.byType(FushiPopupSurface))
+      .borderRadius;
+}
+
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.en);
+  });
+
+  testWidgets('dock 态：弹窗圆角摊平，surface 真正边到边', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(_layer(bottomDocked: true)));
+    await tester.pump();
+
+    expect(_surfaceRadius(tester), BorderRadius.zero);
+  });
+
+  testWidgets('跟随模式：圆角不动（沿用设计令牌的卡片圆角）', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(_layer(bottomDocked: false)));
+    await tester.pump();
+
+    expect(
+      _surfaceRadius(tester),
+      isNull,
+      reason: 'null = 走令牌默认；写死一个数会让卡片圆角在此处偷偷分叉',
+    );
+  });
+
+  testWidgets('同一层：dock 与跟随的圆角确实不同（开关真的改变观感）', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(_layer(bottomDocked: false)));
+    await tester.pump();
+    final BorderRadius? following = _surfaceRadius(tester);
+
+    await tester.pumpWidget(_host(_layer(bottomDocked: true)));
+    await tester.pump();
+    final BorderRadius? docked = _surfaceRadius(tester);
+
+    expect(docked, isNot(equals(following)));
+  });
+
+  test('FushiPopupSurface 的圆角覆写逐角内缩描边（摊平角不会被减成负数）', () {
+    // BUG-2166 的 `_borderInsetChild` 用的是「外圈半径 - 笔宽」。改成可覆写之后，
+    // dock 的 0 半径必须仍然是 0，不能变成负半径把 ClipRRect 打爆。
+    final String source = File(
+      'lib/src/utils/components/fushi_material_components.dart',
+    ).readAsStringSync();
+    expect(
+      source,
+      contains('math.max(0, r.x - _borderWidth)'),
+      reason: '摊平的角必须夹在 0，否则 dock 面板的 ClipRRect 收到负半径',
+    );
+  });
+
+  test('两个宿主都把 dock 偏好传进弹窗层（漏传是静默的：只是圆角没摊平）', () {
+    for (final String path in <String>[
+      'lib/src/pages/base_source_page.dart',
+      'lib/src/pages/implementations/dictionary_page_mixin.dart',
+    ]) {
+      expect(
+        File(path).readAsStringSync(),
+        contains('bottomDocked:'),
+        reason: '$path 必须把 popupBottomDocked 传给 DictionaryPopupLayer',
+      );
+    }
+  });
+}

--- a/fushi/test/pages/dictionary_popup_layer_body_swipe_close_test.dart
+++ b/fushi/test/pages/dictionary_popup_layer_body_swipe_close_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/media.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
 import 'package:fushi/src/utils/misc/swipe_dismiss_wrapper.dart';
 import 'package:fushi_dictionary/fushi_dictionary.dart';
@@ -118,6 +119,8 @@ void main() {
   setUp(() async {
     LocaleSettings.setLocale(AppLocale.en);
     await ReaderFushiSource.instance.setDismissSwipeSensitivity(0.6);
+    // 单例偏好：跟手动画默认开着，别让 BUG-2439 那组的关闭态泄漏进本文件其余用例。
+    await ReaderFushiSource.instance.setPopupDismissAnimation(true);
   });
 
   testWidgets(
@@ -446,5 +449,89 @@ void main() {
           'the popup (TODO-896 symptom①). The detector half-(a) asserts above '
           'stay valid because they run with NO real WebView mounted.',
     );
+  });
+
+  _bug2439BodyFollowGuards();
+}
+
+/// BUG-2439：弹窗**正文**横拖在「弹窗关闭动画」关掉后同样不许跟手。
+///
+/// 与顶栏 wrapper 是两套独立实现（这里是不进竞技场的 raw `Listener`，BUG-1242），
+/// BUG-2405 也是两处分别打的补丁，所以两边各要一组守卫——只测一边，另一边回归时
+/// 全绿。判别点同样落在**手指还没抬起**的那一帧。
+void _bug2439BodyFollowGuards() {
+  group('弹窗正文横拖：关掉动画后跟手期零位移（BUG-2439）', () {
+    tearDown(() async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(true);
+    });
+
+    /// 过阈值横拖但**不抬手**，回报弹窗表面左上角相对拖动前挪了多少 px。
+    Future<double> dragWithoutReleasing(
+      WidgetTester tester, {
+      required bool animation,
+    }) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(animation);
+      int dismissed = 0;
+      await tester.pumpWidget(_host(_layer(
+        onDismiss: () => dismissed++,
+        enableSwipeToClose: true,
+        onClose: () {},
+      )));
+      await tester.pump();
+
+      final Finder surface = find.byType(FushiPopupSurface);
+      final Offset before = tester.getTopLeft(surface);
+      final TestGesture gesture = await tester.startGesture(
+        _popupBodyPoint,
+        kind: PointerDeviceKind.touch,
+      );
+      const int steps = 12;
+      for (int i = 0; i < steps; i++) {
+        await gesture.moveBy(const Offset(200 / steps, 0));
+        await tester.pump();
+      }
+      final double moved = tester.getTopLeft(surface).dx - before.dx;
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(dismissed, 1, reason: '过阈值抬手后总该关一层，两版一致');
+      return moved;
+    }
+
+    testWidgets('开关开着：跟手期弹窗跟着手指走（既有手感不变）', (WidgetTester tester) async {
+      // 12 步累加有浮点尾数（199.9999…），跟手判据只关心「挪没挪、挪多少」。
+      expect(await dragWithoutReleasing(tester, animation: true),
+          moreOrLessEquals(200, epsilon: 0.01));
+    });
+
+    testWidgets('开关关掉：跟手期弹窗一动不动', (WidgetTester tester) async {
+      expect(await dragWithoutReleasing(tester, animation: false), 0);
+    });
+
+    testWidgets('同一条拖动：开着跟手位移 200、关掉恒 0（开关真的改变跟手期行为）',
+        (WidgetTester tester) async {
+      final double on = await dragWithoutReleasing(tester, animation: true);
+      final double off = await dragWithoutReleasing(tester, animation: false);
+      expect(on, moreOrLessEquals(200, epsilon: 0.01));
+      expect(off, 0);
+      expect(on, isNot(equals(off)));
+    });
+
+    testWidgets('开关关掉、未过阈值：不误关，弹窗也没挪过', (WidgetTester tester) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(false);
+      int dismissed = 0;
+      await tester.pumpWidget(_host(_layer(
+        onDismiss: () => dismissed++,
+        enableSwipeToClose: true,
+        onClose: () {},
+      )));
+      await tester.pump();
+
+      final Finder surface = find.byType(FushiPopupSurface);
+      final Offset before = tester.getTopLeft(surface);
+      await _dragOn(tester, _popupBodyPoint, dx: 40);
+
+      expect(dismissed, 0);
+      expect(tester.getTopLeft(surface), before);
+    });
   });
 }

--- a/fushi/test/pages/dictionary_popup_layer_test.dart
+++ b/fushi/test/pages/dictionary_popup_layer_test.dart
@@ -526,12 +526,41 @@ void main() {
         dockedHeight: 360,
       );
 
-      // 全宽（减左右内边距），贴屏底（减底内边距），与选区无关。
-      expect(docked.left, 6, reason: '左边距=inset');
-      expect(docked.width, 800 - 6 * 2, reason: '占满屏宽减左右内边距');
-      expect(docked.right, lessThanOrEqualTo(800));
+      // BUG-2439：横向真·铺满（左缘 0、右缘 = 屏宽），纵向仍留 inset 贴屏底。
+      expect(docked.left, 0, reason: '整宽面板从屏幕最左开始');
+      expect(docked.width, 800, reason: '占满整个屏宽，左右一像素都不留');
+      expect(docked.right, 800, reason: '一直铺到屏幕最右');
       expect(docked.bottom, lessThanOrEqualTo(600 - 6), reason: '底边贴屏底减底内边距');
       expect(docked.height, 360);
+    });
+
+    test('BUG-2439: 跟随模式的贴边 padding 不再削掉 dock 的左右两边', () {
+      // 两个收口点都把跟随模式的 padding（默认 6）传进 resolvePopupRect；那个数是
+      // 「别贴着屏幕边缘弹出」，与 dock 的「铺满」相反，转发进横向就是本 bug 的根因。
+      final Rect docked = resolvePopupRect(
+        selectionRect: const Rect.fromLTWH(10, 10, 20, 20),
+        screen: screen,
+        bottomDocked: true,
+        maxWidth: 360,
+        maxHeight: 360,
+        padding: 6,
+      );
+
+      expect(docked.left, 0);
+      expect(docked.width, 800);
+      // padding 仍然管纵向：面板与屏底之间保留那 6px。
+      expect(docked.bottom, 600 - 6);
+    });
+
+    test('BUG-2439: 横向 inset 仍可显式给出（分轴而非删掉）', () {
+      final Rect docked = dockedPopupRect(
+        screen: screen,
+        horizontalInset: 12,
+        dockedHeight: 360,
+      );
+
+      expect(docked.left, 12);
+      expect(docked.width, 800 - 12 * 2);
     });
 
     test('docked rect is identical regardless of where the word sits', () {

--- a/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
+++ b/fushi/test/widgets/swipe_dismiss_wrapper_test.dart
@@ -571,16 +571,141 @@ void main() {
         buildApp(eink: false, onDismiss: () => dismissed = true),
       );
       final Offset center = tester.getCenter(find.byType(SizedBox).first);
+      final Offset before = tester.getTopLeft(find.byType(SizedBox).first);
       final TestGesture gesture = await tester.startGesture(center);
       await gesture.moveBy(const Offset(60, 0));
       await gesture.up();
       await tester.pump();
 
       expect(dismissed, isFalse);
-      final Transform transform = tester.widget<Transform>(
-        find.byType(Transform).first,
+      // 开关关掉后本 wrapper 一层 [Transform] 都不挂（BUG-2439），所以断言落在
+      // 「卡片没挪过」这一用户可见事实上，而不是补间控制器的中间量。
+      expect(
+        find.descendant(
+          of: find.byType(SwipeDismissWrapper),
+          matching: find.byType(Transform),
+        ),
+        findsNothing,
       );
-      expect(transform.transform.getTranslation().x, 0);
+      expect(tester.getTopLeft(find.byType(SizedBox).first), before);
+    });
+  });
+
+  /// BUG-2439：开关关掉后**跟手期**也不许有位移。
+  ///
+  /// BUG-2405 只归零了松手后的补间，`Transform.translate` 原样留着 —— 用户拖动时仍看
+  /// 得见弹窗跟着手指滑一段才消失，与「关掉则瞬间关闭」的副标题不符。判别点必须落在
+  /// **手指还没抬起**的那一帧：抬手后的行为两版一样（都当帧关），只看结果分不出来。
+  group('SwipeDismissWrapper「弹窗关闭动画」关掉后跟手期零位移（BUG-2439）', () {
+    tearDown(() async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(true);
+    });
+
+    /// 过阈值横拖但**不抬手**，回报卡片左上角相对拖动前挪了多少 px。
+    Future<double> dragWithoutReleasing(
+      WidgetTester tester, {
+      required bool animation,
+      Key? key,
+    }) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(animation);
+      bool dismissed = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SwipeDismissWrapper(
+              key: key,
+              onDismiss: () => dismissed = true,
+              child: const SizedBox(
+                width: 300,
+                height: 100,
+                child: ColoredBox(color: Colors.blue),
+              ),
+            ),
+          ),
+        ),
+      );
+      final Finder card = find.byType(SizedBox).first;
+      final Offset before = tester.getTopLeft(card);
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(card),
+      );
+      await gesture.moveBy(const Offset(200, 0));
+      await tester.pump();
+      final double moved = tester.getTopLeft(card).dx - before.dx;
+      // 收尾：抬手 + settle，别把手势和补间漏给下一个用例。
+      await gesture.up();
+      await tester.pumpAndSettle();
+      expect(dismissed, isTrue, reason: '过阈值抬手后总该关，两版一致');
+      return moved;
+    }
+
+    testWidgets('开关开着：跟手期卡片跟着手指走（既有手感不变）', (WidgetTester tester) async {
+      expect(await dragWithoutReleasing(tester, animation: true), 200);
+    });
+
+    testWidgets('开关关掉：跟手期卡片一动不动', (WidgetTester tester) async {
+      expect(await dragWithoutReleasing(tester, animation: false), 0);
+    });
+
+    testWidgets('同一条拖动：开着跟手位移 200、关掉恒 0（开关真的改变跟手期行为）', (
+      WidgetTester tester,
+    ) async {
+      final double on = await dragWithoutReleasing(
+        tester,
+        animation: true,
+        key: const ValueKey<String>('follow-on'),
+      );
+      final double off = await dragWithoutReleasing(
+        tester,
+        animation: false,
+        key: const ValueKey<String>('follow-off'),
+      );
+      expect(on, 200);
+      expect(off, 0);
+      expect(on, isNot(equals(off)));
+    });
+
+    testWidgets('开关关掉：跟手期不挂 Transform/Opacity（不是靠 offset 0 假装不动）', (
+      WidgetTester tester,
+    ) async {
+      await ReaderFushiSource.instance.setPopupDismissAnimation(false);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SwipeDismissWrapper(
+              onDismiss: () {},
+              child: const SizedBox(
+                width: 300,
+                height: 100,
+                child: ColoredBox(color: Colors.blue),
+              ),
+            ),
+          ),
+        ),
+      );
+      final Finder card = find.byType(SizedBox).first;
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(card),
+      );
+      await gesture.moveBy(const Offset(200, 0));
+      await tester.pump();
+
+      expect(
+        find.descendant(
+          of: find.byType(SwipeDismissWrapper),
+          matching: find.byType(Transform),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(SwipeDismissWrapper),
+          matching: find.byType(Opacity),
+        ),
+        findsNothing,
+      );
+      await gesture.up();
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
用户报了两件事，都是既有实现只做了一半。BUG-2439。

## ① 「弹窗关闭动画」关掉后，拖动时弹窗仍跟着手指滑一段才消失

BUG-2405 只把**松手后**的补间时长归零（`popupDismissAnimationDuration`），跟手期的 `Transform.translate` + 淡出原样留着。那个开关的副标题写的是「关掉则瞬间关闭」，用户看到的却是完整的跟手过程。

新增 `popupSwipeDismissIsInstant()` 收口（与补间时长同文件、同为用时取值）。为真时两处滑关实现——`swipe_dismiss_wrapper.dart` 的顶栏可拖区与独立查词窗整窗、`dictionary_popup_layer.dart` 的正文横拖——跟手期都不重绘、不挂 `Transform`/`Opacity`，抬手当帧按累计横向位移判阈值：过了直接 `onDismiss`，没过原地不动（没位移过，也就没有 spring-back 可弹）。

判定时机仍在**抬手**，与 Hoshi Reader Android 一致：那边的滑关只监听 `touchstart`/`touchend`、不听 `touchmove`（`LookupPopupHtml.kt`），拖动期间弹窗零位移，抬手过阈值直接 `dismiss()`，全链路无补间、无 exit transition。改成「越过阈值即刻关」会在拖到一半时误关，没有采用。

墨水屏那条来源不变，仍只压补间时长、保留跟手方向反馈；两条来源正交。

## ② 「底部停靠查词弹窗」标称整宽面板，实际左右各缺 6px

`dockedPopupRect` 的 `inset` 横纵共用一个数，而两个收口点转发进来的是**跟随模式**的贴边避让 padding（6）——那个数的语义是「别贴着屏幕边缘弹出」，与 dock 的「铺满」正好相反。

把内边距分轴：新增 `horizontalInset`（默认 0），`inset` 只管纵向；`resolvePopupRect` 的 dock 分支不再把 `padding` 转发进横向。

矩形铺满后卡片圆角（令牌 10）的四段弧仍会在屏幕左右缘露出背景，观感上还是没铺满，所以 `FushiPopupSurface` 新增 `borderRadius` 覆写（内圈半径逐角内缩描边、夹在 0，不会给 `ClipRRect` 送负半径），`DictionaryPopupLayer` 新增 `bottomDocked`，dock 态把圆角摊平；两个宿主传 `popupBottomDocked`。跟随模式四周有留白，圆角不动。

（参考的 Hoshi Reader Android 全宽模式是屏宽 −6dp×2、8dp 圆角，本仓按用户要求做到真正 edge-to-edge。）

## 测试

10 条新用例，**摘掉修复正好全红**（判别力已验证），恢复后相关 8 个套件 119/119 绿。

- 顶栏 wrapper 与正文横拖是两套独立实现，两边各一组守卫；判别点都落在「手指还没抬起」的那一帧——抬手后的行为两版一样（都当帧关），只看结果分不出来。
- dock 两半分开锁：几何在 `dictionary_popup_layer_test.dart`（左缘 0 / 宽 = 屏宽 / 传 padding=6 时横向仍铺满而纵向保留 6 / 横向 inset 显式给出仍生效），观感 + 两条源码守卫在新文件 `dictionary_popup_dock_full_width_test.dart`。

`flutter analyze` 无新增问题。基线上已有一条与本 PR 无关的红：`integration_test/module_gating_test.dart:98` 调用了仓库里没有定义的 `buildListeningDestination`，未触碰。

https://claude.ai/code/session_01Hnuxr4RJYRtZpeWNFCFzk3
