### PR TITLE
fix(ios): AnkiMobile 回跳不再被引擎 deep linking 压出第二个 HomePage（BUG-2456）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2265 条。点号进各自文件。
+> 共 2266 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2456](bugs/BUG-2456-ios-ankimobile-callback-deeplink-home-push.md) | ✅ | ✅ | iOS AnkiMobile 回跳被引擎 deep linking 压出第二个 HomePage |
 | [BUG-2455](bugs/BUG-2455-interconnect-video-native-tls-trust.md) | ✅ | ✅ | 互联远端视频打不开：随包 libmpv 换 libcurl 后默认校验自签证书 |
 | [BUG-2454](bugs/BUG-2454-scrape-image-language-ignores-locale.md) | ✅ | ✅ | 刮削图片语言写死中文，不看资料语言偏好 |
 | [BUG-2453](bugs/BUG-2453-synthetic-hover-device-leak.md) | ✅ | ✅ | 视频播放页合成 hover 设备退出后不注销，库页中心卡片被幽灵指针悬停放大 |

--- a/docs/bugs/BUG-2456-ios-ankimobile-callback-deeplink-home-push.md
+++ b/docs/bugs/BUG-2456-ios-ankimobile-callback-deeplink-home-push.md
@@ -1,0 +1,35 @@
+## BUG-2456 · iOS AnkiMobile 回跳被引擎 deep linking 压出第二个 HomePage
+- **报告**：2026-09-11（用户：「ios端刷新牌组和笔记类型 anki同意后跳回fushi后，fushi跳回主页然后也没成功」）
+- **真实性**：✅ 真 bug。**不是**剪贴板链路（BUG-2150 那条），而是同一个 URL 被两条路各处理了一遍：
+  1. 我们自己的路：`fushi/ios/Runner/SceneDelegate.swift:16` `scene(_:openURLContexts:)` → `AppDelegate.deliverUrl`
+     → EventChannel `app.fushi.reader/url_events` → `fushi/lib/main.dart` `handleIncomingUrl` → `_handleAnkiMobileInfoCallback`。这条是对的。
+  2. **引擎自带的路**：`SceneDelegate` 随后 `super.scene(scene, openURLContexts:)` → Flutter 引擎
+     `FlutterPluginSceneLifeCycleDelegate.scene:openURLContexts:`（3.44.0 `FlutterSceneLifeCycle.mm:289`）：没有任何插件消费这条 URL，
+     且 `FlutterSharedApplication.isFlutterDeepLinkingEnabled`（`FlutterSharedApplication.mm:60`：Info.plist 缺 `FlutterDeepLinkingEnabled` 时**缺省 YES**，
+     Flutter ≥ 3.27 行为）→ `sendDeepLinkToFramework:` → `flutter/navigation` `pushRouteInformation`
+     → 框架 `WidgetsApp.didPushRouteInformation`（`packages/flutter/lib/src/widgets/app.dart:1636`）对无 Router 的
+     `MaterialApp(home:, navigatorKey:)` 直接 `navigator.pushNamed(uri.path.isEmpty ? '/' : uri.path)`。
+     `fushi://ankiFetch` 的 path 为空 → `pushNamed('/')` → `home`（`HomePage`）**在制卡设置页上面又压了一份**。
+  用户看到的「跳回主页」就是这份多出来的 HomePage；设置页连同它正在等的结果一起埋在栈底。剪贴板那条并行跑完了也没人看得到，
+  且第二个 HomePage 的整套 init（词典预热、焦点接管、生命周期观察者）与栈底那份并存。`fushi/ios/Runner/Info.plist` 此前没有 `FlutterDeepLinkingEnabled`。
+  `fushi://ankiSuccess`（制卡回跳）与 `fushi://auth/<provider>`（OAuth 回跳）走同一条错路：前者同样复制 home，后者 path 非空会撞 `onUnknownRoute`。
+- **[x] ① 已修复** — 两层，互为双保险：
+  - **Apple 侧官方关法**：`fushi/ios/Runner/Info.plist` 加 `FlutterDeepLinkingEnabled=false`（引擎源码注释原话：「Developers may disable deep linking through their Info.plist if they are using a plugin that handles deeplinking instead」——我们正是自己处理 `fushi://`）。
+  - **框架侧不变式（平台无关）**：新增 `fushi/lib/src/platform/engine_deep_link_route_guard.dart`（`swallowEngineDeepLinkRoute` + `EngineDeepLinkRouteGuard`），
+    `_FushiReaderAppState` 覆写 `didPushRouteInformation` 答 `true`。根 observer 在 `initState` 里 `addObserver` 早于子树 build，
+    `WidgetsBinding._handlePushRouteInformation` 按注册顺序问、第一个答 true 即终止，`WidgetsApp` 永远看不到这条推送。
+    本 app 没有任何命名路由表（无 `routes` / `onGenerateRoute`），引擎推来的任何 route information 都没有合法落点，所以不按 scheme 分流、整层截断；Android 引擎 `onNewIntent` 同样会推送，这层一并盖住。
+    URL 的真正处理仍由各平台通道送进 `handleIncomingUrl`，零改动。
+- **[x] ② 已加自动化测试** — `fushi/test/platform/engine_deep_link_route_guard_test.dart`（6 条）：
+  - **复现**：走**真实的** `flutter/navigation` 平台消息（`defaultBinaryMessenger.handlePlatformMessage` 送 `pushRouteInformation{location:'fushi://ankiFetch'}`），
+    不挂守卫时 `MaterialApp(home:)` 上 `_Home` 变成 2 份、`_Settings` 被压到 offstage——框架自己把这条链演了一遍。
+  - **修复**：与 main.dart 同序（observer 先于 WidgetsApp 注册）挂 `EngineDeepLinkRouteGuard`，同一条消息后栈纹丝不动。
+  - 四种回跳 URL（ankiFetch / ankiSuccess / auth / lookup）都被截断；源码守卫钉住 Info.plist 的 `FlutterDeepLinkingEnabled=false` 与
+    `_FushiReaderAppState` 的「`initState` → `addObserver(this)` → `build`」顺序（注册顺序是这层不变式的前提）。
+  - **变异实测**：把 `swallowEngineDeepLinkRoute` 改成 `return false` → 修复用例红（`Found 0 widgets with type "_Settings"`）+ 四 URL 用例红；还原后 11/11 绿（含相邻 `ankimobile_ios_callback_static_test.dart`）。
+- **备注**：
+  - 与 BUG-2150 的关系：那次修的是「回到前台前读剪贴板必空」（时序）与三态文案；本次修的是 URL 被引擎再推一次导航。两次都在同一条回跳链上，症状不同（那次是错误文案，这次是页面被换掉）。
+  - **真机缺口**：本机没有能跑 AnkiMobile 的 iOS 设备（付费 app、装不进模拟器），「回到原始失败路径复测」没做。已做到的最强验证是让框架真跑一遍
+    `pushRouteInformation` 复现/修复（不是 mock），以及引擎源码（3.44.0 `FlutterSceneLifeCycle.mm` / `FlutterSharedApplication.mm`）逐行核对默认值与调用链。
+    若真机复测后设置页留在栈顶但刷新仍报错，那就是 BUG-2150 三态里的某一条，错误行会直接写明是哪一条。
+  - Android 主 Activity 的 `fushi://auth/<provider>` 有同款隐患（manifest 也没写 `flutter_deeplinking_enabled=false`），本次由 Dart 守卫盖住；弹窗词典 Activity（独立引擎、`fushi://lookup`）不在本次范围。

--- a/fushi/ios/Runner/Info.plist
+++ b/fushi/ios/Runner/Info.plist
@@ -85,6 +85,13 @@
 					</array>
 				</dict>
 			</dict>
+		<!-- BUG-2456：关掉引擎自带的 deep linking（Flutter ≥ 3.27 缺省为开）。
+		     fushi:// 的每一条 URL（AnkiMobile x-callback、OAuth 回跳）都由
+		     SceneDelegate → app.fushi.reader/url_events 通道自己处理，从来不是
+		     Navigator 路由名；引擎若再把它推成 pushRouteInformation，框架会
+		     pushNamed('/') 在当前页面上面再压一个 HomePage（「跳回主页」）。 -->
+		<key>FlutterDeepLinkingEnabled</key>
+		<false/>
 			<key>CFBundleURLTypes</key>
 		<array>
 			<dict>

--- a/fushi/lib/main.dart
+++ b/fushi/lib/main.dart
@@ -66,6 +66,7 @@ import 'package:fushi/src/platform/windows_ime_guard.dart';
 import 'package:fushi/src/platform/platform_providers.dart';
 import 'package:fushi/src/platform/desktop/desktop_lifecycle_service.dart';
 import 'package:fushi/src/platform/ios/ios_url_event_channel.dart';
+import 'package:fushi/src/platform/engine_deep_link_route_guard.dart';
 import 'package:fushi/src/media/audiobook/floating_lyric_lookup_host.dart';
 import 'package:fushi/src/media/manga/aidoku/aidoku_cloudflare_challenge_page.dart';
 import 'package:fushi_engine/media/video/download/video_download_pipeline_service.dart';
@@ -852,6 +853,16 @@ class _FushiReaderAppState extends ConsumerState<FushiReaderApp>
         );
       });
     }
+  }
+
+  /// BUG-2456：引擎默认 deep linking 会把 `fushi://ankiFetch` 这类 x-callback
+  /// 回跳再推成 `pushRouteInformation`，`WidgetsApp` 据此 `pushNamed('/')` 在
+  /// 设置页上面又压一个 HomePage（用户看到「跳回主页」）。本 observer 在
+  /// `WidgetsApp` 之前注册，先答 true 把这条推送截断；真正的 URL 处理仍由各平台
+  /// 通道送进 [handleIncomingUrl]。理由与边界见 [swallowEngineDeepLinkRoute]。
+  @override
+  Future<bool> didPushRouteInformation(RouteInformation routeInformation) async {
+    return swallowEngineDeepLinkRoute(routeInformation);
   }
 
   @override

--- a/fushi/lib/src/platform/engine_deep_link_route_guard.dart
+++ b/fushi/lib/src/platform/engine_deep_link_route_guard.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/widgets.dart';
+
+/// BUG-2456：把引擎自带的 deep-link 路由推送在根部截断。
+///
+/// Flutter ≥ 3.27 默认开启引擎 deep linking：iOS 引擎在
+/// `scene:openURLContexts:` / `scene:willConnectToSession:` 里，把没被任何
+/// 插件消费的 URL 经 `flutter/navigation` 的 `pushRouteInformation` 转给框架；
+/// 框架侧 `WidgetsApp.didPushRouteInformation` 对**没有 Router** 的
+/// `MaterialApp(home:, navigatorKey:)` 直接 `navigator.pushNamed(path)`——
+/// `fushi://ankiFetch` 的 path 为空被补成 `'/'`，于是在当前页面**上面再压一个
+/// 全新的 [home]**。用户在制卡设置页点「刷新牌组」→ AnkiMobile 同意 → 回跳，
+/// 看到的就是「Fushi 跳回主页」；设置页连同它正在等的结果一起被埋在栈底。
+///
+/// Fushi 的每一条 `fushi://` URL（AnkiMobile x-callback、OAuth 回跳、查词深链）
+/// 都由自己的平台通道（iOS `app.fushi.reader/url_events`、Android
+/// `receive_intent`、Windows WM_COPYDATA）送到 `handleIncomingUrl` 处理，
+/// **从来不是导航路由名**；这个 app 也没有任何命名路由表（无 `routes` /
+/// `onGenerateRoute`），所以引擎推来的任何 route information 都没有合法落点：
+/// 空 path 会复制一份 home，非空 path 会撞 `onUnknownRoute`。
+///
+/// 截断方式：根 widget 的 [WidgetsBindingObserver] 在 `WidgetsApp` 之前注册
+/// （`initState` 里 `addObserver` 早于子树 build），`WidgetsBinding` 按注册顺序
+/// 逐个问 [WidgetsBindingObserver.didPushRouteInformation]，第一个答 `true`
+/// 的就终止分发——根观察者在这里答 `true`，`WidgetsApp` 永远看不到这条推送。
+/// 这一层与 iOS `Info.plist` 的 `FlutterDeepLinkingEnabled=false` 互为
+/// 双保险：前者是与平台无关的框架侧不变式（Android 引擎同样会在 `onNewIntent`
+/// 里推送），后者是 Apple 侧的官方关法。
+///
+/// 若将来 app 引入命名路由并希望引擎深链真的走 Navigator，这里必须改成按
+/// scheme 分流，而不是删掉整层。
+bool swallowEngineDeepLinkRoute(RouteInformation routeInformation) {
+  // 有意不看 scheme：见上——本 app 没有任何命名路由，`pushNamed` 没有合法目标。
+  return true;
+}
+
+/// [swallowEngineDeepLinkRoute] 的独立观察者形态，供根 widget 之外的宿主
+/// （测试、弹窗词典等第二 entry point）复用同一条不变式。
+class EngineDeepLinkRouteGuard with WidgetsBindingObserver {
+  @override
+  Future<bool> didPushRouteInformation(
+    RouteInformation routeInformation,
+  ) async {
+    return swallowEngineDeepLinkRoute(routeInformation);
+  }
+}

--- a/fushi/test/platform/engine_deep_link_route_guard_test.dart
+++ b/fushi/test/platform/engine_deep_link_route_guard_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/platform/engine_deep_link_route_guard.dart';
+
+/// BUG-2456：引擎默认 deep linking 把 `fushi://ankiFetch` 推成
+/// `pushRouteInformation`，`WidgetsApp` 对无 Router 的 `MaterialApp(home:)`
+/// 直接 `pushNamed('/')`——在当前页面上面又压一份 home。这里走**真实的**
+/// `flutter/navigation` 平台消息，让框架自己演一遍这条链：不挂守卫时多出一个
+/// home（复现），挂上守卫后栈不动（修复）。
+void main() {
+  const JSONMethodCodec codec = JSONMethodCodec();
+
+  Future<void> pushRouteInformation(WidgetTester tester, String location) {
+    return tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      'flutter/navigation',
+      codec.encodeMethodCall(
+        MethodCall('pushRouteInformation', <String, Object?>{
+          'location': location,
+          'state': null,
+        }),
+      ),
+      (ByteData? _) {},
+    );
+  }
+
+  Widget buildApp(GlobalKey<NavigatorState> navigatorKey) {
+    return MaterialApp(navigatorKey: navigatorKey, home: const _Home());
+  }
+
+  testWidgets('复现：不挂守卫时引擎深链把 home 又压了一份在设置页上面', (WidgetTester tester) async {
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(buildApp(navigatorKey));
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(builder: (_) => const _Settings()),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(_Settings), findsOneWidget);
+
+    await pushRouteInformation(tester, 'fushi://ankiFetch');
+    await tester.pumpAndSettle();
+
+    // 第二份 _Home 出现在栈顶，设置页被埋在下面——这就是用户看到的「跳回主页」。
+    expect(find.byType(_Home), findsOneWidget);
+    expect(find.byType(_Settings, skipOffstage: false), findsOneWidget);
+    expect(find.byType(_Home, skipOffstage: false), findsNWidgets(2));
+  });
+
+  testWidgets('修复：守卫先于 WidgetsApp 注册时，引擎深链不再动导航栈', (WidgetTester tester) async {
+    final EngineDeepLinkRouteGuard guard = EngineDeepLinkRouteGuard();
+    // 与 main.dart 的根 widget 同序：observer 在子树（WidgetsApp）build 之前注册。
+    tester.binding.addObserver(guard);
+    addTearDown(() => tester.binding.removeObserver(guard));
+
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(buildApp(navigatorKey));
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(builder: (_) => const _Settings()),
+    );
+    await tester.pumpAndSettle();
+
+    await pushRouteInformation(tester, 'fushi://ankiFetch');
+    await tester.pumpAndSettle();
+
+    expect(find.byType(_Settings), findsOneWidget);
+    expect(find.byType(_Home, skipOffstage: false), findsOneWidget);
+  });
+
+  test('swallowEngineDeepLinkRoute 对本 app 会收到的每种回跳 URL 都答 true', () {
+    for (final String url in <String>[
+      'fushi://ankiFetch',
+      'fushi://ankiSuccess?expression=%E8%A8%80%E8%91%89',
+      'fushi://auth/onedrive?code=abc',
+      'fushi://lookup?word=%E8%A8%80%E8%91%89',
+    ]) {
+      expect(
+        swallowEngineDeepLinkRoute(RouteInformation(uri: Uri.parse(url))),
+        isTrue,
+        reason: url,
+      );
+    }
+  });
+
+  // 源码守卫：Swift / plist 进不了 flutter test，这层是 iOS 侧唯一可落地的自动化。
+  group('iOS 侧', () {
+    test('Info.plist 显式关掉引擎 deep linking', () {
+      final String plist = File('ios/Runner/Info.plist').readAsStringSync();
+      final RegExp key = RegExp(
+        r'<key>FlutterDeepLinkingEnabled</key>\s*<false\s*/>',
+      );
+      expect(
+        plist,
+        matches(key),
+        reason:
+            'Flutter ≥ 3.27 缺省开启引擎 deep linking；不显式写 false，'
+            'fushi:// 回跳就会被推成 pushRouteInformation → pushNamed("/")',
+      );
+    });
+
+    test('根 widget 的 observer 先于 WidgetsApp 截断 pushRouteInformation', () {
+      final String src = File('lib/main.dart').readAsStringSync();
+      const String anchor = 'class _FushiReaderAppState';
+      final int start = src.indexOf(anchor);
+      expect(start, greaterThan(-1), reason: '锚点漂移，守卫失效');
+      final String body = src.substring(start);
+      expect(body, contains('with WidgetsBindingObserver'));
+      expect(body, contains('Future<bool> didPushRouteInformation('));
+      expect(body, contains('swallowEngineDeepLinkRoute(routeInformation)'));
+      // 注册顺序是这层不变式的前提：observer 必须在 initState 里、build 之前挂上。
+      final int initState = body.indexOf('void initState()');
+      final int addObserver = body.indexOf(
+        'WidgetsBinding.instance.addObserver(this)',
+      );
+      final int build = body.indexOf('Widget build(BuildContext context)');
+      expect(initState, greaterThan(-1));
+      expect(addObserver, greaterThan(initState));
+      expect(build, greaterThan(addObserver));
+    });
+  });
+}
+
+class _Home extends StatelessWidget {
+  const _Home();
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: Text('home'));
+}
+
+class _Settings extends StatelessWidget {
+  const _Settings();
+
+  @override
+  Widget build(BuildContext context) => const Scaffold(body: Text('settings'));
+}


### PR DESCRIPTION
## 症状

iOS 制卡设置页点「刷新牌组和笔记类型」→ AnkiMobile 同意 → 回到 Fushi 后**跳回主页**，刷新结果看不到。

## 根因（不是剪贴板链路）

同一条 `fushi://ankiFetch` 被两条路各处理了一遍：

1. 我们自己的路：`SceneDelegate.scene(_:openURLContexts:)` → `deliverUrl` → `app.fushi.reader/url_events` → `handleIncomingUrl` → `_handleAnkiMobileInfoCallback`。这条是对的。
2. **引擎自带的路**：`super.scene(...)` → 引擎 `FlutterPluginSceneLifeCycleDelegate.scene:openURLContexts:`（3.44.0 `FlutterSceneLifeCycle.mm:289`）：没有插件消费这条 URL，且 Info.plist 缺 `FlutterDeepLinkingEnabled` 时引擎**缺省开启** deep linking（`FlutterSharedApplication.mm:60`，Flutter ≥ 3.27 行为）→ `sendDeepLinkToFramework:` → `flutter/navigation` `pushRouteInformation` → 框架 `WidgetsApp.didPushRouteInformation`（`app.dart:1636`）对无 Router 的 `MaterialApp(home:, navigatorKey:)` 直接 `navigator.pushNamed(path.isEmpty ? '/' : path)` → **在设置页上面又压了一份 `HomePage`**。

`fushi://ankiSuccess` / `fushi://auth/<provider>` 走同一条错路（后者 path 非空还会撞 `onUnknownRoute`）。

## 修复（两层双保险）

- `fushi/ios/Runner/Info.plist`：`FlutterDeepLinkingEnabled=false`——引擎源码注释原话「Developers may disable deep linking through their Info.plist if they are using a plugin that handles deeplinking instead」，我们正是自己处理 `fushi://`。
- `fushi/lib/src/platform/engine_deep_link_route_guard.dart` + `_FushiReaderAppState.didPushRouteInformation` 答 `true`：根 observer 在 `initState` 里注册、早于 `WidgetsApp`，`WidgetsBinding` 按注册顺序问、第一个答 true 即终止。本 app 没有任何命名路由表，引擎推来的 route information 没有合法落点，整层截断（Android `onNewIntent` 同款推送一并盖住）。URL 的真正处理零改动。

## 测试

`fushi/test/platform/engine_deep_link_route_guard_test.dart`（6 条）：
- **复现**：走真实的 `flutter/navigation` 平台消息（`handlePlatformMessage` 送 `pushRouteInformation{location:'fushi://ankiFetch'}`），不挂守卫时 `_Home` 变 2 份、`_Settings` 被压到 offstage——框架自己把这条链演了一遍。
- **修复**：同序挂守卫后栈纹丝不动。
- 四种回跳 URL 都截断；源码守卫钉 plist 键与 observer 注册顺序。
- 变异实测：守卫改 `return false` → 红；还原 → 11/11 绿。

`flutter analyze` 无问题；52 条目录枚举型守卫 368 用例全绿。

## 未做

**真机复测缺口**：本机没有能跑 AnkiMobile 的 iOS 设备（付费 app、装不进模拟器）。已做到的最强验证是让框架真跑一遍 `pushRouteInformation` 复现/修复（非 mock）+ 引擎源码逐行核对默认值与调用链。若真机复测后设置页留在栈顶但刷新仍报错，那就是 BUG-2150 三态里的某一条，错误行会直接写明是哪一条。

Bug 记录：`docs/bugs/BUG-2456-ios-ankimobile-callback-deeplink-home-push.md`

https://claude.ai/code/session_01F5AgCu8aKRBd8G8YMAyJF6
