### PR TITLE
fix(ui): 页面底部安全区不再扣 viewport，改由内容补偿（BUG-2440）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2247 条。点号进各自文件。
+> 共 2249 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2440](bugs/BUG-2440-ios-bottom-safearea-gap.md) | ✅ | ✅ | iOS 页面底部安全区留下一条不可用空白，滚动内容被硬切 |
 | [BUG-2438](bugs/BUG-2438-galgame-lookups-mined-as-book.md) | ✅ | ✅ | galgame 查词/制卡/收藏被记成 book 来源，游戏统计缺四个指标 |
 | [BUG-2437](bugs/BUG-2437-stats-tabs-layout-not-unified.md) | ✅ | ✅ | 统计中心阅读 tab 独有页面级限宽，四个 tab 布局不统一 |
 | [BUG-2436](bugs/BUG-2436-eink-popup-body-opacity-not-flattened.md) | ✅ | ✅ | 墨水屏弹窗只压了按钮 opacity，正文侧十几处静息半透明与亚像素位移漏网 |

--- a/docs/bugs/BUG-2440-ios-bottom-safearea-gap.md
+++ b/docs/bugs/BUG-2440-ios-bottom-safearea-gap.md
@@ -1,0 +1,11 @@
+## BUG-2440 · iOS 页面底部安全区留下一条不可用空白，滚动内容被硬切
+- **报告**：2026-09-10（用户录屏：设置 › 查词 详情页，iPhone）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/utils/components/fushi_material_components.dart:2277`（`FushiPageScaffold` 的 `body: SafeArea(...)` 默认 `bottom: true`）与 `:2374`（`FushiToolScaffold` 同款）——行号为修复前 `develop` 上的位置。
+  - 现象：iPhone（home indicator 34pt）上页面底部有一条纯背景色空白，滚动内容在这条线被硬切——卡片边框、文字被切一半，且怎么滚都进不去。
+  - 机制：`SafeArea` 把 body 的 viewport 下界硬切在 home indicator 之上，同时通过 `MediaQuery.removePadding` 把 `padding.bottom` 清零；于是
+    `settings/material_settings_renderer.dart:94`、`:163`、`settings/settings_home_page.dart:232`、`settings/cupertino_settings_renderer.dart:153`、`utils/components/settings_shared.dart:87` 这几处**已经写好的** `mediaPadding.bottom` 全部恒为 0（死代码）——本来就打算让滚动内容滚过安全区、由内容 padding 兜底，被外层 `SafeArea` 掐掉了。
+  - 复现（widget 测试，无需真机）：`size 402×874` + `padding.bottom: 34` 下渲染 `FushiPageScaffold(body: ListView)`，list 底边 = 840 而非 874。
+  - 与本仓既有范式一致：BUG-383 / BUG-1783 都把 `SafeArea` 拿掉、改走显式 inset，理由同样是「SafeArea 与内容自己的 inset 重复/打架」。
+- **[x] ① 已修复** — 两处脚手架 body 的 `SafeArea` 改 `bottom: false`，底部 inset 交给 body 自己消费，并新增 `bottomSafeInsetOf` / `withBottomSafeInset` 两个 helper。消费侧只补真需要的：显式传 padding 的滚动视图包 helper；`padding == null` 的不动（`BoxScrollView` 自动取 `MediaQuery.padding`）；统计三页尾部 sliver 抽成共用 `buildStatTailSliver`；`Column` 尾部有固定动作条的（mihon 预览、mokuro 嵌入、onboarding）动作条自补安全区、同 `Column` 的滚动视图 `removeBottom`，避免各补一次多顶 34pt；传了 `bottomNavigationBar` 的页面一律不补——`Scaffold` 已把 body 的 `padding.bottom` 清零（`scaffold.dart` 的 `removeBottomPadding`），补了是加 0。
+- **[x] ② 已加自动化测试** — `fushi/test/widgets/fushi_page_scaffold_bottom_inset_test.dart`：注入 34pt 底部安全区，断言 ① body 铺满到屏幕底（把脚手架改回 `bottom: true` 这条立刻红）② 滚动到底时最后一项完整可见、不被手势条压住 ③ helper 是相加而非取 max ④ 无安全区的桌面形态下是空操作。
+- **备注**：桌面 / 无手势条设备上 `padding.bottom == 0`，整套改动为空操作。未在 iOS 真机复测（提交者无 iOS 设备），证据为 widget 层注入安全区的真实渲染像素。

--- a/fushi/lib/src/media/manga/aidoku/aidoku_source_browse_page.dart
+++ b/fushi/lib/src/media/manga/aidoku/aidoku_source_browse_page.dart
@@ -237,7 +237,9 @@ class _AidokuSourceBrowsePageState extends State<AidokuSourceBrowsePage> {
       builder: (BuildContext context, BoxConstraints constraints) {
         final int columns = (constraints.maxWidth / 180).floor().clamp(2, 8);
         return GridView.builder(
-          padding: const EdgeInsets.all(16),
+          // BUG-2440：scaffold 的 body 不再扣底部安全区，网格最后一行要靠这里
+          // 补出手势条那一段，否则静止时被压住点不到。
+          padding: withBottomSafeInset(context, const EdgeInsets.all(16)),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: columns,
             childAspectRatio: 0.62,

--- a/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
+++ b/fushi/lib/src/media/manga/discovery/manga_discovery_detail_page.dart
@@ -253,7 +253,9 @@ class _MangaDiscoveryDetailPageState
     return FushiPageScaffold(
       title: entry.preferredTitle,
       body: ListView(
-        padding: const EdgeInsets.all(16),
+        // BUG-2440：scaffold 的 body 不再扣底部安全区，简介滚到底时最后一段
+        // 会被手势条压住，这里把这段补进滚动 padding。
+        padding: withBottomSafeInset(context, const EdgeInsets.all(16)),
         children: <Widget>[
           _buildHero(entry),
           const SizedBox(height: 16),

--- a/fushi/lib/src/media/manga/library/manga_series_page.dart
+++ b/fushi/lib/src/media/manga/library/manga_series_page.dart
@@ -606,7 +606,9 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
       return _buildLoadError(context, loadError);
     }
     return ListView(
-      padding: const EdgeInsets.all(16),
+      // BUG-2440：scaffold 的 body 不再扣底部安全区，章节列表得自己把这段补进
+      // 滚动 padding，否则最后一章静止时压在手势条底下点不到。
+      padding: withBottomSafeInset(context, const EdgeInsets.all(16)),
       children: <Widget>[
         if (_refreshError != null) ...<Widget>[
           _buildRefreshBanner(context, _refreshError!),

--- a/fushi/lib/src/media/manga/manga_global_search_page.dart
+++ b/fushi/lib/src/media/manga/manga_global_search_page.dart
@@ -255,7 +255,12 @@ class _MangaGlobalSearchPageState extends State<MangaGlobalSearchPage> {
       );
     }
     return ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 8),
+      // BUG-2440：scaffold 的 body 不再扣底部安全区，最后一个源的结果块得靠这里
+      // 补出手势条那一段，否则静止时被压住。
+      padding: withBottomSafeInset(
+        context,
+        const EdgeInsets.symmetric(vertical: 8),
+      ),
       itemCount: _runs.length,
       itemBuilder: (BuildContext context, int index) =>
           _buildSection(_runs[index]),

--- a/fushi/lib/src/media/manga/mihon/mihon_source_browse_page.dart
+++ b/fushi/lib/src/media/manga/mihon/mihon_source_browse_page.dart
@@ -59,6 +59,11 @@ class MihonSourceBrowsePage extends StatefulWidget {
   final MihonBrowseTarget target;
 
   /// 钉在正文底部的操作条。预览用它放「放弃 / 信任并安装」。
+  ///
+  /// BUG-2440：scaffold 的 body 不再扣底部安全区，所以这条动作条贴的是屏幕真正的
+  /// 最底边。**底部安全区由 footer 自己套 SafeArea 补**（`_PreviewFooter` 就是这么
+  /// 做的：`ColoredBox` 包在 `SafeArea` 外，让手势条那一段也上底色）——这里不代劳，
+  /// 在外面补会把那一段留成页面底色的空条。
   final Widget? footer;
 
   @override
@@ -284,7 +289,18 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
               error: _error,
               onVerified: () => _load(reset: false),
             ),
-          Expanded(child: _buildResults()),
+          // BUG-2440：scaffold 的 body 不再扣底部安全区。有 footer 时那段归 footer
+          // 自己的 SafeArea 认领，先从网格的 MediaQuery 里摘掉，免得网格底部和
+          // footer 各补一次、在动作条上方多顶出一条空白。
+          Expanded(
+            child: widget.footer == null
+                ? _buildResults()
+                : MediaQuery.removePadding(
+                    context: context,
+                    removeBottom: true,
+                    child: _buildResults(),
+                  ),
+          ),
           if (widget.footer != null) widget.footer!,
         ],
       ),
@@ -321,7 +337,10 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
       builder: (BuildContext context, BoxConstraints constraints) {
         final int columns = (constraints.maxWidth / 180).floor().clamp(2, 8);
         return GridView.builder(
-          padding: const EdgeInsets.all(16),
+          // BUG-2440：scaffold 的 body 不再扣底部安全区，网格最后一行要靠这里
+          // 补出手势条那一段。有 footer 时上面已把这段从 MediaQuery 摘掉，这里
+          // 自动退回纯 16。
+          padding: withBottomSafeInset(context, const EdgeInsets.all(16)),
           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: columns,
             childAspectRatio: 0.62,

--- a/fushi/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
+++ b/fushi/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
@@ -390,11 +390,27 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
     // 对话框语境：正文原样交给外层约束（动作按钮由对话框 footer 提供）。
     if (!widget.embedded) return body;
     // 页面语境：正文撑满可用空间，series 阶段在底部画动作行。
+    final bool hasActions = _stage == _CatalogStage.series;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        Expanded(child: body),
-        if (_stage == _CatalogStage.series) _buildEmbeddedActions(tokens),
+        // BUG-2440：页面语境下 scaffold 的 body 不再扣底部安全区，内部无 padding
+        // 的网格/列表会自动把 MediaQuery.padding 当滚动 padding 用（正是要的）；
+        // 但动作行在时那段归动作行的 SafeArea，先摘掉，免得两边各补一次、在按钮
+        // 上方多顶出一条空白。对话框语境上面已 return，不受影响。
+        Expanded(
+          child: hasActions
+              ? MediaQuery.removePadding(
+                  context: context,
+                  removeBottom: true,
+                  child: body,
+                )
+              : body,
+        ),
+        // BUG-2440：动作行是贴屏幕最底的固定元素，自己套 SafeArea 才不会被
+        // home indicator / 手势条压住。
+        if (hasActions)
+          SafeArea(top: false, child: _buildEmbeddedActions(tokens)),
       ],
     );
   }

--- a/fushi/lib/src/onboarding/online_services_onboarding_view.dart
+++ b/fushi/lib/src/onboarding/online_services_onboarding_view.dart
@@ -171,7 +171,9 @@ class OnlineServicesOnboardingPage extends StatelessWidget {
   Widget build(BuildContext context) => FushiPageScaffold(
         title: t.settings_destination_services,
         body: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
+          // BUG-2440：scaffold 底部安全区不再从 viewport 扣掉，滚动内容末尾自己
+          // 补上 home indicator / 手势条的高度。
+          padding: withBottomSafeInset(context, const EdgeInsets.all(24)),
           child: Center(
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 720),

--- a/fushi/lib/src/pages/implementations/changelog_page.dart
+++ b/fushi/lib/src/pages/implementations/changelog_page.dart
@@ -100,7 +100,9 @@ class _ChangelogPageState extends State<ChangelogPage>
     }
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     return ListView.builder(
-      padding: EdgeInsets.all(tokens.spacing.gap),
+      // BUG-2440：scaffold 底部安全区不再从 viewport 扣掉，末条卡片得靠内容
+      // padding 自己让开 home indicator / 手势条。
+      padding: withBottomSafeInset(context, EdgeInsets.all(tokens.spacing.gap)),
       itemCount: _releases.length,
       itemBuilder: (BuildContext context, int index) {
         return Padding(

--- a/fushi/lib/src/pages/implementations/game_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/game_statistics_page.dart
@@ -246,9 +246,7 @@ class _GameStatisticsPageState extends BasePageState<GameStatisticsPage> {
             childCount: _aggregate.byGame.length,
           ),
         ),
-        SliverPadding(
-          padding: EdgeInsets.only(bottom: tokens.spacing.card * 2),
-        ),
+        buildStatTailSliver(context),
       ],
     );
   }

--- a/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/fushi/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -342,7 +342,12 @@ class _IllustrationsViewerPageState extends State<IllustrationsViewerPage> {
         if (_loading) const LinearProgressIndicator(),
         Expanded(
           child: GridView.builder(
-            padding: EdgeInsets.all(tokens.spacing.gap),
+            // BUG-2440：scaffold 底部安全区不再从 viewport 扣掉，末行缩略图得靠
+            // 内容 padding 自己让开 home indicator / 手势条。
+            padding: withBottomSafeInset(
+              context,
+              EdgeInsets.all(tokens.spacing.gap),
+            ),
             gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
               maxCrossAxisExtent: 200,
               mainAxisSpacing: tokens.spacing.gap,

--- a/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
+++ b/fushi/lib/src/pages/implementations/onboarding_wizard_page.dart
@@ -816,13 +816,22 @@ class _OnboardingWizardPageState extends BasePageState<OnboardingWizardPage>
       ),
       body: Column(
         children: <Widget>[
+          // BUG-2440：脚手架的 body 不再扣底部安全区，那一段归下面这条按钮行的
+          // SafeArea 认领。步骤正文在按钮行**上方**、够不着屏幕底边，所以先把
+          // 底部 inset 从它的 MediaQuery 里摘掉——不摘的话，自己补安全区的步骤
+          // （如 [OnlineServicesOnboardingView]）会和按钮行各补一次，在按钮上方
+          // 顶出一条 34pt 空白。
           Expanded(
-            child: Center(
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(
-                  maxWidth: _kOnboardingContentMaxWidth,
+            child: MediaQuery.removePadding(
+              context: context,
+              removeBottom: true,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: _kOnboardingContentMaxWidth,
+                  ),
+                  child: _buildStep(step),
                 ),
-                child: _buildStep(step),
               ),
             ),
           ),

--- a/fushi/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/reading_statistics_page.dart
@@ -560,7 +560,9 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
                 childCount: _bookData.length,
               ),
             ),
-            SliverPadding(padding: EdgeInsets.only(bottom: card * 2)),
+            // BUG-2440：收尾留白连带补上底部安全区，否则脚手架让出 home indicator
+            // 那一段后，最后一本书会被手势条压住。
+            buildStatTailSliver(context),
           ],
         );
       },

--- a/fushi/lib/src/pages/implementations/stat_shared.dart
+++ b/fushi/lib/src/pages/implementations/stat_shared.dart
@@ -243,6 +243,22 @@ const double kStatPeriodSummaryMinColumnWidth = 144;
 /// 20dp 四边内边距会吃掉四成可用宽度，主值被压得比单列还小。
 const double kStatPeriodSummaryCompactColumnWidth = 200;
 
+/// 统计页滚动内容的收尾留白：原有的两倍卡片间距 + 底部安全区（BUG-2440）。
+///
+/// [FushiPageScaffold] 的 SafeArea 已改成 `bottom: false`（内容画得到屏幕最底，
+/// 不再留一条谁也用不了的底色空白），代价是 body 自己要把 inset 补进滚动内容，
+/// 否则静止时最后一行被 home indicator / 手势条压住。三域统计页的独立页路径与
+/// 统计中心 tab 路径（[buildEmbeddedStatTab]）的滚动视图都直抵屏幕底部，补偿相同，
+/// 所以补在这一层而不是各自的 scaffold 分支里。
+Widget buildStatTailSliver(BuildContext context) {
+  final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+  return SliverPadding(
+    padding: EdgeInsets.only(
+      bottom: tokens.spacing.card * 2 + bottomSafeInsetOf(context),
+    ),
+  );
+}
+
 /// 统计页共用的四周期汇总卡网格：能放下两列就 2×2，放不下才单列。
 ///
 /// BUG：旧实现按「可用宽度 ≥ 380」判两列。这层外面还有 [FushiSpacingTokens.card]

--- a/fushi/lib/src/pages/implementations/statistics_center_page.dart
+++ b/fushi/lib/src/pages/implementations/statistics_center_page.dart
@@ -206,7 +206,12 @@ class _StatsOverviewTabState extends ConsumerState<_StatsOverviewTab> {
     }
     final StatWindow w = StatWindow(DateTime.now());
     return ListView(
-      padding: EdgeInsets.only(bottom: tokens.spacing.card * 2),
+      // BUG-2440：scaffold 底部安全区不再从 viewport 扣掉，tab 内容末尾自己让开
+      // home indicator / 手势条（三个域 tab 走 [buildStatTailSliver]）。
+      padding: withBottomSafeInset(
+        context,
+        EdgeInsets.only(bottom: tokens.spacing.card * 2),
+      ),
       children: <Widget>[
         _buildGoalCard(tokens, w),
         _buildSummaryCards(w),

--- a/fushi/lib/src/pages/implementations/tag_picker_page.dart
+++ b/fushi/lib/src/pages/implementations/tag_picker_page.dart
@@ -163,7 +163,12 @@ class _TagPickerPageState extends ConsumerState<TagPickerPage> {
               ),
             )
           : ListView.separated(
-              padding: EdgeInsets.all(tokens.spacing.card),
+              // BUG-2440：scaffold 底部安全区不再从 viewport 扣掉，末条标签得靠
+              // 内容 padding 自己让开 home indicator / 手势条。
+              padding: withBottomSafeInset(
+                context,
+                EdgeInsets.all(tokens.spacing.card),
+              ),
               itemCount: _allTags.length,
               separatorBuilder: (_, __) => SizedBox(height: tokens.spacing.gap),
               itemBuilder: (context, index) {

--- a/fushi/lib/src/pages/implementations/video_statistics_page.dart
+++ b/fushi/lib/src/pages/implementations/video_statistics_page.dart
@@ -317,9 +317,7 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
             childCount: _agg.byVideo.length,
           ),
         ),
-        SliverPadding(
-          padding: EdgeInsets.only(bottom: tokens.spacing.card * 2),
-        ),
+        buildStatTailSliver(context),
       ],
     );
   }

--- a/fushi/lib/src/utils/components/fushi_material_components.dart
+++ b/fushi/lib/src/utils/components/fushi_material_components.dart
@@ -2191,6 +2191,28 @@ class _FushiPageHeaderRowState extends State<_FushiPageHeaderRow> {
   }
 }
 
+/// 底部安全区（iOS home indicator / Android 手势条）的高度。
+///
+/// [FushiPageScaffold] / [FushiToolScaffold] 的 body 外层 `SafeArea` 是
+/// `bottom: false`——底部 inset **不扣 viewport**，让内容能一直画到屏幕最底（否则那条
+/// 34pt 就是一条谁也用不了的底色空白，滚动内容在切线处被拦腰截断，BUG-2440）。代价是
+/// body 自己得把这段补进滚动 padding，不然末项静止时被手势条压住。
+///
+/// 取 `padding` 而不是 `viewPadding`：键盘弹出时 `padding.bottom` 归零（那段已被
+/// `viewInsets` 接管），跟着归零才不会在键盘上方多顶一块空白；桌面与无手势条的设备上
+/// 本来就是 0，本函数与整套改动一并成为空操作。
+double bottomSafeInsetOf(BuildContext context) =>
+    MediaQuery.paddingOf(context).bottom;
+
+/// 把底部安全区补进 [base] 的下边（**相加**，不是取 max）。
+///
+/// 这里与 BUG-383「逐边 max、不相加」的口径**故意不同**，因为语义不同：那边两个值描述
+/// 的是同一段「离屏幕边缘的距离」（控件 margin vs 系统 inset），取大的即可；这里 [base]
+/// 是内容与内容之间的呼吸位（卡片间距 / 页边距），系统 inset 是被手势条吃掉的不可用区，
+/// 两段各自成立——只取 max 会让末项贴着手势条，视觉上比别的项少一截间距。
+EdgeInsets withBottomSafeInset(BuildContext context, EdgeInsets base) =>
+    base.copyWith(bottom: base.bottom + bottomSafeInsetOf(context));
+
 class FushiPageScaffold extends StatefulWidget {
   const FushiPageScaffold({
     required this.title,
@@ -2275,6 +2297,16 @@ class _FushiPageScaffoldState extends State<FushiPageScaffold> {
         floatingActionButtonLocation: widget.floatingActionButtonLocation,
         bottomNavigationBar: widget.bottomNavigationBar,
         body: SafeArea(
+          // bottom:false —— 底部安全区（iOS home indicator / Android 手势条）**不在这里
+          // 扣**，交给 body 自己按 [bottomSafeInsetOf] 加进内容 padding（BUG-2440）。
+          // SafeArea 扣底是把 viewport 硬切在手势条之上：那条 34pt 变成一条谁也用不了的
+          // 底色空白，滚动内容在切线处被拦腰截断（卡片边框、文字切一半），怎么滚都进不去；
+          // 更糟的是它同时 removePadding 把 padding.bottom 清零，让 body 里**已经写好**的
+          // `+ mediaPadding.bottom` 集体变成死代码（settings 三处渲染器都中招）。
+          // 让内容滚过安全区、只在滚动 padding 里补偿，才是这两条诉求（不留空白 + 末项
+          // 不被压）唯一同时成立的形态。与 BUG-383 / BUG-1783 同一范式：拿掉 SafeArea、
+          // 改走显式 inset，逐边取值不相加。
+          bottom: false,
           // stretch (not start) so every page body receives a tight full-width
           // constraint. Under start the cross axis stays loose, and any body
           // that shrink-wraps its width (e.g. a vertical SingleChildScrollView
@@ -2372,6 +2404,10 @@ class FushiToolScaffold extends StatelessWidget {
       backgroundColor: backgroundColor ?? tokens.surfaces.page,
       bottomNavigationBar: bottomNavigationBar,
       body: SafeArea(
+        // 与 [FushiPageScaffold] 同一口径（BUG-2440）：底部 inset 不扣 viewport。
+        // 本脚手架的底部动作条走 [Scaffold.bottomNavigationBar]（在这层 SafeArea 之外、
+        // 各自已套 SafeArea），不受影响；body 的滚动内容按 [withBottomSafeInset] 补偿。
+        bottom: false,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[

--- a/fushi/test/widgets/fushi_page_scaffold_bottom_inset_test.dart
+++ b/fushi/test/widgets/fushi_page_scaffold_bottom_inset_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/components/fushi_material_components.dart';
+
+/// BUG-2440：页面脚手架的底部安全区（iOS home indicator / Android 手势条）。
+///
+/// 两条诉求必须**同时**成立，缺一条就是原来那个 bug 或它的反面：
+///   ① body 的 viewport 要一直铺到屏幕最底——否则被扣掉的那段是一条谁也用不了的底色
+///      空白，滚动内容在切线处被拦腰截断（用户 2026-09-10 录屏：设置 › 查词，卡片边框
+///      和文字被切一半，怎么滚都进不去）。
+///   ② 滚动到底时最后一项要完整可见——否则只是把「空白」换成了「末项被手势条压住」。
+///
+/// ① 由脚手架的 `SafeArea(bottom: false)` 保证，② 由 body 自己用
+/// [withBottomSafeInset] 把 inset 补进滚动 padding 保证。两条各测一次。
+void main() {
+  const double screenWidth = 402;
+  const double screenHeight = 874;
+  const double bottomInset = 34; // iPhone home indicator
+
+  /// 模拟一台有手势条的手机。逻辑尺寸靠 physicalSize / dpr 得出，所以
+  /// physicalSize 要自己乘 dpr（写逻辑值会得到 1/3 大的屏，满屏 overflow）。
+  void useHandsetView(WidgetTester tester) {
+    tester.view.physicalSize = const Size(screenWidth * 3, screenHeight * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+  }
+
+  Widget hostPage(Widget body) => MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(screenWidth, screenHeight),
+            devicePixelRatio: 3.0,
+            padding: EdgeInsets.only(top: 59, bottom: bottomInset),
+            viewPadding: EdgeInsets.only(top: 59, bottom: bottomInset),
+          ),
+          child: FushiPageScaffold(title: 'Lookup', body: body),
+        ),
+      );
+
+  testWidgets(
+    'page body extends under the bottom safe area instead of being clipped above it',
+    (WidgetTester tester) async {
+      useHandsetView(tester);
+      await tester.pumpWidget(
+        hostPage(
+          ListView.builder(
+            itemCount: 40,
+            itemBuilder: (BuildContext context, int index) =>
+                SizedBox(height: 60, child: Text('row $index')),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getRect(find.byType(ListView)).bottom,
+        screenHeight,
+        reason:
+            'SafeArea(bottom: true) 会把 viewport 切在 $screenHeight - $bottomInset，'
+            '留下一条谁也用不了的底色空白，滚动内容在切线处被拦腰截断（BUG-2440）',
+      );
+    },
+  );
+
+  testWidgets(
+    'scroll padding built with withBottomSafeInset keeps the last row clear of the gesture bar',
+    (WidgetTester tester) async {
+      useHandsetView(tester);
+      const double basePadding = 16;
+      await tester.pumpWidget(
+        hostPage(
+          Builder(
+            builder: (BuildContext context) => ListView.builder(
+              // 页面显式传 padding 时 Flutter 不再自动套 MediaQuery.padding，
+              // 必须自己补——这正是本 helper 存在的理由。
+              padding: withBottomSafeInset(
+                context,
+                const EdgeInsets.all(basePadding),
+              ),
+              itemCount: 40,
+              itemBuilder: (BuildContext context, int index) =>
+                  SizedBox(height: 60, child: Text('row $index')),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 滚到底：末项底边必须停在手势条之上，且还要留出原有的 16 呼吸位。
+      await tester.drag(find.byType(ListView), const Offset(0, -4000));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getRect(find.text('row 39')).bottom,
+        lessThanOrEqualTo(screenHeight - bottomInset - basePadding),
+        reason: '末项被 home indicator 压住的话，这次修复只是把空白换成了遮挡',
+      );
+    },
+  );
+
+  testWidgets('withBottomSafeInset adds to the base padding, never replaces it',
+      (WidgetTester tester) async {
+    late EdgeInsets resolved;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          padding: EdgeInsets.only(bottom: bottomInset),
+        ),
+        child: Builder(
+          builder: (BuildContext context) {
+            resolved = withBottomSafeInset(
+              context,
+              const EdgeInsets.fromLTRB(8, 12, 8, 20),
+            );
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    // 相加而不是取 max：base 是内容之间的呼吸位，inset 是被手势条吃掉的不可用区，
+    // 两段各自成立（与 BUG-383「逐边 max」的口径**故意**不同，语义不同）。
+    expect(resolved, const EdgeInsets.fromLTRB(8, 12, 8, 20 + bottomInset));
+  });
+
+  testWidgets(
+      'no bottom inset on a desktop-shaped view leaves padding untouched',
+      (WidgetTester tester) async {
+    late EdgeInsets resolved;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Builder(
+          builder: (BuildContext context) {
+            resolved = withBottomSafeInset(context, const EdgeInsets.all(24));
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    expect(resolved, const EdgeInsets.all(24));
+  });
+}


### PR DESCRIPTION
## 问题

iPhone（以及所有有手势条的设备）上，页面底部有一条**纯背景色的空白带**，滚动内容在这条线被拦腰截断——卡片边框和文字被切一半，怎么滚都进不去。用户录屏复现于「设置 › 查词」详情页，但这是所有页面共有的。

## 根因

`FushiPageScaffold`（`fushi_material_components.dart:2277`）与 `FushiToolScaffold`（`:2374`）的 `body: SafeArea(...)` 默认 `bottom: true`，把 home indicator 那 34pt 从 body 的 viewport 里**硬切**掉。被切掉的那条既画不了内容也滚不进去，就是那条空白。

更隐蔽的一层：`SafeArea` 同时通过 `MediaQuery.removePadding` 把 `padding.bottom` 清零，于是这几处**已经写好**的补偿全部恒为 0，成了死代码：

- `settings/material_settings_renderer.dart:94`、`:163`
- `settings/settings_home_page.dart:232`
- `settings/cupertino_settings_renderer.dart:153`
- `utils/components/settings_shared.dart:87`

也就是说，「让内容滚过安全区、由内容 padding 兜底」本来就是原设计意图，只是被外层 `SafeArea` 掐掉了。

## 改法

两处脚手架改 `bottom: false`，底部 inset 交给 body 自己消费，并新增两个 helper：

```dart
double bottomSafeInsetOf(BuildContext context);                       // MediaQuery.paddingOf(context).bottom
EdgeInsets withBottomSafeInset(BuildContext context, EdgeInsets base); // base.bottom 上再加安全区
```

与本仓既有范式一致（BUG-383 / BUG-1783 同样是「拿掉 SafeArea、改走显式 inset」）。

消费侧**只补真需要的**，逐点判断而非批量套：

| 情形 | 处理 |
|---|---|
| 显式传 `padding` 的滚动视图 | 包 `withBottomSafeInset` |
| `padding == null` 的滚动视图 | **不动**——`BoxScrollView` 自动把 `MediaQuery.padding` 当默认 padding |
| 统计三页尾部 `SliverPadding` | 抽成共用 `buildStatTailSliver`，独立页与统计中心 tab 两条路径同源 |
| `Column` 尾部有固定动作条（mihon 预览 / mokuro 嵌入 / onboarding） | 动作条自补 `SafeArea(top: false)`，同一 `Column` 的滚动视图 `removeBottom`，避免各补一次在按钮上方多顶 34pt |
| 传了 `bottomNavigationBar` 的页面 | **一律不补**——`Scaffold` 已把 body 的 `padding.bottom` 清零（`scaffold.dart` 的 `removeBottomPadding`），补了是加 0 |

`_PreviewFooter` 那类 `ColoredBox(child: SafeArea(...))` 的既有写法保持不动：底色要铺到手势条下面，外面再包一层会让动作条悬空。

桌面 / 无手势条设备上 `padding.bottom == 0`，整套改动是空操作。

## 测试

新增 `fushi/test/widgets/fushi_page_scaffold_bottom_inset_test.dart`（4 条），注入 34pt 底部安全区：

1. body 的 viewport 铺满到屏幕底（把脚手架改回 `bottom: true`，这条立刻红——已实测反向验证）
2. 用 helper 建的滚动 padding 让末项滚到底时完整可见、不被手势条压住（否则只是把「空白」换成「遮挡」）
3. helper 是**相加**而非取 max（与 BUG-383「逐边 max」口径故意不同，语义不同：base 是内容间的呼吸位，inset 是不可用区）
4. 无安全区的桌面形态下 padding 原样返回

## 验证

- `flutter analyze` 零问题
- 新测试 4 条 + `fushi_page_scaffold_scroll_test` + 统计页静态守卫：26 条全绿
- 共享组件侧（`tests_for_changes` 反查出的）`fushi_material_components_test` / `settings_shared_test` / `platform_layout_test` / log panel 两条守卫：104 条全绿
- 目录枚举型守卫整批：368 条全绿
- `test/media/manga`：单跑相关 suite 全绿；**整目录跑在我本机是 flaky**——同一命令在干净的 `upstream/develop` 上也会漂红（一次 `FocusManager was used after being disposed`，一次 Windows 临时目录被占用的 `PathAccessException`），红点在不同 suite 间漂移，与本改动无关。已用「基线整目录对跑」确认，不是拿 flaky 当借口

## 已知限制

**未在 iOS 真机复测**（提交者无 iOS 设备）。证据是 widget 层注入 34pt 安全区后的真实渲染像素与几何断言（body 底边 840 → 874），不是真机截图。按仓库规矩，布局类改动该在真机上再走一遍原始路径。

记录在 `docs/bugs/BUG-2440-ios-bottom-safearea-gap.md`。

https://claude.ai/code/session_01NCqJa186qTqKSTge48YNAE
