### PR TITLE
feat(lookup): 弹窗内点词头/链接/汉字原地跳转，顶栏 ← → 历史导航（对齐 Hoshi Reader）

### DIFF
--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -4869,6 +4869,23 @@ function __fushiReportedContentHeight(){
     return Math.ceil(__fushiScrollHeight() * __fushiPopupContentZoom());
 }
 
+// 弹窗内原地跳转（对齐 Hoshi Reader iOS 的 backStack/forwardStack）：后退 / 前进回到
+// 历史页时，Dart 在 renderPopup() 之前把该页离开时的 scrollTop 写进
+// window.__fushiPendingScrollTop（新词 / load-more 写 0 = 不恢复）。内容是分批进
+// DOM 的，首发 popupRendered 时文档往往还不够高、直接 scrollTo 会被夹到底；所以
+// 每个尾批切片后都试一次「够高就恢复」，尾批全部完成（final）时不管够不够高都
+// 应用一次兜底（浏览器自行夹紧）。应用后清零，同一份 pending 绝不影响下一次渲染。
+window.__fushiPendingScrollTop = 0;
+function __fushiApplyPendingScrollTop(isFinal) {
+    const y = window.__fushiPendingScrollTop || 0;
+    if (!(y > 0)) return;
+    const el = document.scrollingElement || document.documentElement;
+    if (!el) return;
+    if (!isFinal && (el.scrollHeight - el.clientHeight) < y) return;
+    el.scrollTop = y;
+    window.__fushiPendingScrollTop = 0;
+}
+
 // 性能（查词时延）：多词条渲染现在**双发**同一 token 的 popupRendered——首词条
 // 同步渲染完（build + 局部 postProcessRuby + applyCustomCSS）立即发第一次，宿主
 // 据此撤盖板/翻可见（首屏可见性只依赖首词条，Dart 侧全部消费方幂等）；尾批词条
@@ -4884,6 +4901,7 @@ function _firePopupRendered(stillRendering) {
         // Its own render signal owns the reveal gate; never let this stale
         // callback reveal the new card early.
         if (generation !== window._renderGeneration) return;
+        __fushiApplyPendingScrollTop(!stillRendering);
         _reportPopupHeight();
         // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
         // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
@@ -5477,6 +5495,8 @@ window.renderPopup = function() {
         } while ((activeEntryElement || nextEntryIndex < entries.length) &&
             performance.now() - sliceStart < TAIL_SLICE_BUDGET_MS);
         if (activeEntryElement || nextEntryIndex < entries.length) {
+            // 历史页回退：内容一够高就把滚动位恢复回去，不等尾批全部完成。
+            __fushiApplyPendingScrollTop(false);
             scheduleRenderTail(renderNextDictionaryBlock);
             return;
         }

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -4869,6 +4869,23 @@ function __fushiReportedContentHeight(){
     return Math.ceil(__fushiScrollHeight() * __fushiPopupContentZoom());
 }
 
+// 弹窗内原地跳转（对齐 Hoshi Reader iOS 的 backStack/forwardStack）：后退 / 前进回到
+// 历史页时，Dart 在 renderPopup() 之前把该页离开时的 scrollTop 写进
+// window.__fushiPendingScrollTop（新词 / load-more 写 0 = 不恢复）。内容是分批进
+// DOM 的，首发 popupRendered 时文档往往还不够高、直接 scrollTo 会被夹到底；所以
+// 每个尾批切片后都试一次「够高就恢复」，尾批全部完成（final）时不管够不够高都
+// 应用一次兜底（浏览器自行夹紧）。应用后清零，同一份 pending 绝不影响下一次渲染。
+window.__fushiPendingScrollTop = 0;
+function __fushiApplyPendingScrollTop(isFinal) {
+    const y = window.__fushiPendingScrollTop || 0;
+    if (!(y > 0)) return;
+    const el = document.scrollingElement || document.documentElement;
+    if (!el) return;
+    if (!isFinal && (el.scrollHeight - el.clientHeight) < y) return;
+    el.scrollTop = y;
+    window.__fushiPendingScrollTop = 0;
+}
+
 // 性能（查词时延）：多词条渲染现在**双发**同一 token 的 popupRendered——首词条
 // 同步渲染完（build + 局部 postProcessRuby + applyCustomCSS）立即发第一次，宿主
 // 据此撤盖板/翻可见（首屏可见性只依赖首词条，Dart 侧全部消费方幂等）；尾批词条
@@ -4884,6 +4901,7 @@ function _firePopupRendered(stillRendering) {
         // Its own render signal owns the reveal gate; never let this stale
         // callback reveal the new card early.
         if (generation !== window._renderGeneration) return;
+        __fushiApplyPendingScrollTop(!stillRendering);
         _reportPopupHeight();
         // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
         // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
@@ -5477,6 +5495,8 @@ window.renderPopup = function() {
         } while ((activeEntryElement || nextEntryIndex < entries.length) &&
             performance.now() - sliceStart < TAIL_SLICE_BUDGET_MS);
         if (activeEntryElement || nextEntryIndex < entries.length) {
+            // 历史页回退：内容一够高就把滚动位恢复回去，不等尾批全部完成。
+            __fushiApplyPendingScrollTop(false);
             scheduleRenderTail(renderNextDictionaryBlock);
             return;
         }

--- a/fushi/integration_test/popup_inplace_navigation_itest.dart
+++ b/fushi/integration_test/popup_inplace_navigation_itest.dart
@@ -1,0 +1,220 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/home_dictionary_page.dart';
+import 'package:fushi/src/pages/implementations/home_page.dart'
+    show HomePage, HomeTab;
+import 'package:fushi/src/utils/components/fushi_icon_button.dart';
+import 'package:fushi_dictionary/fushi_dictionary.dart' show Dictionary;
+import 'package:integration_test/integration_test.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'helpers/library_fixture.dart' show readyAppModel;
+import 'helpers/observe_capture.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+/// 真 app 复测：查词弹窗内点交叉引用链接 = **原地跳转**（对齐 Hoshi Reader），
+/// 顶栏 ← → 在历史页间来回，回来时滚动位恢复。
+///
+/// 路径：首页查词 tab → 生产 `_pushNestedPopup` 开「足」的弹窗（真 WebView）→ 把弹窗
+/// 滚到 300px → DOM `.click()` 词典正文里的 `?query=揚げ足` 链接（走真实 popup.js
+/// onclick → `onLinkClick` 桥 → mixin `navigatePopupInPlace`）→ 断言：栈深仍是 1、
+/// 同一个 WebView State、词头换成「揚げ足」、顶栏出现 ← →（← 可用 / → 置灰）→ 触发
+/// ← 的生产回调 → 词头回到「足」、scrollTop 回到 ≈300、→ 变可用。每一步抓真帧。
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('弹窗内链接原地跳转 + ← → 历史 + 滚动位恢复', (WidgetTester tester) async {
+    await launchFushiTestApp();
+    expect(await waitForHome(tester), isTrue, reason: '主页应在 90s 内出现');
+    await tester.pump(const Duration(seconds: 2));
+
+    final AppModel appModel = await readyAppModel(tester);
+    expect(await _seedLinkDictionary(tester, appModel), isTrue,
+        reason: '本用例需要一本「足」的释义里带 ?query=揚げ足 链接的真词典');
+
+    expect(HomePage.debugSelectTab, isNotNull);
+    HomePage.debugSelectTab!(HomeTab.dictionaries);
+    await tester.pump(const Duration(seconds: 2));
+
+    final HomeDictionarySearchDebug page = tester
+        .state(find.byType(HomeDictionaryPage)) as HomeDictionarySearchDebug;
+
+    // ① 开「足」的弹窗（真 WebView），等链接渲染出来。
+    final int matches = await page.debugOpenPopup('足');
+    expect(matches, greaterThan(0));
+    expect(await _waitForExpression(tester, page, '足'), isTrue,
+        reason: '弹窗必须渲染出「足」的词头');
+    final Object? webViewBefore = page.debugTopPopupWebViewState;
+    expect(webViewBefore, isNotNull);
+    final int links = await _evalInt(
+        page, "document.querySelectorAll('a.gloss-sc-a').length");
+    expect(links, greaterThan(0), reason: '释义里必须渲染出交叉引用链接');
+    expect(
+        find.byKey(const ValueKey<String>('popup_history_back')), findsNothing,
+        reason: '还没跳过：顶栏不画 ← →');
+
+    // 把弹窗滚到 300px（释义故意造得很长，滚得动）。
+    final int scrollable = await _evalInt(page,
+        '(document.scrollingElement.scrollHeight - document.scrollingElement.clientHeight)');
+    expect(scrollable, greaterThan(300), reason: '内容必须比视口高 300px 以上');
+    await page.debugEvaluateTopPopup(
+        'document.scrollingElement.scrollTop = 300; true');
+    await tester.pump(const Duration(milliseconds: 300));
+    final int scrollBefore =
+        await _evalInt(page, 'document.scrollingElement.scrollTop');
+    debugPrint('[inplace-probe] scrollTop before link click = $scrollBefore');
+    expect(scrollBefore, greaterThanOrEqualTo(290));
+    ObserveShot shot = await captureFlutterFrame(tester, '01-root-popup');
+    expect(shot.saved, isTrue);
+
+    // ② DOM 点链接：真实 popup.js onclick → onLinkClick 桥 → 原地跳转。
+    await page.debugEvaluateTopPopup(
+        "document.querySelector('a.gloss-sc-a').click(); true");
+    expect(await _waitForExpression(tester, page, '揚げ足'), isTrue,
+        reason: '同一弹窗必须换成「揚げ足」');
+    expect(page.debugPopupStackShape.depth, 1, reason: '原地跳转不叠子层，栈深仍是 1');
+    expect(identical(page.debugTopPopupWebViewState, webViewBefore), isTrue,
+        reason: '还是同一个 WebView（不是新建一层）');
+    final Finder backFinder =
+        find.byKey(const ValueKey<String>('popup_history_back'));
+    final Finder forwardFinder =
+        find.byKey(const ValueKey<String>('popup_history_forward'));
+    expect(backFinder, findsOneWidget, reason: '跳过之后顶栏出现 ←');
+    expect(forwardFinder, findsOneWidget);
+    expect(tester.widget<FushiIconButton>(backFinder).enabled, isTrue);
+    expect(tester.widget<FushiIconButton>(forwardFinder).enabled, isFalse,
+        reason: '没有前进页：→ 置灰');
+    final int scrollAfterNav =
+        await _evalInt(page, 'document.scrollingElement.scrollTop');
+    debugPrint('[inplace-probe] scrollTop on 揚げ足 = $scrollAfterNav');
+    expect(scrollAfterNav, 0, reason: '新词从顶部开始');
+    shot = await captureFlutterFrame(tester, '02-after-link-navigate');
+    expect(shot.saved, isTrue);
+
+    // ③ ←：回到「足」，滚动位恢复到 300，→ 变可用。焦点驱动纪律禁坐标点击，这里
+    // 直接驱动按钮对外的生产回调（onTap 就是 ← 唯一出口）。
+    await tester.widget<FushiIconButton>(backFinder).onTap!();
+    expect(await _waitForExpression(tester, page, '足'), isTrue,
+        reason: '← 必须回到「足」');
+    expect(page.debugPopupStackShape.depth, 1);
+    int restored = -1;
+    for (int i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 250));
+      restored = await _evalInt(page, 'document.scrollingElement.scrollTop');
+      if (restored >= 290) break;
+    }
+    debugPrint('[inplace-probe] scrollTop after back = $restored');
+    expect(restored, greaterThanOrEqualTo(290),
+        reason: '回到历史页必须恢复离开时的滚动位（≈300）');
+    expect(tester.widget<FushiIconButton>(backFinder).enabled, isFalse,
+        reason: '回到栈底：← 置灰');
+    expect(tester.widget<FushiIconButton>(forwardFinder).enabled, isTrue,
+        reason: '有前进页：→ 可用');
+    shot = await captureFlutterFrame(tester, '03-after-back');
+    expect(shot.saved, isTrue);
+
+    // ④ →：再到「揚げ足」。
+    await tester.widget<FushiIconButton>(forwardFinder).onTap!();
+    expect(await _waitForExpression(tester, page, '揚げ足'), isTrue);
+    expect(tester.widget<FushiIconButton>(forwardFinder).enabled, isFalse);
+    expect(tester.widget<FushiIconButton>(backFinder).enabled, isTrue);
+    shot = await captureFlutterFrame(tester, '04-after-forward');
+    expect(shot.saved, isTrue);
+
+    page.debugClosePopup();
+    await tester.pump(const Duration(seconds: 1));
+  });
+}
+
+/// 轮询顶层弹窗 WebView 的首个词头文本，直到等于 [expression]。
+Future<bool> _waitForExpression(
+  WidgetTester tester,
+  HomeDictionarySearchDebug page,
+  String expression,
+) async {
+  for (int i = 0; i < 80; i++) {
+    await tester.pump(const Duration(milliseconds: 250));
+    final dynamic raw = await page.debugEvaluateTopPopup(
+        "(document.querySelector('.entry .expression') || {}).textContent || ''");
+    if (raw is String && raw.trim() == expression) return true;
+  }
+  return false;
+}
+
+Future<int> _evalInt(HomeDictionarySearchDebug page, String source) async {
+  final dynamic raw = await page.debugEvaluateTopPopup(source);
+  if (raw is num) return raw.round();
+  if (raw is String) return int.tryParse(raw) ?? -1;
+  return -1;
+}
+
+/// 造一本只为本用例服务的 yomitan 词典：「足」的释义先铺 60 行占位（让弹窗滚得动），
+/// 末尾一条结构化内容带 `?query=揚げ足` 链接；「揚げ足」是跳转目标。
+Future<bool> _seedLinkDictionary(
+  WidgetTester tester,
+  AppModel appModel,
+) async {
+  final Directory cacheDir = await getTemporaryDirectory();
+  final File dictFile = File('${cacheDir.path}/inplace_nav_dict.zip');
+  final Map<String, dynamic> index = <String, dynamic>{
+    'title': 'FushiInplaceNavProbeDict',
+    'format': 3,
+    'revision': 'inplace-nav-probe-1',
+    'sequenced': false,
+  };
+  final List<dynamic> ashiGloss = <dynamic>[
+    for (int i = 0; i < 60; i++) 'inplace probe filler line $i',
+    <String, dynamic>{
+      'type': 'structured-content',
+      'content': <String, dynamic>{
+        'tag': 'a',
+        'href': '?query=揚げ足',
+        'content': '揚げ足',
+      },
+    },
+  ];
+  List<dynamic> term(String word, String reading, List<dynamic> gloss) =>
+      <dynamic>[word, reading, '', '', 0, gloss, 0, ''];
+  final List<List<dynamic>> termBank = <List<dynamic>>[
+    term('足', 'あし', ashiGloss),
+    term('揚げ足', 'あげあし', <dynamic>['inplace probe: 揚げ足']),
+  ];
+
+  final Archive archive = Archive()
+    ..addFile(_jsonFile('index.json', index))
+    ..addFile(_jsonFile('term_bank_1.json', termBank));
+  final List<int> zipBytes = ZipEncoder().encode(archive)!;
+  dictFile.parent.createSync(recursive: true);
+  await dictFile.writeAsBytes(zipBytes, flush: true);
+
+  final ValueNotifier<String> progress = ValueNotifier<String>('');
+  bool ok = false;
+  try {
+    await appModel.importDictionary(
+      file: dictFile,
+      progressNotifier: progress,
+      onImportSuccess: () => ok = true,
+    );
+  } catch (e, stack) {
+    debugPrint('[inplace-probe] dictionary import failed: $e\n$stack');
+  } finally {
+    progress.dispose();
+  }
+  await tester.pump(const Duration(seconds: 1));
+  final bool installed = ok ||
+      appModel.dictionaries
+          .any((Dictionary d) => d.name == 'FushiInplaceNavProbeDict');
+  debugPrint('[inplace-probe] dictionary seed success=$installed');
+  return installed;
+}
+
+ArchiveFile _jsonFile(String name, Object json) {
+  final List<int> bytes = utf8.encode(jsonEncode(json));
+  return ArchiveFile(name, bytes.length, bytes);
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 79968 (4704 per locale)
+/// Strings: 80002 (4706 per locale)
 ///
-/// Built on 2026-09-10 at 17:52 UTC
+/// Built on 2026-09-11 at 05:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6543,6 +6543,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  String get popup_history_back => 'Back';
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -17617,6 +17619,10 @@ class _StringsAr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -28919,6 +28925,10 @@ class _StringsDe extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -40275,6 +40285,10 @@ class _StringsEs extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -51665,6 +51679,10 @@ class _StringsFr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -62857,6 +62875,10 @@ class _StringsId extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -74142,6 +74164,10 @@ class _StringsIt extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -84804,6 +84830,10 @@ class _StringsJa extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -95476,6 +95506,10 @@ class _StringsKo extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -106717,6 +106751,10 @@ class _StringsNl extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -118012,6 +118050,10 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -129284,6 +129326,10 @@ class _StringsRu extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -140355,6 +140401,10 @@ class _StringsTh extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -151542,6 +151592,10 @@ class _StringsTr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -162700,6 +162754,10 @@ class _StringsVi extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 // Path: <root>
@@ -172937,6 +172995,10 @@ class _StringsZhCn extends _StringsEn {
       '在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。';
   @override
   String get browser_extension_test_page_server_off => '请先开启查词服务器，再打开试用网页。';
+  @override
+  String get popup_history_back => '后退';
+  @override
+  String get popup_history_forward => '前进';
 }
 
 // Path: <root>
@@ -183281,6 +183343,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get popup_history_back => 'Back';
+  @override
+  String get popup_history_forward => 'Forward';
 }
 
 /// Flat map(s) containing all translations.
@@ -192969,6 +193035,10 @@ extension on _StringsEn {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -202652,6 +202722,10 @@ extension on _StringsAr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -212380,6 +212454,10 @@ extension on _StringsDe {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -222099,6 +222177,10 @@ extension on _StringsEs {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -231827,6 +231909,10 @@ extension on _StringsFr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -241526,6 +241612,10 @@ extension on _StringsId {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -251247,6 +251337,10 @@ extension on _StringsIt {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -260895,6 +260989,10 @@ extension on _StringsJa {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -270547,6 +270645,10 @@ extension on _StringsKo {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -280261,6 +280363,10 @@ extension on _StringsNl {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -289970,6 +290076,10 @@ extension on _StringsPtBr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -299686,6 +299796,10 @@ extension on _StringsRu {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -309374,6 +309488,10 @@ extension on _StringsTh {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -319077,6 +319195,10 @@ extension on _StringsTr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -328774,6 +328896,10 @@ extension on _StringsVi {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }
@@ -338385,6 +338511,10 @@ extension on _StringsZhCn {
         return '在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。';
       case 'browser_extension_test_page_server_off':
         return '请先开启查词服务器，再打开试用网页。';
+      case 'popup_history_back':
+        return '后退';
+      case 'popup_history_forward':
+        return '前进';
       default:
         return null;
     }
@@ -348011,6 +348141,10 @@ extension on _StringsZhHk {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'popup_history_back':
+        return 'Back';
+      case 'popup_history_forward':
+        return 'Forward';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "练习句",
   "browser_extension_test_page_action": "打开试用网页",
   "browser_extension_test_page_action_desc": "在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。",
-  "browser_extension_test_page_server_off": "请先开启查词服务器，再打开试用网页。"
+  "browser_extension_test_page_server_off": "请先开启查词服务器，再打开试用网页。",
+  "popup_history_back": "后退",
+  "popup_history_forward": "前进"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4702,5 +4702,7 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "popup_history_back": "Back",
+  "popup_history_forward": "Forward"
 }

--- a/fushi/lib/src/pages/base_source_page.dart
+++ b/fushi/lib/src/pages/base_source_page.dart
@@ -400,15 +400,22 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
     // BUG-1478：按**词头**递增，不是按 glossary 行数（entries.length）——
     // 后者是另一个单位，一个词头带十几条注释时上限会一次暴涨十几倍。
     final int newMax = current.headwordCount + appModel.maximumTerms;
+    final String term = entry.searchTerm;
     entry.isSearching = true;
     try {
       final DictionarySearchResult result = await appModel.searchDictionary(
-        searchTerm: entry.searchTerm,
+        searchTerm: term,
         searchWithWildcards: false,
         overrideMaximumTerms: newMax,
       );
       // 续查期间该层可能被裁掉/换词（嵌套查词、关栈）；用身份核对确保只更新原层。
-      if (!mounted || !_popup.entries.contains(entry)) return;
+      // 原地跳转 / 后退 / 前进会在**同一个 entry** 上换词，所以还要核对词没变，
+      // 否则旧词的续查结果会灌进新页。
+      if (!mounted ||
+          !_popup.entries.contains(entry) ||
+          entry.searchTerm != term) {
+        return;
+      }
       _popup.fillResult(
         entry,
         result: result,
@@ -419,6 +426,82 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       if (_popup.entries.contains(entry) && entry.isSearching) {
         entry.isSearching = false;
       }
+    }
+  }
+
+  /// 弹窗内原地跳转（词头 / 交叉引用链接 / 汉字点击）：先裁掉 [index] 之上的子层，
+  /// 查 [query]，**有结果才**把 [item] 当前页压进后退栈、在同一个 WebView 里换成新词
+  /// （Hoshi iOS：`if (count > 0) redirect(count)`，空结果什么都不发生，弹窗不动）。
+  /// 弹窗位置 / 尺寸都不变：selectionRect 保留，外壳高度由新内容的 onContentMetrics
+  /// 再伸缩。
+  ///
+  /// 身份门：查询往返期间本层可能被关掉（`entries.contains`）或已被另一次跳转 /
+  /// 顶层换词换掉内容（`searchTerm` 变了）——迟到的结果一律丢弃，不灌进别的词。
+  /// 查询期间置 [DictionaryPopupEntry.isSearching] 挡住同层 load-more 并发写入。
+  Future<void> navigatePopupInPlace({
+    required int index,
+    required DictionaryPopupEntry item,
+    required String query,
+  }) async {
+    final String trimmed = query.trim();
+    if (trimmed.isEmpty || item.isSearching) return;
+    prunePopupStack(index + 1);
+    // 离开当前页前记下它的滚动位（回来时恢复）；查询开始后再读会读到新内容。
+    final double scrollTop =
+        await item.webViewKey.currentState?.currentScrollTop() ?? 0;
+    if (!mounted || !_popup.entries.contains(item)) return;
+    final String termAtStart = item.searchTerm;
+    item.isSearching = true;
+    try {
+      final DictionarySearchResult result = await appModel.searchDictionary(
+        searchTerm: trimmed,
+        searchWithWildcards: false,
+        overrideMaximumTerms: appModel.maximumTerms,
+      );
+      if (!mounted ||
+          !_popup.entries.contains(item) ||
+          item.searchTerm != termAtStart) {
+        return;
+      }
+      if (result.entries.isEmpty && result.kanjiResults.isEmpty) return;
+      appModel.addToDictionaryHistory(result: result);
+      _popup.navigateInPlace(
+        item,
+        term: trimmed,
+        result: result,
+        allLoaded: !result.truncated,
+        scrollTop: scrollTop,
+      );
+      if (ReaderFushiSource.instance.autoReadOnLookup &&
+          result.entries.isNotEmpty) {
+        final DictionaryEntry entry = result.entries.first;
+        if (entry.word.isNotEmpty) {
+          _autoReadWord(entry.word, entry.reading);
+        }
+      }
+    } finally {
+      // navigateInPlace 成功路径已清 isSearching；失败 / 提前 return 在此兜底复位。
+      if (_popup.entries.contains(item) && item.isSearching) {
+        item.isSearching = false;
+      }
+    }
+  }
+
+  /// 顶栏 ← / →：在 [item] 的原地跳转历史里后退 / 前进一页。先记当前页滚动位（再往
+  /// 回走时恢复），controller 换页后 `notifyListeners` 经 [buildDictionary] 的
+  /// AnimatedBuilder 重建，WebView 按 result 身份重推、渲染完恢复该页滚动位。
+  Future<void> _navigatePopupHistory(
+    DictionaryPopupEntry item, {
+    required bool forward,
+  }) async {
+    if (item.isSearching) return;
+    final double scrollTop =
+        await item.webViewKey.currentState?.currentScrollTop() ?? 0;
+    if (!mounted || !_popup.entries.contains(item)) return;
+    if (forward) {
+      _popup.goForward(item, scrollTop: scrollTop);
+    } else {
+      _popup.goBack(item, scrollTop: scrollTop);
     }
   }
 
@@ -792,6 +875,7 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       screen: screen,
       child: DictionaryPopupLayer(
         result: item.result,
+        restoreScrollTop: item.restoreScrollTop,
         webViewKey: item.webViewKey,
         keepWebViewWarm: item.isWarmSlot,
         // TODO-869：本层有后代弹窗时注入 __hasChildPopup，点卡片本体留白才能关子窗。
@@ -864,42 +948,20 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
             }
           }
         },
-        onLinkClick: (query, localRect) async {
-          final childRect = localRect == Rect.zero
-              ? item.selectionRect
-              : popupWordScreenRect(
-                  webViewKey: item.webViewKey,
-                  localRect: localRect,
-                  fallback: item.selectionRect,
-                  coordinateSpaceKey: _popupCoordinateSpaceKey,
-                );
-          prunePopupStack(index + 1);
-          // TODO-1190: symmetric with onTextSelected above — mark the clicked
-          // headword/link target in this parent card after the child search
-          // (it previously highlighted only on plain-text selection, so a
-          // headword/kanji-tag tap left the source word unmarked).
-          final count = await searchDictionaryResult(
-            searchTerm: query,
-            selectionRect: childRect,
-          );
-          if (count > 0) {
-            // BUG-2054：与 onTextSelected 对称（含两道身份门）。
-            final int generation = activeLookupGeneration;
-            final Rect? wordRect =
-                await item.webViewKey.currentState?.highlightSelection(count);
-            if (mounted && generation == activeLookupGeneration) {
-              reanchorNestedPopupToWord(
-                controller: _popup,
-                parentWebViewKey: item.webViewKey,
-                parentIndex: index,
-                expectedTerm: query,
-                wordLocalRect: wordRect,
-                fallback: childRect,
-                coordinateSpaceKey: _popupCoordinateSpaceKey,
-              );
-            }
-          }
-        },
+        // 词头 / 交叉引用链接 / 汉字（onLinkClick 通道）：**原地跳转**而不是叠一层
+        // 子弹窗——对齐 Hoshi Reader iOS（`lookupRedirect` → `redirect(count)`：
+        // 同一个 WebView 换内容，← → 在历史页间来回）。释义正文点词（onTextSelected）
+        // 仍叠子层，也与 Hoshi 一致（那边 `textSelected` 走 `popups.append`）。
+        onLinkClick: (query, localRect) =>
+            navigatePopupInPlace(index: index, item: item, query: query),
+        historyNav: item.hasNavigationHistory
+            ? DictionaryPopupHistoryNav(
+                canGoBack: item.canGoBack,
+                canGoForward: item.canGoForward,
+                onBack: () => _navigatePopupHistory(item, forward: false),
+                onForward: () => _navigatePopupHistory(item, forward: true),
+              )
+            : null,
         // TODO-962：弹窗滚到底时若该层结果可能被截断（!allLoaded）就续查下一批词头
         // （与 dictionary_page_mixin / home_dictionary_page 同构），webview 的
         // _pushResults 据 searchTerm 不变 + entries 增多自动判 isLoadMore → 走

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -697,6 +697,9 @@ mixin DictionaryPageMixin {
     required DictionaryPopupController controller,
     required Future<int> Function(String text, Rect selectionRect) onPush,
     required void Function(int index) onPop,
+    // 词头 / 链接 / 汉字点击原地跳转时是否自动朗读首词条（视频页传 true，与其嵌套
+    // 查词的 autoRead 同口径；其余宿主默认 false）。
+    bool autoReadOnNavigate = false,
   }) {
     final DictionaryPopupEntry entry = controller.entries[index];
     final Rect pos = _calcMixinPopupPosition(
@@ -726,6 +729,7 @@ mixin DictionaryPageMixin {
       screen: screen,
       child: DictionaryPopupLayer(
         result: entry.result,
+        restoreScrollTop: entry.restoreScrollTop,
         isSearching: entry.isSearching,
         keepWebViewWarm: entry.isWarmSlot,
         webViewKey: entry.webViewKey,
@@ -749,6 +753,24 @@ mixin DictionaryPageMixin {
         onClose: () => onPop(index),
         // TODO-485：嵌套层即便禁用滑动关闭，也有显式返回父层入口。
         onBack: null,
+        // 弹窗内原地跳转历史（词头 / 链接 / 汉字点击）：跳过才画 ← →。mixin 家族不
+        // 监听 controller，换页后自己 setState 重建。
+        historyNav: entry.hasNavigationHistory
+            ? DictionaryPopupHistoryNav(
+                canGoBack: entry.canGoBack,
+                canGoForward: entry.canGoForward,
+                onBack: () => navigatePopupHistory(
+                  controller: controller,
+                  entry: entry,
+                  forward: false,
+                ),
+                onForward: () => navigatePopupHistory(
+                  controller: controller,
+                  entry: entry,
+                  forward: true,
+                ),
+              )
+            : null,
         // Phase B：app 内弹窗右下角尺寸拖拽把手（video/首页/texthooker 共用此收口）。
         // 拖动 = 可视化改「最大宽高」偏好（与设置滑杆同一真值）；预览态在 mixin 级。
         showResizeGrip: true,
@@ -842,35 +864,17 @@ mixin DictionaryPageMixin {
             }
           }
         },
-        onLinkClick: (query, localRect) async {
-          final Rect childRect = localRect == Rect.zero
-              ? entry.selectionRect
-              : popupWordScreenRect(
-                  webViewKey: entry.webViewKey,
-                  localRect: localRect,
-                  fallback: entry.selectionRect,
-                );
-          setState(() => controller.truncateTo(index + 1));
-          // TODO-1190: symmetric with onTextSelected — highlight the clicked
-          // headword/link target in this parent card after the child search.
-          final int count = await onPush(query, childRect);
-          if (count > 0) {
-            // BUG-2054：与 onTextSelected 对称——点词头/链接同样按整词 bbox 重锚子层。
-            final Rect? wordRect =
-                await entry.webViewKey.currentState?.highlightSelection(count);
-            if (mounted &&
-                reanchorNestedPopupToWord(
-                  controller: controller,
-                  parentWebViewKey: entry.webViewKey,
-                  parentIndex: index,
-                  expectedTerm: query,
-                  wordLocalRect: wordRect,
-                  fallback: childRect,
-                )) {
-              setState(() {});
-            }
-          }
-        },
+        // 词头 / 交叉引用链接 / 汉字（onLinkClick 通道）：**原地跳转**而不是叠一层
+        // 子弹窗——对齐 Hoshi Reader iOS（`lookupRedirect` → `redirect(count)`：
+        // 同一个 WebView 换内容，← → 在历史页间来回）。释义正文点词（onTextSelected）
+        // 仍叠子层，也与 Hoshi 一致（那边 `textSelected` 走 `popups.append`）。
+        onLinkClick: (query, localRect) => navigatePopupInPlace(
+          controller: controller,
+          index: index,
+          entry: entry,
+          query: query,
+          autoRead: autoReadOnNavigate,
+        ),
         onMineEntry: onMineEntry,
         onUpdateEntry: onUpdateEntry,
         onDuplicateCheck: checkDuplicate,
@@ -1101,15 +1105,19 @@ mixin DictionaryPageMixin {
     // BUG-1478：按词头递增（见 base_source_page 同处注释）。
     final int current = entry.result!.headwordCount;
     final int newMax = current + mixinAppModel.maximumTerms;
+    final String term = entry.searchTerm;
     setState(() => entry.isSearching = true);
     try {
       final DictionarySearchResult result =
           await mixinAppModel.searchDictionary(
-        searchTerm: entry.searchTerm,
+        searchTerm: term,
         searchWithWildcards: true,
         overrideMaximumTerms: newMax,
       );
-      if (mounted && controller.entries.contains(entry)) {
+      // 原地跳转 / 后退 / 前进会在同一个 entry 上换词：词变了就丢弃这批续查结果。
+      if (mounted &&
+          controller.entries.contains(entry) &&
+          entry.searchTerm == term) {
         setState(() => controller.fillResult(
               entry,
               result: result,
@@ -1133,6 +1141,96 @@ mixin DictionaryPageMixin {
   /// TODO-834：关闭第 [index] 层**衍生的所有后代层**（index 更大的全部），保留本层
   /// + 祖先。线性扁平栈里 index 即 depth、无分叉，故后代 = `index+1..end`，用
   /// [DictionaryPopupController.truncateTo] 精确裁。点最顶层（无后代）= no-op 栈不变。
+  /// 弹窗内原地跳转（词头 / 交叉引用链接 / 汉字点击）：先裁掉 [index] 之上的子层，
+  /// 查 [query]，**有结果才**把 [entry] 当前页压进后退栈、在同一个 WebView 里换成
+  /// 新词（Hoshi iOS：`if (count > 0) redirect(count)`，空结果什么都不发生，弹窗
+  /// 不动）。弹窗位置 / 尺寸都不变：selectionRect 保留，外壳高度由新内容的
+  /// onContentMetrics 再伸缩。与 [BaseSourcePageState.navigatePopupInPlace] 同语义
+  /// （mixin 家族不监听 controller，换页后显式 setState）。
+  ///
+  /// 身份门：查询往返期间本层可能被关掉（`entries.contains`）或已被另一次跳转 /
+  /// 顶层换词换掉内容（`searchTerm` 变了）——迟到的结果一律丢弃。查询期间置
+  /// [DictionaryPopupEntry.isSearching] 挡住同层 load-more 并发写入。
+  Future<void> navigatePopupInPlace({
+    required DictionaryPopupController controller,
+    required int index,
+    required DictionaryPopupEntry entry,
+    required String query,
+    bool autoRead = false,
+  }) async {
+    final String trimmed = query.trim();
+    if (trimmed.isEmpty || entry.isSearching) return;
+    if (controller.entries.length > index + 1) {
+      setState(() => controller.truncateTo(index + 1));
+    }
+    // 离开当前页前记下它的滚动位（回来时恢复）；查询开始后再读会读到新内容。
+    final double scrollTop =
+        await entry.webViewKey.currentState?.currentScrollTop() ?? 0;
+    if (!mounted || !controller.entries.contains(entry)) return;
+    final String termAtStart = entry.searchTerm;
+    entry.isSearching = true;
+    try {
+      final DictionarySearchResult result =
+          await mixinAppModel.searchDictionary(
+        searchTerm: trimmed,
+        searchWithWildcards: true,
+        overrideMaximumTerms: mixinAppModel.maximumTerms,
+      );
+      if (!mounted ||
+          !controller.entries.contains(entry) ||
+          entry.searchTerm != termAtStart) {
+        return;
+      }
+      if (result.entries.isEmpty && result.kanjiResults.isEmpty) return;
+      mixinAppModel.addToSearchHistory(
+        historyKey: DictionaryMediaType.instance.uniqueKey,
+        searchTerm: trimmed,
+      );
+      mixinAppModel.addToDictionaryHistory(result: result);
+      setState(() {
+        controller.navigateInPlace(
+          entry,
+          term: trimmed,
+          result: result,
+          allLoaded: !result.truncated,
+          scrollTop: scrollTop,
+        );
+      });
+      if (autoRead &&
+          ReaderFushiSource.instance.autoReadOnLookup &&
+          result.entries.isNotEmpty) {
+        final DictionaryEntry first = result.entries.first;
+        if (first.word.isNotEmpty) {
+          autoReadWord(first.word, first.reading,
+              popupState: entry.webViewKey.currentState);
+        }
+      }
+    } finally {
+      // navigateInPlace 成功路径已清 isSearching；失败 / 提前 return 在此兜底复位。
+      if (mounted && controller.entries.contains(entry) && entry.isSearching) {
+        setState(() => entry.isSearching = false);
+      }
+    }
+  }
+
+  /// 顶栏 ← / →：在 [entry] 的原地跳转历史里后退 / 前进一页。先记当前页滚动位
+  /// （再往回走时恢复），换页后 setState 重建：WebView 按 result 身份重推、渲染完
+  /// 恢复该页滚动位。
+  Future<void> navigatePopupHistory({
+    required DictionaryPopupController controller,
+    required DictionaryPopupEntry entry,
+    required bool forward,
+  }) async {
+    if (entry.isSearching) return;
+    final double scrollTop =
+        await entry.webViewKey.currentState?.currentScrollTop() ?? 0;
+    if (!mounted || !controller.entries.contains(entry)) return;
+    final bool moved = forward
+        ? controller.goForward(entry, scrollTop: scrollTop)
+        : controller.goBack(entry, scrollTop: scrollTop);
+    if (moved) setState(() {});
+  }
+
   /// 与基类 [BaseSourcePageState] 的同名 helper 同语义（mixin 路径不监听 controller，
   /// 故显式 setState 重建）。
   void _dismissDescendantsOfLayer(

--- a/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_controller.dart
@@ -21,6 +21,32 @@ import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
 final DictionarySearchResult kPopupSearchingPlaceholderResult =
     DictionarySearchResult(searchTerm: '');
 
+/// 弹窗**原地跳转**历史里的一页（对齐 Hoshi Reader iOS `popup.js` 的
+/// `backStack/forwardStack` 快照：条目 + 滚动位）。
+///
+/// 点弹窗内的词头 / 交叉引用链接 / 汉字（`onLinkClick` 通道）不再叠一层子弹窗，
+/// 而是把本层正在显示的这一页存进后退栈、在**同一个** WebView 里换成新词；顶栏
+/// ← → 在栈间来回。Hoshi 存的是渲染好的 DOM 节点，这里存 Dart 侧真值
+/// （[result]）：Dart 才是 `entry.result` / load-more / 面包屑 / 制卡上下文的
+/// 事实源，JS 单独换 DOM 会让这些全部指向旧词。回到某页 = 重推该页 result（同一
+/// 对象身份 ⇒ `didUpdateWidget` 全量 renderPopup）+ 渲染完把滚动位恢复到
+/// [scrollTop]。
+class DictionaryPopupHistoryPage {
+  const DictionaryPopupHistoryPage({
+    required this.searchTerm,
+    required this.result,
+    required this.allLoaded,
+    required this.scrollTop,
+  });
+
+  final String searchTerm;
+  final DictionarySearchResult? result;
+  final bool allLoaded;
+
+  /// 离开该页时弹窗内容的 `scrollTop`（CSS px，WebView 局部）；回来时恢复。
+  final double scrollTop;
+}
+
 /// 统一的查词弹窗条目（合并旧 `_PopupStackItem`（base_source_page）与
 /// `NestedPopupEntry`（dictionary_page_mixin）两份近乎重复的类型）。
 class DictionaryPopupEntry {
@@ -57,6 +83,25 @@ class DictionaryPopupEntry {
   /// BUG-1651：本层按 DOM 内容测量得到的外壳总高度（Flutter 逻辑像素）。null 表示
   /// 尚未测量，先按用户最大高度布局；每次新顶层查词重置，增量结果则在当前高度上伸缩。
   double? autoFitHeight;
+
+  /// 原地跳转的后退 / 前进栈（栈顶在末尾）。只由 [DictionaryPopupController]
+  /// 写；随本层一起消亡（关层 / 热槽复位 / 顶层新查词都清空，不跨查词会话）。
+  final List<DictionaryPopupHistoryPage> _backHistory =
+      <DictionaryPopupHistoryPage>[];
+  final List<DictionaryPopupHistoryPage> _forwardHistory =
+      <DictionaryPopupHistoryPage>[];
+
+  bool get canGoBack => _backHistory.isNotEmpty;
+  bool get canGoForward => _forwardHistory.isNotEmpty;
+
+  /// 本层发生过原地跳转（任一方向还有页可去）。宿主据此决定顶栏是否画 ← →：
+  /// 与 Hoshi iOS 默认（`popupActionBar=false`）同——没跳过就不占顶栏。
+  bool get hasNavigationHistory => canGoBack || canGoForward;
+
+  /// 下一次推本层 result 渲染完成后要恢复到的 `scrollTop`；null = 归零（新词从
+  /// 顶部开始）。只有后退 / 前进回到历史页时非空，由 [DictionaryPopupWebView]
+  /// 经 `window.__fushiPendingScrollTop` 交给 popup.js 在渲染尾批应用。
+  double? restoreScrollTop;
 
   /// 仅常驻热槽为 true：其 WebView 全程挂载复用，关栈时隐藏而非销毁。
   final bool isWarmSlot;
@@ -298,6 +343,15 @@ class DictionaryPopupController extends ChangeNotifier {
       ..isSearching = false
       ..allLoaded = false;
     e.autoFitHeight = null;
+    _clearHistory(e);
+  }
+
+  /// 清掉 [e] 的原地跳转历史与待恢复滚动位。所有「本层换成一个新查词会话」的路径
+  /// （复用热槽 / 热槽复位）都要经这里，历史绝不跨会话残留。
+  void _clearHistory(DictionaryPopupEntry e) {
+    e._backHistory.clear();
+    e._forwardHistory.clear();
+    e.restoreScrollTop = null;
   }
 
   /// 顶层查词目标：能复用常驻热槽（首条且 isWarmSlot）就原地复用并丢弃子层；
@@ -328,6 +382,7 @@ class DictionaryPopupController extends ChangeNotifier {
         ..isSearching = true
         ..revealOnRender = false
         ..visible = visible;
+      _clearHistory(e);
     } else {
       if (replaceStack) {
         _retireEntries(_entries);
@@ -418,8 +473,95 @@ class DictionaryPopupController extends ChangeNotifier {
     e
       ..result = result
       ..allLoaded = allLoaded
-      ..isSearching = false;
+      ..isSearching = false
+      // 新结果 / load-more 都从当前滚动位出发；只有历史页回退才带恢复位
+      //（[goBack] / [goForward] 自己设）。
+      ..restoreScrollTop = null;
     notifyListeners();
+  }
+
+  // ── 原地跳转历史（Hoshi Reader iOS 的 backStack/forwardStack）────────────
+
+  DictionaryPopupHistoryPage _snapshot(
+      DictionaryPopupEntry e, double scrollTop) {
+    return DictionaryPopupHistoryPage(
+      searchTerm: e.searchTerm,
+      result: e.result,
+      allLoaded: e.allLoaded,
+      scrollTop: scrollTop,
+    );
+  }
+
+  void _applyPage(
+    DictionaryPopupEntry e,
+    DictionaryPopupHistoryPage page, {
+    required double? restoreScrollTop,
+  }) {
+    e
+      ..searchTerm = page.searchTerm
+      ..result = page.result
+      ..allLoaded = page.allLoaded
+      ..isSearching = false
+      ..restoreScrollTop = restoreScrollTop;
+    // 弹窗不动：selectionRect / autoFitHeight 都保留。高度由新内容的
+    // onContentMetrics 再伸缩，先重置会让外壳先跳到最大高再收回来。
+  }
+
+  /// 本层原地跳到 [term]：当前页（连同离开时的 [scrollTop]）压入后退栈、前进栈
+  /// 清空（与浏览器 / Hoshi 同语义），本层换成 [result]。宿主已经查完才调——空
+  /// 结果不跳（Hoshi：`if (count > 0) redirect(count)`），所以这里不存在
+  /// 「搜索期」中间态，`isSearching` 由宿主自己在查询期间置位。
+  ///
+  /// [e] 已不在栈内（查询期间被关掉 / 顶层换词）→ no-op，返回 false。
+  bool navigateInPlace(
+    DictionaryPopupEntry e, {
+    required String term,
+    required DictionarySearchResult result,
+    required bool allLoaded,
+    required double scrollTop,
+  }) {
+    if (!_entries.contains(e)) return false;
+    onLookupStarted?.call();
+    e._backHistory.add(_snapshot(e, scrollTop));
+    e._forwardHistory.clear();
+    _applyPage(
+      e,
+      DictionaryPopupHistoryPage(
+        searchTerm: term,
+        result: result,
+        allLoaded: allLoaded,
+        scrollTop: 0,
+      ),
+      restoreScrollTop: null,
+    );
+    notifyListeners();
+    _notifyLookupStackDepth();
+    return true;
+  }
+
+  /// 后退一页；[scrollTop] 是当前页离开时的滚动位（进前进栈，再前进时恢复）。
+  bool goBack(DictionaryPopupEntry e, {required double scrollTop}) =>
+      _navigate(e,
+          from: e._backHistory, to: e._forwardHistory, scrollTop: scrollTop);
+
+  /// 前进一页；[scrollTop] 同 [goBack]。
+  bool goForward(DictionaryPopupEntry e, {required double scrollTop}) =>
+      _navigate(e,
+          from: e._forwardHistory, to: e._backHistory, scrollTop: scrollTop);
+
+  bool _navigate(
+    DictionaryPopupEntry e, {
+    required List<DictionaryPopupHistoryPage> from,
+    required List<DictionaryPopupHistoryPage> to,
+    required double scrollTop,
+  }) {
+    if (!_entries.contains(e) || from.isEmpty) return false;
+    to.add(_snapshot(e, scrollTop));
+    final DictionaryPopupHistoryPage page = from.removeLast();
+    _applyPage(e, page, restoreScrollTop: page.scrollTop);
+    notifyListeners();
+    _notifyLookupStackDepth();
+    return true;
   }
 
   /// 显示 [e]（搜索→就绪才显示路径在 [fillResult] 后调用）。

--- a/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -611,6 +611,25 @@ bool reanchorNestedPopupToWord({
 // dictionary_popup_controller.dart，经文件头 export 在此可用（_buildBody 的
 // `result ?? kPopupSearchingPlaceholderResult` 兜底与热槽 seed 是同一单例）。
 
+/// 弹窗顶栏「← →」（弹窗内原地跳转历史，对齐 Hoshi Reader iOS `PopupView.actionBar`）
+/// 的接线。宿主只在本层**发生过**原地跳转（[DictionaryPopupEntry.hasNavigationHistory]）
+/// 时传入：与 Hoshi 默认（`popupActionBar=false`）一致——没跳过就不占顶栏。两颗按钮
+/// 总是一起画，不可去的方向置灰（Hoshi：`.disabled` + `opacity(0.3)`），而不是消失，
+/// 否则 ← 一按到底按钮就跳位。
+class DictionaryPopupHistoryNav {
+  const DictionaryPopupHistoryNav({
+    required this.canGoBack,
+    required this.canGoForward,
+    required this.onBack,
+    required this.onForward,
+  });
+
+  final bool canGoBack;
+  final bool canGoForward;
+  final VoidCallback onBack;
+  final VoidCallback onForward;
+}
+
 class DictionaryPopupLayer extends StatelessWidget {
   const DictionaryPopupLayer({
     required this.result,
@@ -652,6 +671,8 @@ class DictionaryPopupLayer extends StatelessWidget {
     this.enableSwipeToClose = true,
     this.onClose,
     this.onBack,
+    this.historyNav,
+    this.restoreScrollTop,
     this.transparentDocumentBackground = false,
     this.showResizeGrip = false,
     this.onResizeStart,
@@ -786,6 +807,15 @@ class DictionaryPopupLayer extends StatelessWidget {
   /// TODO-485：嵌套层左端"返回"按钮的回调。非空时弹窗顶栏渲染一个不依赖滑动
   /// 的返回入口，语义是关闭当前子层并回到父层。
   final VoidCallback? onBack;
+
+  /// 弹窗内原地跳转的 ← → 历史导航（见 [DictionaryPopupHistoryNav]）。null = 不画。
+  /// 与 [onBack] 语义不同：[onBack] 是关掉**一层**弹窗，这里是在**同一层**的历史页
+  /// 间来回。
+  final DictionaryPopupHistoryNav? historyNav;
+
+  /// 透传 [DictionaryPopupWebView.restoreScrollTop]：后退 / 前进回到历史页时该页离开
+  /// 时的滚动位（[DictionaryPopupEntry.restoreScrollTop]）；常态 null。
+  final double? restoreScrollTop;
 
   /// TODO-1065：转发给 [DictionaryPopupWebView] —— 本层属「app 外 / 悬浮字幕」独立
   /// 查词窗（popup_main 宿主）时 true，令弹窗 `<html>` 透明消除整窗泛白（默认 false =
@@ -1085,14 +1115,18 @@ class DictionaryPopupLayer extends StatelessWidget {
   /// 不失效）。header 缺省（app 外覆盖窗）时中段退化成 [Spacer]，行为与旧的「只有 A−/A+ +
   /// 关闭」一致。
   Widget? _buildTopBar(BuildContext context) {
-    if (headerWidget == null && onClose == null && onBack == null) {
+    if (headerWidget == null &&
+        onClose == null &&
+        onBack == null &&
+        historyNav == null) {
       return null;
     }
 
     final String backTooltip =
         MaterialLocalizations.of(context).backButtonTooltip;
+    final DictionaryPopupHistoryNav? nav = historyNav;
 
-    // 左簇：返回（可选）+ A−/A+ 字号按钮（TODO-1353）。定宽，钉在行首。
+    // 左簇：返回（可选）+ 历史 ← →（可选）+ A−/A+ 字号按钮（TODO-1353）。定宽，钉在行首。
     final Widget leftCluster = Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
@@ -1105,6 +1139,28 @@ class DictionaryPopupLayer extends StatelessWidget {
             padding: EdgeInsets.zero,
             onTap: onBack,
           ),
+        if (nav != null) ...<Widget>[
+          FushiIconButton(
+            key: const ValueKey<String>('popup_history_back'),
+            icon: Icons.arrow_back,
+            size: 20,
+            tooltip: t.popup_history_back,
+            constraints: _topActionConstraints,
+            padding: EdgeInsets.zero,
+            enabled: nav.canGoBack,
+            onTap: nav.onBack,
+          ),
+          FushiIconButton(
+            key: const ValueKey<String>('popup_history_forward'),
+            icon: Icons.arrow_forward,
+            size: 20,
+            tooltip: t.popup_history_forward,
+            constraints: _topActionConstraints,
+            padding: EdgeInsets.zero,
+            enabled: nav.canGoForward,
+            onTap: nav.onForward,
+          ),
+        ],
         _buildZoomFontButton(context, zoomIn: false),
         _buildZoomFontButton(context, zoomIn: true),
       ],
@@ -1204,6 +1260,7 @@ class DictionaryPopupLayer extends StatelessWidget {
             key: webViewKey,
             transparentDocumentBackground: transparentDocumentBackground,
             result: result ?? kPopupSearchingPlaceholderResult,
+            restoreScrollTop: restoreScrollTop,
             hasChildPopup: hasChildPopup,
             onTapOutside: onTapOutside,
             onTextSelected: onTextSelected,

--- a/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -205,9 +205,18 @@ class DictionaryPopupWebView extends ConsumerStatefulWidget {
     this.inputSpec = const DictionaryPopupInputSpec(),
     this.onHostInputToken,
     this.nudgeSurfaceOnRender = false,
+    this.restoreScrollTop,
   });
 
   final DictionarySearchResult result;
+
+  /// 弹窗内原地跳转（[DictionaryPopupEntry.restoreScrollTop]）：后退 / 前进回到历史
+  /// 页时，[result] 渲染完成后要恢复到的 `scrollTop`（CSS px）。null（新词 / load-more
+  /// / 常态）= 每次全量渲染照旧从顶部开始。只在 [_pushResults] 推全量渲染的那一刻读
+  /// 一次，交给 popup.js 的 `window.__fushiPendingScrollTop`，由渲染管线在内容够高时
+  /// 应用（尾批渲染完兜底应用一次）——Dart 侧渲染后直接 scrollTo 不可靠：内容分批
+  /// 进 DOM，首发 popupRendered 时文档往往还不够高，滚不到目标位。
+  final double? restoreScrollTop;
 
   /// TODO-869：本层弹窗是否有子（后代）弹窗。注入 `window.__hasChildPopup`，让
   /// popup.js 在点卡片本体留白时据此决定是否发 `tapOutside`（有子层才关后代，叶子层
@@ -977,6 +986,30 @@ JSON.stringify((function(){
     );
   }
 
+  /// 弹窗内容当前的 `scrollTop`（CSS px）。原地跳转 / 后退 / 前进前由宿主读一次，
+  /// 存进被离开那一页的历史快照（[DictionaryPopupHistoryPage.scrollTop]）。WebView
+  /// 未就绪 / 通道已废 / 返回值非数 → null，调用方按 0 处理（回来时停在顶部，只是
+  /// 少恢复一次滚动位，绝不打断跳转）。
+  Future<double?> currentScrollTop() async {
+    final InAppWebViewController? controller = _controller;
+    if (controller == null) return null;
+    try {
+      final Object? raw = await controller.evaluateJavascript(
+        source: '(document.scrollingElement || document.documentElement)'
+            '.scrollTop',
+      );
+      if (raw is num) return raw.toDouble();
+      if (raw is String) return double.tryParse(raw);
+      return null;
+    } catch (e, stack) {
+      // 与 highlightSelection 同理：半销毁的 WebView 通道已摘，evaluateJavascript
+      // 抛 MissingPluginException；滚动位是锦上添花，吞掉记日志即可。
+      ErrorLogService.instance
+          .log('DictPopupWebview.currentScrollTop', e, stack);
+      return null;
+    }
+  }
+
   /// 手柄右摇杆：连续滚动弹窗内容 [dy] CSS 像素（正=向下）。
   Future<void> scrollContentBy(double dy) async {
     await _controller?.evaluateJavascript(
@@ -1219,10 +1252,14 @@ JSON.stringify((function(){
     final bool popupInstantScroll = appModel.popupInstantScroll;
 
     final bool needsScrollCheck = widget.onScrolledToBottom != null;
+    // 原地跳转回到历史页：渲染管线在内容够高 / 尾批完成时把滚动位恢复到该页离开时
+    // 的位置（popup.js `__fushiApplyPendingScrollTop`）。其余全量渲染 0 = 不恢复。
+    final double pendingScrollTop = widget.restoreScrollTop ?? 0;
     final String beforeRenderJs = isLoadMore
         ? 'window.updatePopupIncremental();'
         : '''
           window.__fushiResetPopupScroll();
+          window.__fushiPendingScrollTop = ${pendingScrollTop.toStringAsFixed(1)};
           // BUG-297 / TODO-393：换词复用常驻热槽 WebView 时只重注入 lookupEntries 不重载
           // 页面，popup.js 句子上下文镜像标量（sentenceCtxPrev/Next）不会自动归零。宿主
           // 已在换词处清空草稿（reader/video 的 _miningDraft.clear()），这里同步把 JS 镜像

--- a/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/fushi/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -228,6 +228,43 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
     popNestedPopupAt(index, _popup);
   }
 
+  /// 弹窗内原地跳转（词头 / 链接 / 汉字）。跳成功后搜索栏跟着显示当前词——此前嵌套
+  /// 层走 [_pushSearch] 时搜索栏也是随下钻词走的，保持这一观感。
+  Future<void> _navigateInPlace(
+    int index,
+    DictionaryPopupEntry entry,
+    String query,
+  ) async {
+    await navigatePopupInPlace(
+      controller: _popup,
+      index: index,
+      entry: entry,
+      query: query,
+      autoRead: true,
+    );
+    _syncSearchBarToEntry(entry);
+  }
+
+  Future<void> _navigateHistory(
+    DictionaryPopupEntry entry, {
+    required bool forward,
+  }) async {
+    await navigatePopupHistory(
+      controller: _popup,
+      entry: entry,
+      forward: forward,
+    );
+    _syncSearchBarToEntry(entry);
+  }
+
+  void _syncSearchBarToEntry(DictionaryPopupEntry entry) {
+    if (!mounted || !_popup.entries.contains(entry)) return;
+    final String term = entry.searchTerm;
+    if (term.isEmpty || _searchController.text == term) return;
+    _searchController.text = term;
+    _searchController.selection = TextSelection.collapsed(offset: term.length);
+  }
+
   Future<void> _close() async {
     if (_isClosing) return;
     _isClosing = true;
@@ -514,6 +551,7 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       // documentElement 不透明填充铺满整窗的泛白（in-app 与桌面 global-lookup 不受影响）。
       transparentDocumentBackground: true,
       result: entry.result,
+      restoreScrollTop: entry.restoreScrollTop,
       isSearching: entry.isSearching,
       // TODO-951 症状C：常驻热槽（isWarmSlot）的 WebView 全程挂载、冷加载一次后复用，
       // 消除「每次查词重建弹窗 WebView 露白屏一瞬」。与 reader/video/首页查词同口径。
@@ -531,6 +569,15 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       onDismiss: isBase ? _close : () => _popAt(index),
       onClose: isBase ? null : () => _popAt(index),
       onBack: null,
+      // 弹窗内原地跳转历史（词头 / 链接 / 汉字点击）：跳过才画 ← →。
+      historyNav: entry.hasNavigationHistory
+          ? DictionaryPopupHistoryNav(
+              canGoBack: entry.canGoBack,
+              canGoForward: entry.canGoForward,
+              onBack: () => _navigateHistory(entry, forward: false),
+              onForward: () => _navigateHistory(entry, forward: true),
+            )
+          : null,
       onRendered: () {
         if (_popup.revealRendered(entry) && mounted) setState(() {});
       },
@@ -548,12 +595,10 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
         }
         _pushSearch(text, localRect);
       },
-      onLinkClick: (query, localRect) {
-        if (_popup.entries.length > index + 1) {
-          setState(() => _popup.truncateTo(index + 1));
-        }
-        _pushSearch(query, localRect);
-      },
+      // 词头 / 交叉引用链接 / 汉字（onLinkClick 通道）：**原地跳转**而不是叠一层
+      // 满卡子层——对齐 Hoshi Reader iOS（同一个 WebView 换内容，← → 在历史页间
+      // 来回）。释义正文点词（onTextSelected）仍叠子层。
+      onLinkClick: (query, localRect) => _navigateInPlace(index, entry, query),
       onMineEntry: onMineEntry,
       onUpdateEntry: onUpdateEntry,
       onDuplicateCheck: checkDuplicate,

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -4736,6 +4736,8 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
         );
       },
       onPop: _popNestedPopupAt,
+      // 词头 / 链接 / 汉字点击原地跳转也自动朗读，与上面嵌套查词的 autoRead 同口径。
+      autoReadOnNavigate: true,
     );
   }
 

--- a/fushi/test/lookup/lookup_word_highlight_surfaces_guard_test.dart
+++ b/fushi/test/lookup/lookup_word_highlight_surfaces_guard_test.dart
@@ -6,15 +6,21 @@ import '../helpers/source_guard.dart';
 
 /// TODO-1190 守卫：查词弹窗「高亮被查词」补齐所有缺失面（源码扫描，不依赖真机）。
 ///
-/// 在词头/链接/纯文本被点开子查词后，父卡片必须像 base_source_page 阅读器车道一样
+/// 在纯文本被点开子查词后，父卡片必须像 base_source_page 阅读器车道一样
 /// 用 `highlightSelection` 标出被查的源词（CSS Custom Highlights）。此前三处缺口：
-///   1. mixin 车道（video / 首页 / texthooker）的 onTextSelected/onLinkClick 只
+///   1. mixin 车道（video / 首页 / texthooker）的 onTextSelected 只
 ///      truncate + onPush，未高亮父卡片；
 ///   2. base_source_page 阅读器车道的 onLinkClick 只 push、未与 onTextSelected 对称
 ///      高亮；
 ///   3. app 外全局查词嵌套（global_lookup_controller._lookupNested）无任何高亮。
 /// 守住这三处不被回退（app 外根查词源词在别的窗口/悬浮字幕、非可控 webview，
 /// 无法高亮，属已知边界，不在守卫范围）。
+///
+/// 2026-09（弹窗内原地跳转，对齐 Hoshi Reader iOS）：词头 / 链接 / 汉字的
+/// `onLinkClick` 通道不再叠子层，而是在**同一个** WebView 里换词——父卡片本身被
+/// 替换，「高亮父卡片里被点的词」在这条通道上不再成立。第 2 条的对称高亮随之退役，
+/// 改守「onLinkClick 走 navigatePopupInPlace、不再回退成 push 子层 + 高亮」。
+/// onTextSelected（释义正文点词）仍叠子层、仍高亮，与 Hoshi 一致。
 void main() {
   // flutter test 的 cwd 是 hibiki 包根。
   final File mixin = File(
@@ -25,23 +31,33 @@ void main() {
   final File render = File('lib/src/lookup/global_lookup_render.dart');
 
   group('TODO-1190 查词高亮补缺失面守卫', () {
-    test('mixin 车道 onTextSelected + onLinkClick 都高亮父卡片', () {
+    test('mixin 车道 onTextSelected 高亮父卡片；onLinkClick 原地跳转不叠层', () {
       final String src = mixin.readAsStringSync();
-      // 两处（选文/点链）都必须 await onPush 拿匹配长度并 highlightSelection。
+      // 选文必须 await onPush 拿匹配长度并 highlightSelection。
       final int occurrences = 'highlightSelection(count)'
           .allMatches(src)
           .length;
       expect(
         occurrences,
-        greaterThanOrEqualTo(2),
-        reason:
-            'mixin onTextSelected/onLinkClick 未各自 highlightSelection(count)',
+        greaterThanOrEqualTo(1),
+        reason: 'mixin onTextSelected 未 highlightSelection(count)',
       );
       expect(
         src.contains('final int count = await onPush('),
         isTrue,
         reason: 'mixin 未 await onPush 取匹配字数用于高亮',
       );
+      final int link = src.indexOf('onLinkClick: (query, localRect) =>');
+      expect(link, greaterThanOrEqualTo(0),
+          reason: 'mixin onLinkClick 必须是原地跳转（=> navigatePopupInPlace）');
+      final String linkBody = src.substring(
+        link,
+        src.indexOf('onMineEntry:', link),
+      );
+      expect(linkBody.contains('navigatePopupInPlace('), isTrue,
+          reason: 'mixin onLinkClick 未走 navigatePopupInPlace');
+      expect(linkBody.contains('onPush('), isFalse,
+          reason: 'mixin onLinkClick 不得再 push 子层（回退成叠层）');
       // onPush 必须返回匹配字数（Future<int>），否则拿不到 count。
       expect(
         src.contains(
@@ -62,30 +78,33 @@ void main() {
       );
     });
 
-    test('阅读器车道 onLinkClick 与 onTextSelected 对称高亮', () {
+    test('阅读器车道 onTextSelected 高亮父卡片；onLinkClick 原地跳转不叠层', () {
       final String src = base.readAsStringSync();
-      final int idx = src.indexOf('onLinkClick: (query, localRect) async {');
+      final int text = src.indexOf('onTextSelected: (text, localRect) async {');
+      expect(text, greaterThanOrEqualTo(0),
+          reason: 'base_source_page 缺 onTextSelected');
+      final int idx = src.indexOf('onLinkClick: (query, localRect) =>', text);
       expect(
         idx,
         greaterThanOrEqualTo(0),
-        reason: 'base_source_page 缺 onLinkClick',
+        reason: 'base_source_page 缺原地跳转形态的 onLinkClick',
       );
-      // onLinkClick 之后必须有 highlightSelection（与 onTextSelected 对称）。
-      //
-      // 定界用**下一个回调的起点**，不用固定字符数：BUG-2054 往这个回调里加了两道
-      // 身份门后，原来的 1000 字符窗口就把 highlightSelection 挤了出去（判据的语义
-      // 没变，只是被推远）。把数字调大是削弱——真正的边界是「还在 onLinkClick 这一
-      // 段里」，语义定界既不会随段落长度漂移，也不会漏进隔壁回调。
+      // 定界用**下一个回调的起点**，不用固定字符数（BUG-2054 的教训）。
+      final String textBody = src.substring(text, idx);
+      expect(
+        textBody.contains('item.webViewKey.currentState?.highlightSelection('),
+        isTrue,
+        reason: 'reader onTextSelected 未高亮点中的源词',
+      );
       final int nextCallback = src.indexOf('onScrolledToBottom', idx);
-      final String after = src.substring(
+      final String linkBody = src.substring(
         idx,
         nextCallback > idx ? nextCallback : src.length,
       );
-      expect(
-        after.contains('item.webViewKey.currentState?.highlightSelection('),
-        isTrue,
-        reason: 'reader onLinkClick 未对称高亮点中的词头/链接',
-      );
+      expect(linkBody.contains('navigatePopupInPlace('), isTrue,
+          reason: 'reader onLinkClick 未走 navigatePopupInPlace');
+      expect(linkBody.contains('searchDictionaryResult('), isFalse,
+          reason: 'reader onLinkClick 不得再 push 子层（回退成叠层）');
     });
 
     test('app 外全局查词嵌套高亮父 iframe', () {

--- a/fushi/test/pages/dictionary_popup_controller_test.dart
+++ b/fushi/test/pages/dictionary_popup_controller_test.dart
@@ -693,4 +693,174 @@ void main() {
       expect(identical(again.webViewKey, child.webViewKey), true);
     });
   });
+
+  group('弹窗内原地跳转历史（Hoshi iOS backStack/forwardStack 对齐）', () {
+    DictionarySearchResult resultFor(String term) =>
+        DictionarySearchResult(searchTerm: term);
+
+    DictionaryPopupEntry visibleTop(DictionaryPopupController c, String term) {
+      final DictionaryPopupEntry e = c.beginTop(
+        term: term,
+        rect: const Rect.fromLTWH(10, 20, 30, 40),
+        reuseWarmSlot: true,
+        replaceStack: false,
+        visible: true,
+      );
+      c.fillResult(e, result: resultFor(term), allLoaded: true);
+      return e;
+    }
+
+    test('navigateInPlace：同一 entry 换词，当前页入后退栈、前进栈清空、弹窗不动', () {
+      final c = DictionaryPopupController(lowMemory: false)..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, '足');
+      final DictionarySearchResult first = e.result!;
+      expect(e.hasNavigationHistory, false, reason: '没跳过不画 ← →');
+
+      int notified = 0;
+      c.addListener(() => notified++);
+      final bool ok = c.navigateInPlace(
+        e,
+        term: '揚げ足を取る',
+        result: resultFor('揚げ足を取る'),
+        allLoaded: false,
+        scrollTop: 120,
+      );
+      expect(ok, true);
+      expect(notified, 1);
+      expect(c.entries.length, 1, reason: '不叠子层，仍是同一层');
+      expect(identical(c.entries.single, e), true);
+      expect(e.searchTerm, '揚げ足を取る');
+      expect(e.allLoaded, false);
+      expect(e.isSearching, false);
+      expect(e.visible, true);
+      expect(e.selectionRect, const Rect.fromLTWH(10, 20, 30, 40),
+          reason: '弹窗锚点不变');
+      expect(e.restoreScrollTop, isNull, reason: '新词从顶部开始');
+      expect(e.canGoBack, true);
+      expect(e.canGoForward, false);
+      expect(e.hasNavigationHistory, true);
+
+      // 后退：回到「足」并带回离开时的滚动位；当前页进前进栈。
+      expect(c.goBack(e, scrollTop: 33), true);
+      expect(e.searchTerm, '足');
+      expect(identical(e.result, first), true,
+          reason: '回退用缓存的同一 result 对象（WebView 按身份重推）');
+      expect(e.allLoaded, true);
+      expect(e.restoreScrollTop, 120);
+      expect(e.canGoBack, false);
+      expect(e.canGoForward, true);
+
+      // 前进：回到「揚げ足を取る」，恢复的是刚才离开它时的 33。
+      expect(c.goForward(e, scrollTop: 0), true);
+      expect(e.searchTerm, '揚げ足を取る');
+      expect(e.restoreScrollTop, 33);
+      expect(e.canGoForward, false);
+
+      // 栈底 / 栈顶再走：no-op、不通知。
+      final int before = notified;
+      expect(c.goForward(e, scrollTop: 0), false);
+      expect(notified, before);
+    });
+
+    test('后退后再原地跳转：前进栈被清空（与浏览器 / Hoshi 同语义）', () {
+      final c = DictionaryPopupController(lowMemory: false)..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: true, scrollTop: 0);
+      c.navigateInPlace(e,
+          term: 'c', result: resultFor('c'), allLoaded: true, scrollTop: 0);
+      c.goBack(e, scrollTop: 0);
+      c.goBack(e, scrollTop: 0);
+      expect(e.searchTerm, 'a');
+      expect(e.canGoForward, true);
+      c.navigateInPlace(e,
+          term: 'd', result: resultFor('d'), allLoaded: true, scrollTop: 0);
+      expect(e.canGoForward, false);
+      expect(c.goBack(e, scrollTop: 0), true);
+      expect(e.searchTerm, 'a');
+    });
+
+    test('fillResult（load-more）清掉 restoreScrollTop，不把历史页滚动位带进增量渲染', () {
+      final c = DictionaryPopupController(lowMemory: false)..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: false, scrollTop: 50);
+      c.goBack(e, scrollTop: 0);
+      expect(e.restoreScrollTop, 50);
+      c.fillResult(e, result: resultFor('a'), allLoaded: true);
+      expect(e.restoreScrollTop, isNull);
+      expect(e.canGoForward, true, reason: 'load-more 不动历史');
+    });
+
+    test('历史不跨查词会话：复用热槽 / 关栈复位都清空', () {
+      final c = DictionaryPopupController(lowMemory: false)..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: true, scrollTop: 0);
+      expect(e.hasNavigationHistory, true);
+
+      // 顶层新查词复用热槽：同一 entry，历史必须归零。
+      final DictionaryPopupEntry again = c.beginTop(
+        term: 'x',
+        rect: Rect.zero,
+        reuseWarmSlot: true,
+        replaceStack: false,
+        visible: true,
+      );
+      expect(identical(again, e), true);
+      expect(e.hasNavigationHistory, false);
+      expect(e.restoreScrollTop, isNull);
+
+      c.navigateInPlace(e,
+          term: 'y', result: resultFor('y'), allLoaded: true, scrollTop: 0);
+      c.dismissAt(0);
+      expect(c.entries.single.isWarmSlot, true);
+      expect(c.entries.single.hasNavigationHistory, false,
+          reason: '热槽复位（_restoreWarmSeed）连历史一起清');
+    });
+
+    test('不在栈内的 entry：navigateInPlace / goBack 都 no-op', () {
+      final c = DictionaryPopupController(lowMemory: false)..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: true, scrollTop: 0);
+      c.clear();
+      expect(
+          c.navigateInPlace(e,
+              term: 'c', result: resultFor('c'), allLoaded: true, scrollTop: 0),
+          false);
+      expect(c.goBack(e, scrollTop: 0), false);
+      expect(e.searchTerm, 'b', reason: '离栈 entry 内容不再被改');
+    });
+
+    test('每次原地跳转算一次查词（onLookupStarted）；后退 / 前进不算', () {
+      int started = 0;
+      final c = DictionaryPopupController(lowMemory: false);
+      c.onLookupStarted = () => started++;
+      c.seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      expect(started, 1);
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: true, scrollTop: 0);
+      expect(started, 2);
+      c.goBack(e, scrollTop: 0);
+      c.goForward(e, scrollTop: 0);
+      expect(started, 2);
+    });
+
+    test('面包屑：原地跳转 / 后退后栈顶词跟着变，深度仍是 1', () {
+      final List<(int, String?)> seen = <(int, String?)>[];
+      final c = DictionaryPopupController(
+        lowMemory: false,
+        onLookupStackDepthChanged: (int d, String? t) => seen.add((d, t)),
+      )..seedWarmSlot();
+      final DictionaryPopupEntry e = visibleTop(c, 'a');
+      seen.clear();
+      c.navigateInPlace(e,
+          term: 'b', result: resultFor('b'), allLoaded: true, scrollTop: 0);
+      expect(seen.last, (1, 'b'));
+      c.goBack(e, scrollTop: 0);
+      expect(seen.last, (1, 'a'));
+    });
+  });
 }

--- a/fushi/test/pages/dictionary_popup_inplace_navigation_test.dart
+++ b/fushi/test/pages/dictionary_popup_inplace_navigation_test.dart
@@ -1,0 +1,227 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi/src/utils/components/fushi_icon_button.dart';
+
+import '../widgets/widget_test_helpers.dart';
+
+/// 查词弹窗「原地跳转 + ← → 历史」（对齐 Hoshi Reader iOS：点词头 / 交叉引用链接 /
+/// 汉字在同一个 WebView 里换词，顶栏 ← → 在历史页间来回；释义正文点词仍叠子层）。
+///
+/// 三层：
+/// ① 顶栏 widget 行为：传 [DictionaryPopupHistoryNav] 才画两颗按钮、不可去的方向置灰
+///    不消失、点按回调接线正确；不传 = 顶栏与从前一模一样。
+/// ② 宿主接线源码守卫：三个建层宿主（书内 / mixin 家族 / 安卓独立查词窗）的
+///    `onLinkClick` 都走 `navigatePopupInPlace`（不再 push 子层），都把 `historyNav` /
+///    `restoreScrollTop` 传进 [DictionaryPopupLayer]；load-more 续查带词身份门。
+/// ③ 滚动位恢复链路守卫：Dart 侧把 `restoreScrollTop` 注进 `__fushiPendingScrollTop`，
+///    popup.js 在首发 / 尾批切片 / 尾批完成三处应用；三份 popup.js 镜像逐字节一致。
+/// 控制器纯逻辑（后退 / 前进栈）在 dictionary_popup_controller_test.dart。
+void main() {
+  Future<void> pumpLayer(
+    WidgetTester tester, {
+    DictionaryPopupHistoryNav? historyNav,
+  }) async {
+    await tester.pumpWidget(
+      buildTestApp(
+        SizedBox(
+          width: 360,
+          height: 240,
+          child: DictionaryPopupLayer(
+            result: null,
+            isSearching: false,
+            webViewKey: GlobalKey<DictionaryPopupWebViewState>(),
+            historyNav: historyNav,
+            onClose: () {},
+            onDismiss: () {},
+            onTextSelected: (text, rect) {},
+            onLinkClick: (query, rect) {},
+            onMineEntry: (fields) async => const MinePopupResult(),
+            onDuplicateCheck: (expression, reading) async => false,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  FushiIconButton navButton(WidgetTester tester, String key) {
+    final Finder f = find.byKey(ValueKey<String>(key));
+    expect(f, findsOneWidget, reason: '顶栏必须有 $key');
+    return tester.widget<FushiIconButton>(f);
+  }
+
+  testWidgets('不传 historyNav：顶栏没有 ← →（没跳过就不占顶栏，与 Hoshi 默认一致）',
+      (WidgetTester tester) async {
+    await pumpLayer(tester);
+    expect(
+        find.byKey(const ValueKey<String>('popup_history_back')), findsNothing);
+    expect(find.byKey(const ValueKey<String>('popup_history_forward')),
+        findsNothing);
+    expect(find.byIcon(Icons.text_decrease), findsOneWidget,
+        reason: 'A−/A+ 与关闭照旧');
+    expect(find.byIcon(Icons.close), findsOneWidget);
+  });
+
+  testWidgets('传 historyNav：两颗按钮都画；不可去的方向置灰而不是消失', (WidgetTester tester) async {
+    int backs = 0;
+    int forwards = 0;
+    await pumpLayer(
+      tester,
+      historyNav: DictionaryPopupHistoryNav(
+        canGoBack: true,
+        canGoForward: false,
+        onBack: () => backs++,
+        onForward: () => forwards++,
+      ),
+    );
+    final FushiIconButton back = navButton(tester, 'popup_history_back');
+    final FushiIconButton forward = navButton(tester, 'popup_history_forward');
+    expect(back.enabled, true);
+    expect(forward.enabled, false, reason: '栈顶没有前进页：按钮仍在（位置不跳），只是置灰');
+    expect(back.icon, Icons.arrow_back);
+    expect(forward.icon, Icons.arrow_forward);
+
+    // 顺序：← → 在 A− 左边（左簇行首），关闭仍在最右。
+    final double backX = tester
+        .getRect(find.byKey(const ValueKey<String>('popup_history_back')))
+        .left;
+    final double forwardX = tester
+        .getRect(find.byKey(const ValueKey<String>('popup_history_forward')))
+        .left;
+    final double zoomOutX =
+        tester.getRect(find.byIcon(Icons.text_decrease)).left;
+    final double closeX = tester.getRect(find.byIcon(Icons.close)).left;
+    expect(backX, lessThan(forwardX));
+    expect(forwardX, lessThan(zoomOutX));
+    expect(zoomOutX, lessThan(closeX));
+
+    await tester.tap(find.byKey(const ValueKey<String>('popup_history_back')));
+    await tester.pump();
+    expect(backs, 1);
+    await tester
+        .tap(find.byKey(const ValueKey<String>('popup_history_forward')));
+    await tester.pump();
+    expect(forwards, 0, reason: '置灰的方向点了不触发');
+  });
+
+  group('宿主接线源码守卫', () {
+    // 本机 autocrlf 检出是 CRLF，CI 是 LF：统一成 LF 再找块边界。
+    String read(String path) =>
+        File(path).readAsStringSync().replaceAll('\r\n', '\n');
+
+    test('三个建层宿主：onLinkClick 原地跳转，historyNav / restoreScrollTop 传进层', () {
+      const Map<String, String> hosts = <String, String>{
+        '书内 base_source_page': 'lib/src/pages/base_source_page.dart',
+        'mixin 家族 dictionary_page_mixin':
+            'lib/src/pages/implementations/dictionary_page_mixin.dart',
+        '安卓独立查词窗 popup_dictionary_page':
+            'lib/src/pages/implementations/popup_dictionary_page.dart',
+      };
+      hosts.forEach((String name, String path) {
+        final String src = read(path);
+        final RegExp linkClick =
+            RegExp(r'onLinkClick:\s*\(query, localRect\)\s*=>\s*[\s\S]{0,120}?'
+                r'navigat\w*InPlace\(');
+        expect(linkClick.hasMatch(src), isTrue,
+            reason: '$name 的 onLinkClick 必须原地跳转（不再 push 子层）');
+        expect(
+            src.contains('historyNav: entry.hasNavigationHistory') ||
+                src.contains('historyNav: item.hasNavigationHistory'),
+            isTrue,
+            reason: '$name 必须按 hasNavigationHistory 把 ← → 传进层');
+        expect(
+            src.contains('restoreScrollTop: entry.restoreScrollTop') ||
+                src.contains('restoreScrollTop: item.restoreScrollTop'),
+            isTrue,
+            reason: '$name 必须把待恢复滚动位透传进层');
+      });
+    });
+
+    test('原地跳转：空结果不跳、迟到结果按词身份丢弃（两份 navigatePopupInPlace）', () {
+      for (final String path in <String>[
+        'lib/src/pages/base_source_page.dart',
+        'lib/src/pages/implementations/dictionary_page_mixin.dart',
+      ]) {
+        final String src = read(path);
+        final int start = src.indexOf('Future<void> navigatePopupInPlace(');
+        expect(start, isNonNegative, reason: '$path 缺 navigatePopupInPlace');
+        final int end = src.indexOf('\n  }\n', start);
+        final String fn = src.substring(start, end);
+        expect(
+            fn.contains(
+                'result.entries.isEmpty && result.kanjiResults.isEmpty'),
+            isTrue,
+            reason: '$path：空结果不跳（Hoshi：count > 0 才 redirect）');
+        expect(fn.contains('searchTerm != termAtStart'), isTrue,
+            reason: '$path：往返期间本层已换词的迟到结果必须丢弃');
+        expect(fn.contains('currentScrollTop()'), isTrue,
+            reason: '$path：离开当前页前必须记滚动位');
+        expect(fn.contains('.navigateInPlace('), isTrue);
+      }
+    });
+
+    test('load-more 续查带词身份门（同一 entry 会被原地换词）', () {
+      final String base = read('lib/src/pages/base_source_page.dart');
+      final int s1 = base.indexOf('Future<void> loadMoreForLayer(');
+      final String f1 = base.substring(s1, base.indexOf('\n  }\n', s1));
+      expect(f1.contains('entry.searchTerm != term'), isTrue,
+          reason: 'base_source_page.loadMoreForLayer 必须核对词未变');
+
+      final String mixin =
+          read('lib/src/pages/implementations/dictionary_page_mixin.dart');
+      final int s2 = mixin.indexOf('Future<void> loadMoreForEntry(');
+      final String f2 = mixin.substring(s2, mixin.indexOf('\n  }\n', s2));
+      expect(f2.contains('entry.searchTerm == term'), isTrue,
+          reason: 'mixin.loadMoreForEntry 必须核对词未变');
+    });
+  });
+
+  group('滚动位恢复链路', () {
+    test('Dart 全量渲染前注入 __fushiPendingScrollTop（load-more 增量不注）', () {
+      final String src = File(
+        'lib/src/pages/implementations/dictionary_popup_webview.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      final int start = src.indexOf('void _pushResults()');
+      final String fn = src.substring(start, src.indexOf('\n  }\n', start));
+      expect(fn.contains('widget.restoreScrollTop ?? 0'), isTrue);
+      final int incremental = fn.indexOf('window.updatePopupIncremental();');
+      final int pending = fn.indexOf('window.__fushiPendingScrollTop =');
+      final int reset = fn.indexOf('window.__fushiResetPopupScroll();');
+      expect(incremental, isNonNegative);
+      expect(pending, greaterThan(reset),
+          reason: '先归零再写 pending，pending 才是渲染后的最终落点');
+      expect(pending, greaterThan(incremental),
+          reason: 'pending 只在全量渲染分支（增量追加保持当前滚动位）');
+    });
+
+    test('popup.js：首发 / 尾批切片 / 尾批完成三处应用 pending，三份镜像一致', () {
+      String readJs(String path) =>
+          File(path).readAsStringSync().replaceAll('\r\n', '\n');
+      final String js = readJs('assets/popup/popup.js');
+      expect(js.contains('function __fushiApplyPendingScrollTop(isFinal)'),
+          isTrue);
+      final int fire = js.indexOf('function _firePopupRendered(');
+      final String fireFn = js.substring(fire, js.indexOf('\n}\n', fire));
+      expect(fireFn.contains('__fushiApplyPendingScrollTop(!stillRendering)'),
+          isTrue,
+          reason: '首发（仍在渲染 → 够高才滚）与尾批完成（final → 兜底必滚）');
+      final int tail =
+          js.indexOf('scheduleRenderTail(renderNextDictionaryBlock);');
+      final String beforeTail = js.substring(tail - 200, tail);
+      expect(beforeTail.contains('__fushiApplyPendingScrollTop(false)'), isTrue,
+          reason: '每个尾批切片后试一次：内容一够高就恢复，不等全部渲完');
+
+      for (final String mirror in <String>[
+        'assets/browser_extension/vendor/popup.js',
+        '../tools/browser-extension/vendor/popup.js',
+      ]) {
+        expect(readJs(mirror), js,
+            reason: '$mirror 必须与 assets/popup/popup.js 逐字节一致');
+      }
+    });
+  });
+}

--- a/fushi/test/pages/nested_lookup_word_anchor_test.dart
+++ b/fushi/test/pages/nested_lookup_word_anchor_test.dart
@@ -292,7 +292,11 @@ void main() {
     });
   });
 
-  group('BUG-2054 源码守卫：四条嵌套车道都不得再丢弃 highlightSelection 的 bbox', () {
+  // 2026-09 弹窗内原地跳转（对齐 Hoshi Reader iOS）后，onLinkClick 通道不再叠子层
+  // （同一 WebView 换词，无子层可重锚），四条车道收成两条：只剩两家宿主的
+  // onTextSelected。计数从 ≥2 改成 ≥1，其余判据不变。
+  group('BUG-2054 源码守卫：嵌套（onTextSelected）车道都不得再丢弃 highlightSelection 的 bbox',
+      () {
     // flutter test 的 cwd 是 fushi 包根。
     final File webview = File(
       'lib/src/pages/implementations/dictionary_popup_webview.dart',
@@ -321,51 +325,51 @@ void main() {
       );
     });
 
-    test('mixin 车道两个回调都取回 bbox 并重锚子层', () {
+    test('mixin 车道 onTextSelected 取回 bbox 并重锚子层', () {
       final String src = mixin.readAsStringSync();
       expect(
         'await entry.webViewKey.currentState?.highlightSelection(count)'
             .allMatches(src)
             .length,
-        greaterThanOrEqualTo(2),
-        reason: 'onTextSelected / onLinkClick 未各自取回整词 bbox',
+        greaterThanOrEqualTo(1),
+        reason: 'onTextSelected 未取回整词 bbox',
       );
       expect(
         'reanchorNestedPopupToWord('.allMatches(src).length,
-        greaterThanOrEqualTo(2),
-        reason: 'mixin 两个回调未各自重锚子层',
+        greaterThanOrEqualTo(1),
+        reason: 'mixin onTextSelected 未重锚子层',
       );
       // 身份门：eval 往返期间同一下标可能已被另一个词的子层占住。
       expect(
         'expectedTerm:'.allMatches(src).length,
-        greaterThanOrEqualTo(2),
+        greaterThanOrEqualTo(1),
         reason: 'mixin 重锚未带身份门 ⇒ 连点时会把上一个词的 bbox 锚到新子层',
       );
     });
 
-    test('阅读器车道两个回调都取回 bbox 并重锚子层', () {
+    test('阅读器车道 onTextSelected 取回 bbox 并重锚子层', () {
       final String src = base.readAsStringSync();
       expect(
         'await item.webViewKey.currentState?.highlightSelection(count)'
             .allMatches(src)
             .length,
-        greaterThanOrEqualTo(2),
-        reason: 'onTextSelected / onLinkClick 未各自取回整词 bbox',
+        greaterThanOrEqualTo(1),
+        reason: 'onTextSelected 未取回整词 bbox',
       );
       expect(
         'reanchorNestedPopupToWord('.allMatches(src).length,
-        greaterThanOrEqualTo(2),
-        reason: 'base_source_page 两个回调未各自重锚子层',
+        greaterThanOrEqualTo(1),
+        reason: 'base_source_page onTextSelected 未重锚子层',
       );
       // 身份门：词形 + BUG-717② 的查词代次快照两道。
       expect(
         'expectedTerm:'.allMatches(src).length,
-        greaterThanOrEqualTo(2),
+        greaterThanOrEqualTo(1),
         reason: 'base 重锚未带词形门 ⇒ 连点时会把上一个词的 bbox 锚到新子层',
       );
       expect(
         'generation == activeLookupGeneration'.allMatches(src).length,
-        greaterThanOrEqualTo(2),
+        greaterThanOrEqualTo(1),
         reason: 'base 重锚未带代次门（BUG-717② 已有的现成守卫）',
       );
     });

--- a/fushi/test/pages/popup_pending_scroll_restore_test.dart
+++ b/fushi/test/pages/popup_pending_scroll_restore_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 弹窗内原地跳转：后退 / 前进回到历史页时的滚动位恢复（Node 真执行 popup.js，
+/// 见同名 .js）。
+///
+/// 守的是 `__fushiApplyPendingScrollTop` 的可观测行为：没有 pending 不动；非 final
+/// 且文档不够高时**不滚、pending 保留**（提前滚会被夹到底、再被后续内容顶回去）；
+/// 够高即滚到位并清零；final 兜底一律应用并清零。Dart 侧 / 三处调用点的接线守卫在
+/// dictionary_popup_inplace_navigation_test.dart。无 node 时 skip（与
+/// popup_render_tail_batching_test.dart 同款约定）。
+void main() {
+  test('popup pending scroll restore (executes popup.js via node)', () async {
+    final String? nodeExe = _resolveNode();
+    if (nodeExe == null) {
+      markTestSkipped('node not found on PATH; skipping JS behavior execution');
+      return;
+    }
+
+    final File jsTest = File('test/pages/popup_pending_scroll_restore_test.js');
+    expect(jsTest.existsSync(), isTrue,
+        reason: 'behavior harness ${jsTest.path} must exist');
+
+    final ProcessResult result = await Process.run(
+      nodeExe,
+      <String>[jsTest.path],
+      workingDirectory: Directory.current.path,
+    );
+
+    expect(
+      result.exitCode,
+      0,
+      reason: 'popup pending-scroll JS behavior test failed.\n'
+          'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+    );
+    expect(result.stdout.toString(), contains('all assertions passed'));
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates =
+      Platform.isWindows ? <String>['node.exe', 'node'] : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) return name;
+    } on ProcessException {
+      // try next candidate
+    }
+  }
+  return null;
+}

--- a/fushi/test/pages/popup_pending_scroll_restore_test.js
+++ b/fushi/test/pages/popup_pending_scroll_restore_test.js
@@ -1,0 +1,68 @@
+// 弹窗内原地跳转：后退 / 前进回到历史页时的滚动位恢复（`__fushiApplyPendingScrollTop`）。
+//
+// Dart 在 renderPopup() 之前把该页离开时的 scrollTop 写进 window.__fushiPendingScrollTop；
+// 内容分批进 DOM，所以 popup.js 在三处应用它：首发 popupRendered（仍在渲染，够高才滚）、
+// 每个尾批切片后（够高才滚）、尾批完成（final，兜底必滚、浏览器自行夹紧）。
+//
+// 用 Node 真执行 popup.js（vm + 极简假 DOM，见 _popup_dom_host.js），直接驱动这个函数：
+//   1. pending = 0 / 负数 → 什么都不动。
+//   2. 非 final 且文档还不够高 → 不滚、pending 保留（等下一片）。
+//   3. 非 final 且够高 → 滚到位、pending 清零（同一份 pending 不会影响下一次渲染）。
+//   4. final 且不够高 → 照样写 scrollTop（浏览器夹紧）、pending 清零。
+//
+// Run: node fushi/test/pages/popup_pending_scroll_restore_test.js
+// (also driven from popup_pending_scroll_restore_test.dart inside `flutter test`).
+
+const assert = require('assert');
+const vm = require('vm');
+const { loadPopup } = require('./_popup_dom_host.js');
+
+function makeScroller(scrollHeight, clientHeight) {
+  return { scrollHeight, clientHeight, scrollTop: 0 };
+}
+
+function run(pending, scroller, isFinal) {
+  const sandbox = loadPopup();
+  sandbox.document.scrollingElement = scroller;
+  sandbox.window.__fushiPendingScrollTop = pending;
+  vm.runInContext(`__fushiApplyPendingScrollTop(${isFinal ? 'true' : 'false'})`, sandbox);
+  return { scrollTop: scroller.scrollTop, pending: sandbox.window.__fushiPendingScrollTop };
+}
+
+// 1. 没有待恢复位：不动。
+{
+  const r = run(0, makeScroller(2000, 400), true);
+  assert.strictEqual(r.scrollTop, 0);
+  assert.strictEqual(r.pending, 0);
+  const neg = run(-5, makeScroller(2000, 400), true);
+  assert.strictEqual(neg.scrollTop, 0);
+}
+
+// 2. 非 final、还不够高：不滚，pending 保留给下一片。
+{
+  const r = run(1200, makeScroller(900, 400), false);
+  assert.strictEqual(r.scrollTop, 0, '文档不够高时提前滚会被夹到底、随后又被后续内容顶回去');
+  assert.strictEqual(r.pending, 1200, 'pending 必须保留，等下一个切片再试');
+}
+
+// 3. 非 final、够高：滚到位并清零。
+{
+  const r = run(1200, makeScroller(2000, 400), false);
+  assert.strictEqual(r.scrollTop, 1200);
+  assert.strictEqual(r.pending, 0, '应用后清零：下一次渲染不得再被这份 pending 影响');
+}
+
+// 4. final 兜底：不够高也写（浏览器夹紧），并清零。
+{
+  const r = run(1200, makeScroller(900, 400), true);
+  assert.strictEqual(r.scrollTop, 1200, 'final 一律应用（真实浏览器会夹到 scrollHeight-clientHeight）');
+  assert.strictEqual(r.pending, 0);
+}
+
+// 5. 装载后初值：popup.js 自己把 pending 初始化为 0（热槽跨查词不带脏值）。
+{
+  const sandbox = loadPopup();
+  assert.strictEqual(sandbox.window.__fushiPendingScrollTop, 0);
+}
+
+console.log('popup_pending_scroll_restore: all assertions passed');

--- a/fushi/test/pages/reader_nested_popup_coordinate_space_test.dart
+++ b/fushi/test/pages/reader_nested_popup_coordinate_space_test.dart
@@ -122,15 +122,17 @@ void main() {
   }
 
   test(
-    'reader text and link callbacks convert initial and whole-word anchors',
+    'reader text callback converts initial and whole-word anchors',
     () {
       final String source = File(
         'lib/src/pages/base_source_page.dart',
       ).readAsStringSync();
       expect(source, contains('key: _popupCoordinateSpaceKey'));
+      // 只剩 onTextSelected 一条嵌套车道（首字符锚 + 整词重锚各一处）：onLinkClick
+      // 通道已改成弹窗内原地跳转（对齐 Hoshi Reader iOS），不再叠子层、不再换算坐标。
       expect(
         'coordinateSpaceKey: _popupCoordinateSpaceKey'.allMatches(source),
-        hasLength(4),
+        hasLength(2),
       );
     },
   );

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -4869,6 +4869,23 @@ function __fushiReportedContentHeight(){
     return Math.ceil(__fushiScrollHeight() * __fushiPopupContentZoom());
 }
 
+// 弹窗内原地跳转（对齐 Hoshi Reader iOS 的 backStack/forwardStack）：后退 / 前进回到
+// 历史页时，Dart 在 renderPopup() 之前把该页离开时的 scrollTop 写进
+// window.__fushiPendingScrollTop（新词 / load-more 写 0 = 不恢复）。内容是分批进
+// DOM 的，首发 popupRendered 时文档往往还不够高、直接 scrollTo 会被夹到底；所以
+// 每个尾批切片后都试一次「够高就恢复」，尾批全部完成（final）时不管够不够高都
+// 应用一次兜底（浏览器自行夹紧）。应用后清零，同一份 pending 绝不影响下一次渲染。
+window.__fushiPendingScrollTop = 0;
+function __fushiApplyPendingScrollTop(isFinal) {
+    const y = window.__fushiPendingScrollTop || 0;
+    if (!(y > 0)) return;
+    const el = document.scrollingElement || document.documentElement;
+    if (!el) return;
+    if (!isFinal && (el.scrollHeight - el.clientHeight) < y) return;
+    el.scrollTop = y;
+    window.__fushiPendingScrollTop = 0;
+}
+
 // 性能（查词时延）：多词条渲染现在**双发**同一 token 的 popupRendered——首词条
 // 同步渲染完（build + 局部 postProcessRuby + applyCustomCSS）立即发第一次，宿主
 // 据此撤盖板/翻可见（首屏可见性只依赖首词条，Dart 侧全部消费方幂等）；尾批词条
@@ -4884,6 +4901,7 @@ function _firePopupRendered(stillRendering) {
         // Its own render signal owns the reveal gate; never let this stale
         // callback reveal the new card early.
         if (generation !== window._renderGeneration) return;
+        __fushiApplyPendingScrollTop(!stillRendering);
         _reportPopupHeight();
         // 词典方框排列：渲染完成后（含首条 + 其余条两次调用）铺 masonry。masonry 在下一帧
         // RAF 里跑，跑完会自行 _reportPopupHeight() 复报修正后的高度。
@@ -5477,6 +5495,8 @@ window.renderPopup = function() {
         } while ((activeEntryElement || nextEntryIndex < entries.length) &&
             performance.now() - sliceStart < TAIL_SLICE_BUDGET_MS);
         if (activeEntryElement || nextEntryIndex < entries.length) {
+            // 历史页回退：内容一够高就把滚动位恢复回去，不等尾批全部完成。
+            __fushiApplyPendingScrollTop(false);
             scheduleRenderTail(renderNextDictionaryBlock);
             return;
         }


### PR DESCRIPTION
## 背景

用户对比 Hoshi Reader：Fushi 的查词弹窗里点词头 / 交叉引用链接 / 汉字一律**叠一层子弹窗**，而 Hoshi（iOS `PopupView.actionBar` + `popup.js` `redirect()`）是在**同一个弹窗里换内容**，顶栏 ← → 在历史页之间来回。本 PR 对齐这一行为。

对齐范围与 Hoshi 一致：

- `onLinkClick` 通道（词头字格 / 结构化内容 `?query=` 链接 / 汉字卡 / MDX 锚点）→ **原地跳转**；
- `onTextSelected` 通道（释义正文点词）→ **仍叠子层**（Hoshi 那边 `textSelected` 也是 `popups.append`）；
- 空结果不跳、弹窗不动（Hoshi：`if (count > 0) redirect(count)`）；
- ← → 只在本层跳过一次之后出现（Hoshi 默认 `popupActionBar=false`），不可去的方向置灰不消失。

## 实现

- **控制器**（`dictionary_popup_controller.dart`）：`DictionaryPopupEntry` 上加后退 / 前进栈（`DictionaryPopupHistoryPage` = 词 + result + allLoaded + 离开时 scrollTop）与 `restoreScrollTop`；`navigateInPlace` / `goBack` / `goForward`；复用热槽 / 热槽复位 / `fillResult` 清历史或待恢复位。Dart 侧 `entry.result` 仍是唯一真值（load-more / 面包屑 / 制卡上下文照旧指向当前页），不像 Hoshi 那样只在 JS 里换 DOM。
- **三个建层宿主**（书内 `base_source_page` / mixin 家族 `dictionary_page_mixin`（视频 / 首页 / texthooker / 悬浮歌词 / web 视频）/ 安卓独立查词窗 `popup_dictionary_page`）：`onLinkClick` 改走 `navigatePopupInPlace`——先裁子层、记当前 scrollTop、查词、有结果才跳；迟到结果按 entry 身份 + 词形丢弃。load-more 续查加词身份门（同一 entry 现在会被换词）。
- **顶栏**（`dictionary_popup_layer.dart`）：左簇加 ← →（`DictionaryPopupHistoryNav`），i18n `popup_history_back/forward`。
- **滚动位恢复**：WebView 新增 `currentScrollTop()`；回到历史页时把该页 scrollTop 经 `window.__fushiPendingScrollTop` 交给 popup.js，在首发 / 每个尾批切片 / 尾批完成三处「够高就滚、final 兜底」应用（三份 popup.js 镜像同步）。

## 测试

- 单测：控制器历史栈（`dictionary_popup_controller_test.dart` 新增 7 条）；顶栏 widget 行为 + 宿主接线 / 滚动链路源码守卫（`dictionary_popup_inplace_navigation_test.dart`）；popup.js 滚动恢复 Node 行为测试（`popup_pending_scroll_restore_test.{dart,js}`）。
- 旧守卫按「onLinkClick 不再叠层」收窄到 onTextSelected 车道：`lookup_word_highlight_surfaces_guard_test` / `nested_lookup_word_anchor_test` / `reader_nested_popup_coordinate_space_test`。
- 真 app：写了 Windows 离屏集成测试 `integration_test/popup_inplace_navigation_itest.dart`——真词典（释义带 `?query=揚げ足` 链接）→ 真 WebView 弹窗 → DOM 点链接走真实 popup.js → 断言栈深仍 1、同一 WebView、词头换成「揚げ足」、← → 出现且 → 置灰 → 触发 ← 回到「足」且 scrollTop 恢复到 ≈300 → → 再前进。**本机没跑成**：Windows 构建卡在 `b11a7e602f`（2026-09-09「四域投递点 + 系统通知后端」）引入的 `flutter_local_notifications_windows` 需要 ATL 头（`atlbase.h`），本机 BuildTools 没装 ATL 组件，与本 PR 无关；需要在带 ATL 的机器上跑一次。
- `flutter analyze` 零问题；弹窗 / 嵌套 / 查词相关定向测试 ~160 个文件全绿。

## 未动 / 已知边界

- app 外 Windows 全局查词窗（`global_lookup_host.js` 的 iframe 嵌套栈）是另一套实现，本 PR 不改。
- 旧的嵌套叠层机制（`pushChild` / 停驻 realm / `hasChildPopup` / `reanchorNestedPopupToWord`）仍被 onTextSelected 通道使用，不删。

https://claude.ai/code/session_01F6YHJsZXQrtxGvUY1bevrT
