### PR TITLE
fix(video): 互联视频的 TLS 信任收进 app 中继，native 只拿明文 loopback（BUG-2448）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,13 +29,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2259 条。点号进各自文件。
+> 共 2260 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-2451](bugs/BUG-2451-manga-global-search-ganma-fuzzy.md) | 🚧 | 🚧 | 全局搜索里 GANMA! 返回与关键词无关的作品（未复现为本仓 bug：源站服务端分词模糊匹配） |
 | [BUG-2450](bugs/BUG-2450-manga-online-image-timeout-no-retry.md) | 🚧 | 🚧 | 在线漫画封面与页图超时或失败后没有退避重试、没有重刷入口、加载队列排队无超时 |
 | [BUG-2449](bugs/BUG-2449-manga-ocr-job-dies-on-reader-exit.md) | 🚧 | 🚧 | 退出漫画阅读页会真停掉正在跑的整卷 OCR 任务 |
+| [BUG-2448](bugs/BUG-2448-interconnect-video-native-tls-trust.md) | ✅ | ✅ | 互联远端视频打不开：随包 libmpv 换 libcurl 后默认校验自签证书 |
 | [BUG-2446](bugs/BUG-2446-ext-subtitle-drop-scope.md) | ✅ | ✅ | 浏览器扩展：任何网页拖文件都弹整屏「松开以加载字幕」 |
 | [BUG-2445](bugs/BUG-2445-mihon-protobuf-not-registered.md) | ✅ | ✅ | Injekt 未注册 ProtoBuf 导致 5 个 protobuf 漫画源整源不可用 |
 | [BUG-2444](bugs/BUG-2444-mihon-proxy-policy-selector-throws.md) | ✅ | ✅ | 宿主代理策略故障时 ProxySelector 抛异常导致 sidecar 堆耗尽、请求挂死到超时 |

--- a/docs/bugs/BUG-2448-interconnect-video-native-tls-trust.md
+++ b/docs/bugs/BUG-2448-interconnect-video-native-tls-trust.md
@@ -21,7 +21,7 @@
   - 2026-09-08 `000726dde9` 又给 libmpv 设了 `http-proxy` 指向 app 内置 loopback 中继（`app_native_proxy.dart`），
     但对 https 目标中继只做 CONNECT 隧道，TLS 仍是 native 端到端 → 经中继同样 `Failure when receiving data from the peer`。
     中继的既有测试 `app_native_proxy_mpv_test.dart` 只盖了公网明文 http，从没测过「自签 https + token 流」。
-- **[x] ① 已修复** — 提交见分支 `worktree-fix-interconnect-video-open`
+- **[x] ① 已修复** — `20b942a1eb`（主修）+ 同 PR #1418 的 code review 返工提交（登记撤销 / 客户端复用 / 连接超时）
   - TLS 信任收进中继一处：`app_native_proxy.dart` 新增钉扎原点登记 `registerPinnedNativeOrigin(host, port, 指纹)` +
     `nativePlaybackUri(url)`（已登记原点的 https 降成**带显式端口**的明文 http；其它 URL 原样）；`_forward` 按
     `(host, port)` 查到指纹就把 upstream 升回 https、用 `createPinnedHttpClient` 连——native 无论哪个后端都只看到
@@ -32,14 +32,24 @@
     native 拿 URL 只此两个入口。本地文件 / 公网流 / YouTube / Jellyfin（`api_key` 鉴权、系统 CA）零变化。
   - 没选 `tls-verify=no`：那是把互联流对任意证书放行（ffmpeg 时代的「碰巧能播」），且各平台 libmpv 是否认这个选项
     又是一道新的分叉。
+  - code review（PR #1418）返工三条：① 登记表原本只增不删——host 关 TLS 后同一端口改回明文重新配对，残留旧指纹会让中继把
+    明文请求硬升 https 去握手明文端口（API/字幕都正常、只有视频 502 到重启）→ `_ensureResolved` 解析成 http 即
+    `unregisterPinnedNativeOrigin`；② 钉扎客户端每请求新建、请求完即关 → libmpv 每个 Range/seek 都重新 TCP+TLS 握手
+    → 改为按 `(host, port, 指纹)` 缓存复用（指纹换了关旧的，`close()` 一并关）；③ 钉扎客户端补 `kAppHttpConnectionTimeout`
+    （对端休眠 / WAN 黑洞时不卡到 OS 默认超时）。
+  - 有意不改：钉扎客户端不走 app 代理策略（与 `WebDavOps` 等 Dart 侧钉扎通道一致，API 能通视频就能通）；登记表是
+    进程级 ambient 状态 + 控制器单一收口，而非把指纹随 `RemoteVideoStreamUrls` 携带——`downloadRemoteVideo` 等 Dart 侧
+    消费者需要真 https URL，两种形态在产出端分叉反而多一处分歧点，收口处有源码守卫钉住。
 - **[x] ② 已加自动化测试**
-  - `fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart`（新）— 真自签证书起 https 原点，以 native 的请求形状
-    （absolute-form GET + Proxy-Authorization）过中继：指纹相符 200 透传 / Range 206 + Content-Range 透传 /
-    指纹不符 502 / 未登记明文直连必失败；`nativePlaybackUri` 四条真值（含隐含 443 必须显式端口、大小写、覆盖登记）。
+  - `fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart`（新，11 条）— 真自签证书起 https 原点，以 native 的
+    请求形状（absolute-form GET + Proxy-Authorization）过中继：指纹相符 200 透传 / Range 206 + Content-Range 透传 /
+    指纹不符 502 / 未登记明文直连 502 / 撤销登记后 502 / 连续 3 个 Range 请求原点只见 1 条连接（复用）；
+    `nativePlaybackUri` 四条真值（含隐含 443 必须显式端口、大小写、覆盖登记）。
   - `fushi/test/utils/net/app_native_proxy_mpv_test.dart` — 补「自签 https 原点经钉扎中继」真库用例（`FUSHI_TEST_MPV_DLL`
     指向随包 `libmpv-2.dll` 时跑，本机实跑 2/2 绿；无 DLL 跳过）。
   - `fushi/test/sync/fushi_client_live_video_test.dart` — https host 解析后已登记为钉扎原点、`remoteVideoStreamUrls`
-    仍回真 https、`nativePlaybackUri` 降成同 host 显式端口 http；明文 http host 不登记。
+    仍回真 https、`nativePlaybackUri` 降成同 host 显式端口 http；明文 http host 不登记；同一 host:port 解析成明文会
+    撤销旧登记。
   - `fushi/test/media/video/video_player_native_playback_uri_guard_test.dart`（新）— 源码守卫：`load` 里主流与外挂音轨
     两个 native 入口必须过 `nativePlaybackUri`，带反向断言。
 - **备注**：真机证据：修复路径在本机生产 host 上用随包 libmpv 实跑（登记 host 指纹 → `nativePlaybackUri` → 经真实

--- a/docs/bugs/BUG-2448-interconnect-video-native-tls-trust.md
+++ b/docs/bugs/BUG-2448-interconnect-video-native-tls-trust.md
@@ -1,0 +1,48 @@
+## BUG-2448 · 互联远端视频打不开：随包 libmpv 换 libcurl 后默认校验自签证书
+- **报告**：2026-09-11（用户：fushi 互联打不开视频了，根本性修复一下，统一这里代码）
+- **真实性**：✅ 真 bug。用 app 随包的 `libmpv-2.dll`（安装版 2.4.0-debug.14539，`mpv v0.41.0-923-g7b8915bc1`）
+  直接 `loadfile` 本机生产 host 签发的 stream URL（`https://127.0.0.1:38765/api/library/videos/<id>/stream?token=…`）：
+  ```
+  [curl/error] error: SSL peer certificate or SSH remote key was not OK
+  [curl/error] TLS certificate verification failed. ... a self-signed certificate ...
+  [stream/error] Failed to open https://127.0.0.1:38765/api/library/videos/.../stream?token=...
+  RESULT LOAD_FAILED
+  ```
+  同一条 URL 用 curl 走 Basic/token 直连 host 是 206 正常回流（host 侧没坏）；同一 DLL 加 `tls-verify=no` 即
+  `FILE_LOADED duration=1420.928`。根因链：
+  - `third_party/media_kit_libs_windows_video/windows/CMakeLists.txt:120`（BUG-1644，2026-08-14）把随包 libmpv 钉到
+    `mpv-dev-x86_64-20260813-git-7b8915bc1d.7z`——这个 master 构建的 http(s) 取流后端从 ffmpeg lavf 换成了 **libcurl**，
+    curl 默认校验证书；ffmpeg 的 tls 从不校验，所以之前自签 https 一直「碰巧能播」。
+  - 互联 host 默认开 TLS（`applyFirstHostingTlsDefault`），证书自签、信任判据是配对时 TOFU 记下的指纹，只有 Dart 侧
+    的 `createPinnedHttpClient`（`packages/fushi_engine/lib/sync/tls/fushi_pinning_http.dart:46`）知道；播放页却把
+    https stream URL 原样塞给 native（`fushi/lib/src/media/video/video_player_controller.dart:1436` 的 `sourceUri` →
+    `Media(sourceUri)`），让 libmpv 自己做 TLS。Android 随包 libmpv 仍是 ffmpeg 6.1.6 后端、不校验；Windows 校验——
+    同一条流两端两种结局，说明 TLS 信任一开始就放错了层。
+  - 2026-09-08 `000726dde9` 又给 libmpv 设了 `http-proxy` 指向 app 内置 loopback 中继（`app_native_proxy.dart`），
+    但对 https 目标中继只做 CONNECT 隧道，TLS 仍是 native 端到端 → 经中继同样 `Failure when receiving data from the peer`。
+    中继的既有测试 `app_native_proxy_mpv_test.dart` 只盖了公网明文 http，从没测过「自签 https + token 流」。
+- **[x] ① 已修复** — 提交见分支 `worktree-fix-interconnect-video-open`
+  - TLS 信任收进中继一处：`app_native_proxy.dart` 新增钉扎原点登记 `registerPinnedNativeOrigin(host, port, 指纹)` +
+    `nativePlaybackUri(url)`（已登记原点的 https 降成**带显式端口**的明文 http；其它 URL 原样）；`_forward` 按
+    `(host, port)` 查到指纹就把 upstream 升回 https、用 `createPinnedHttpClient` 连——native 无论哪个后端都只看到
+    loopback 明文，证书判据与 API/字幕/封面通道同一份。
+  - `InterconnectSyncBackend._ensureResolved` 每次解析出 https host 就登记（幂等覆盖，重新配对换证书时指纹跟着刷新）；
+    明文 http host 不登记。`downloadRemoteVideo` 等 Dart 侧通道仍拿真 https URL 自己钉扎，不受影响。
+  - `VideoPlayerController.load` 的主流 `sourceUri` 与外挂音轨 `AudioTrack.uri(...)` 统一过 `nativePlaybackUri`——
+    native 拿 URL 只此两个入口。本地文件 / 公网流 / YouTube / Jellyfin（`api_key` 鉴权、系统 CA）零变化。
+  - 没选 `tls-verify=no`：那是把互联流对任意证书放行（ffmpeg 时代的「碰巧能播」），且各平台 libmpv 是否认这个选项
+    又是一道新的分叉。
+- **[x] ② 已加自动化测试**
+  - `fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart`（新）— 真自签证书起 https 原点，以 native 的请求形状
+    （absolute-form GET + Proxy-Authorization）过中继：指纹相符 200 透传 / Range 206 + Content-Range 透传 /
+    指纹不符 502 / 未登记明文直连必失败；`nativePlaybackUri` 四条真值（含隐含 443 必须显式端口、大小写、覆盖登记）。
+  - `fushi/test/utils/net/app_native_proxy_mpv_test.dart` — 补「自签 https 原点经钉扎中继」真库用例（`FUSHI_TEST_MPV_DLL`
+    指向随包 `libmpv-2.dll` 时跑，本机实跑 2/2 绿；无 DLL 跳过）。
+  - `fushi/test/sync/fushi_client_live_video_test.dart` — https host 解析后已登记为钉扎原点、`remoteVideoStreamUrls`
+    仍回真 https、`nativePlaybackUri` 降成同 host 显式端口 http；明文 http host 不登记。
+  - `fushi/test/media/video/video_player_native_playback_uri_guard_test.dart`（新）— 源码守卫：`load` 里主流与外挂音轨
+    两个 native 入口必须过 `nativePlaybackUri`，带反向断言。
+- **备注**：真机证据：修复路径在本机生产 host 上用随包 libmpv 实跑（登记 host 指纹 → `nativePlaybackUri` → 经真实
+  `AppNativeProxy`），`Opening done: http://127.0.0.1:38765/.../stream?token=…`、`FILE_LOADED duration=1420.928`。
+  手机端（Android，ffmpeg 后端 libmpv）本轮未真机复测：修复后它同样只经中继取明文 http，与 Windows 走同一条链。
+  制卡回退的「client ffmpeg 直连抽取」（BUG-891 缺口）不在本轮：`miningSource` 仍是原 https URL，行为不变。

--- a/fushi/lib/src/media/video/video_player_controller.dart
+++ b/fushi/lib/src/media/video/video_player_controller.dart
@@ -1433,7 +1433,13 @@ class VideoPlayerController extends ChangeNotifier
     _mediaOpened = false;
     _bookUid = bookUid;
     _videoPath = videoFile?.path;
-    final String sourceUri = mediaUri ?? mediaUriForVideoPath(videoFile!.path);
+    // BUG-2448：交给 native 的 URL 统一过 [nativePlaybackUri]——互联 host 的自签
+    // https 流降成明文 http 交给中继，由中继按配对指纹钉扎升回 https；本地文件 /
+    // 公网流原样。native 侧从此不碰互联 host 的 TLS（随包 libmpv 换成 libcurl 后默认
+    // 校验证书，自签 host 直连必失败）。
+    final String sourceUri = nativePlaybackUri(
+      mediaUri ?? mediaUriForVideoPath(videoFile!.path),
+    );
     debugPrint('[video-load] cues=${cues.length} uri=$sourceUri');
     // TODO-1312：换片复位副字幕 cue 流（旧下标对新片失效；新集副字幕由页面
     // _restoreSecondarySubtitle 重挂）。在 setCues 之前复位，让 setCues 的单次
@@ -1666,7 +1672,10 @@ class VideoPlayerController extends ChangeNotifier
     // 与视频同步出声（修「初始无声、跳转后才有声」）。放在 header 注入之后——audio-only 流同走
     // googlevideo，UA 不匹配首个请求会 403（http-header-fields 已设为全局属性，audio-add 继承）。
     if (externalAudioTrackUrl != null && externalAudioTrackUrl.isNotEmpty) {
-      await player.setAudioTrack(AudioTrack.uri(externalAudioTrackUrl));
+      // 与主流同一收口（BUG-2448）：外挂音轨也是 native 自己去取的 URL。
+      await player.setAudioTrack(
+        AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl)),
+      );
       if (!_isCurrentLoad(player, loadToken)) return; // 外挂音轨后换片/销毁。
     }
 

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -398,7 +398,9 @@ class InterconnectSyncBackend extends SyncBackend
   /// BUG-2448：https host 的 TOFU 指纹登记给 app 内置中继，让 native 播放器
   /// （libmpv / ffmpeg）取这台 host 的视频流时由 Dart 侧钉扎 TLS，而不是各平台
   /// libmpv 自己去判自签证书（curl 后端默认校验 → 一律打不开）。明文 http host
-  /// 无需登记。每次解析都登记（幂等覆盖）：重新配对换了证书时指纹跟着刷新。
+  /// 每次解析都登记（幂等覆盖）：重新配对换了证书时指纹跟着刷新。解析成明文
+  /// http 的 host 则**撤销**同一 (host, port) 的登记（host 关了 TLS 后重新配对，
+  /// 端口不变）——残留旧指纹会让中继把明文请求硬升 https 去握手明文端口。
   static void _registerPinnedNativeOrigin(
     String baseUrl,
     String? fingerprintSha256,
@@ -407,6 +409,7 @@ class InterconnectSyncBackend extends SyncBackend
     if (!base.isScheme('https') ||
         fingerprintSha256 == null ||
         fingerprintSha256.isEmpty) {
+      unregisterPinnedNativeOrigin(host: base.host, port: base.port);
       return;
     }
     registerPinnedNativeOrigin(

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -21,6 +21,7 @@ import 'package:fushi_engine/sync/tls/fushi_pinning_http.dart';
 import 'package:fushi/src/sync/sync_utils.dart';
 import 'package:fushi_engine/sync/ttu_filename.dart';
 import 'package:fushi/src/sync/sync_file_ref.dart';
+import 'package:fushi/src/utils/net/app_native_proxy.dart';
 import 'package:fushi_engine/sync/ttu_models.dart';
 import 'package:fushi/src/sync/webdav_ops.dart';
 import 'package:fushi/src/sync/webdav_path_backend_mixin.dart';
@@ -390,7 +391,29 @@ class InterconnectSyncBackend extends SyncBackend
       _activeToken = token;
       clearCache();
     }
+    _registerPinnedNativeOrigin(normalized, chosen.fingerprintSha256);
     _sessionResolved = true;
+  }
+
+  /// BUG-2448：https host 的 TOFU 指纹登记给 app 内置中继，让 native 播放器
+  /// （libmpv / ffmpeg）取这台 host 的视频流时由 Dart 侧钉扎 TLS，而不是各平台
+  /// libmpv 自己去判自签证书（curl 后端默认校验 → 一律打不开）。明文 http host
+  /// 无需登记。每次解析都登记（幂等覆盖）：重新配对换了证书时指纹跟着刷新。
+  static void _registerPinnedNativeOrigin(
+    String baseUrl,
+    String? fingerprintSha256,
+  ) {
+    final Uri base = Uri.parse(baseUrl);
+    if (!base.isScheme('https') ||
+        fingerprintSha256 == null ||
+        fingerprintSha256.isEmpty) {
+      return;
+    }
+    registerPinnedNativeOrigin(
+      host: base.host,
+      port: base.port,
+      fingerprintSha256: fingerprintSha256,
+    );
   }
 
   /// BUG-1550：是否至少有一个已启用候选拿得出凭据（自带 token 或全局回落）。

--- a/fushi/lib/src/utils/net/app_native_proxy.dart
+++ b/fushi/lib/src/utils/net/app_native_proxy.dart
@@ -39,6 +39,13 @@ void registerPinnedNativeOrigin({
   _pinnedNativeOrigins[_pinnedOriginKey(host, port)] = fingerprintSha256;
 }
 
+/// 撤销登记：同一 `(host, port)` 改回明文 http（host 关了 TLS、对端重新配对）时必须
+/// 调用，否则残留的旧指纹会让中继把 native 的真明文请求硬升成 https 去握手一个
+/// 明文端口——API/字幕通道都正常、只有视频 502，直到重启 app。
+void unregisterPinnedNativeOrigin({required String host, required int port}) {
+  _pinnedNativeOrigins.remove(_pinnedOriginKey(host, port));
+}
+
 /// `(host, port)` 已登记的钉扎指纹；未登记返回 null。
 String? pinnedNativeOriginFingerprint(String host, int port) =>
     _pinnedNativeOrigins[_pinnedOriginKey(host, port)];
@@ -156,6 +163,12 @@ class AppNativeProxy {
   final bool _publicTargetsOnly;
   final Set<Socket> _sockets = <Socket>{};
   final Set<HttpClient> _clients = <HttpClient>{};
+
+  /// 钉扎原点的客户端按 `(host, port, 指纹)` 缓存复用：libmpv 取流是一串 Range /
+  /// seek / 缓存回填请求，每个都新建客户端就是每个都重新 TCP + TLS 握手（旧 CONNECT
+  /// 隧道时代 curl 只握一次）。复用同一客户端才有 keep-alive 连接池。指纹换了
+  /// （重新配对）就换客户端、关旧的。
+  final Map<String, HttpClient> _pinnedClients = <String, HttpClient>{};
   bool _closed = false;
 
   /// 监听 socket 还活着。为 false 时 [ensureAppNativeProxy] 会另起一个。
@@ -207,7 +220,34 @@ class AppNativeProxy {
     for (final HttpClient client in _clients.toList()) {
       client.close(force: true);
     }
+    for (final HttpClient client in _pinnedClients.values) {
+      client.close(force: true);
+    }
+    _pinnedClients.clear();
     await _server.close(force: true);
+  }
+
+  /// 钉扎原点的复用客户端（见 [_pinnedClients]）。连接超时与非钉扎分支、
+  /// `WebDavOps` 的钉扎客户端同一常量：对端休眠 / WAN 地址黑洞时不能让 libmpv 的
+  /// 下一个 Range 请求卡到操作系统默认超时。
+  HttpClient _pinnedClientFor(String host, int port, String fingerprint) {
+    final String key = '${_pinnedOriginKey(host, port)}|$fingerprint';
+    final HttpClient? cached = _pinnedClients[key];
+    if (cached != null) return cached;
+    // 同一原点换了指纹：旧客户端连同它池里的连接一起作废。
+    final String stalePrefix = '${_pinnedOriginKey(host, port)}|';
+    for (final String staleKey
+        in _pinnedClients.keys
+            .where((String k) => k.startsWith(stalePrefix))
+            .toList()) {
+      _pinnedClients.remove(staleKey)?.close(force: true);
+    }
+    final HttpClient client = createPinnedHttpClient(
+      expectedFingerprint: fingerprint,
+      connectionTimeout: kAppHttpConnectionTimeout,
+    )..autoUncompress = false;
+    _pinnedClients[key] = client;
+    return client;
   }
 
   Future<void> _serve(HttpRequest request) async {
@@ -276,11 +316,11 @@ class AppNativeProxy {
     final Uri upstreamUri = pinnedFingerprint == null
         ? uri
         : uri.replace(scheme: 'https', port: uri.port);
+    // 非钉扎：一请求一客户端（原样）。钉扎：按原点复用，请求结束不关。
     final HttpClient client = pinnedFingerprint == null
-        ? createAppHttpClient()
-        : createPinnedHttpClient(expectedFingerprint: pinnedFingerprint);
-    client.autoUncompress = false;
-    _clients.add(client);
+        ? (createAppHttpClient()..autoUncompress = false)
+        : _pinnedClientFor(uri.host, uri.port, pinnedFingerprint);
+    if (pinnedFingerprint == null) _clients.add(client);
     try {
       final HttpClientRequest outbound = await client.openUrl(
         request.method,
@@ -295,8 +335,10 @@ class AppNativeProxy {
       await request.response.addStream(response);
       await request.response.close();
     } finally {
-      _clients.remove(client);
-      client.close(force: true);
+      if (pinnedFingerprint == null) {
+        _clients.remove(client);
+        client.close(force: true);
+      }
     }
   }
 

--- a/fushi/lib/src/utils/net/app_native_proxy.dart
+++ b/fushi/lib/src/utils/net/app_native_proxy.dart
@@ -5,12 +5,60 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:fushi_engine/sync/tls/fushi_pinning_http.dart';
 import 'package:fushi_engine/utils/net/app_http.dart';
 import 'package:fushi_engine/utils/net/app_proxy.dart';
 
 Future<AppNativeProxy>? _sharedProxy;
 Future<AppNativeProxy>? _challengeProxy;
 final Set<String> _nativeProxySecrets = <String>{};
+
+/// 已登记的「钉扎原点」`host:port → 证书 SHA-256 指纹`。
+///
+/// 互联 host 用自签证书，信任判据是配对时 TOFU 记下的指纹——只有 Dart 侧知道它。
+/// native 播放器自己连 https 时，证书怎么判全看那份 libmpv 怎么编：ffmpeg 的 tls
+/// 从不校验（Android 随包 libmpv 仍是它），而 2026-08 起 Windows 随包的 libmpv 改用
+/// libcurl 取流、默认校验证书，自签 host 一律 `SSL peer certificate ... was not OK`
+/// → 互联视频整个打不开（BUG-2448）。同一条流在两端两种结局，说明信任根本不该放在
+/// native 侧。
+///
+/// 收口：交给 native 的 URL 经 [nativePlaybackUri] 降成**明文 http**（带显式端口），
+/// native 照常经本中继取流，[AppNativeProxy._forward] 按 `(host, port)` 查到指纹后
+/// 用 [createPinnedHttpClient] 升回 https 连真正的 host。native 无论哪个后端都只
+/// 看到 loopback 明文；证书信任只在 Dart 这一处裁决，和 API/字幕/封面通道同一判据。
+final Map<String, String> _pinnedNativeOrigins = <String, String>{};
+
+String _pinnedOriginKey(String host, int port) => '${host.toLowerCase()}:$port';
+
+/// 登记一个钉扎原点（互联 backend 每次解析出 https host 时调用，重复登记覆盖）。
+void registerPinnedNativeOrigin({
+  required String host,
+  required int port,
+  required String fingerprintSha256,
+}) {
+  _pinnedNativeOrigins[_pinnedOriginKey(host, port)] = fingerprintSha256;
+}
+
+/// `(host, port)` 已登记的钉扎指纹；未登记返回 null。
+String? pinnedNativeOriginFingerprint(String host, int port) =>
+    _pinnedNativeOrigins[_pinnedOriginKey(host, port)];
+
+@visibleForTesting
+void clearPinnedNativeOriginsForTesting() => _pinnedNativeOrigins.clear();
+
+/// 把要交给 native 播放器 / ffmpeg 的 URL 换成中继能识别的形式。
+///
+/// 已登记钉扎原点的 https URL → 同 host、**显式端口**的 http（中继据此升回钉扎
+/// https）；其它 URL（本地文件、公网流、未登记的 https）原样返回。端口必须显式：
+/// `https://h/x`（隐含 443）降成 `http://h/x` 会变成隐含 80，中继就查不到登记项。
+String nativePlaybackUri(String uri) {
+  final Uri? parsed = Uri.tryParse(uri);
+  if (parsed == null || !parsed.isScheme('https')) return uri;
+  if (pinnedNativeOriginFingerprint(parsed.host, parsed.port) == null) {
+    return uri;
+  }
+  return parsed.replace(scheme: 'http', port: parsed.port).toString();
+}
 
 /// Scrub native diagnostics before forwarding them to application logs/UI.
 String redactAppNativeProxySecrets(String value) {
@@ -219,12 +267,24 @@ class AppNativeProxy {
       return;
     }
     if (await _rejectPrivateTarget(request, uri)) return;
-    final HttpClient client = createAppHttpClient()..autoUncompress = false;
+    // 钉扎原点：native 拿到的是 [nativePlaybackUri] 降下来的明文 http，这里按
+    // (host, port) 查到指纹就升回 https、用钉扎客户端连——TLS 只在 Dart 这一处裁决。
+    final String? pinnedFingerprint = pinnedNativeOriginFingerprint(
+      uri.host,
+      uri.port,
+    );
+    final Uri upstreamUri = pinnedFingerprint == null
+        ? uri
+        : uri.replace(scheme: 'https', port: uri.port);
+    final HttpClient client = pinnedFingerprint == null
+        ? createAppHttpClient()
+        : createPinnedHttpClient(expectedFingerprint: pinnedFingerprint);
+    client.autoUncompress = false;
     _clients.add(client);
     try {
       final HttpClientRequest outbound = await client.openUrl(
         request.method,
-        uri,
+        upstreamUri,
       );
       outbound.followRedirects = false;
       _copyHeaders(request.headers, outbound.headers);

--- a/fushi/test/media/video/video_player_native_playback_uri_guard_test.dart
+++ b/fushi/test/media/video/video_player_native_playback_uri_guard_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-2448 源码守卫：native 播放器拿到的每一个 URL 都必须过 `nativePlaybackUri`。
+///
+/// 钉不变式而非写法：`VideoPlayerController.load` 里 `Media(...)` 的主流 URL 与
+/// `AudioTrack.uri(...)` 的外挂音轨 URL 是 native 自己去取的两个入口，任何一个绕开
+/// 收口，互联 host 的自签 https 就又落回 libmpv 自己做 TLS（curl 后端默认校验 →
+/// 打不开）。这类回归 analyze 全绿、单测全绿，只有真机能看见，所以钉在源码上。
+void main() {
+  final String src = File(
+    'lib/src/media/video/video_player_controller.dart',
+  ).readAsStringSync();
+
+  test('主流 URL 经 nativePlaybackUri 收口', () {
+    expect(
+      src,
+      contains('final String sourceUri = nativePlaybackUri('),
+      reason: 'sourceUri 必须由 nativePlaybackUri 产出（BUG-2448）',
+    );
+    expect(
+      src,
+      isNot(contains('final String sourceUri = mediaUri ??')),
+      reason: '不得再直接把 mediaUri 交给 Media()',
+    );
+  });
+
+  test('外挂音轨 URL 经 nativePlaybackUri 收口', () {
+    expect(
+      src,
+      contains('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))'),
+    );
+    expect(src, isNot(contains('AudioTrack.uri(externalAudioTrackUrl)')));
+  });
+
+  test('反向断言：守卫盯的两处确实存在于 load 路径上', () {
+    // 方法体被删空 / 改名时上面的 isNot 会恒真，这里钉住两个入口本身还在。
+    expect(src, contains('Media('));
+    expect(src, contains('setAudioTrack('));
+    expect(
+      src,
+      contains("import 'package:fushi/src/utils/net/app_native_proxy.dart'"),
+    );
+  });
+}

--- a/fushi/test/media/video/youtube_external_audio_before_play_guard_test.dart
+++ b/fushi/test/media/video/youtube_external_audio_before_play_guard_test.dart
@@ -18,6 +18,10 @@ import 'package:flutter_test/flutter_test.dart';
 ///
 /// 真实音画同步只能在真机（可能 ANDROID_VR 流）复测；此守卫锁住「外挂音轨早于 seek/play」
 /// 的静态时序不变量，防止有人把它挪回 load 之后（回归无声）。
+/// 外挂音轨的调用形状（BUG-2448 起 URL 先过 nativePlaybackUri 收口）。
+const String _kAttachCall =
+    'AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))';
+
 void main() {
   String read(String relPath) {
     for (final String prefix in <String>['', '../']) {
@@ -38,14 +42,13 @@ void main() {
     });
 
     test('load() 内经 AudioTrack.uri 外挂 externalAudioTrackUrl', () {
-      expect(ctrl.contains('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))'), isTrue,
-          reason:
-              '必须用 AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))（libmpv audio-add）外挂音轨');
+      // BUG-2448：URL 先过 nativePlaybackUri 收口，再 audio-add。
+      expect(ctrl.contains(_kAttachCall), isTrue,
+          reason: '必须用 $_kAttachCall（libmpv audio-add）外挂音轨');
     });
 
     test('外挂音轨 (audio-add) 出现在恢复 seek 与 play() 之前', () {
-      final int attachAt =
-          ctrl.indexOf('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))');
+      final int attachAt = ctrl.indexOf(_kAttachCall);
       final int seekAt =
           ctrl.indexOf('player.seek(Duration(milliseconds: resolvedStartMs))');
       final int playAt = ctrl.indexOf('await player.play();');
@@ -61,8 +64,7 @@ void main() {
 
     test('外挂音轨在 http-header-fields 注入之后（audio-only 流同需 UA 防 403）', () {
       final int headerAt = ctrl.indexOf('applyHttpHeaderFieldsToPlayer');
-      final int attachAt =
-          ctrl.indexOf('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))');
+      final int attachAt = ctrl.indexOf(_kAttachCall);
       expect(headerAt, greaterThanOrEqualTo(0));
       expect(attachAt, greaterThan(headerAt),
           reason:

--- a/fushi/test/media/video/youtube_external_audio_before_play_guard_test.dart
+++ b/fushi/test/media/video/youtube_external_audio_before_play_guard_test.dart
@@ -38,14 +38,14 @@ void main() {
     });
 
     test('load() 内经 AudioTrack.uri 外挂 externalAudioTrackUrl', () {
-      expect(ctrl.contains('AudioTrack.uri(externalAudioTrackUrl)'), isTrue,
+      expect(ctrl.contains('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))'), isTrue,
           reason:
-              '必须用 AudioTrack.uri(externalAudioTrackUrl)（libmpv audio-add）外挂音轨');
+              '必须用 AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))（libmpv audio-add）外挂音轨');
     });
 
     test('外挂音轨 (audio-add) 出现在恢复 seek 与 play() 之前', () {
       final int attachAt =
-          ctrl.indexOf('AudioTrack.uri(externalAudioTrackUrl)');
+          ctrl.indexOf('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))');
       final int seekAt =
           ctrl.indexOf('player.seek(Duration(milliseconds: resolvedStartMs))');
       final int playAt = ctrl.indexOf('await player.play();');
@@ -62,7 +62,7 @@ void main() {
     test('外挂音轨在 http-header-fields 注入之后（audio-only 流同需 UA 防 403）', () {
       final int headerAt = ctrl.indexOf('applyHttpHeaderFieldsToPlayer');
       final int attachAt =
-          ctrl.indexOf('AudioTrack.uri(externalAudioTrackUrl)');
+          ctrl.indexOf('AudioTrack.uri(nativePlaybackUri(externalAudioTrackUrl))');
       expect(headerAt, greaterThanOrEqualTo(0));
       expect(attachAt, greaterThan(headerAt),
           reason:

--- a/fushi/test/sync/fushi_client_live_video_test.dart
+++ b/fushi/test/sync/fushi_client_live_video_test.dart
@@ -662,6 +662,24 @@ void main() {
     expect(pinnedNativeOriginFingerprint(parsed.host, parsed.port), isNull);
   });
 
+  // host 关了 TLS、同一端口改回明文后重新配对：解析成 http 必须撤销旧登记，否则
+  // 中继会把 native 的明文请求硬升 https 去握手明文端口，视频 502 直到重启 app。
+  test('BUG-2448: resolving the same host:port as plaintext http drops a stale pin',
+      () async {
+    clearPinnedNativeOriginsForTesting();
+    addTearDown(clearPinnedNativeOriginsForTesting);
+    final Uri parsed = Uri.parse(base);
+    registerPinnedNativeOrigin(
+      host: parsed.host,
+      port: parsed.port,
+      fingerprintSha256: 'aa:bb',
+    );
+    final InterconnectSyncBackend backend =
+        await _buildBackend(base: base, token: token);
+    await backend.listRemoteVideos();
+    expect(pinnedNativeOriginFingerprint(parsed.host, parsed.port), isNull);
+  });
+
   test('fetchRemoteCover still works over plaintext http (老路径零破坏)', () async {
     final InterconnectSyncBackend backend =
         await _buildBackend(base: base, token: token);

--- a/fushi/test/sync/fushi_client_live_video_test.dart
+++ b/fushi/test/sync/fushi_client_live_video_test.dart
@@ -11,6 +11,7 @@ import 'package:fushi_engine/sync/fushi_library_host_service.dart';
 import 'package:fushi_engine/sync/fushi_sync_server.dart';
 import 'package:fushi/src/sync/sync_backend.dart';
 import 'package:fushi/src/sync/sync_repository.dart';
+import 'package:fushi/src/utils/net/app_native_proxy.dart';
 import 'package:fushi_engine/sync/tls/fushi_tls_identity.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -626,6 +627,39 @@ void main() {
       await expectLater(attempt(), throwsA(anything),
           reason: '指纹不符必须被钉扎拒绝，绝不放行任意自签证书');
     });
+
+    // BUG-2448：https host 解析成功即把 (host, port) → 指纹登记给 app 内置中继，
+    // 播放页交给 native 的 stream URL 才会被降成明文 http、由中继钉扎升回 https。
+    // 没有这一步，nativePlaybackUri 原样返回 https，libmpv（curl 后端）自己校验
+    // 自签证书 → 互联视频打不开。
+    test('BUG-2448: resolved https host is registered as a pinned native origin',
+        () async {
+      clearPinnedNativeOriginsForTesting();
+      addTearDown(clearPinnedNativeOriginsForTesting);
+      final Uri base = Uri.parse(tlsBase);
+      expect(pinnedNativeOriginFingerprint(base.host, base.port), isNull);
+      final InterconnectSyncBackend backend =
+          await buildPinnedBackend(fingerprint);
+      final RemoteVideoStreamUrls urls =
+          await backend.remoteVideoStreamUrls('video/sample');
+      expect(pinnedNativeOriginFingerprint(base.host, base.port), fingerprint);
+      expect(urls.streamUrl, startsWith('$tlsBase/'),
+          reason: 'Dart 侧下载通道仍拿真 https URL（钉扎客户端自己连）');
+      expect(nativePlaybackUri(urls.streamUrl),
+          'http://${base.host}:${base.port}${Uri.parse(urls.streamUrl).path}?${Uri.parse(urls.streamUrl).query}',
+          reason: '交给 native 的形式降成同 host 显式端口的明文 http');
+    });
+  });
+
+  test('BUG-2448: plaintext http host registers no pinned native origin',
+      () async {
+    clearPinnedNativeOriginsForTesting();
+    addTearDown(clearPinnedNativeOriginsForTesting);
+    final InterconnectSyncBackend backend =
+        await _buildBackend(base: base, token: token);
+    await backend.listRemoteVideos();
+    final Uri parsed = Uri.parse(base);
+    expect(pinnedNativeOriginFingerprint(parsed.host, parsed.port), isNull);
   });
 
   test('fetchRemoteCover still works over plaintext http (老路径零破坏)', () async {

--- a/fushi/test/utils/net/app_native_proxy_mpv_test.dart
+++ b/fushi/test/utils/net/app_native_proxy_mpv_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/utils/net/app_native_proxy.dart';
+import 'package:fushi_engine/sync/tls/fushi_tls_identity.dart';
 import 'package:fushi_engine/utils/net/app_proxy.dart';
 
 /// Optional real native-library probe. No user player is touched; a separate
@@ -70,6 +71,91 @@ void main() {
     skip: Platform.environment['FUSHI_TEST_MPV_DLL'] == null,
     timeout: const Timeout(Duration(seconds: 40)),
   );
+
+  // BUG-2448：互联 host 的形状——自签 https + 流 URL。随包 libmpv（curl 后端）直连
+  // 会因证书校验失败打不开；修复后 URL 经 nativePlaybackUri 降成明文 http，中继按
+  // 登记指纹钉扎升回 https。这里用真自签证书 + 真 libmpv 端到端证明这条链。
+  test(
+    'installed libmpv loads a self-signed https origin through the pinned relay',
+    () async {
+      clearPinnedNativeOriginsForTesting();
+      addTearDown(clearPinnedNativeOriginsForTesting);
+      final String Function() oldMode = appUserProxyModeReader;
+      addTearDown(() => appUserProxyModeReader = oldMode);
+      appUserProxyModeReader = () => kProxyModeDirect;
+      final ({String certificatePem, String privateKeyPem}) cert =
+          FushiSelfSignedCertGenerator.generate(
+            commonName: 'fushi-test',
+            sanIpAddresses: <String>['127.0.0.1'],
+          );
+      final String fingerprint = FushiTlsIdentityStore.fingerprintOf(
+        cert.certificatePem,
+      );
+      final SecurityContext ctx = SecurityContext()
+        ..useCertificateChainBytes(cert.certificatePem.codeUnits)
+        ..usePrivateKeyBytes(cert.privateKeyPem.codeUnits);
+      final HttpServer origin = await HttpServer.bindSecure(
+        InternetAddress.loopbackIPv4,
+        0,
+        ctx,
+      );
+      addTearDown(() => origin.close(force: true));
+      final Uint8List wav = _probeWav();
+      int requests = 0;
+      origin.listen((HttpRequest request) async {
+        requests++;
+        request.response.headers.contentType = ContentType('audio', 'wav');
+        request.response.contentLength = wav.length;
+        request.response.add(wav);
+        await request.response.close();
+      });
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: fingerprint,
+      );
+      final String playbackUrl = nativePlaybackUri(
+        'https://127.0.0.1:${origin.port}/probe.wav?token=x',
+      );
+      expect(playbackUrl, startsWith('http://127.0.0.1:${origin.port}/'));
+      final AppNativeProxy relay = await AppNativeProxy.start();
+      addTearDown(relay.close);
+      final ProcessResult result = await Process.run(
+        'python',
+        <String>['-c', _probe],
+        environment: <String, String>{
+          'FUSHI_PROBE_PROXY': relay.endpoint.toString(),
+          'FUSHI_PROBE_URL': playbackUrl,
+        },
+      );
+      expect(
+        result.exitCode,
+        0,
+        reason: 'libmpv did not report FILE_LOADED: ${result.stdout}',
+      );
+      expect(requests, greaterThan(0));
+    },
+    skip: Platform.environment['FUSHI_TEST_MPV_DLL'] == null,
+    timeout: const Timeout(Duration(seconds: 40)),
+  );
+}
+
+Uint8List _probeWav() {
+  final Uint8List wav = Uint8List(16044);
+  final ByteData header = ByteData.sublistView(wav);
+  wav.setRange(0, 4, 'RIFF'.codeUnits);
+  header.setUint32(4, wav.length - 8, Endian.little);
+  wav.setRange(8, 16, 'WAVEfmt '.codeUnits);
+  header.setUint32(16, 16, Endian.little);
+  header.setUint16(20, 1, Endian.little);
+  header.setUint16(22, 1, Endian.little);
+  header.setUint32(24, 16000, Endian.little);
+  header.setUint32(28, 32000, Endian.little);
+  header.setUint16(32, 2, Endian.little);
+  header.setUint16(34, 16, Endian.little);
+  wav.setRange(36, 40, 'data'.codeUnits);
+  header.setUint32(40, wav.length - 44, Endian.little);
+  return wav;
 }
 
 const String _probe = r'''
@@ -91,7 +177,8 @@ try:
         assert m.mpv_set_option_string(h, k.encode(), v.encode()) >= 0
     assert m.mpv_initialize(h) >= 0
     assert m.mpv_set_property_string(h, b'http-proxy', os.environ['FUSHI_PROBE_PROXY'].encode()) >= 0
-    args = (c.c_char_p * 3)(b'loadfile', b'http://native-source.invalid/probe.wav', None)
+    url = os.environ.get('FUSHI_PROBE_URL', 'http://native-source.invalid/probe.wav')
+    args = (c.c_char_p * 3)(b'loadfile', url.encode(), None)
     assert m.mpv_command(h, args) >= 0
     loaded = False
     deadline = time.monotonic() + 25

--- a/fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart
+++ b/fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart
@@ -202,10 +202,40 @@ void main() {
       expect(r.body, isEmpty);
     });
 
-    test('未登记：中继按明文 http 直连 TLS 端口，必失败（登记是唯一放行条件）', () async {
+    test('未登记：中继按明文 http 直连 TLS 端口 → 502（登记是唯一放行条件）', () async {
       final ({String head, List<int> body}) r = await viaRelay('/clip.bin');
-      expect(r.head, isNot(startsWith('HTTP/1.1 200')));
-      expect(r.body, isNot(equals(body)));
+      expect(r.head, startsWith('HTTP/1.1 502'));
+      expect(r.body, isEmpty);
+    });
+
+    test('撤销登记后同一原点回到明文直连 → 502（host 关 TLS 后不残留旧指纹）', () async {
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: fingerprint,
+      );
+      expect((await viaRelay('/clip.bin')).head, startsWith('HTTP/1.1 200'));
+      unregisterPinnedNativeOrigin(host: '127.0.0.1', port: origin.port);
+      expect(pinnedNativeOriginFingerprint('127.0.0.1', origin.port), isNull);
+      final ({String head, List<int> body}) r = await viaRelay('/clip.bin');
+      expect(r.head, startsWith('HTTP/1.1 502'));
+    });
+
+    test('同一钉扎原点的连续请求复用一条上游连接（不逐请求重新 TLS 握手）', () async {
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: fingerprint,
+      );
+      for (int i = 0; i < 3; i++) {
+        final ({String head, List<int> body}) r = await viaRelay(
+          '/clip.bin',
+          range: 'bytes=$i-$i',
+        );
+        expect(r.head, startsWith('HTTP/1.1 206'), reason: 'request #$i');
+      }
+      // 三个 Range 请求若各起一个客户端，原点会看到 3 条连接；复用后只有 1 条。
+      expect(origin.connectionsInfo().total, 1);
     });
   });
 }

--- a/fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart
+++ b/fushi/test/utils/net/app_native_proxy_pinned_origin_test.dart
@@ -1,0 +1,211 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/utils/net/app_native_proxy.dart';
+import 'package:fushi_engine/sync/tls/fushi_tls_identity.dart';
+import 'package:fushi_engine/utils/net/app_proxy.dart';
+
+/// BUG-2448：互联 host 的自签 https 流不再交给 native 自己去做 TLS——URL 经
+/// [nativePlaybackUri] 降成明文 http，中继按登记的 (host, port) 指纹升回钉扎 https。
+///
+/// 这里用真自签证书起一个 https 原点，从中继的 loopback 入口以 native 播放器的
+/// 请求形状（absolute-form GET + Proxy-Authorization）走一遍，证明：
+///  - 指纹相符 → 200/206 原样透传（Range 是 libmpv 取流的基本形状）；
+///  - 指纹不符 → 502（绝不放行任意自签证书）；
+///  - 未登记 → 明文直连 https 端口，必失败（说明「登记」是唯一放行条件）。
+void main() {
+  late AppNativeProxy relay;
+  late HttpServer origin;
+  late String fingerprint;
+  late String Function() oldMode;
+  final List<int> body = List<int>.generate(4096, (int i) => i % 251);
+
+  setUp(() async {
+    oldMode = appUserProxyModeReader;
+    appUserProxyModeReader = () => kProxyModeDirect;
+    clearPinnedNativeOriginsForTesting();
+    final ({String certificatePem, String privateKeyPem}) cert =
+        FushiSelfSignedCertGenerator.generate(
+          commonName: 'fushi-test',
+          sanIpAddresses: <String>['127.0.0.1'],
+        );
+    fingerprint = FushiTlsIdentityStore.fingerprintOf(cert.certificatePem);
+    final SecurityContext ctx = SecurityContext()
+      ..useCertificateChainBytes(cert.certificatePem.codeUnits)
+      ..usePrivateKeyBytes(cert.privateKeyPem.codeUnits);
+    origin = await HttpServer.bindSecure(InternetAddress.loopbackIPv4, 0, ctx);
+    origin.listen((HttpRequest request) async {
+      final String? range = request.headers.value(HttpHeaders.rangeHeader);
+      request.response.headers.contentType = ContentType.binary;
+      if (range == null) {
+        request.response.contentLength = body.length;
+        request.response.add(body);
+      } else {
+        final RegExpMatch m = RegExp(r'bytes=(\d+)-(\d+)').firstMatch(range)!;
+        final int start = int.parse(m.group(1)!);
+        final int end = int.parse(m.group(2)!);
+        request.response.statusCode = HttpStatus.partialContent;
+        request.response.headers.set(
+          HttpHeaders.contentRangeHeader,
+          'bytes $start-$end/${body.length}',
+        );
+        request.response.contentLength = end - start + 1;
+        request.response.add(body.sublist(start, end + 1));
+      }
+      await request.response.close();
+    });
+    relay = await AppNativeProxy.start();
+  });
+
+  tearDown(() async {
+    await relay.close();
+    await origin.close(force: true);
+    clearPinnedNativeOriginsForTesting();
+    appUserProxyModeReader = oldMode;
+  });
+
+  String auth() =>
+      'Basic ${base64.encode(utf8.encode(relay.endpoint.userInfo))}';
+
+  /// native 播放器的请求形状：absolute-form 明文 http + 中继凭据。
+  Future<({String head, List<int> body})> viaRelay(
+    String path, {
+    String? range,
+  }) async {
+    final Socket socket = await Socket.connect(
+      relay.endpoint.host,
+      relay.endpoint.port,
+    );
+    try {
+      final String authority = '127.0.0.1:${origin.port}';
+      socket.write(
+        'GET http://$authority$path HTTP/1.1\r\n'
+        'Host: $authority\r\n'
+        'Proxy-Authorization: ${auth()}\r\n'
+        '${range == null ? '' : 'Range: $range\r\n'}'
+        'Connection: close\r\n\r\n',
+      );
+      final List<int> bytes = <int>[];
+      await for (final List<int> chunk in socket.timeout(
+        const Duration(seconds: 10),
+      )) {
+        bytes.addAll(chunk);
+      }
+      final int split = latin1.decode(bytes).indexOf('\r\n\r\n');
+      return (
+        head: latin1.decode(bytes.sublist(0, split)),
+        body: bytes.sublist(split + 4),
+      );
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  group('nativePlaybackUri', () {
+    test('已登记原点的 https 降成带显式端口的 http，路径与 query 一字不改', () {
+      registerPinnedNativeOrigin(
+        host: '192.168.1.5',
+        port: 38765,
+        fingerprintSha256: fingerprint,
+      );
+      const String path =
+          '/api/library/videos/video/%E6%A1%9CTrick%20(2014)/stream?token=aB-c_d';
+      expect(
+        nativePlaybackUri('https://192.168.1.5:38765$path'),
+        'http://192.168.1.5:38765$path',
+      );
+    });
+
+    test('隐含 443 的 https 降级后端口必须显式（否则中继查不到登记项）', () {
+      registerPinnedNativeOrigin(
+        host: 'host.example',
+        port: 443,
+        fingerprintSha256: fingerprint,
+      );
+      expect(
+        nativePlaybackUri('https://host.example/stream'),
+        'http://host.example:443/stream',
+      );
+    });
+
+    test('未登记 / 非 https / 本地文件 原样返回', () {
+      expect(
+        nativePlaybackUri('https://unknown.example:1/x'),
+        'https://unknown.example:1/x',
+      );
+      expect(
+        nativePlaybackUri('http://192.168.1.5:38765/x'),
+        'http://192.168.1.5:38765/x',
+      );
+      expect(nativePlaybackUri('file:///C:/a%20b.mkv'), 'file:///C:/a%20b.mkv');
+      expect(nativePlaybackUri('not a uri'), 'not a uri');
+    });
+
+    test('host 匹配不分大小写、重复登记以最新指纹为准', () {
+      registerPinnedNativeOrigin(
+        host: 'Desktop.local',
+        port: 1,
+        fingerprintSha256: 'old',
+      );
+      registerPinnedNativeOrigin(
+        host: 'desktop.LOCAL',
+        port: 1,
+        fingerprintSha256: 'new',
+      );
+      expect(pinnedNativeOriginFingerprint('DESKTOP.local', 1), 'new');
+      expect(pinnedNativeOriginFingerprint('desktop.local', 2), isNull);
+    });
+  });
+
+  group('relay upgrades a registered origin to pinned https', () {
+    test('指纹相符：整段 GET 200 透传', () async {
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: fingerprint,
+      );
+      final ({String head, List<int> body}) r = await viaRelay('/clip.bin');
+      expect(r.head, startsWith('HTTP/1.1 200'));
+      expect(r.body, body);
+    });
+
+    test('指纹相符：Range 请求 206 + Content-Range 原样透传（libmpv 取流形状）', () async {
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: fingerprint,
+      );
+      final ({String head, List<int> body}) r = await viaRelay(
+        '/clip.bin',
+        range: 'bytes=100-199',
+      );
+      expect(r.head, startsWith('HTTP/1.1 206'));
+      expect(
+        r.head.toLowerCase(),
+        contains('content-range: bytes 100-199/${body.length}'),
+      );
+      expect(r.body, body.sublist(100, 200));
+    });
+
+    test('指纹不符：钉扎拒绝 → 502，绝不放行任意自签证书', () async {
+      final String wrong = fingerprint.startsWith('00:')
+          ? '11:${fingerprint.substring(3)}'
+          : '00:${fingerprint.substring(3)}';
+      registerPinnedNativeOrigin(
+        host: '127.0.0.1',
+        port: origin.port,
+        fingerprintSha256: wrong,
+      );
+      final ({String head, List<int> body}) r = await viaRelay('/clip.bin');
+      expect(r.head, startsWith('HTTP/1.1 502'));
+      expect(r.body, isEmpty);
+    });
+
+    test('未登记：中继按明文 http 直连 TLS 端口，必失败（登记是唯一放行条件）', () async {
+      final ({String head, List<int> body}) r = await viaRelay('/clip.bin');
+      expect(r.head, isNot(startsWith('HTTP/1.1 200')));
+      expect(r.body, isNot(equals(body)));
+    });
+  });
+}


### PR DESCRIPTION
## 症状

fushi 互联点开对端视频打不开（BUG-2448）。

## 根因

- Windows 随包 libmpv 自 BUG-1644（2026-08-14）钉到 `mpv-dev-x86_64-20260813-git-7b8915bc1d.7z`（`mpv v0.41.0-923`），这个 master 构建的 http(s) 取流后端从 ffmpeg lavf 换成了 **libcurl**，默认校验证书。
- 互联 host 默认开 TLS、证书自签、信任判据是配对时 TOFU 记下的指纹——只有 Dart 侧的 `createPinnedHttpClient` 知道；播放页却把 https stream URL 原样交给 native，让 libmpv 自己做 TLS：

```
[curl/error] error: SSL peer certificate or SSH remote key was not OK
[curl/error] TLS certificate verification failed. ... a self-signed certificate ...
[stream/error] Failed to open https://127.0.0.1:38765/api/library/videos/.../stream?token=...
```

- Android 随包 libmpv 仍是 ffmpeg 6.1.6 后端、从不校验；同一条流两端两种结局，说明 TLS 信任一开始就放错了层。
- 2026-09-08 给 libmpv 设的 `http-proxy`（app 内置 loopback 中继）对 https 只做 CONNECT 隧道，TLS 仍是 native 端到端，经中继一样失败。既有 `app_native_proxy_mpv_test` 只盖了公网明文 http。

## 修法（统一为一条链）

- `app_native_proxy.dart`：新增钉扎原点登记 `registerPinnedNativeOrigin(host, port, 指纹)` + `nativePlaybackUri(url)`（已登记原点的 https 降成**显式端口**的明文 http）；`_forward` 按 `(host, port)` 查到指纹就用 `createPinnedHttpClient` 升回 https。native 无论哪个后端都只看到 loopback 明文，证书判据与 API/字幕/封面通道同一份。
- `InterconnectSyncBackend._ensureResolved`：https host 解析成功即登记（幂等覆盖，重配对换证书时指纹跟着刷新）。Dart 侧 `downloadRemoteVideo` 等仍拿真 https URL 自己钉扎。
- `VideoPlayerController.load`：主流与外挂音轨两个 native 入口统一过 `nativePlaybackUri`；本地文件 / 公网流 / YouTube / Jellyfin 零变化。
- 没选 `tls-verify=no`：那是对任意证书放行，且各平台 libmpv 认不认这个选项又是一道分叉。

## code review 返工（第 2 个提交）

- 登记表只增不删 → host 关 TLS、同一端口改回明文重新配对时残留旧指纹会把明文请求硬升 https（视频 502 到重启）：解析成 http 即撤销登记。
- 钉扎客户端每请求新建 + 用完即关 → libmpv 每个 Range/seek 都重新 TCP+TLS 握手：改按 `(host, port, 指纹)` 缓存复用。
- 钉扎客户端补 `kAppHttpConnectionTimeout`。
- 「未登记必失败」断言收紧为 502；新增撤销登记、连接复用（3 个 Range 只 1 条上游连接）、backend 撤销登记三条用例。
- 有意不改：钉扎客户端不走 app 代理策略（与 `WebDavOps` 等 Dart 侧钉扎通道一致）；登记表是进程级状态 + 控制器单一收口（`downloadRemoteVideo` 等 Dart 侧消费者需要真 https URL，在产出端分叉两种形态反而多一处分歧）。

## 验证

- 随包 `libmpv-2.dll` 对本机生产 host 直连 → `LOAD_FAILED`（上面的 curl 报错）；修复路径（登记指纹 → `nativePlaybackUri` → 真实 `AppNativeProxy`）→ `Opening done: http://127.0.0.1:38765/.../stream` / `FILE_LOADED duration=1420.928`。
- 新增 `test/utils/net/app_native_proxy_pinned_origin_test.dart` 8 条（真自签证书 https 原点：指纹相符 200/Range 206 透传、指纹不符 502、未登记必失败、`nativePlaybackUri` 真值）；`app_native_proxy_mpv_test.dart` +1 真库用例（`FUSHI_TEST_MPV_DLL` 指向随包 DLL 本机 2/2 绿）；`fushi_client_live_video_test.dart` +2（https 登记 / http 不登记）；源码守卫 `video_player_native_playback_uri_guard_test.dart` 3 条；既有 `youtube_external_audio_before_play_guard_test` 锚点跟着换。
- `flutter analyze`（lib+test）零问题；`test/utils/net` + `test/media/video` + 互联 backend 消费方 16 个文件共 111 条全绿。
- 未做：Android 真机复测（修复后手机同样只经中继取明文 http，与 Windows 同一条链）。

https://claude.ai/code/session_01KAmJkizGgfc5soKNXF7gSw
