### PR TITLE
fix(popup): 词典分组 <summary> 不再因鼠标点击获焦，修 macOS 展开/折叠后快捷键失灵（BUG-2447）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2256 条。点号进各自文件。
+> 共 2257 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2447](bugs/BUG-2447-macos-summary-focus-steals-shortcuts.md) | ✅ | ✅ | macOS 查词弹窗展开/折叠词典分组后全局快捷键失灵 |
 | [BUG-2446](bugs/BUG-2446-ext-subtitle-drop-scope.md) | ✅ | ✅ | 浏览器扩展：任何网页拖文件都弹整屏「松开以加载字幕」 |
 | [BUG-2445](bugs/BUG-2445-mihon-protobuf-not-registered.md) | ✅ | ✅ | Injekt 未注册 ProtoBuf 导致 5 个 protobuf 漫画源整源不可用 |
 | [BUG-2444](bugs/BUG-2444-mihon-proxy-policy-selector-throws.md) | ✅ | ✅ | 宿主代理策略故障时 ProxySelector 抛异常导致 sidecar 堆耗尽、请求挂死到超时 |

--- a/docs/bugs/BUG-2447-macos-summary-focus-steals-shortcuts.md
+++ b/docs/bugs/BUG-2447-macos-summary-focus-steals-shortcuts.md
@@ -1,0 +1,31 @@
+## BUG-2447 · macOS 查词弹窗展开/折叠词典分组后全局快捷键失灵
+- **报告**：2026-09-11（用户：查词后在查词弹框点击展开/关闭词条，之后快捷键就失灵）
+- **真实性**：✅ 真 bug（沿真实代码路径定位；症状本身由用户在 macOS 真机观察到，本仓无 macOS 机器，未做真机复测——见「验证边界」）
+
+  **根因链（每一环都有代码/引擎源码支撑）**
+
+  1. `fushi/assets/popup/popup.js:4215` 词典分组的 `<summary class="dict-label">` 上只挂了长按选词典的监听，**不取消 mousedown 的默认动作**，于是鼠标点它 → 节点获得 DOM 焦点。
+     `<summary>` 是弹窗里**唯一**「鼠标点一下就会获焦」的元素：按钮与链接在 macOS WebKit 下按平台惯例 `isMouseFocusable` 恒为 false，释义正文与留白根本不可聚焦。这正是「为什么偏偏是展开/折叠、点别处没事」。
+  2. 节点一获焦，WebKit 就把承载它的 `WKWebView` 交成窗口 first responder，此后 `keyDown:` 全部进 WebKit，`FlutterViewController` 再也收不到按键。
+  3. macOS 上**没有任何东西能把 first responder 还回来**：
+     - Flutter 引擎平台视图层零 first-responder 代码——`engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterMutatorView.mm`（683 行）与 `FlutterPlatformViewController.mm` 里 `grep firstResponder` 零命中（本机 Flutter 3.44.0 SDK 自带 engine 源码）；
+     - `fushi/lib/src/focus/page_focus_ownership.dart:89-103` `reclaim()` 只调 `node.requestFocus()`，**零 method channel / 零原生调用**，动的是 Flutter 自己的焦点树；
+     - 全仓 `makeFirstResponder` / `becomeFirstResponder` / `resignFirstResponder` **0 命中**，`fushi/macos/Runner/` 下无任何键盘或 responder 代码；
+     - Windows 那条兜底不是通道而是 fork：`packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart:515-524` 每次 `onPointerDown` 都 `_focusNode.requestFocus()` 并在 50ms 后补一次。它成立的前提是 WebView2 的**无窗口合成**（指针先到 Flutter），macOS 用的是上游 `flutter_inappwebview_macos` 的**真原生 `WKWebView` 子视图**（BUG-1692 已确认是真 `NSView` 层级），这条前提不存在。
+  4. 于是弹窗持焦期间只剩弹窗内的 JS 桥一条路，而它**按构造**只转发宿主显式声明的动作：`dictionaryPopupInputSpecFor`（`fushi/lib/src/pages/implementations/dictionary_popup_input_bridge.dart:73-106`）从宿主的 `dictionaryPopupForwardedActions` 导出键表，阅读器只声明了 `globalBack` + `readerDismissDict`（`reader_fushi_page.dart:3990-3996`）。**其余全部快捷键无人接管**。
+  5. 而「弹窗渲染那一刻抢一次焦点」这条旧兜底也够不着：`reader_fushi_page.dart:3974` 的 `popupRendered` 回收只在渲染时跑一次；`popup.js:6115` 的 `__fushiPopupClick` 对 `summary` 是**早退**（不发 `tapOutside`、不重查词、不重渲染），所以点展开/折叠连那一帧的 reclaim 都不会发生。点释义正文之所以没事，是因为它会触发选词→重新查词→`popupRendered`→reclaim。
+
+  **家族关系**：BUG-136（手势后 WebView 抢走 OS 焦点无人归还）→ BUG-1071（弹窗渲染时抢回一次）→ BUG-1269（改用弹窗内 JS 桥，但只转发宿主声明的动作）→ BUG-1347（Windows 指针所有权分流）。本条是这条链在 **macOS + 可聚焦 DOM 节点** 上的未覆盖残余。
+
+- **[x] ① 已修复** — `fushi/assets/popup/popup.js:4215`（三份镜像同步：`fushi/assets/browser_extension/vendor/popup.js`、`tools/browser-extension/vendor/popup.js`，byte-parity 守卫 `fushi/test/build/browser_extension_popup_parity_guard_test.dart`）：`<summary>` 的**主键** mousedown 取消默认动作，掐断「点击 → 节点获焦」这一步。
+  - `<details>` 的开合是 `click` 的 **activation behavior**，与 mousedown 的默认动作无关 → 展开/折叠照常。
+  - Tab 聚焦不受影响（只有**鼠标**聚焦是 mousedown 的默认动作），键盘可达性不变。
+  - 只对主键生效：非主键本就不参与聚焦，中键/右键要原样留给弹窗输入桥的 `Mouse<n>` 转发判定。
+  - 长按选词典（制卡用）、`mouseup` / `mouseleave` 撤销长按全部保留。
+- **[x] ② 已加自动化测试** — `fushi/test/dictionary/popup_summary_mouse_focus_test.dart` + 同名 `.js`（node 真执行 popup.js 里提取出的 `createGlossarySection`，拿它**实际挂上去的** mousedown 监听派发事件）：
+  ① 主键 mousedown 必须 `defaultPrevented`；② 非主键必须不被拦；③ 长按仍能选中词典；④ `mouseup` 仍撤销长按。
+  另有独立于被测源码的派生判据：popup.js 里 `summary` 的 mousedown 监听必须**有且只有一处**，抓错就不是自证。
+  **变异实测**：删掉修复那一行后该测试红在断言 ①（`false !== true`），恢复后绿。
+- **备注**：
+  - **验证边界（不要写成「已验证」）**：本机无 macOS 设备，未在真机复测原始失败路径。「取消 mousedown 默认动作能阻止节点获焦」是 DOM 规范里 mousedown 的可取消默认动作，合成事件不是 trusted、默认动作本就不跑，**任何自动化层都测不到这一步**，只能靠真机手势验。上面第 1~5 环全部有代码/引擎源码支撑，但「WebKit 正是在节点获焦时移交 first responder」这一环取自 WebKit 的平台行为，本仓无法本地取证。
+  - **残余（本条不处理，值得单开）**：① 弹窗里的**文本输入**（句子上下文编辑框）合法获焦，关掉之后 first responder 同样回不来——macOS 缺一条「把 first responder 还给 FlutterView」的原生通道，这是上面第 3 环的通用缺口；② `window.__fushiPopupModalDepth` 只在 `showMinedCardActionPanel` 的 `finish()` 里减（`popup.js:2173` / `:2177-2178`），而热槽 WebView 跨查词不重载、`renderPopup` 会把面板 DOM 连同 backdrop 一起抹掉 → `finish` 永不执行 → depth 永久 ≥1 → 整座 JS 桥（键盘 + 鼠标四个监听）永久让位。这是同一症状的第二条独立成因，与本条无关但同样会表现为「弹窗里快捷键全死」。

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -4212,9 +4212,26 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
         if (longPressed) event?.preventDefault?.();
     });
     summary.addEventListener('touchmove', () => clearTimeout(longPressTimer));
-    summary.addEventListener('mousedown', () => {
+    // BUG-2447：`<summary>` 是查词弹窗里唯一「鼠标点一下就会拿到 DOM 焦点」的元素——
+    // 按钮与链接在 macOS WebKit 下按平台惯例 `isMouseFocusable` 恒为 false，释义正文与
+    // 留白根本不可聚焦。而节点一旦获得焦点，WebKit 就让承载它的 WKWebView 成为窗口的
+    // first responder，此后 `keyDown:` 全部进 WebKit，FlutterViewController 再也收不到
+    // 按键。macOS 上**没有任何东西能把 first responder 还回来**：Flutter 引擎的平台视图
+    // 层（FlutterMutatorView / FlutterPlatformViewController）整层没有 firstResponder
+    // 代码，`PageFocusOwnership.reclaim` 只动 Flutter 自己的焦点树，而 Windows 那条兜底
+    // （fork 的 custom_platform_view 每次 onPointerDown 都 requestFocus）依赖 WebView2 的
+    // 无窗口合成、在真原生 WKWebView 上并不存在。于是「展开/折叠一次词典分组」之后宿主
+    // 页面的快捷键整条失效，只剩 JS 桥里宿主显式转发的那两三个动作还活着——BUG-1269 当年
+    // 补的正是那条桥，它按构造覆盖不到其余绑定。
+    //
+    // 取消 mousedown 的默认动作即掐断「点击 → 节点获焦」这一步，而 `<details>` 的开合是
+    // `click` 的 activation behavior，与 mousedown 的默认动作无关，照常发生；Tab 聚焦也
+    // 不受影响（只有**鼠标**聚焦是 mousedown 的默认动作）。只对主键生效：非主键本就不
+    // 参与聚焦，中键/右键要原样留给弹窗输入桥的 `Mouse<n>` 转发判定。
+    summary.addEventListener('mousedown', (e) => {
         longPressed = false;
         longPressTimer = setTimeout(toggleSelection, 500);
+        if (e && e.button === 0) e.preventDefault();
     });
     summary.addEventListener('mouseup', () => clearTimeout(longPressTimer));
     summary.addEventListener('mouseleave', () => clearTimeout(longPressTimer));

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -4212,9 +4212,26 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
         if (longPressed) event?.preventDefault?.();
     });
     summary.addEventListener('touchmove', () => clearTimeout(longPressTimer));
-    summary.addEventListener('mousedown', () => {
+    // BUG-2447：`<summary>` 是查词弹窗里唯一「鼠标点一下就会拿到 DOM 焦点」的元素——
+    // 按钮与链接在 macOS WebKit 下按平台惯例 `isMouseFocusable` 恒为 false，释义正文与
+    // 留白根本不可聚焦。而节点一旦获得焦点，WebKit 就让承载它的 WKWebView 成为窗口的
+    // first responder，此后 `keyDown:` 全部进 WebKit，FlutterViewController 再也收不到
+    // 按键。macOS 上**没有任何东西能把 first responder 还回来**：Flutter 引擎的平台视图
+    // 层（FlutterMutatorView / FlutterPlatformViewController）整层没有 firstResponder
+    // 代码，`PageFocusOwnership.reclaim` 只动 Flutter 自己的焦点树，而 Windows 那条兜底
+    // （fork 的 custom_platform_view 每次 onPointerDown 都 requestFocus）依赖 WebView2 的
+    // 无窗口合成、在真原生 WKWebView 上并不存在。于是「展开/折叠一次词典分组」之后宿主
+    // 页面的快捷键整条失效，只剩 JS 桥里宿主显式转发的那两三个动作还活着——BUG-1269 当年
+    // 补的正是那条桥，它按构造覆盖不到其余绑定。
+    //
+    // 取消 mousedown 的默认动作即掐断「点击 → 节点获焦」这一步，而 `<details>` 的开合是
+    // `click` 的 activation behavior，与 mousedown 的默认动作无关，照常发生；Tab 聚焦也
+    // 不受影响（只有**鼠标**聚焦是 mousedown 的默认动作）。只对主键生效：非主键本就不
+    // 参与聚焦，中键/右键要原样留给弹窗输入桥的 `Mouse<n>` 转发判定。
+    summary.addEventListener('mousedown', (e) => {
         longPressed = false;
         longPressTimer = setTimeout(toggleSelection, 500);
+        if (e && e.button === 0) e.preventDefault();
     });
     summary.addEventListener('mouseup', () => clearTimeout(longPressTimer));
     summary.addEventListener('mouseleave', () => clearTimeout(longPressTimer));

--- a/fushi/test/dictionary/popup_summary_mouse_focus_test.dart
+++ b/fushi/test/dictionary/popup_summary_mouse_focus_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2447：macOS 上在查词弹窗里展开/折叠词典分组之后，宿主页面的快捷键整条失效。
+///
+/// 根因不在快捷键绑定层，而在**谁持有 OS 键盘焦点**：`<summary>` 是弹窗里唯一「鼠标
+/// 点一下就会拿到 DOM 焦点」的元素（按钮与链接在 macOS WebKit 下按平台惯例
+/// `isMouseFocusable` 恒为 false，释义正文与留白根本不可聚焦）。节点一获焦，WebKit
+/// 就让承载它的 WKWebView 成为窗口 first responder，此后按键全部进 WebKit，
+/// `FlutterViewController` 再也收不到。macOS 侧**没有任何东西能把 first responder
+/// 还回来**：Flutter 引擎的 `FlutterMutatorView` / `FlutterPlatformViewController`
+/// 整层没有 firstResponder 代码；`PageFocusOwnership.reclaim` 只动 Flutter 自己的焦点
+/// 树；Windows 那条兜底（fork 的 `custom_platform_view` 每次 `onPointerDown` 都
+/// `requestFocus`）依赖 WebView2 的无窗口合成，真原生 WKWebView 上并不存在。于是
+/// 只剩弹窗 JS 桥一条路，而它按构造只转发宿主显式声明的那两三个动作（BUG-1269 修的
+/// 就是那条桥），其余绑定全部落空。
+///
+/// 修复：`<summary>` 的主键 mousedown 取消默认动作，掐断「点击 → 节点获焦」这一步。
+/// `<details>` 的开合是 `click` 的 activation behavior，与 mousedown 的默认动作无关，
+/// 照常发生；Tab 聚焦也不受影响（只有**鼠标**聚焦是 mousedown 的默认动作）。
+///
+/// 本 wrapper 只负责驱动 node 真执行 popup.js 里的 `createGlossarySection` 并拿它
+/// 实际挂上去的监听派发事件——判据与分层说明都写在同名 `.js` 里。无 node 时 skip。
+void main() {
+  test(
+    'dict <summary> cancels primary-button mousedown so it never takes DOM focus '
+    '(executes popup.js via node)',
+    () async {
+      final String? nodeExe = _resolveNode();
+      if (nodeExe == null) {
+        markTestSkipped(
+            'node not found on PATH; skipping JS behavior execution');
+        return;
+      }
+
+      final File jsTest =
+          File('test/dictionary/popup_summary_mouse_focus_test.js');
+      expect(jsTest.existsSync(), isTrue,
+          reason: 'behavior harness ${jsTest.path} must exist');
+
+      final ProcessResult result = await Process.run(
+        nodeExe,
+        <String>[jsTest.path],
+        workingDirectory: Directory.current.path,
+      );
+
+      expect(
+        result.exitCode,
+        0,
+        reason: 'popup <summary> mouse-focus behavior test failed.\n'
+            'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+      );
+      expect(result.stdout.toString(), contains('all assertions passed'),
+          reason: 'behavior harness must reach its success marker');
+    },
+  );
+}
+
+String? _resolveNode() {
+  final String exe = Platform.isWindows ? 'node.exe' : 'node';
+  final String pathEnv = Platform.environment['PATH'] ?? '';
+  final String separator = Platform.isWindows ? ';' : ':';
+  for (final String dir in pathEnv.split(separator)) {
+    if (dir.isEmpty) continue;
+    final File candidate = File('$dir${Platform.pathSeparator}$exe');
+    if (candidate.existsSync()) return candidate.path;
+  }
+  return null;
+}

--- a/fushi/test/dictionary/popup_summary_mouse_focus_test.js
+++ b/fushi/test/dictionary/popup_summary_mouse_focus_test.js
@@ -1,0 +1,256 @@
+// BUG-2447 的**行为级**守卫：查词弹窗里词典分组的 `<summary>`（点它展开/折叠）
+// 在主键 mousedown 上必须取消默认动作，否则该节点会拿到 DOM 焦点。
+//
+// 为什么这条值得单测（别把它当「一行 preventDefault」）：节点获焦在 macOS WebKit 上
+// 会把承载它的 WKWebView 变成窗口 first responder，而 macOS 侧**没有任何东西能把
+// first responder 还回来**（Flutter 引擎的 FlutterMutatorView /
+// FlutterPlatformViewController 整层无 firstResponder 代码；`PageFocusOwnership`
+// 只动 Flutter 自己的焦点树；Windows 那条兜底是 fork 的 custom_platform_view 在每次
+// onPointerDown 里 requestFocus，依赖 WebView2 的无窗口合成，真原生 WKWebView 上不
+// 存在）。于是「展开一次词典分组」= 宿主页面快捷键整条失效，且关掉弹窗也回不来。
+// `<summary>` 是弹窗里唯一「鼠标点一下就获焦」的元素——按钮与链接在 macOS WebKit 下
+// 按平台惯例 `isMouseFocusable` 恒为 false，释义正文与留白根本不可聚焦。
+//
+// 分层说明：
+//   * 本文件真执行 popup.js 里提取出的 `createGlossarySection`，拿到它**实际挂上去
+//     的** mousedown 监听再派发事件，所以测的是出货代码，不是复刻品。
+//   * 「取消 mousedown 默认动作确实能阻止节点获焦」是 DOM 规范语义，只有真浏览器
+//     的真用户手势能验（合成事件不是 trusted，默认动作本就不跑），不在本层。
+//   * `<details>` 的开合是 `click` 的 activation behavior，与 mousedown 的默认动作
+//     无关——这正是这条修复不会把展开/折叠一起掐掉的原因。
+//
+// 运行：node fushi/test/dictionary/popup_summary_mouse_focus_test.js
+// 由同名 .dart wrapper 通过 Process.run('node', ...) 驱动（无 node 时 skip）。
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const popupPath = path.resolve(
+  __dirname, '..', '..', 'assets', 'popup', 'popup.js');
+const popupSrc = fs.readFileSync(popupPath, 'utf8');
+
+// ---- 最小 fake DOM ---------------------------------------------------------
+// 只实现被测代码真正用到的原语：属性赋值（el 用 `key in element` 分流）、子节点
+// 挂载、classList、以及 addEventListener/dispatchEvent（本测试的观测面）。
+class FakeEvent {
+  constructor(type, button) {
+    this.type = type;
+    this.button = button;
+    this.defaultPrevented = false;
+  }
+
+  preventDefault() {
+    this.defaultPrevented = true;
+  }
+}
+
+class FakeClassList {
+  constructor() {
+    this._set = new Set();
+  }
+
+  add(name) {
+    this._set.add(name);
+  }
+
+  remove(name) {
+    this._set.delete(name);
+  }
+
+  contains(name) {
+    return this._set.has(name);
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.nodeType = 1;
+    this.tagName = String(tagName).toUpperCase();
+    this.className = '';
+    this.textContent = '';
+    this.innerHTML = '';
+    this.open = false;
+    this.childNodes = [];
+    this.parentNode = null;
+    this.attributes = {};
+    this.classList = new FakeClassList();
+    this._listeners = new Map();
+  }
+
+  appendChild(child) {
+    this.childNodes.push(child);
+    if (child && typeof child === 'object') child.parentNode = this;
+    return child;
+  }
+
+  append(...children) {
+    for (const child of children) this.appendChild(child);
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  addEventListener(type, handler) {
+    if (!this._listeners.has(type)) this._listeners.set(type, []);
+    this._listeners.get(type).push(handler);
+  }
+
+  /// 派发到本节点上注册的监听（不冒泡：被测监听就挂在 summary 自己身上）。
+  dispatchEvent(event) {
+    for (const handler of this._listeners.get(event.type) || []) {
+      handler(event);
+    }
+    return !event.defaultPrevented;
+  }
+
+  querySelectorAll() {
+    return [];
+  }
+}
+
+// ---- 提取被测函数（不执行整个 popup.js：它依赖真实 DOM/window） -------------
+function extract(pattern, what) {
+  const match = popupSrc.match(pattern);
+  assert.ok(match, 'popup.js must define ' + what);
+  return match[0];
+}
+
+const elFn = extract(
+  /function el\(tag, props = \{\}, children = \[\]\) \{[\s\S]*?\n\}/,
+  'el(tag, props, children)',
+);
+const displayNameFn = extract(
+  /function __fushiDictDisplayName\(name\)\{[\s\S]*?\n\}/,
+  '__fushiDictDisplayName(name)',
+);
+const autoExpandFn = extract(
+  /function autoExpandCount\(totalDicts\) \{[\s\S]*?\n\}/,
+  'autoExpandCount(totalDicts)',
+);
+const sectionFn = extract(
+  /function createGlossarySection\(dictName, contents, dictIdx, entryIdx, totalDicts\) \{[\s\S]*?\n\}/,
+  'createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts)',
+);
+
+// 派生判据必须独立于被测源码：这两条只用来保证我们抓到的确实是**唯一**那处
+// summary mousedown 监听，抓错了下面的行为断言就成了自证。
+const summaryMouseDownSites =
+  popupSrc.match(/summary\.addEventListener\('mousedown'/g) || [];
+assert.strictEqual(
+  summaryMouseDownSites.length, 1,
+  'popup.js must register exactly one mousedown listener on the dict <summary>; '
+  + 'found ' + summaryMouseDownSites.length);
+
+const timers = [];
+const context = {
+  console,
+  JSON,
+  Set,
+  Math,
+  Number,
+  Object,
+  Array,
+  RegExp,
+  setTimeout: (fn, ms) => {
+    timers.push({ fn, ms });
+    return timers.length;
+  },
+  clearTimeout: (id) => {
+    if (id >= 1 && id <= timers.length) timers[id - 1].cancelled = true;
+  },
+  document: {
+    createElement: (tag) => new FakeElement(tag),
+  },
+  window: {},
+  selectedDictionaries: {},
+  // createGlossarySection 在本测试关心的那段之外还会碰到的协作者，一律最小桩：
+  // 它们与 summary 的鼠标聚焦语义无关，桩掉不影响本文件的判据。
+  dictColumns: () => 1,
+  ensureDictionaryStyle: () => {},
+  constructDictCss: (css) => css,
+  parseTags: () => [],
+  createGlossaryTags: () => null,
+  tagGlossaryContent: () => {},
+  renderStructuredContent: () => {},
+  rewriteDictLinks: (html) => html,
+  runDictScripts: () => {},
+  NUMERIC_TAG: /^\d+$/,
+  isPartOfSpeech: () => false,
+};
+vm.createContext(context);
+vm.runInContext(
+  elFn + '\n' + displayNameFn + '\n' + autoExpandFn + '\n' + sectionFn +
+  '\nthis.__createGlossarySection = createGlossarySection;',
+  context,
+);
+const createGlossarySection = context.__createGlossarySection;
+
+function buildSection() {
+  timers.length = 0;
+  context.selectedDictionaries = {};
+  const details = createGlossarySection(
+    '三省堂国語辞典', [{ content: 'かいせつ', glossaryIndex: 0 }], 0, 0, 1);
+  const summary = details.childNodes.find((n) => n.tagName === 'SUMMARY');
+  assert.ok(summary, 'createGlossarySection must build a <summary> header');
+  return { details, summary };
+}
+
+// ---- ① 主键 mousedown 必须取消默认动作（= 不让 <summary> 拿到 DOM 焦点）------
+{
+  const { summary } = buildSection();
+  const event = new FakeEvent('mousedown', 0);
+  summary.dispatchEvent(event);
+  assert.strictEqual(
+    event.defaultPrevented, true,
+    'primary-button mousedown on the dict <summary> must be default-prevented, '
+    + 'otherwise the node takes DOM focus and (on macOS WebKit) hands the window '
+    + 'first responder to the WKWebView with no way back — BUG-2447');
+}
+
+// ---- ② 非主键不受影响（中键/右键要留给弹窗输入桥的 Mouse<n> 转发）----------
+for (const button of [1, 2, 3, 4]) {
+  const { summary } = buildSection();
+  const event = new FakeEvent('mousedown', button);
+  summary.dispatchEvent(event);
+  assert.strictEqual(
+    event.defaultPrevented, false,
+    'non-primary mousedown (button ' + button + ') on the dict <summary> must be '
+    + 'left alone: it never focuses the node, and the popup input bridge still '
+    + 'needs it for Mouse<n> forwarding');
+}
+
+// ---- ③ 长按选词典（制卡用）没有被这条修复掐掉 ------------------------------
+{
+  const { summary } = buildSection();
+  summary.dispatchEvent(new FakeEvent('mousedown', 0));
+  const armed = timers.filter((t) => !t.cancelled && t.ms === 500);
+  assert.strictEqual(
+    armed.length, 1,
+    'primary-button mousedown must still arm the 500ms long-press timer that '
+    + 'selects this dictionary for mining');
+  armed[0].fn();
+  assert.strictEqual(
+    summary.classList.contains('selected'), true,
+    'the long-press must still mark the dictionary as selected');
+}
+
+// ---- ④ mouseup / mouseleave 仍然撤销长按（回归防线）------------------------
+{
+  const { summary } = buildSection();
+  summary.dispatchEvent(new FakeEvent('mousedown', 0));
+  summary.dispatchEvent(new FakeEvent('mouseup', 0));
+  assert.strictEqual(
+    timers.filter((t) => !t.cancelled).length, 0,
+    'mouseup must still cancel the pending long-press timer');
+}
+
+console.log('all assertions passed');

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -4212,9 +4212,26 @@ function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts
         if (longPressed) event?.preventDefault?.();
     });
     summary.addEventListener('touchmove', () => clearTimeout(longPressTimer));
-    summary.addEventListener('mousedown', () => {
+    // BUG-2447：`<summary>` 是查词弹窗里唯一「鼠标点一下就会拿到 DOM 焦点」的元素——
+    // 按钮与链接在 macOS WebKit 下按平台惯例 `isMouseFocusable` 恒为 false，释义正文与
+    // 留白根本不可聚焦。而节点一旦获得焦点，WebKit 就让承载它的 WKWebView 成为窗口的
+    // first responder，此后 `keyDown:` 全部进 WebKit，FlutterViewController 再也收不到
+    // 按键。macOS 上**没有任何东西能把 first responder 还回来**：Flutter 引擎的平台视图
+    // 层（FlutterMutatorView / FlutterPlatformViewController）整层没有 firstResponder
+    // 代码，`PageFocusOwnership.reclaim` 只动 Flutter 自己的焦点树，而 Windows 那条兜底
+    // （fork 的 custom_platform_view 每次 onPointerDown 都 requestFocus）依赖 WebView2 的
+    // 无窗口合成、在真原生 WKWebView 上并不存在。于是「展开/折叠一次词典分组」之后宿主
+    // 页面的快捷键整条失效，只剩 JS 桥里宿主显式转发的那两三个动作还活着——BUG-1269 当年
+    // 补的正是那条桥，它按构造覆盖不到其余绑定。
+    //
+    // 取消 mousedown 的默认动作即掐断「点击 → 节点获焦」这一步，而 `<details>` 的开合是
+    // `click` 的 activation behavior，与 mousedown 的默认动作无关，照常发生；Tab 聚焦也
+    // 不受影响（只有**鼠标**聚焦是 mousedown 的默认动作）。只对主键生效：非主键本就不
+    // 参与聚焦，中键/右键要原样留给弹窗输入桥的 `Mouse<n>` 转发判定。
+    summary.addEventListener('mousedown', (e) => {
         longPressed = false;
         longPressTimer = setTimeout(toggleSelection, 500);
+        if (e && e.button === 0) e.preventDefault();
     });
     summary.addEventListener('mouseup', () => clearTimeout(longPressTimer));
     summary.addEventListener('mouseleave', () => clearTimeout(longPressTimer));


### PR DESCRIPTION
## 症状

macOS：查词后在查词弹窗里点一次词典分组的**展开/折叠**，之后宿主页面（阅读器/视频）的快捷键整条失灵；点释义正文、点按钮都没事，偏偏是展开/折叠。

## 根因（BUG-2447）

不在绑定层，在**谁持有 OS 键盘焦点**：

1. `<summary class="dict-label">` 是弹窗里**唯一「鼠标点一下就获得 DOM 焦点」的元素**——按钮/链接在 macOS WebKit 下按平台惯例 `isMouseFocusable` 为 false，释义正文与留白根本不可聚焦。这就是「为什么偏偏是展开/折叠」。
2. 节点一获焦，WebKit 把承载它的 WKWebView 交成窗口 first responder，此后 `keyDown:` 全进 WebKit，`FlutterViewController` 再也收不到按键。
3. macOS 侧**没有任何东西能把 first responder 还回来**：
   - Flutter 3.44 engine 的 `FlutterMutatorView.mm` / `FlutterPlatformViewController.mm` 整层 `grep firstResponder` 零命中；
   - `PageFocusOwnership.reclaim()`（`page_focus_ownership.dart:89-103`）只调 `node.requestFocus()`，零原生调用；
   - 全仓 `makeFirstResponder` 0 命中，`fushi/macos/Runner/` 无任何键盘代码；
   - Windows 那条兜底是 fork 的 `custom_platform_view.dart:515-524`（每次 `onPointerDown` 都 `requestFocus`），前提是 WebView2 无窗口合成、指针先到 Flutter；macOS 用的是上游真原生 `WKWebView` 子视图，这条前提不存在。
4. 于是只剩弹窗内 JS 桥一条路，而它按构造只转发宿主显式声明的动作（阅读器只有 `globalBack` + `readerDismissDict`），其余绑定全部落空。
5. 旧兜底「弹窗渲染那一刻抢一次焦点」也够不着：`__fushiPopupClick` 对 `summary` 是早退（不重查词、不重渲染），连那一帧的 reclaim 都不会发生；点正文之所以没事，是因为它会触发选词→重查→`popupRendered`→reclaim。

家族：BUG-136 → BUG-1071 → BUG-1269 → BUG-1347，本条是这条链在 **macOS + 可聚焦 DOM 节点** 上的未覆盖残余。

## 修复

`popup.js` `createGlossarySection`：`<summary>` 的**主键** mousedown `preventDefault()`，掐断「点击 → 节点获焦」这一步。

- `<details>` 开合是 `click` 的 activation behavior，与 mousedown 默认动作无关 → 展开/折叠照常。
- Tab 聚焦不受影响（只有**鼠标**聚焦是 mousedown 的默认动作）。
- 只对主键生效：中键/右键原样留给弹窗输入桥的 `Mouse<n>` 转发判定。
- 长按选词典（制卡用）、`mouseup`/`mouseleave` 撤销全部保留。
- 三份 popup.js 镜像同步（byte-parity 守卫绿）。

## 测试

`fushi/test/dictionary/popup_summary_mouse_focus_test.{dart,js}`：node 真执行 popup.js 里提取出的 `createGlossarySection`，用它**实际挂上去的**监听派发事件——① 主键 mousedown 必须 `defaultPrevented`；② 非主键（1/2/3/4）必须不拦；③ 长按仍能选中词典；④ `mouseup` 仍撤销长按。另有独立判据：popup.js 里 `summary` 的 mousedown 监听必须有且只有一处。

**变异实测**：删掉修复行 → 断言 ① 红（`false !== true`）；恢复后绿。

本地：`flutter analyze` 0 issues；定向 `flutter test` 共 115 + 39 条绿（含 parity / disclosure-triangle / bugs_per_file / webview_key_bridge / input_spec 守卫）。

## 验证边界（如实）

本机无 macOS 设备，**未在真机复测原始失败路径**。「取消 mousedown 默认动作能阻止节点获焦」是 DOM 规范里 mousedown 的可取消默认动作，合成事件不是 trusted、默认动作本就不跑，任何自动化层都测不到这一步，只能真机手势验。根因链 1~5 全部有代码/引擎源码支撑；「WebKit 正是在节点获焦时移交 first responder」这一环是 WebKit 平台行为，本仓无法本地取证。请 macOS 侧按原始路径复测：查词 → 点展开/折叠 → 按任意宿主快捷键（翻页/关词典等）。

## 残余（本 PR 不处理，记在 bug 文档备注里）

1. 弹窗里的**文本输入**（句子上下文编辑框）合法获焦后同样回不来——macOS 缺一条「把 first responder 还给 FlutterView」的原生通道，这是上面第 3 环的通用缺口。
2. `window.__fushiPopupModalDepth` 只在 `showMinedCardActionPanel` 的 `finish()` 里减；热槽 WebView 跨查词不重载而 `renderPopup` 会抹掉面板 DOM → `finish` 永不执行 → depth 永久 ≥1 → 整座 JS 桥永久让位。同一症状的第二条独立成因。

https://claude.ai/code/session_0153rBYwgmFn9kNaMkSGVpBD
