### PR TITLE
fix(settings): 窗格接缝——导航窗格提一档 tonal，详情正文左右对称（BUG-2443）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2252 条。点号进各自文件。
+> 共 2253 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2443](bugs/BUG-2443-settings-pane-seam-flat.md) | ✅ | ✅ | 设置页导航窗格与详情窗格之间那条分隔线两侧读不出窗格 |
 | [BUG-2442](bugs/BUG-2442-activity-video-cover-landscape-slot.md) | ✅ | ✅ | 首页活动时间轴的视频缩略用横版槽，竖版海报被缩成模糊小条 |
 | [BUG-2441](bugs/BUG-2441-video-reopen-black-screen.md) | ✅ | ✅ | video-reopen-black-screen |
 | [BUG-2440](bugs/BUG-2440-ios-bottom-safearea-gap.md) | ✅ | ✅ | iOS 页面底部安全区留下一条不可用空白，滚动内容被硬切 |

--- a/docs/bugs/BUG-2443-settings-pane-seam-flat.md
+++ b/docs/bugs/BUG-2443-settings-pane-seam-flat.md
@@ -1,0 +1,31 @@
+## BUG-2443 · 设置页导航窗格与详情窗格之间那条分隔线两侧读不出窗格
+- **报告**：2026-09-11（用户：截图圈出设置页中间那条竖线，「总觉得这条线还是有点怪」）
+- **真实性**：✅ 真 bug（观感缺陷，可像素判定）。对用户截图（2940×1734，DPR 1.92）逐行采样，
+  接缝一行的实际色块是：
+  `[导航分组卡 #ECECF3] … [窗格底 #F4F4FB ×20dp] [线 #C4C6D0 1px] [详情底 #FFFDFF ×28dp] [详情卡 #ECECF3]`
+  两处根因：
+  - `fushi/lib/src/settings/settings_home_page.dart:348` 导航窗格底色取 `tokens.surfaces.group`
+    （surfaceContainerLow）。它与详情窗格所在的 `surfaces.page`（surface）在浅色主题下只差
+    约 2%（#F4F4FB vs #FFFDFF，11/255），**线两侧几乎同色**——人眼预期一条线两边是两个不同
+    的面，这里看不到面，线就只能读成一条凭空的竖线。同一屏里 `surfaces.card` 的分组卡又铺在
+    `surfaces.group` 的窗格上（差同样约 2%），等于窗格里再套一层看不见的卡，窗格自己反而没有
+    一整块可辨的实色面。
+  - `fushi/lib/src/settings/material_settings_renderer.dart:19-24` 详情正文左内边距是
+    `page + gap`(28)、右边 `page`(20)。正文在自己的窗格里左右不等宽；落到接缝上就是线左边
+    20dp、右边 28dp，**一条线两侧呼吸不一样宽**，线看着偏向左侧。
+  左边「图标侧栏 | 导航窗格」那条缝本来就没有分隔线（`home_page.dart:1315-1331` 是裸 `Row`，
+  rail 与内容同为 `surface`），于是同一屏里两条同类接缝一条隐形、一条画硬线，左右不对称。
+- **[x] ① 已修复** — 导航窗格底色提一档到 `tokens.surfaces.card`（surfaceContainer，与详情底
+  面差约 4.3%，线两侧真有两个面）；宽屏主从的分类分组不再铺同色卡片（`surfaceColor:
+  Colors.transparent`），窗格本身就是那块 tonal 面，窄屏 push 列表没有窗格底、分组卡是它唯一
+  的容器，保持不变；窗格里的搜索框相应提到 `surfaces.overlay`，在更深的窗格底上保持原有的
+  4.7% 对比；详情正文左右内边距都取 `page`，正文左右对称、分隔线居中于 20+20 的缝里。
+  分隔线本身（`surfaces.outline` / 1px）不动——实测这个浅色主题相邻 tonal 档只差 2~4%，
+  单靠面差撑不住窗格边界，线仍是必要的，问题从来不是它存在，而是它两侧没有面。
+- **[x] ② 已加自动化测试** — `fushi/test/settings/settings_pane_seam_test.dart`（行为层：宽屏
+  导航窗格必须画在 `surfaces.card` 档、且该档与 `page`/`group` 不同色；详情正文左右内边距必须
+  相等。两条都做过反向验证：改回旧值确实变红）。源码层对应守卫在
+  `fushi/test/settings/settings_redesign_static_test.dart`（窗格底色档位 + 宽窄两侧分组卡策略）。
+- **备注**：改前/改后真实像素对照见 `.codex-test/settings-seam/seam_before_zh.png` /
+  `seam_after_zh.png`（widget 预览，1200×750 逻辑、DPR 2，中文真字体）。暗色主题同法采样：
+  窗格 #1B2023 / 详情底 #0F1417（面差 4.7%）、搜索框 #303638，均正常。

--- a/fushi/lib/src/settings/material_settings_renderer.dart
+++ b/fushi/lib/src/settings/material_settings_renderer.dart
@@ -13,13 +13,17 @@ import 'package:fushi/src/utils/components/settings_shared.dart';
 class MaterialSettingsRenderer implements SettingsRenderer {
   const MaterialSettingsRenderer();
 
-  /// 详情页正文的水平内边距（唯一真相源）：左侧贴近 pane 分隔线，给 MD3 expanded
-  /// 呼吸量（page + gap），右侧 page。[buildDetailContent] 与任何要与 schema
-  /// section 等宽对齐的兄弟卡片（如阅读器快捷设置里并入 layout 子页顶部的主题选
-  /// 择器卡）都必须从这里取横向缩进，避免各自硬编码导致左右对不齐。
+  /// 详情页正文的水平内边距（唯一真相源）：左右都是 page。[buildDetailContent]
+  /// 与任何要与 schema section 等宽对齐的兄弟卡片（如阅读器快捷设置里并入 layout
+  /// 子页顶部的主题选择器卡）都必须从这里取横向缩进，避免各自硬编码导致左右对不齐。
+  ///
+  /// 左侧曾是 `page + gap`（28），比右侧宽 8：详情正文在自己的窗格里左右不等宽，
+  /// 而且宽屏主从下正文左缘紧邻 pane 分隔线——线左边是导航窗格的 20，右边是详情的
+  /// 28，一条线两侧呼吸不一样宽，线看着偏向左侧。两边同取 page 后，正文在窗格内
+  /// 左右对称，分隔线也居中于 20 + 20 的缝里。
   static EdgeInsets detailHorizontalInsets(FushiDesignTokens tokens) {
     return EdgeInsets.only(
-      left: tokens.spacing.page + tokens.spacing.gap,
+      left: tokens.spacing.page,
       right: tokens.spacing.page,
     );
   }
@@ -102,7 +106,12 @@ class MaterialSettingsRenderer implements SettingsRenderer {
             AdaptiveSettingsSection(
               key: ValueKey<SettingsNavigationGroupId>(group.id),
               title: group.id.title(context),
-              surfaceColor: tokens.surfaces.card,
+              // 宽屏主从（pushRoutes:false）下导航窗格自己已经是一块 tonal 面
+              // （`surfaces.card`），分组再铺一层同色卡片就是卡中卡：卡片边界看不见，
+              // 窗格却因此少了一整块可辨的实色面。那里分组只做分段与标题，填充交给
+              // 窗格本身。窄屏 push 列表没有窗格底、直接铺在 `surfaces.page` 上，
+              // 分组卡仍是它唯一的容器，保持不变。
+              surfaceColor: pushRoutes ? null : Colors.transparent,
               children: group.destinations
                   .map(destinationRow)
                   .toList(growable: false),

--- a/fushi/lib/src/settings/settings_home_page.dart
+++ b/fushi/lib/src/settings/settings_home_page.dart
@@ -139,7 +139,10 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
     return _buildEmbeddedShell(content);
   }
 
-  Widget _buildSearchField() {
+  /// [onNavPane] 为 true 时搜索框画在宽屏导航窗格的 tonal 底上（`surfaces.card`），
+  /// 那里 `surfaces.search` 与底色只差一档、几乎糊掉，故再提一档到 `surfaces.overlay`；
+  /// 窄屏单列画在页面底（`surfaces.page`）上，保持原来的 `surfaces.search`。
+  Widget _buildSearchField({bool onNavPane = false}) {
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     // 搜索框与设置分组卡走同一套边界语言：填充分层，不描边。原来它吃全局
     // inputDecorationTheme 的 colorScheme.outline 描边——比分组卡的
@@ -183,7 +186,11 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
                   ),
             isDense: true,
             filled: !eink,
-            fillColor: eink ? null : tokens.surfaces.search,
+            fillColor: eink
+                ? null
+                : (onNavPane
+                      ? tokens.surfaces.overlay
+                      : tokens.surfaces.search),
             border: eink
                 ? OutlineInputBorder(
                     // MD3 守卫：圆角一律走 design tokens，不自持字面量。
@@ -338,9 +345,9 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
         ? CupertinoColors.separator.resolveFrom(context)
         : tokens.surfaces.outline;
     // MD3 list-detail: the nav pane sits on the tonal container token
-    // (`surfaces.group`) while the detail pane stays on the base page surface.
+    // (`surfaces.card`) while the detail pane stays on the base page surface.
     // Material only — Cupertino keeps its system background untouched.
-    final Color? navPaneColor = cupertino ? null : tokens.surfaces.group;
+    final Color? navPaneColor = cupertino ? null : tokens.surfaces.card;
     return MaterialSupportingPaneLayout(
       minSplitWidth: 720,
       supportingSide: SupportingPaneSide.start,
@@ -350,7 +357,7 @@ class _SettingsHomePageState extends BasePageState<SettingsHomePage>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            _buildSearchField(),
+            _buildSearchField(onNavPane: true),
             Expanded(
               child: _searchQuery.trim().isEmpty
                   ? renderer.buildDestinationList(

--- a/fushi/test/settings/settings_pane_seam_test.dart
+++ b/fushi/test/settings/settings_pane_seam_test.dart
@@ -1,0 +1,142 @@
+// 宽屏设置主从布局的「窗格接缝」行为守卫（BUG-2443）。
+//
+// 接缝指导航窗格与详情窗格之间那条 1px 分隔线。线本身没问题，问题是它两侧读不出
+// 「两个窗格」：
+//   * 导航窗格底色曾取 `surfaces.group`（surfaceContainerLow），与详情窗格的
+//     `surfaces.page`（surface）在浅色主题下只差约 2%（#F0F4F8 vs #F5FAFD），
+//     线两侧几乎同色，于是线读成一条凭空的竖线；
+//   * 详情正文左内边距曾是 `page + gap`(28)、右边 `page`(20)，线左边是导航窗格的
+//     20、右边是详情的 28，一条线两侧呼吸不一样宽。
+//
+// 这里钉住修复后的两条不变式：窗格底色取更高一档的 tonal（`surfaces.card`，面差
+// 约 4.3%），详情正文左右内边距相等。源码层面的对应守卫在
+// settings_redesign_static_test.dart。
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi/src/models/theme_notifier.dart';
+import 'package:fushi/src/settings/material_settings_renderer.dart';
+import 'package:fushi/src/settings/settings_home_page.dart';
+import 'package:fushi/utils.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../helpers/test_platform_services.dart';
+
+class _SeamTestAppModel extends AppModel {
+  _SeamTestAppModel() : super(testPlatformServices());
+
+  @override
+  Locale get appLocale => const Locale('en', 'US');
+
+  @override
+  PackageInfo get packageInfo => PackageInfo(
+    appName: 'Hibiki',
+    packageName: 'jp.hibiki.test',
+    version: '1.0.0',
+    buildNumber: '1',
+  );
+
+  @override
+  bool get reverseReaderBottomBar => false;
+}
+
+Future<AppModel> _buildAppModel() async {
+  final FushiDatabase db = FushiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+  addTearDown(db.close);
+  final PreferencesRepository prefsRepo = PreferencesRepository(db);
+  await prefsRepo.loadFromDb();
+  final Directory tempDir = Directory.systemTemp.createTempSync(
+    'hibiki_settings_seam_',
+  );
+  addTearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  final ThemeNotifier themeNotifier = ThemeNotifier(db, () => const TextTheme())
+    ..loadFromPrefsSnapshot(<String, String>{
+      'design_system': PrefCodec.encode('auto'),
+      'app_theme_key': PrefCodec.encode('system-theme'),
+      'brightness_mode': PrefCodec.encode('light'),
+      'custom_theme_seed': PrefCodec.encode(0xFF1F4959),
+    });
+  addTearDown(themeNotifier.dispose);
+
+  return _SeamTestAppModel()
+    ..themeNotifier = themeNotifier
+    ..wireLocalAudioForTesting(prefsRepo: prefsRepo, databaseDirectory: tempDir)
+    ..wireDatabaseForTesting(db);
+}
+
+Widget _wideSettings(AppModel appModel, ThemeNotifier themeNotifier) {
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+    child: TranslationProvider(
+      child: MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          platform: TargetPlatform.windows,
+          colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF1F4959)),
+          extensions: <ThemeExtension<dynamic>>[
+            FushiDesignSystemTheme(themeNotifier.designSystemTheme),
+          ],
+        ),
+        home: const Scaffold(body: SettingsHomePage(embedded: true)),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('wide nav pane paints a tonal surface distinct from the detail '
+      'pane, and the detail body is symmetric, so the divider reads as a pane '
+      'edge sitting centred in the seam', (WidgetTester tester) async {
+    final AppModel appModel = await _buildAppModel();
+    final ThemeNotifier themeNotifier = appModel.themeNotifier;
+
+    tester.view.devicePixelRatio = 1.0;
+    // 宽屏主从分支的门是 maxWidth >= 720。
+    tester.view.physicalSize = const Size(1200, 900);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    await tester.pumpWidget(_wideSettings(appModel, themeNotifier));
+    await tester.pump();
+
+    final BuildContext context = tester.element(
+      find.byType(SettingsHomePage).first,
+    );
+    final FushiDesignTokens tokens = FushiDesignTokens.of(context);
+
+    // 导航窗格是 MaterialSupportingPaneLayout 的 supporting，被一个上色 Container 包着。
+    final Iterable<Container> panes = tester
+        .widgetList<Container>(find.byType(Container))
+        .where(
+          (Container container) => container.color == tokens.surfaces.card,
+        );
+    expect(panes, isNotEmpty, reason: '宽屏导航窗格必须画在 surfaces.card 这一档 tonal 面上');
+
+    // 与详情窗格所在的页面底色确实不同档——同档等于没有分层，分隔线两侧就会同色。
+    expect(tokens.surfaces.card, isNot(tokens.surfaces.page));
+    expect(tokens.surfaces.card, isNot(tokens.surfaces.group));
+
+    // 详情正文左右内边距相等：左边曾多出一个 gap（28 对 20），正文在自己的窗格里
+    // 左右不等宽，而且线左是导航窗格的 20、线右是详情的 28，一条分隔线两侧呼吸
+    // 不一样宽，线看着偏向左侧。
+    final EdgeInsets insets = MaterialSettingsRenderer.detailHorizontalInsets(
+      tokens,
+    );
+    expect(insets.left, insets.right, reason: '详情正文左右内边距必须相等，否则分隔线不居中于窗格之间的缝里');
+    expect(insets.left, tokens.spacing.page);
+  });
+}

--- a/fushi/test/settings/settings_redesign_static_test.dart
+++ b/fushi/test/settings/settings_redesign_static_test.dart
@@ -551,15 +551,19 @@ void main() {
       final String source = readNormalizedSource(
         'lib/src/settings/settings_home_page.dart',
       );
-      // MD3 list-detail: nav pane on tonal token surface (surfaces.group =
-      // surfaceContainerLow), gated to Material via the cupertino branch。
+      // MD3 list-detail: nav pane on tonal token surface, gated to Material via
+      // the cupertino branch。
       // 旧锚点 `'cupertino ? null :'` 把三元表达式的**排版**写进了契约（换行一改
-      // 就红）。契约是「取 surfaces.group 的那条语句本身被 cupertino 门控」。
-      expect(source, contains('tokens.surfaces.group'));
-      final String statement = _statementAround(
-        source,
-        'tokens.surfaces.group',
-      );
+      // 就红）。契约是「取 tonal 底色的那条语句本身被 cupertino 门控」。
+      //
+      // 底色档位从 `surfaces.group`（surfaceContainerLow）提到 `surfaces.card`
+      // （surfaceContainer）：实测浅色主题下 surfaceContainerLow 与 surface 只差
+      // 约 2%（#F0F4F8 vs #F5FAFD），窗格与详情之间那条 1px 分隔线两侧几乎同色，
+      // 线因此读不出「两个窗格」、只读成一条凭空的竖线。提一档后面差约 4.3%，线
+      // 两侧真有两个面，同时左边「图标侧栏 | 导航窗格」那条本就没有分隔线的缝也
+      // 一并变得可辨。
+      expect(source, contains('tokens.surfaces.card'));
+      final String statement = _statementAround(source, 'tokens.surfaces.card');
       expect(
         statement,
         contains('cupertino'),
@@ -633,11 +637,16 @@ void main() {
       isTrue,
       reason: 'Material destination groups must retain shared section surfaces',
     );
+    // 分组卡只在**窄屏 push 列表**里铺：那里列表直接落在 `surfaces.page` 上，卡是
+    // 它唯一的容器。宽屏主从的导航窗格本身已经是一块 tonal 面（`surfaces.card`，
+    // 见下面那条守卫），再铺一层同色卡片就是卡中卡——卡边界看不见，窗格反而少了
+    // 一整块可辨的实色面，于是窗格与详情之间那条分隔线两侧都是近乎同色的浅面，
+    // 线读不出「两个窗格」、只读成一条凭空的竖线。宽屏那侧显式传 transparent。
     expect(
       material,
-      contains('surfaceColor: tokens.surfaces.card'),
+      contains('surfaceColor: pushRoutes ? null : Colors.transparent'),
       reason:
-          'wide supporting-pane list needs a visible lightweight surface over its tonal pane',
+          'narrow push list keeps the group card; the wide nav pane is itself the tonal surface',
     );
     expect(
       containsIdentifierCall(material, 'ListView.separated'),


### PR DESCRIPTION
## 问题

用户圈出设置页宽屏主从中间那条竖线，说「总觉得这条线还是有点怪」。对截图逐行采样（2940×1734，DPR 1.92），接缝一行的实际色块是：

```
[导航分组卡 #ECECF3] … [窗格底 #F4F4FB ×20dp] [线 #C4C6D0 1px] [详情底 #FFFDFF ×28dp] [详情卡 #ECECF3]
```

两处根因：

- **线两侧读不出「两个窗格」**：导航窗格底色取 `surfaces.group`（surfaceContainerLow），与详情窗格所在的 `surfaces.page`（surface）在浅色主题下只差约 **2%**（11/255）。人眼预期一条线两边是两个不同的面，这里看不到面，线就只能读成一条凭空的竖线。同一屏里 `surfaces.card` 的分组卡又铺在 `surfaces.group` 的窗格上（差同样约 2%），等于窗格里再套一层看不见的卡，窗格自己反而没有一整块可辨的实色面。
- **线两侧呼吸不一样宽**：详情正文左内边距是 `page + gap`(28)、右边 `page`(20)。正文在自己的窗格里左右不等宽；落到接缝上就是线左 20dp、右 28dp，线看着偏向左侧。

（左边「图标侧栏 | 导航窗格」那条缝本来就没有分隔线，rail 与内容同为 `surface`，于是同一屏里两条同类接缝一条隐形、一条画硬线。）

## 改动

- 导航窗格底色提一档到 `surfaces.card`（surfaceContainer）：与详情底面差从 2% 到约 **4.3%**，线两侧真有两个面；左边那条本就没有分隔线的缝也一并变得可辨。
- 宽屏主从的分类分组不再铺同色卡片（`surfaceColor: pushRoutes ? null : Colors.transparent`）：窗格本身就是那块 tonal 面，不再卡中卡。**窄屏 push 列表没有窗格底、直接铺在 `surfaces.page` 上，分组卡是它唯一的容器，保持不变。**
- 窗格里的搜索框相应提到 `surfaces.overlay`，在更深的窗格底上保持原有的 4.7% 对比（不提就会糊）。
- 详情正文左右内边距都取 `page`：正文左右对称，分隔线居中于 20 + 20 的缝里。

**分隔线本身（`surfaces.outline` / 1px）不动。** 实测这个浅色主题相邻 tonal 档只差 2~4%，单靠面差撑不住窗格边界（去掉线的变体两侧只剩 2% 亮度差，边界几乎消失），线仍是必要的——问题从来不是它存在，而是它两侧没有面。

## 验证

- 真实像素（widget 预览，1200×750 逻辑 / DPR 2 / 中文真字体）逐行采样，改后接缝：`[窗格 #EAEEF2] [线 #C0C8CC] [详情底 #F5FAFD ×20dp] [详情卡 #EAEEF2]`；暗色主题同法：窗格 #1B2023 / 详情底 #0F1417（面差 4.7%）/ 搜索框 #303638，均正常。
- 新增 `fushi/test/settings/settings_pane_seam_test.dart`（行为层）钉住两条不变式：宽屏导航窗格必须画在 `surfaces.card` 档且该档与 `page`/`group` 不同色；详情正文左右内边距必须相等。**两条都做过反向验证**——改回旧值确实变红。
- `settings_redesign_static_test.dart` 的两条源码守卫同步改写为新契约（窗格底色档位、宽窄两侧分组卡策略），不是删断言。
- `flutter analyze` 全量 0 issue；`test/settings/` 全目录 + 相邻域（module_settings / video_player_settings master-detail / reader_quick_settings / platform_layout / settings_wide_left_aligned）共 **516 条全绿**。

https://claude.ai/code/session_01PPWK8gFzt7RYv7UKgQEvd8
