### PR TITLE
fix(video): 控制按键编辑器宽窗舞台按行堆叠，槽位不再重叠（BUG-2448）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2256 条。点号进各自文件。
+> 共 2257 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2448](bugs/BUG-2448-video-control-editor-slots-overlap.md) | ✅ | ✅ | 视频控制按键编辑器宽窗舞台各槽位互相重叠 |
 | [BUG-2446](bugs/BUG-2446-ext-subtitle-drop-scope.md) | ✅ | ✅ | 浏览器扩展：任何网页拖文件都弹整屏「松开以加载字幕」 |
 | [BUG-2445](bugs/BUG-2445-mihon-protobuf-not-registered.md) | ✅ | ✅ | Injekt 未注册 ProtoBuf 导致 5 个 protobuf 漫画源整源不可用 |
 | [BUG-2444](bugs/BUG-2444-mihon-proxy-policy-selector-throws.md) | ✅ | ✅ | 宿主代理策略故障时 ProxySelector 抛异常导致 sidecar 堆耗尽、请求挂死到超时 |

--- a/docs/bugs/BUG-2448-video-control-editor-slots-overlap.md
+++ b/docs/bugs/BUG-2448-video-control-editor-slots-overlap.md
@@ -1,0 +1,6 @@
+## BUG-2448 · 视频控制按键编辑器宽窗舞台各槽位互相重叠
+- **报告**：2026-09-11（用户：安卓平板上视频设置「控制按键」页，右列「顶栏（右）/ 屏幕右侧 / 底栏（右）」三块与「底栏（中）」挤成一团、互相盖住，按键看不清也拖不准）
+- **真实性**：✅ 真 bug。根因 `fushi/lib/src/media/video/video_control_layout_editor.dart:139-243`（修复前）：宽窗（≥480）舞台是「固定高 `Stack` + `Positioned` 绝对定位」，高度只按 `min(420, max(260, 宽×9/16))` 取，而每个槽位按内容长高（默认布局底栏右 6 个 chip、顶栏右 6 个 chip，侧栏宽 128~224 只排得下 2~4 个/行）。同一侧三个槽位（顶 / 中 / 底）之间没有任何布局约束阻止重叠，平板宽度（480~900）下右列高度之和超过舞台高，直接盖在一起；同时槽位内 `maxHeight 148` + 嵌套 `SingleChildScrollView` 又把超出的 chip 截掉。widget 测试在 500/600/640/720/900 宽度全部复现（`topRight` 与 `screenRight` 相交）。
+- **[x] ① 已修复** — 宽窗舞台改为**按行堆叠**：顶栏行 / 屏幕侧行 / 底栏行三个 `Row`，侧槽位定宽贴边、中央槽位居中，槽位 `growToContent` 完整展开、行高由内容决定；舞台只保留 16:9 的**最小**高度（`ConstrainedBox(minHeight)` + `spaceBetween`）维持播放器方位感，内容更高时整体跟着长（外层设置页本就纵向滚动）。窄窗（<480）原有 compact 网格不变。`fix(video): 控制按键编辑器宽窗舞台按行堆叠，槽位不再重叠`
+- **[x] ② 已加自动化测试** — `fushi/test/pages/video_quick_settings_sheet_test.dart`「wide preview slots never overlap at Npx and UI scale S (BUG-2448)」×5：8 个舞台槽位两两不相交、都落在舞台内，且 `bottomRight` 内每个已放置 chip 完整落在槽位矩形内（不再被嵌套滚动截断）；原有「preview places slots at player-like positions」方位断言与 7 组无溢出用例照常通过。
+- **备注**：像素证据走 widget golden 临时预览（380/600/800 逻辑宽，Deng.ttf），三档分区清晰、无重叠；真机安卓平板复测待用户确认。

--- a/fushi/lib/src/media/video/video_control_layout_editor.dart
+++ b/fushi/lib/src/media/video/video_control_layout_editor.dart
@@ -141,120 +141,117 @@ class _VideoControlLayoutEditorState extends State<VideoControlLayoutEditor> {
           );
         }
 
+        // BUG-2448：宽窗舞台不再是「固定高 Stack + 绝对定位」。那套布局里同一侧的
+        // 顶栏 / 屏幕侧 / 底栏三个槽位各按内容长高，却没有任何约束阻止它们互相盖住，
+        // 平板宽度（480~900）上右列直接挤成一团，chip 还被槽位内的嵌套滚动截断。
+        // 现在按三行堆叠（顶栏行 / 屏幕侧行 / 底栏行），每行高度由内容决定、槽位
+        // 完整展开；舞台只保留 16:9 的**最小**高度维持播放器方位感，内容更高时
+        // 整体跟着长——外层设置页本来就是纵向滚动，长高不会截断任何东西。
         final double stageWidth = constraints.maxWidth;
-        final double stageHeight = math.min(
+        final double stageMinHeight = math.min(
           420,
           math.max(260, stageWidth * 9 / 16),
         );
-        return SizedBox(
-          width: stageWidth,
-          height: stageHeight,
-          child: DecoratedBox(
-            key: const ValueKey<String>('video-control-editor-preview'),
-            decoration: BoxDecoration(
-              color: cs.surfaceContainerHighest,
-              borderRadius: tokens.radii.controlRadius,
-              border: Border.all(color: cs.outlineVariant),
-            ),
-            child: ClipRRect(
-              borderRadius: tokens.radii.controlRadius,
-              child: LayoutBuilder(
-                builder: (BuildContext context, BoxConstraints preview) {
-                  final double sideWidth =
-                      math.min(224, math.max(128, preview.maxWidth * 0.24));
-                  final double centerWidth =
-                      math.min(236, math.max(128, preview.maxWidth * 0.22));
-                  const double inset = 10;
-                  return Stack(
+        const double inset = 10;
+        final double innerWidth = stageWidth - inset * 2;
+        final double sideWidth =
+            math.min(224, math.max(128, innerWidth * 0.24));
+        final double centerWidth =
+            math.min(236, math.max(128, innerWidth * 0.22));
+        final double gap = tokens.spacing.gap;
+        return DecoratedBox(
+          key: const ValueKey<String>('video-control-editor-preview'),
+          decoration: BoxDecoration(
+            color: cs.surfaceContainerHighest,
+            borderRadius: tokens.radii.controlRadius,
+            border: Border.all(color: cs.outlineVariant),
+          ),
+          child: ClipRRect(
+            borderRadius: tokens.radii.controlRadius,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: <Color>[
+                    cs.surfaceContainerHigh,
+                    cs.surfaceContainerHighest,
+                  ],
+                ),
+              ),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: stageMinHeight),
+                child: Padding(
+                  padding: const EdgeInsets.all(inset),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
-                      Positioned.fill(
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: <Color>[
-                                cs.surfaceContainerHigh,
-                                cs.surfaceContainerHighest,
-                              ],
-                            ),
-                          ),
-                        ),
+                      _buildStageRow(
+                        left: VideoControlSlot.topLeft,
+                        center: VideoControlSlot.topCenter,
+                        right: VideoControlSlot.topRight,
+                        sideWidth: sideWidth,
+                        centerWidth: centerWidth,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                       ),
-                      Positioned(
-                        top: inset,
-                        left: inset,
-                        width: sideWidth,
-                        child: _buildSlotRegion(VideoControlSlot.topLeft),
+                      SizedBox(height: gap),
+                      _buildStageRow(
+                        left: VideoControlSlot.screenLeft,
+                        center: null,
+                        right: VideoControlSlot.screenRight,
+                        sideWidth: sideWidth,
+                        centerWidth: centerWidth,
+                        crossAxisAlignment: CrossAxisAlignment.center,
                       ),
-                      Positioned(
-                        top: inset,
-                        right: inset,
-                        width: sideWidth,
-                        child: _buildSlotRegion(VideoControlSlot.topRight),
-                      ),
-                      Align(
-                        alignment: Alignment.topCenter,
-                        child: Padding(
-                          padding: const EdgeInsets.only(top: inset),
-                          child: SizedBox(
-                            width: centerWidth,
-                            child: _buildSlotRegion(
-                              VideoControlSlot.topCenter,
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        left: inset,
-                        top: 0,
-                        bottom: 0,
-                        width: sideWidth,
-                        child: Center(
-                          child: _buildSlotRegion(VideoControlSlot.screenLeft),
-                        ),
-                      ),
-                      Positioned(
-                        right: inset,
-                        top: 0,
-                        bottom: 0,
-                        width: sideWidth,
-                        child: Center(
-                          child: _buildSlotRegion(VideoControlSlot.screenRight),
-                        ),
-                      ),
-                      Positioned(
-                        left: inset,
-                        bottom: inset,
-                        width: sideWidth,
-                        child: _buildSlotRegion(VideoControlSlot.bottomLeft),
-                      ),
-                      Align(
-                        alignment: Alignment.bottomCenter,
-                        child: Padding(
-                          padding: const EdgeInsets.only(bottom: inset),
-                          child: SizedBox(
-                            width: centerWidth,
-                            child: _buildSlotRegion(
-                              VideoControlSlot.bottomCenter,
-                            ),
-                          ),
-                        ),
-                      ),
-                      Positioned(
-                        right: inset,
-                        bottom: inset,
-                        width: sideWidth,
-                        child: _buildSlotRegion(VideoControlSlot.bottomRight),
+                      SizedBox(height: gap),
+                      _buildStageRow(
+                        left: VideoControlSlot.bottomLeft,
+                        center: VideoControlSlot.bottomCenter,
+                        right: VideoControlSlot.bottomRight,
+                        sideWidth: sideWidth,
+                        centerWidth: centerWidth,
+                        crossAxisAlignment: CrossAxisAlignment.end,
                       ),
                     ],
-                  );
-                },
+                  ),
+                ),
               ),
             ),
           ),
         );
       },
+    );
+  }
+
+  /// 舞台一行：左右两个侧槽位定宽贴边、中央槽位居中；[center] 为 null 时中央留空
+  /// （屏幕侧行没有中央槽位）。槽位按内容长高，行高取三者最高，互不重叠。
+  Widget _buildStageRow({
+    required VideoControlSlot left,
+    required VideoControlSlot? center,
+    required VideoControlSlot right,
+    required double sideWidth,
+    required double centerWidth,
+    required CrossAxisAlignment crossAxisAlignment,
+  }) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: crossAxisAlignment,
+      children: <Widget>[
+        SizedBox(
+          width: sideWidth,
+          child: _buildSlotRegion(left, growToContent: true),
+        ),
+        if (center != null)
+          SizedBox(
+            width: centerWidth,
+            child: _buildSlotRegion(center, growToContent: true),
+          ),
+        SizedBox(
+          width: sideWidth,
+          child: _buildSlotRegion(right, growToContent: true),
+        ),
+      ],
     );
   }
 

--- a/fushi/test/pages/video_quick_settings_sheet_test.dart
+++ b/fushi/test/pages/video_quick_settings_sheet_test.dart
@@ -1867,6 +1867,77 @@ void main() {
       expect(hidden.top, greaterThanOrEqualTo(preview.bottom));
     });
 
+    // BUG-2448：宽窗舞台原是「固定高 Stack + 绝对定位」——同一侧三个槽位（顶栏 /
+    // 屏幕侧 / 底栏）按内容长高后没有任何布局约束阻止它们互相盖住，平板宽度
+    // （480~900）上右列直接挤成一团。改成按行堆叠后：任意宽度、任意 UI 缩放，
+    // 槽位两两不相交，且不再靠槽位内嵌套滚动截断内容。
+    for (final ({double width, double scale}) sizeCase
+        in <({double width, double scale})>[
+      (width: 500, scale: 1.0),
+      (width: 600, scale: 1.0),
+      (width: 640, scale: 1.5),
+      (width: 720, scale: 2.0),
+      (width: 900, scale: 1.0),
+    ]) {
+      testWidgets(
+          'wide preview slots never overlap at ${sizeCase.width.round()}px '
+          'and UI scale ${sizeCase.scale} (BUG-2448)', (tester) async {
+        await tester.binding.setSurfaceSize(Size(sizeCase.width, 1600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        await _pumpSheet(
+          tester,
+          uiScale: sizeCase.scale,
+          wrapScale: sizeCase.scale,
+        );
+        await openControls(tester);
+
+        final Rect preview = tester.getRect(find.byKey(
+          const ValueKey<String>('video-control-editor-preview'),
+        ));
+        final List<VideoControlSlot> stageSlots = <VideoControlSlot>[
+          VideoControlSlot.topLeft,
+          VideoControlSlot.topCenter,
+          VideoControlSlot.topRight,
+          VideoControlSlot.screenLeft,
+          VideoControlSlot.screenRight,
+          VideoControlSlot.bottomLeft,
+          VideoControlSlot.bottomCenter,
+          VideoControlSlot.bottomRight,
+        ];
+        for (int i = 0; i < stageSlots.length; i++) {
+          final Rect a = tester.getRect(slotFinder(stageSlots[i]));
+          expect(a.top, greaterThanOrEqualTo(preview.top - 0.5),
+              reason: '${stageSlots[i]} escapes the stage top');
+          expect(a.bottom, lessThanOrEqualTo(preview.bottom + 0.5),
+              reason: '${stageSlots[i]} escapes the stage bottom');
+          for (int j = i + 1; j < stageSlots.length; j++) {
+            final Rect b = tester.getRect(slotFinder(stageSlots[j]));
+            expect(a.overlaps(b), isFalse,
+                reason: '${stageSlots[i]} and ${stageSlots[j]} overlap');
+          }
+        }
+        // 槽位内不再嵌套滚动：所有已放置的 chip 必须完整落在自己槽位里。
+        final Rect bottomRight =
+            tester.getRect(slotFinder(VideoControlSlot.bottomRight));
+        final List<VideoControlItem> placed = VideoControlLayout.currentChrome
+            .itemsIn(VideoControlSlot.bottomRight);
+        expect(placed.length, greaterThanOrEqualTo(4));
+        for (int index = 0; index < placed.length; index++) {
+          if (!placed[index].isChipRenderable) continue;
+          final Rect chip = tester.getRect(chipFinder(
+            placed[index],
+            VideoControlSlot.bottomRight,
+            index,
+          ));
+          expect(bottomRight.contains(chip.topLeft), isTrue,
+              reason: '${placed[index]} chip clipped at the slot top');
+          expect(bottomRight.contains(chip.bottomRight), isTrue,
+              reason: '${placed[index]} chip clipped at the slot bottom');
+        }
+        _expectNoFlutterErrors(tester);
+      });
+    }
+
     testWidgets(
         'narrow preview uses a compact slot grid without horizontal tail',
         (tester) async {


### PR DESCRIPTION
## 问题

安卓平板上视频设置「控制按键」页，右列「顶栏（右）/ 屏幕右侧 / 底栏（右）」与「底栏（中）」挤成一团互相盖住（用户截图）。

## 根因

`video_control_layout_editor.dart` 宽窗（≥480）舞台是「固定高 `Stack` + `Positioned` 绝对定位」，高度只按 `min(420, max(260, 宽×9/16))` 取；每个槽位按内容长高（默认布局顶栏右 / 底栏右各 6 个 chip，侧栏 128~224 宽只排得下 2~4 个/行），同一侧三个槽位之间没有任何约束阻止重叠。平板宽度（480~900）下右列高度之和超过舞台高，直接盖在一起；槽位内 `maxHeight 148` + 嵌套滚动又把超出的 chip 截掉。

## 修复

- 宽窗舞台改为**按行堆叠**：顶栏行 / 屏幕侧行 / 底栏行三个 `Row`，侧槽位定宽贴边、中央槽位居中，槽位 `growToContent` 完整展开、行高由内容决定。
- 舞台只保留 16:9 的**最小**高度（`ConstrainedBox(minHeight)` + `spaceBetween`）维持播放器方位感，内容更高时整体跟着长（外层设置页本就纵向滚动）。
- 窄窗（<480）原有 compact 网格不变。五端共用同一编辑器，自适应对所有平台生效。

## 测试

- 新增 `video_quick_settings_sheet_test.dart`「wide preview slots never overlap at Npx and UI scale S (BUG-2448)」×5（500/600/640@1.5/720@2.0/900）：8 个舞台槽位两两不相交、都落在舞台内，`bottomRight` 每个 chip 完整落在槽位内。修复前 5 组全红（`topRight` 与 `screenRight` 相交），修复后全绿。
- 原有「preview places slots at player-like positions」方位断言、7 组无溢出用例、`video_custom_action_editor_test` / `video_controls_customization_guard_test` / `bugs_per_file_guard_test` 全部通过；`flutter analyze` 零问题。
- 像素证据：widget golden 临时预览 380/600/800 逻辑宽，三档分区清晰无重叠（脚手架未提交）。

https://claude.ai/code/session_01CgUMiknKkRLUsvfjfokpKc
