### PR TITLE
feat(updates): 番剧新集通知带截图 / 发布时间 / 图标，点击直接播放

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 79968 (4704 per locale)
+/// Strings: 80070 (4710 per locale)
 ///
-/// Built on 2026-09-10 at 17:52 UTC
+/// Built on 2026-09-11 at 05:06 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6543,6 +6543,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  String get updates_notification_open_video_episode => 'Play';
+  String get updates_notification_open_manga_chapter => 'Read';
+  String get updates_notification_open_manga_extension => 'Update';
+  String get updates_notification_open_app_release => 'Download';
+  String get updates_notification_view_all => 'View updates';
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -17617,6 +17623,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -28919,6 +28937,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -40275,6 +40305,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -51665,6 +51707,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -62857,6 +62911,18 @@ class _StringsId extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -74142,6 +74208,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -84804,6 +84882,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -95476,6 +95566,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -106717,6 +106819,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -118012,6 +118126,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -129284,6 +129410,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -140355,6 +140493,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -151542,6 +151692,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -162700,6 +162862,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 // Path: <root>
@@ -172937,6 +173111,18 @@ class _StringsZhCn extends _StringsEn {
       '在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。';
   @override
   String get browser_extension_test_page_server_off => '请先开启查词服务器，再打开试用网页。';
+  @override
+  String get updates_notification_open_video_episode => '播放';
+  @override
+  String get updates_notification_open_manga_chapter => '阅读';
+  @override
+  String get updates_notification_open_manga_extension => '更新';
+  @override
+  String get updates_notification_open_app_release => '下载';
+  @override
+  String get updates_notification_view_all => '查看更新';
+  @override
+  String get updates_notification_header => '订阅更新';
 }
 
 // Path: <root>
@@ -183281,6 +183467,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get browser_extension_test_page_server_off =>
       'Enable the lookup server first, then try again.';
+  @override
+  String get updates_notification_open_video_episode => 'Play';
+  @override
+  String get updates_notification_open_manga_chapter => 'Read';
+  @override
+  String get updates_notification_open_manga_extension => 'Update';
+  @override
+  String get updates_notification_open_app_release => 'Download';
+  @override
+  String get updates_notification_view_all => 'View updates';
+  @override
+  String get updates_notification_header => 'Subscription updates';
 }
 
 /// Flat map(s) containing all translations.
@@ -192969,6 +193167,18 @@ extension on _StringsEn {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -202652,6 +202862,18 @@ extension on _StringsAr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -212380,6 +212602,18 @@ extension on _StringsDe {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -222099,6 +222333,18 @@ extension on _StringsEs {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -231827,6 +232073,18 @@ extension on _StringsFr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -241526,6 +241784,18 @@ extension on _StringsId {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -251247,6 +251517,18 @@ extension on _StringsIt {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -260895,6 +261177,18 @@ extension on _StringsJa {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -270547,6 +270841,18 @@ extension on _StringsKo {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -280261,6 +280567,18 @@ extension on _StringsNl {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -289970,6 +290288,18 @@ extension on _StringsPtBr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -299686,6 +300016,18 @@ extension on _StringsRu {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -309374,6 +309716,18 @@ extension on _StringsTh {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -319077,6 +319431,18 @@ extension on _StringsTr {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -328774,6 +329140,18 @@ extension on _StringsVi {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }
@@ -338385,6 +338763,18 @@ extension on _StringsZhCn {
         return '在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。';
       case 'browser_extension_test_page_server_off':
         return '请先开启查词服务器，再打开试用网页。';
+      case 'updates_notification_open_video_episode':
+        return '播放';
+      case 'updates_notification_open_manga_chapter':
+        return '阅读';
+      case 'updates_notification_open_manga_extension':
+        return '更新';
+      case 'updates_notification_open_app_release':
+        return '下载';
+      case 'updates_notification_view_all':
+        return '查看更新';
+      case 'updates_notification_header':
+        return '订阅更新';
       default:
         return null;
     }
@@ -348011,6 +348401,18 @@ extension on _StringsZhHk {
         return 'Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.';
       case 'browser_extension_test_page_server_off':
         return 'Enable the lookup server first, then try again.';
+      case 'updates_notification_open_video_episode':
+        return 'Play';
+      case 'updates_notification_open_manga_chapter':
+        return 'Read';
+      case 'updates_notification_open_manga_extension':
+        return 'Update';
+      case 'updates_notification_open_app_release':
+        return 'Download';
+      case 'updates_notification_view_all':
+        return 'View updates';
+      case 'updates_notification_header':
+        return 'Subscription updates';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "练习句",
   "browser_extension_test_page_action": "打开试用网页",
   "browser_extension_test_page_action_desc": "在浏览器里打开一张由 Fushi 提供的网页，验证右上角弹窗与 Shift 查词。",
-  "browser_extension_test_page_server_off": "请先开启查词服务器，再打开试用网页。"
+  "browser_extension_test_page_server_off": "请先开启查词服务器，再打开试用网页。",
+  "updates_notification_open_video_episode": "播放",
+  "updates_notification_open_manga_chapter": "阅读",
+  "updates_notification_open_manga_extension": "更新",
+  "updates_notification_open_app_release": "下载",
+  "updates_notification_view_all": "查看更新",
+  "updates_notification_header": "订阅更新"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4702,5 +4702,11 @@
   "browser_extension_test_page_sample_label": "Practice sentence",
   "browser_extension_test_page_action": "Open the test page",
   "browser_extension_test_page_action_desc": "Opens a page served by Fushi in your browser to check the toolbar popup and Shift lookup.",
-  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again."
+  "browser_extension_test_page_server_off": "Enable the lookup server first, then try again.",
+  "updates_notification_open_video_episode": "Play",
+  "updates_notification_open_manga_chapter": "Read",
+  "updates_notification_open_manga_extension": "Update",
+  "updates_notification_open_app_release": "Download",
+  "updates_notification_view_all": "View updates",
+  "updates_notification_header": "Subscription updates"
 }

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -1033,6 +1033,9 @@ class AppModel with ChangeNotifier {
   void startUpdateChecks() {
     if (_updateCheckScheduler != null) return;
     final UpdateFeedService feed = updateFeedService;
+    // 通知后端在这里（HomePage 已就绪、navigator 已存在）初始化：点击回调与
+    // 冷启动回放都要有可跳转的 context。
+    unawaited(feed.warmUpNotifier());
     final UpdateCheckScheduler scheduler = UpdateCheckScheduler(
       prefs: prefsRepo,
       isKindEnabled: feed.isKindEnabled,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -14,6 +14,7 @@ import 'package:fushi/src/updates/update_check_scheduler.dart';
 import 'package:fushi_engine/updates/update_feed_kind.dart';
 import 'package:fushi/src/updates/update_feed_service.dart';
 import 'package:fushi/src/updates/update_probes.dart';
+import 'package:fushi/src/pages/implementations/updates_center_open.dart';
 import 'package:fushi/src/updates/update_notifier.dart';
 import 'package:fushi/src/utils/net/app_http_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -925,22 +926,78 @@ class AppModel with ChangeNotifier {
         database: database,
         prefs: prefsRepo,
         notifier: LocalUpdateNotifier.isSupportedPlatform
-            ? LocalUpdateNotifier(appName: 'Fushi')
+            ? LocalUpdateNotifier(
+                appName: 'Fushi',
+                groupTitle: t.updates_notification_header,
+                onResponse: _onUpdateNotificationResponse,
+              )
             : const NoopUpdateNotifier(),
-        notificationText: _localizedUpdateNotificationText,
+        notificationText: localizedUpdateNotificationText,
       );
 
+  /// 用户点了系统通知：本体 / 「打开」→ 那条更新的落点（番剧 = 播放该集）；
+  /// 「查看更新」/ 载荷解不出 / 条目已被清 → 更新中心。先把窗口唤到前台——
+  /// Windows 的 toast 激活只是回调进程，不会替我们把主窗拉起来。
+  Future<void> _onUpdateNotificationResponse(
+    UpdateNotificationResponse response,
+  ) async {
+    await DesktopLookupService.instance.bringMainWindowToFront();
+    final BuildContext? context = navigatorKey.currentContext;
+    if (context == null || !isDatabaseReady) return;
+    final UpdateNotificationPayload? payload =
+        UpdateNotificationPayload.decode(response.payload);
+    final UpdateFeedEntryRow? entry = payload == null ||
+            response.actionId == kUpdateNotificationActionViewAll
+        ? null
+        : await database.getUpdateFeedEntry(payload.entryId);
+    if (!context.mounted) return;
+    if (entry == null) {
+      await openUpdatesCenter(context, updateFeedService);
+      return;
+    }
+    // 与更新中心页同序：先标已读（「点开过」不取决于跳转成败），再跳。
+    await updateFeedService.markSeen(<String>[entry.entryId]);
+    if (!context.mounted) return;
+    await openUpdateFeedEntry(context, entry);
+  }
+
+  /// 「打开落点」按钮的文案，按域。
+  static String _openActionLabel(UpdateFeedKind kind) => switch (kind) {
+        UpdateFeedKind.videoEpisode =>
+          t.updates_notification_open_video_episode,
+        UpdateFeedKind.mangaChapter =>
+          t.updates_notification_open_manga_chapter,
+        UpdateFeedKind.mangaExtension =>
+          t.updates_notification_open_manga_extension,
+        UpdateFeedKind.appRelease => t.updates_notification_open_app_release,
+      };
+
   /// 通知文案的本地化外壳。服务层默认实现只组装结构（那一层要能在纯 Dart 单测里
-  /// 跑，slang 的 `t` 需要 Flutter binding），这里补上句子。
-  static UpdateNotificationText _localizedUpdateNotificationText(
+  /// 跑，slang 的 `t` 需要 Flutter binding），这里补上句子与按钮。
+  ///
+  /// 正文 = 副标题 · 发布时刻（`MM-dd HH:mm`，本地化无关——toast 一行放不下
+  /// 长格式，17 种语言一致）；多条时「第一条 等 N 项」。时刻只在**单条**时进正文：
+  /// 汇总条的时刻属于谁说不清。
+  static UpdateNotificationText localizedUpdateNotificationText(
     UpdateFeedKind kind,
     List<UpdateFeedDraft> fresh,
   ) {
     final UpdateFeedDraft first = fresh.first;
+    final String openLabel = _openActionLabel(kind);
+    final String viewAllLabel = t.updates_notification_view_all;
     if (fresh.length == 1) {
+      final int? publishedAt = first.publishedAt;
+      final String body = <String>[
+        if (first.subtitle case final String subtitle when subtitle.isNotEmpty)
+          subtitle,
+        if (publishedAt != null)
+          _shortMoment(DateTime.fromMillisecondsSinceEpoch(publishedAt)),
+      ].join(' · ');
       return UpdateNotificationText(
         title: first.title,
-        body: first.subtitle ?? '',
+        body: body,
+        openLabel: openLabel,
+        viewAllLabel: viewAllLabel,
       );
     }
     final String firstLine = first.subtitle == null || first.subtitle!.isEmpty
@@ -952,8 +1009,15 @@ class AppModel with ChangeNotifier {
         first: firstLine,
         count: fresh.length - 1,
       ),
+      openLabel: openLabel,
+      viewAllLabel: viewAllLabel,
     );
   }
+
+  /// `MM-dd HH:mm`：[FushiTimeFormat.dayKey] 去掉年份 + [FushiTimeFormat.hourMinute]。
+  static String _shortMoment(DateTime time) =>
+      '${FushiTimeFormat.dayKey(time).substring(5)} '
+      '${FushiTimeFormat.hourMinute(time)}';
 
   UpdateCheckScheduler? _updateCheckScheduler;
 

--- a/fushi/lib/src/pages/implementations/updates_center_open.dart
+++ b/fushi/lib/src/pages/implementations/updates_center_open.dart
@@ -4,30 +4,51 @@
 /// 与它们的装配，塞进页面就等于把四棵依赖树焊进一个本该能独立构建的 widget。
 library;
 
-import 'dart:convert' show jsonDecode;
-
 import 'package:flutter/material.dart';
-import 'package:fushi_core/fushi_core.dart' show UpdateFeedEntryRow;
+import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
+import 'package:fushi_core/fushi_core.dart'
+    show FushiDatabase, UpdateFeedEntryRow;
+import 'package:fushi_engine/media/video/video_book_repository.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:fushi/src/media/manga/library/manga_series_page.dart';
 import 'package:fushi/src/media/manga/mihon/mihon_extensions_page.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/pages/implementations/updates_center_page.dart';
+import 'package:fushi/src/pages/implementations/video_fushi_page.dart';
 import 'package:fushi_engine/updates/update_feed_kind.dart';
+import 'package:fushi/src/updates/update_feed_service.dart';
 import 'package:fushi/utils.dart';
+
+/// 打开更新中心页（首页横幅、系统通知的「查看更新」都落到这里）。
+Future<void> openUpdatesCenter(
+  BuildContext context,
+  UpdateFeedService service,
+) =>
+    Navigator.of(context).push(
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (BuildContext pageContext) => UpdatesCenterPage(
+          service: service,
+          onOpenEntry: (UpdateFeedEntryRow entry) =>
+              openUpdateFeedEntry(pageContext, entry),
+        ),
+      ),
+    );
 
 /// 打开一条更新。
 ///
-/// **视频新集刻意不深链**：合集详情页要 5 个装配正确的回调（打开集、变更回写、
-/// 重刮削、删成员、规格服务），在这里现造一套就会与 `home_video_page` 的那套并存，
-/// 两份装配一漂移就是一类必然的 bug。番剧新集的落点已经有一个更好的：视频首页
-/// 「已更新未看」那一行本来就按订阅算，点开直接播。这里只标已读，不假装能跳。
+/// 番剧新集直接**播放那一集**：走 [VideoFushiPage.neutralized]——与「从 app 外
+/// 打开视频」同一条进程级入口，只要 bookUid + 合集 id，不需要合集详情页那五个
+/// 回调（那套装配只在 `home_video_page` 有一份，这里不复制第二份）。带上
+/// `playlistCollectionId` 播放器就有兄弟集列表、上下集与连播。
 Future<void> openUpdateFeedEntry(
   BuildContext context,
   UpdateFeedEntryRow entry,
 ) async {
   final UpdateFeedKind? kind = UpdateFeedKind.fromDbValue(entry.kind);
   if (kind == null) return;
-  final Map<String, Object?> detail = _decodeDetail(entry.detailJson);
+  final Map<String, Object?> detail = decodeUpdateFeedDetail(entry.detailJson);
   switch (kind) {
     case UpdateFeedKind.mangaChapter:
       final String? bookKey = detail['bookKey'] as String?;
@@ -53,18 +74,24 @@ Future<void> openUpdateFeedEntry(
       if (url == null || url.isEmpty) return;
       await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
     case UpdateFeedKind.videoEpisode:
-      // 见上方注释：不深链。
-      return;
-  }
-}
-
-Map<String, Object?> _decodeDetail(String? json) {
-  if (json == null || json.isEmpty) return const <String, Object?>{};
-  try {
-    final Object? decoded = jsonDecode(json);
-    return decoded is Map<String, Object?> ? decoded : const <String, Object?>{};
-  } on FormatException {
-    // 载荷是本机自己写的，坏掉只可能是版本间格式漂移——那时「打不开」比崩掉好。
-    return const <String, Object?>{};
+      final String? bookUid = detail['bookUid'] as String?;
+      final int? collectionId = detail['collectionId'] as int?;
+      if (bookUid == null || !context.mounted) return;
+      final FushiDatabase database = ProviderScope.containerOf(
+        context,
+        listen: false,
+      ).read(appProvider).database;
+      final VideoBookRepository repo = VideoBookRepository(database);
+      // 那集可能已被用户删掉：不进播放页对着空路径报错，留在列表里。
+      if (await repo.getByBookUid(bookUid) == null || !context.mounted) return;
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => VideoFushiPage.neutralized(
+            bookUid: bookUid,
+            repo: repo,
+            playlistCollectionId: collectionId,
+          ),
+        ),
+      );
   }
 }

--- a/fushi/lib/src/pages/implementations/updates_center_page.dart
+++ b/fushi/lib/src/pages/implementations/updates_center_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show File;
+
 import 'package:flutter/material.dart';
 import 'package:fushi_core/fushi_core.dart' show UpdateFeedEntryRow;
 
@@ -180,23 +182,47 @@ class _UpdateEntryTile extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final UpdateFeedKind? kind = UpdateFeedKind.fromDbValue(entry.kind);
     final bool unseen = entry.seenAt == null;
+    final Map<String, Object?> detail = decodeUpdateFeedDetail(entry.detailJson);
+    // 配图 / 发布时刻是域侧写进 detailJson 的可选投影（番剧域有，其余没有）；
+    // 图文件可能已被封面 GC 收走，不在就退回域图标。
+    final String? imagePath = detail['imagePath'] as String?;
+    final bool hasImage = imagePath != null && File(imagePath).existsSync();
+    final int? publishedAt = detail['publishedAt'] as int?;
+    final String subtitle = <String>[
+      if (entry.subtitle case final String s when s.isNotEmpty) s,
+      if (publishedAt != null)
+        FushiTimeFormat.dateHourMinute(
+          DateTime.fromMillisecondsSinceEpoch(publishedAt),
+        ),
+    ].join(' · ');
     // 走共享的 FushiListItem 而不是裸 ListTile：普通页面外壳的 MD3 决策收口在
     // 组件层（md3_design_system_static_test 守着这条），每页自己拼一遍 ListTile
     // 正是那条守卫要拦的东西。
     return FushiListItem(
-      leading: Icon(
-        kind == null ? Icons.notifications_outlined : updateFeedKindIcon(kind),
-        color: unseen ? theme.colorScheme.primary : theme.colorScheme.outline,
-      ),
+      leading: hasImage
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: Image.file(
+                File(imagePath),
+                width: 64,
+                height: 36,
+                fit: BoxFit.cover,
+              ),
+            )
+          : Icon(
+              kind == null
+                  ? Icons.notifications_outlined
+                  : updateFeedKindIcon(kind),
+              color:
+                  unseen ? theme.colorScheme.primary : theme.colorScheme.outline,
+            ),
       title: Text(
         entry.title,
         style: unseen
             ? theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600)
             : theme.textTheme.bodyLarge,
       ),
-      subtitle: entry.subtitle == null || entry.subtitle!.isEmpty
-          ? null
-          : Text(entry.subtitle!),
+      subtitle: subtitle.isEmpty ? null : Text(subtitle),
       subtitleMaxLines: 1,
       // 未读点：与「加粗 = 未读」同一个事实的第二个可见表征，不靠字重也能分辨。
       trailing: unseen

--- a/fushi/lib/src/pages/implementations/updates_dashboard_banner.dart
+++ b/fushi/lib/src/pages/implementations/updates_dashboard_banner.dart
@@ -51,15 +51,7 @@ class _UpdatesDashboardBannerState extends State<UpdatesDashboardBanner> {
   int get _total => _counts.values.fold<int>(0, (int a, int b) => a + b);
 
   Future<void> _openCenter() async {
-    await Navigator.of(context).push(
-      adaptivePageRoute<void>(
-        context: context,
-        builder: (BuildContext pageContext) => UpdatesCenterPage(
-          service: widget.service,
-          onOpenEntry: (entry) => openUpdateFeedEntry(pageContext, entry),
-        ),
-      ),
-    );
+    await openUpdatesCenter(context, widget.service);
     await _reload();
   }
 

--- a/fushi/lib/src/updates/local_update_notifier.dart
+++ b/fushi/lib/src/updates/local_update_notifier.dart
@@ -4,7 +4,7 @@
 /// 单测里跑完，而这一层一旦被 import 进去，每条测试都要先架 method channel。
 library;
 
-import 'dart:io' show File, Platform;
+import 'dart:io' show Directory, File, Platform;
 
 import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -121,7 +121,26 @@ class LocalUpdateNotifier implements UpdateNotifier {
       );
       _ready = false;
     }
+    if (_ready) await _replayLaunchResponse();
     return _ready;
+  }
+
+  /// 冷启动是被通知拉起来的（Android 进程被杀后点通知）：初始化时回调还没挂
+  /// 上，那次点击只留在 launch details 里，这里补投一次。只在启动期的
+  /// [ensureReady]（`UpdateFeedService.warmUpNotifier`）里走到——时机确定，不会
+  /// 在几小时后第一次发通知时突然回放一次旧点击。
+  Future<void> _replayLaunchResponse() async {
+    if (onResponse == null) return;
+    try {
+      final NotificationAppLaunchDetails? details =
+          await _plugin.getNotificationAppLaunchDetails();
+      final NotificationResponse? response = details?.notificationResponse;
+      if (details?.didNotificationLaunchApp == true && response != null) {
+        _dispatch(response);
+      }
+    } on Object catch (error) {
+      debugPrint('LocalUpdateNotifier: launch details unavailable. $error');
+    }
   }
 
   Future<bool> _initialise() async {
@@ -195,14 +214,17 @@ class LocalUpdateNotifier implements UpdateNotifier {
   Future<void> notify(UpdateNotification notification) async {
     if (!_ready) return;
     try {
+      final DarwinNotificationDetails darwin = await _darwinDetails(
+        notification,
+      );
       await _plugin.show(
         id: notification.id,
         title: notification.title,
         body: notification.body.isEmpty ? null : notification.body,
         notificationDetails: NotificationDetails(
           android: _androidDetails(notification),
-          iOS: _darwinDetails(notification),
-          macOS: _darwinDetails(notification),
+          iOS: darwin,
+          macOS: darwin,
           linux: _linuxDetails(notification),
           windows: _windowsDetails(notification),
         ),
@@ -256,14 +278,44 @@ class LocalUpdateNotifier implements UpdateNotifier {
 
   /// Apple 端：附件即配图；按钮要在初始化时按 category 预先登记文案，而文案
   /// 随语言变、随域变，这里刻意不做——点本体即打开落点，与桌面一致。
-  DarwinNotificationDetails _darwinDetails(UpdateNotification notification) {
-    final String? image = _existingImage(notification);
+  ///
+  /// **附件必须是一份拷贝**：`UNNotificationAttachment` 会把文件**移动**进系统
+  /// 附件存储（只有 bundle 内的资源才是复制）。传来的 [UpdateNotification
+  /// .imagePath] 是这集刚落成的书架封面 / 作品海报，直接挂等于把封面搬走。
+  Future<DarwinNotificationDetails> _darwinDetails(
+    UpdateNotification notification,
+  ) async {
+    String? attachment;
+    if (Platform.isIOS || Platform.isMacOS) {
+      attachment = await _copyForAttachment(_existingImage(notification));
+    }
     return DarwinNotificationDetails(
       presentSound: false,
-      attachments: image == null
+      attachments: attachment == null
           ? null
-          : <DarwinNotificationAttachment>[DarwinNotificationAttachment(image)],
+          : <DarwinNotificationAttachment>[
+              DarwinNotificationAttachment(attachment),
+            ],
     );
+  }
+
+  static Future<String?> _copyForAttachment(String? image) async {
+    if (image == null) return null;
+    try {
+      final Directory dir = Directory(
+        p.join(Directory.systemTemp.path, 'fushi_notification_attachments'),
+      );
+      await dir.create(recursive: true);
+      final String target = p.join(
+        dir.path,
+        '${DateTime.now().microsecondsSinceEpoch}${p.extension(image)}',
+      );
+      await File(image).copy(target);
+      return target;
+    } on Object catch (error) {
+      debugPrint('LocalUpdateNotifier: attachment copy failed. $error');
+      return null;
+    }
   }
 
   LinuxNotificationDetails _linuxDetails(UpdateNotification notification) {

--- a/fushi/lib/src/updates/local_update_notifier.dart
+++ b/fushi/lib/src/updates/local_update_notifier.dart
@@ -4,10 +4,11 @@
 /// 单测里跑完，而这一层一旦被 import 进去，每条测试都要先架 method channel。
 library;
 
-import 'dart:io' show Platform;
+import 'dart:io' show File, Platform;
 
 import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:path/path.dart' as p;
 
 import 'package:fushi/src/updates/update_notifier.dart';
 
@@ -19,16 +20,64 @@ const String kUpdateNotificationChannelId = 'fushi_updates';
 /// 换一个应用身份，已发出的通知与用户的通知设置一起失联。
 const String kWindowsNotificationGuid = '4f6a1c2e-8b3d-4a91-9c27-2d5b8e0f7a13';
 
+/// Windows toast 头部图标：随包 Flutter 资产（构建期已在 `data/flutter_assets`
+/// 下，五端同一张）。不传给插件就没有 `IconUri`，头部只剩文字。
+const String kWindowsNotificationIconAsset = 'assets/meta/icon.png';
+
+/// Windows 按钮参数的封装前缀。插件在 Windows 上把「被点的东西的 arguments」同时
+/// 塞进 `payload` 与 `actionId`——点本体拿到的是 `launch`（= 载荷），点按钮拿到的
+/// 是按钮 `arguments`，本体载荷就丢了。所以按钮参数自带载荷：
+/// `action:<id>|<payload>`，收到后在 [decodeNotificationResponse] 拆开。
+const String kWindowsActionPrefix = 'action:';
+
+/// Windows 按钮的 arguments 编码（与 [decodeNotificationResponse] 互逆）。
+String encodeWindowsActionArguments(String actionId, String? payload) =>
+    '$kWindowsActionPrefix$actionId|${payload ?? ''}';
+
+/// 把插件回传的响应归一成 `(payload, actionId)`：Windows 按钮参数按
+/// [kWindowsActionPrefix] 拆；其它平台的 payload / actionId 本来就分开。
+UpdateNotificationResponse decodeNotificationResponse(
+  NotificationResponse response,
+) {
+  final String? raw = response.payload;
+  if (raw != null && raw.startsWith(kWindowsActionPrefix)) {
+    final int split = raw.indexOf('|');
+    if (split > kWindowsActionPrefix.length) {
+      return UpdateNotificationResponse(
+        payload: raw.substring(split + 1),
+        actionId: raw.substring(kWindowsActionPrefix.length, split),
+      );
+    }
+  }
+  final bool isAction = response.notificationResponseType ==
+      NotificationResponseType.selectedNotificationAction;
+  return UpdateNotificationResponse(
+    payload: raw,
+    actionId: isAction ? response.actionId : null,
+  );
+}
+
 class LocalUpdateNotifier implements UpdateNotifier {
   LocalUpdateNotifier({
     required this.appName,
+    this.groupTitle,
+    this.onResponse,
     FlutterLocalNotificationsPlugin? plugin,
-  }) : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+    String? windowsIconPath,
+  })  : _plugin = plugin ?? FlutterLocalNotificationsPlugin(),
+        _windowsIconPath = windowsIconPath;
 
   /// 通知里显示的应用名 + Windows 的 AUMID 名。
   final String appName;
 
+  /// Windows 通知中心里这组通知的页眉（如「订阅更新」）；null = 不分组。
+  final String? groupTitle;
+
+  /// 用户点了通知（本体或按钮）。null = 只发不收。
+  final void Function(UpdateNotificationResponse response)? onResponse;
+
   final FlutterLocalNotificationsPlugin _plugin;
+  final String? _windowsIconPath;
 
   bool _ready = false;
   bool _initialised = false;
@@ -46,6 +95,15 @@ class LocalUpdateNotifier implements UpdateNotifier {
         Platform.isWindows;
   }
 
+  /// 随包资产在磁盘上的绝对路径：`<exe 目录>/data/flutter_assets/<asset>`。
+  /// 按 exe 定位而不是 cwd——从文件关联 / 开始菜单启动时 cwd 不是安装目录。
+  static String bundledAssetPath(String asset) => p.join(
+        p.dirname(Platform.resolvedExecutable),
+        'data',
+        'flutter_assets',
+        asset,
+      );
+
   @override
   Future<bool> ensureReady() async {
     if (_initialised) return _ready;
@@ -57,14 +115,18 @@ class LocalUpdateNotifier implements UpdateNotifier {
       // 初始化失败（缺渠道权限、Windows 未注册 AUMID、Linux 无 D-Bus 通知服务）
       // 只降级成「不发通知」。更新事件照常投递、红点照常出——把提醒功能整个连坐
       // 掉才是真正的 bug。
-      debugPrint('LocalUpdateNotifier: initialise failed, falling back to '
-          'in-app only. $error');
+      debugPrint(
+        'LocalUpdateNotifier: initialise failed, falling back to '
+        'in-app only. $error',
+      );
       _ready = false;
     }
     return _ready;
   }
 
   Future<bool> _initialise() async {
+    final String iconPath =
+        _windowsIconPath ?? bundledAssetPath(kWindowsNotificationIconAsset);
     final bool? initialised = await _plugin.initialize(
       settings: InitializationSettings(
         android: const AndroidInitializationSettings('@mipmap/ic_launcher'),
@@ -83,11 +145,19 @@ class LocalUpdateNotifier implements UpdateNotifier {
           appName: appName,
           appUserModelId: 'com.hibiki.fushi',
           guid: kWindowsNotificationGuid,
+          // 图标文件不在（开发期从别的 cwd 起、包被裁过）就不传：插件会把不存在
+          // 的路径原样写进注册表，头部反而显示一个坏图。
+          iconPath: File(iconPath).existsSync() ? iconPath : null,
         ),
       ),
+      onDidReceiveNotificationResponse: _dispatch,
     );
     if (initialised == false) return false;
     return _requestPermission();
+  }
+
+  void _dispatch(NotificationResponse response) {
+    onResponse?.call(decodeNotificationResponse(response));
   }
 
   /// 权限申请。三个平台三种口径，返回「现在能不能发」。
@@ -130,25 +200,116 @@ class LocalUpdateNotifier implements UpdateNotifier {
         title: notification.title,
         body: notification.body.isEmpty ? null : notification.body,
         notificationDetails: NotificationDetails(
-          android: AndroidNotificationDetails(
-            kUpdateNotificationChannelId,
-            appName,
-            importance: Importance.defaultImportance,
-            priority: Priority.defaultPriority,
-            // 更新提醒不是即时通讯，不该震动/响铃打断用户。
-            playSound: false,
-            enableVibration: false,
-          ),
-          iOS: const DarwinNotificationDetails(presentSound: false),
-          macOS: const DarwinNotificationDetails(presentSound: false),
-          linux: const LinuxNotificationDetails(),
-          windows: const WindowsNotificationDetails(),
+          android: _androidDetails(notification),
+          iOS: _darwinDetails(notification),
+          macOS: _darwinDetails(notification),
+          linux: _linuxDetails(notification),
+          windows: _windowsDetails(notification),
         ),
         payload: notification.payload,
       );
     } on Object catch (error) {
       debugPrint('LocalUpdateNotifier: show failed. $error');
     }
+  }
+
+  /// 配图文件真的在才挂：抽帧产物可能已被封面 GC 收走，挂个不存在的路径在
+  /// Android 上是整条通知不显示。
+  static String? _existingImage(UpdateNotification notification) {
+    final String? path = notification.imagePath;
+    if (path == null || path.isEmpty) return null;
+    return File(path).existsSync() ? path : null;
+  }
+
+  AndroidNotificationDetails _androidDetails(UpdateNotification notification) {
+    final String? image = _existingImage(notification);
+    return AndroidNotificationDetails(
+      kUpdateNotificationChannelId,
+      appName,
+      importance: Importance.defaultImportance,
+      priority: Priority.defaultPriority,
+      // 更新提醒不是即时通讯，不该震动/响铃打断用户。
+      playSound: false,
+      enableVibration: false,
+      when: notification.timestamp?.millisecondsSinceEpoch,
+      largeIcon: image == null ? null : FilePathAndroidBitmap(image),
+      styleInformation: image == null
+          ? null
+          : BigPictureStyleInformation(
+              FilePathAndroidBitmap(image),
+              // 展开后大图接管，缩略角标隐藏，别一张图出现两次。
+              hideExpandedLargeIcon: true,
+              contentTitle: notification.title,
+              summaryText: notification.body,
+            ),
+      actions: <AndroidNotificationAction>[
+        for (final UpdateNotificationAction action in notification.actions)
+          AndroidNotificationAction(
+            action.id,
+            action.label,
+            showsUserInterface: true,
+            cancelNotification: true,
+          ),
+      ],
+    );
+  }
+
+  /// Apple 端：附件即配图；按钮要在初始化时按 category 预先登记文案，而文案
+  /// 随语言变、随域变，这里刻意不做——点本体即打开落点，与桌面一致。
+  DarwinNotificationDetails _darwinDetails(UpdateNotification notification) {
+    final String? image = _existingImage(notification);
+    return DarwinNotificationDetails(
+      presentSound: false,
+      attachments: image == null
+          ? null
+          : <DarwinNotificationAttachment>[DarwinNotificationAttachment(image)],
+    );
+  }
+
+  LinuxNotificationDetails _linuxDetails(UpdateNotification notification) {
+    final String? image = _existingImage(notification);
+    return LinuxNotificationDetails(
+      icon: image == null ? null : FilePathLinuxIcon(image),
+      suppressSound: true,
+      actions: <LinuxNotificationAction>[
+        for (final UpdateNotificationAction action in notification.actions)
+          LinuxNotificationAction(key: action.id, label: action.label),
+      ],
+    );
+  }
+
+  WindowsNotificationDetails _windowsDetails(UpdateNotification notification) {
+    final String? image = _existingImage(notification);
+    final String? groupTitle = this.groupTitle;
+    return WindowsNotificationDetails(
+      audio: WindowsNotificationAudio.silent(),
+      timestamp: notification.timestamp,
+      header: groupTitle == null
+          ? null
+          : WindowsHeader(
+              id: kUpdateNotificationChannelId,
+              title: groupTitle,
+              arguments: notification.payload ?? '',
+            ),
+      images: <WindowsImage>[
+        if (image != null)
+          WindowsImage(
+            Uri.file(image, windows: true),
+            altText: notification.title,
+            placement: WindowsImagePlacement.hero,
+          ),
+      ],
+      actions: <WindowsAction>[
+        for (final UpdateNotificationAction action in notification.actions)
+          WindowsAction(
+            content: action.label,
+            arguments: encodeWindowsActionArguments(
+              action.id,
+              notification.payload,
+            ),
+          ),
+      ],
+    );
   }
 
   @override

--- a/fushi/lib/src/updates/update_feed_service.dart
+++ b/fushi/lib/src/updates/update_feed_service.dart
@@ -4,6 +4,8 @@
 /// 剩下的事——开关过滤、幂等、系统通知合并、已读——全在这里，各域不再各写一遍。
 library;
 
+import 'dart:convert' show jsonDecode, jsonEncode;
+
 import 'package:drift/drift.dart' show Value;
 import 'package:fushi_core/fushi_core.dart'
     show FushiDatabase, UpdateFeedEntriesCompanion, UpdateFeedEntryRow;
@@ -71,15 +73,9 @@ class UpdateFeedService implements UpdateFeedPublisher {
   /// 通知权限只申请一次；null = 还没问过。
   bool? _notifierReady;
 
-  /// 域 → 系统通知 id。同一个域重复发通知会**替换**上一条而不是叠出一串，
-  /// 所以「订阅的番更新了 5 部」始终只占通知栏一格。
-  static const Map<UpdateFeedKind, int> _notificationIds =
-      <UpdateFeedKind, int>{
-    UpdateFeedKind.videoEpisode: 9101,
-    UpdateFeedKind.mangaChapter: 9102,
-    UpdateFeedKind.mangaExtension: 9103,
-    UpdateFeedKind.appRelease: 9104,
-  };
+  /// 本进程内发过的通知 id，按域——[markAllSeen] 撤通知时要知道该域挂着哪些
+  /// （分组通知的 id 由组名派生，事先不可枚举）。
+  final Map<UpdateFeedKind, Set<int>> _shownIds = <UpdateFeedKind, Set<int>>{};
 
   /// 这个域要不要提醒。默认全开——用户装了订阅功能就是想被告知，默认关等于功能
   /// 不存在。
@@ -145,7 +141,20 @@ class UpdateFeedService implements UpdateFeedPublisher {
         notificationSent: false,
       );
     }
-    final bool sent = await _sendNotification(kind, fresh);
+    // 按通知组拆：同组一条汇总（番剧域 = 一部作品一条），无组的整域一条。
+    // 组在 [drafts] 里首次出现的顺序即通知顺序，稳定可断言。
+    final Map<String?, List<UpdateFeedDraft>> byGroup =
+        <String?, List<UpdateFeedDraft>>{};
+    for (final UpdateFeedDraft draft in fresh) {
+      byGroup
+          .putIfAbsent(draft.notificationGroup, () => <UpdateFeedDraft>[])
+          .add(draft);
+    }
+    bool sent = false;
+    for (final MapEntry<String?, List<UpdateFeedDraft>> group
+        in byGroup.entries) {
+      sent = await _sendNotification(kind, group.key, group.value) || sent;
+    }
     return UpdateFeedPublishResult(newEntries: fresh, notificationSent: sent);
   }
 
@@ -155,18 +164,43 @@ class UpdateFeedService implements UpdateFeedPublisher {
 
   Future<bool> _sendNotification(
     UpdateFeedKind kind,
+    String? group,
     List<UpdateFeedDraft> fresh,
   ) async {
     if (!systemNotificationsEnabled) return false;
     _notifierReady ??= await _notifier.ensureReady();
     if (_notifierReady != true) return false;
     final UpdateNotificationText text = _notificationText(kind, fresh);
+    final UpdateFeedDraft first = fresh.first;
+    final int id = updateNotificationId(kind, group);
+    _shownIds.putIfAbsent(kind, () => <int>{}).add(id);
+    final int? publishedAt = first.publishedAt;
     await _notifier.notify(
       UpdateNotification(
-        id: _notificationIds[kind]!,
+        id: id,
         title: text.title,
         body: text.body,
-        payload: kind.dbValue,
+        // 载荷指向组内第一条：点通知就落到它（番剧 = 播这一集）。
+        payload: UpdateNotificationPayload(
+          kind: kind,
+          entryId: first.entryId,
+        ).encode(),
+        imagePath: first.imagePath,
+        timestamp: publishedAt == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(publishedAt),
+        actions: <UpdateNotificationAction>[
+          if (text.openLabel case final String label)
+            UpdateNotificationAction(
+              id: kUpdateNotificationActionOpen,
+              label: label,
+            ),
+          if (text.viewAllLabel case final String label)
+            UpdateNotificationAction(
+              id: kUpdateNotificationActionViewAll,
+              label: label,
+            ),
+        ],
       ),
     );
     return true;
@@ -209,11 +243,15 @@ class UpdateFeedService implements UpdateFeedPublisher {
       kind: kind?.dbValue,
       seenAt: _now().millisecondsSinceEpoch,
     );
-    if (kind != null) {
-      await _notifier.cancel(_notificationIds[kind]!);
-    } else {
-      for (final int id in _notificationIds.values) {
-        await _notifier.cancel(id);
+    final List<UpdateFeedKind> kinds =
+        kind == null ? UpdateFeedKind.values : <UpdateFeedKind>[kind];
+    for (final UpdateFeedKind k in kinds) {
+      // 域级固定 id 总撤（上个进程留下的那条不在 [_shownIds] 里）；分组 id 撤本
+      // 进程发过的。
+      final int baseId = updateNotificationId(k, null);
+      await _notifier.cancel(baseId);
+      for (final int id in _shownIds.remove(k) ?? const <int>{}) {
+        if (id != baseId) await _notifier.cancel(id);
       }
     }
   }
@@ -227,12 +265,95 @@ class UpdateFeedService implements UpdateFeedPublisher {
   Stream<void> watchChanged() => _db.watchUpdateFeedChanged();
 }
 
+/// 域 → 系统通知的固定 id（v101 起就是这四个值，跨版本稳定：撤销要按同一个
+/// id 找到上个进程发出的那条）。
+const Map<UpdateFeedKind, int> kUpdateNotificationBaseIds =
+    <UpdateFeedKind, int>{
+  UpdateFeedKind.videoEpisode: 9101,
+  UpdateFeedKind.mangaChapter: 9102,
+  UpdateFeedKind.mangaExtension: 9103,
+  UpdateFeedKind.appRelease: 9104,
+};
+
+/// 通知 id：无组 = 域固定 id；有组 = 域序号占高 4 位 + 组名 FNV-1a 哈希占低
+/// 28 位（Android 通知 id 是 32 位有符号 int，取正数范围）。同域同组恒同 id，
+/// 所以「A 又更新了」替换而不是叠加；不用 `String.hashCode`——它不保证跨进程
+/// 稳定，撤不到上个进程发的那条。
+int updateNotificationId(UpdateFeedKind kind, String? group) {
+  if (group == null) return kUpdateNotificationBaseIds[kind]!;
+  int hash = 0x811C9DC5;
+  for (final int unit in group.codeUnits) {
+    hash = ((hash ^ unit) * 0x01000193) & 0xFFFFFFFF;
+  }
+  return ((kind.index + 1) << 28) | (hash & 0x0FFFFFFF);
+}
+
+/// 通知按钮 id：打开那条更新的落点（视频 = 播放该集，漫画 = 作品页，扩展 =
+/// 扩展页，app = 发布页）。点通知本体与它同义。
+const String kUpdateNotificationActionOpen = 'open';
+
+/// 通知按钮 id：进更新中心。
+const String kUpdateNotificationActionViewAll = 'view_all';
+
+/// 通知点击载荷：只带身份，落点从数据库还原（`getUpdateFeedEntry`），通知里不
+/// 复制一份 detailJson——那份可能在发出后被域侧更新。
+class UpdateNotificationPayload {
+  const UpdateNotificationPayload({required this.kind, required this.entryId});
+
+  final UpdateFeedKind kind;
+  final String entryId;
+
+  String encode() => jsonEncode(<String, String>{
+        'kind': kind.dbValue,
+        'entryId': entryId,
+      });
+
+  /// 解不出（旧版本发的裸 `kind.dbValue`、损坏）返回 null，调用方退到更新中心。
+  static UpdateNotificationPayload? decode(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is! Map<String, Object?>) return null;
+      final UpdateFeedKind? kind =
+          UpdateFeedKind.fromDbValue(decoded['kind'] as String? ?? '');
+      final String? entryId = decoded['entryId'] as String?;
+      if (kind == null || entryId == null) return null;
+      return UpdateNotificationPayload(kind: kind, entryId: entryId);
+    } on FormatException {
+      return null;
+    }
+  }
+}
+
+/// 解一条更新的 `detailJson`（本机自己写的）。坏掉只可能是版本间格式漂移——
+/// 那时「打不开 / 不显示」比崩掉好，返回空表。
+Map<String, Object?> decodeUpdateFeedDetail(String? json) {
+  if (json == null || json.isEmpty) return const <String, Object?>{};
+  try {
+    final Object? decoded = jsonDecode(json);
+    return decoded is Map<String, Object?> ? decoded : const <String, Object?>{};
+  } on FormatException {
+    return const <String, Object?>{};
+  }
+}
+
 /// 通知的标题与正文。纯数据，便于单测直接断言文案组装规则。
 class UpdateNotificationText {
-  const UpdateNotificationText({required this.title, required this.body});
+  const UpdateNotificationText({
+    required this.title,
+    required this.body,
+    this.openLabel,
+    this.viewAllLabel,
+  });
 
   final String title;
   final String body;
+
+  /// 「打开落点」按钮文案；null = 不放按钮（默认纯结构实现没有 i18n，给 null）。
+  final String? openLabel;
+
+  /// 「查看更新」按钮文案；null 同上。
+  final String? viewAllLabel;
 }
 
 /// 通知文案的组装规则（纯函数）。

--- a/fushi/lib/src/updates/update_feed_service.dart
+++ b/fushi/lib/src/updates/update_feed_service.dart
@@ -93,6 +93,15 @@ class UpdateFeedService implements UpdateFeedPublisher {
     await _prefs.setPref(kUpdateSystemNotificationsPref, enabled);
   }
 
+  /// 启动期把通知后端初始化好：注册点击回调、回放「被通知冷启动」的那次点击、
+  /// 让上个进程留下的通知能被撤销。没有这一步，回调只在本进程**第一次发通知**
+  /// 时才挂上——重启后点昨晚那条「播放」什么都不发生。总开关关着就不初始化
+  /// （Android 13+ 初始化会弹权限）。
+  Future<void> warmUpNotifier() async {
+    if (!systemNotificationsEnabled) return;
+    _notifierReady ??= await _notifier.ensureReady();
+  }
+
   /// 投递一批事件。**同一域**的一批合成**一条**汇总通知。
   ///
   /// 为什么必须是批量入口：一轮订阅检查落 12 集是常态，逐条发通知等于把通知栏

--- a/fushi/lib/src/updates/update_notifier.dart
+++ b/fushi/lib/src/updates/update_notifier.dart
@@ -6,6 +6,14 @@
 /// `local_update_notifier.dart`，测试用 [RecordingUpdateNotifier]。
 library;
 
+/// 通知上的一个动作按钮。[id] 回流到 [UpdateNotificationResponse.actionId]。
+class UpdateNotificationAction {
+  const UpdateNotificationAction({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
 /// 一条待发的系统通知。
 class UpdateNotification {
   const UpdateNotification({
@@ -13,18 +21,39 @@ class UpdateNotification {
     required this.title,
     required this.body,
     this.payload,
+    this.imagePath,
+    this.timestamp,
+    this.actions = const <UpdateNotificationAction>[],
   });
 
-  /// 平台通知 id。同 id 再发 = 替换而不是叠加，所以按域取固定值即可
-  /// （见 `UpdateFeedService`：一个域最多同时挂一条汇总通知）。
+  /// 平台通知 id。同 id 再发 = 替换而不是叠加（见 `updateNotificationId`：
+  /// 无组 = 域固定值，有组 = 域 + 组名派生）。
   final int id;
 
   final String title;
   final String body;
 
-  /// 点击通知时回传的载荷（当前是 `UpdateFeedKind.dbValue`，用于把用户送到
-  /// 更新页对应分组）。
+  /// 点击通知时回传的载荷（`UpdateNotificationPayload` 编码，见
+  /// `update_feed_service.dart`），用于把用户送到那条更新的落点。
   final String? payload;
+
+  /// 配图的本机绝对路径；null = 纯文字。各平台各自映射（Windows hero 大图 /
+  /// Android BigPicture / Apple attachment / Linux icon）。
+  final String? imagePath;
+
+  /// 通知显示的时刻；null = 平台默认（发出的那一刻）。
+  final DateTime? timestamp;
+
+  /// 动作按钮，按顺序显示。空 = 只有点击本体。
+  final List<UpdateNotificationAction> actions;
+}
+
+/// 用户对一条通知的响应：点本体（[actionId] 为 null）或点某个按钮。
+class UpdateNotificationResponse {
+  const UpdateNotificationResponse({required this.payload, this.actionId});
+
+  final String? payload;
+  final String? actionId;
 }
 
 abstract class UpdateNotifier {

--- a/fushi/test/media/video/download/video_download_pipeline_service_test.dart
+++ b/fushi/test/media/video/download/video_download_pipeline_service_test.dart
@@ -27,6 +27,9 @@ import 'package:fushi_engine/media/video/metadata/video_metadata_resolver.dart';
 import 'package:fushi_engine/media/video/metadata/video_source_scrape_config.dart';
 import 'package:fushi_engine/media/video/metadata/video_source_scrape_coordinator.dart';
 import 'package:fushi_engine/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi_engine/media/video/video_cover_extractor.dart';
+import 'package:fushi_engine/updates/update_feed_kind.dart';
+import 'package:fushi_engine/updates/update_feed_port.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
 
@@ -1257,6 +1260,197 @@ void main() {
     }
   }
   test(
+      'subscription import publishes a per-work episode update with frame, '
+      'release info and published time', () async {
+    final _RecordingUpdateFeed feed = _RecordingUpdateFeed();
+    final List<String> extracted = <String>[];
+    final Directory frames =
+        await Directory.systemTemp.createTemp('fushi-episode-frames-');
+    addTearDown(() => frames.delete(recursive: true));
+    final _PipelineEnvironment environment = await _PipelineEnvironment.create(
+      backend: _FakeTorrentBackend(),
+      updateFeed: feed,
+      coverExtractor: ({
+        required String videoPath,
+        required String bookUid,
+        double atSeconds = 10.0,
+      }) async {
+        extracted.add(videoPath);
+        final File frame = File(
+          p.join(frames.path, '${bookUid.replaceAll('/', '_')}.jpg'),
+        );
+        await frame.create(recursive: true);
+        return frame.path;
+      },
+    );
+    addTearDown(environment.close);
+    const String jobId = 'subscription-episode-job';
+    await environment.insertJob(
+      jobId: jobId,
+      stage: VideoDownloadJobStage.import,
+    );
+    await environment.database.updateVideoDownloadJob(
+      jobId,
+      const VideoDownloadJobsCompanion(
+        resourceTitle: Value<String?>(
+          '[SubsPlease] Show - 02 (1080p) [A1B2C3D4].mkv',
+        ),
+      ),
+    );
+    const int publishedAt = 1_760_000_000_000;
+    await environment.database.upsertVideoDownloadSubscription(
+      VideoDownloadSubscriptionsCompanion.insert(
+        subscriptionId: 'sub-1',
+        resourceProvider: 'nyaa:test-instance',
+        mediaKind: 'tv',
+        title: 'Show',
+        searchQuery: 'Show',
+        backendKind: 'embedded',
+        fingerprint: _expectedIdentity.fingerprint,
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    );
+    await environment.database.upsertVideoDownloadSubscriptionItem(
+      VideoDownloadSubscriptionItemsCompanion.insert(
+        subscriptionId: 'sub-1',
+        logicalItemKey: 's1e2',
+        resourceProvider: 'nyaa:test-instance',
+        selectedResourceId: 'release-1',
+        title: 'Show - 02',
+        season: const Value<int?>(1),
+        episode: const Value<int?>(2),
+        publishedAt: const Value<int?>(publishedAt),
+        jobId: const Value<String?>(jobId),
+        discoveredAt: 1,
+        updatedAt: 1,
+      ),
+    );
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    final String videoPath = p.join(
+      environment.root.path,
+      'Show (2026)',
+      'Show S01E02.mkv',
+    );
+    await environment.database.upsertVideoDownloadJobFile(
+      VideoDownloadJobFilesCompanion.insert(
+        jobId: jobId,
+        backendFileIndex: const Value<int?>(0),
+        originalRelativePath: 'Show S01E02.mkv',
+        currentRelativePath: 'Show S01E02.mkv',
+        finalAbsolutePath: Value<String?>(videoPath),
+        kind: const Value<String>('video'),
+        season: const Value<int?>(1),
+        episode: const Value<int?>(2),
+        status: const Value<String>(VideoDownloadJobFileStatus.organized),
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+
+    environment.service.wake();
+    await _waitForJob(
+      environment.database,
+      jobId,
+      (VideoDownloadJobRow row) =>
+          row.lifecycle == VideoDownloadJobLifecycle.completed,
+    );
+
+    expect(feed.batches, hasLength(1));
+    expect(feed.batches.single.kind, UpdateFeedKind.videoEpisode);
+    final UpdateFeedDraft draft = feed.batches.single.drafts.single;
+    expect(draft.title, 'Show');
+    expect(draft.subtitle, 'S01E02 · 1080p · SubsPlease');
+    expect(draft.publishedAt, publishedAt);
+    expect(extracted, <String>[videoPath]);
+    expect(draft.imagePath, isNotNull);
+    expect(File(draft.imagePath!).existsSync(), isTrue);
+    final Map<String, Object?> detail =
+        jsonDecode(draft.detailJson!) as Map<String, Object?>;
+    expect(draft.notificationGroup, 'collection:${detail['collectionId']}');
+    expect(detail['imagePath'], draft.imagePath);
+    expect(detail['publishedAt'], publishedAt);
+    // 抽的那帧顺手就是这集的书架封面。
+    final VideoBookRow? book = await environment.database.getVideoBookByBookUid(
+      detail['bookUid'] as String,
+    );
+    expect(book?.coverPath, draft.imagePath);
+  });
+
+  test('manual (non-subscription) import publishes no episode update',
+      () async {
+    final _RecordingUpdateFeed feed = _RecordingUpdateFeed();
+    final _PipelineEnvironment environment = await _PipelineEnvironment.create(
+      backend: _FakeTorrentBackend(),
+      updateFeed: feed,
+      coverExtractor: ({
+        required String videoPath,
+        required String bookUid,
+        double atSeconds = 10.0,
+      }) async =>
+          fail('manual import must not extract a notification frame'),
+    );
+    addTearDown(environment.close);
+    const String jobId = 'manual-episode-job';
+    await environment.insertJob(
+      jobId: jobId,
+      stage: VideoDownloadJobStage.import,
+    );
+    final int now = DateTime.now().millisecondsSinceEpoch;
+    await environment.database.upsertVideoDownloadJobFile(
+      VideoDownloadJobFilesCompanion.insert(
+        jobId: jobId,
+        backendFileIndex: const Value<int?>(0),
+        originalRelativePath: 'Show S01E02.mkv',
+        currentRelativePath: 'Show S01E02.mkv',
+        finalAbsolutePath: Value<String?>(
+          p.join(environment.root.path, 'Show S01E02.mkv'),
+        ),
+        kind: const Value<String>('video'),
+        season: const Value<int?>(1),
+        episode: const Value<int?>(2),
+        status: const Value<String>(VideoDownloadJobFileStatus.organized),
+        createdAt: now,
+        updatedAt: now,
+      ),
+    );
+
+    environment.service.wake();
+    await _waitForJob(
+      environment.database,
+      jobId,
+      (VideoDownloadJobRow row) =>
+          row.lifecycle == VideoDownloadJobLifecycle.completed,
+    );
+    expect(feed.batches, isEmpty);
+  });
+
+  group('subscriptionReleaseLabel', () {
+    test('picks resolution and leading group, ignores hash brackets', () {
+      expect(
+        VideoDownloadPipelineService.subscriptionReleaseLabel(
+          '[SubsPlease] Show - 02 (1080p) [A1B2C3D4].mkv',
+        ),
+        '1080p · SubsPlease',
+      );
+      expect(
+        VideoDownloadPipelineService.subscriptionReleaseLabel(
+          '[A1B2C3D4] Show 02 720P',
+        ),
+        '720P',
+      );
+      expect(
+        VideoDownloadPipelineService.subscriptionReleaseLabel('Show 02'),
+        isNull,
+      );
+      expect(
+        VideoDownloadPipelineService.subscriptionReleaseLabel(null),
+        isNull,
+      );
+    });
+  });
+
+  test(
       'a multi-movie torrent imports every standalone movie with its own '
       'title (BUG-2007)', () async {
     final _PipelineEnvironment environment = await _PipelineEnvironment.create(
@@ -2150,6 +2344,8 @@ class _PipelineEnvironment {
     Duration leaseDuration = const Duration(minutes: 1),
     Duration pollInterval = const Duration(hours: 1),
     String? candidateMagnetUri,
+    UpdateFeedPublisher? updateFeed,
+    VideoCoverExtractor? coverExtractor,
   }) async {
     final FushiDatabase database =
         FushiDatabase.forTesting(NativeDatabase.memory());
@@ -2194,6 +2390,9 @@ class _PipelineEnvironment {
       workerId: 'pipeline-test-worker',
       pollInterval: pollInterval,
       leaseDuration: leaseDuration,
+      updateFeed: updateFeed,
+      coverExtractor: coverExtractor,
+      videoCoversDirectory: Directory(p.join(root.path, 'covers')),
     );
     return _PipelineEnvironment._(
       database: database,
@@ -2625,5 +2824,19 @@ class _RecordingMetadataProvider extends _UnavailableAniListMetadataProvider {
   Future<VideoMetadataWork?> fetchWork(VideoMetadataLookup lookup) async {
     lookups.add(lookup);
     throw StateError('recorded confirmed lookup');
+  }
+}
+
+/// 记录投递到更新提醒端口的批次（不落库、不发通知）。
+class _RecordingUpdateFeed implements UpdateFeedPublisher {
+  final List<({UpdateFeedKind kind, List<UpdateFeedDraft> drafts})> batches =
+      <({UpdateFeedKind kind, List<UpdateFeedDraft> drafts})>[];
+
+  @override
+  Future<void> publishBatch(
+    UpdateFeedKind kind,
+    List<UpdateFeedDraft> drafts,
+  ) async {
+    batches.add((kind: kind, drafts: List<UpdateFeedDraft>.of(drafts)));
   }
 }

--- a/fushi/test/media/video/download/video_download_pipeline_service_test.dart
+++ b/fushi/test/media/video/download/video_download_pipeline_service_test.dart
@@ -1440,6 +1440,13 @@ void main() {
         '720P',
       );
       expect(
+        VideoDownloadPipelineService.subscriptionReleaseLabel(
+          '[1080p][Group] Show - 01',
+        ),
+        '1080p',
+        reason: '首方括号就是分辨率时不当字幕组，否则副标题「1080p · 1080p」',
+      );
+      expect(
         VideoDownloadPipelineService.subscriptionReleaseLabel('Show 02'),
         isNull,
       );

--- a/fushi/test/updates/local_update_notifier_test.dart
+++ b/fushi/test/updates/local_update_notifier_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/src/updates/local_update_notifier.dart';
+import 'package:fushi/src/updates/update_feed_service.dart';
+import 'package:fushi/src/updates/update_notifier.dart';
+import 'package:fushi_engine/updates/update_feed_kind.dart';
+
+/// 系统通知后端的两条纯函数契约：
+/// ① Windows 按钮把「按钮 id + 本体载荷」编进 arguments 再拆回来（插件在 Windows
+///   上把 payload 与 actionId 都填成被点元素的 arguments，本体载荷会丢）；
+/// ② 本地化文案：单条带发布时刻与两个按钮，多条汇总不带时刻。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('decodeNotificationResponse', () {
+    const String payload =
+        '{"kind":"video_episode","entryId":"video_episode:1"}';
+
+    test('Windows 按钮：arguments 自带载荷，拆成 (payload, actionId)', () {
+      final String arguments = encodeWindowsActionArguments('open', payload);
+      final UpdateNotificationResponse response = decodeNotificationResponse(
+        NotificationResponse(
+          notificationResponseType:
+              NotificationResponseType.selectedNotificationAction,
+          payload: arguments,
+          actionId: arguments,
+        ),
+      );
+      expect(response.actionId, 'open');
+      expect(response.payload, payload);
+    });
+
+    test('点本体：payload 原样、actionId 为 null（哪怕插件填了东西）', () {
+      final UpdateNotificationResponse response = decodeNotificationResponse(
+        const NotificationResponse(
+          notificationResponseType:
+              NotificationResponseType.selectedNotification,
+          payload: payload,
+          actionId: payload,
+        ),
+      );
+      expect(response.actionId, isNull);
+      expect(response.payload, payload);
+    });
+
+    test('Android/Linux 按钮：payload 与 actionId 本来分开，直接透传', () {
+      final UpdateNotificationResponse response = decodeNotificationResponse(
+        const NotificationResponse(
+          notificationResponseType:
+              NotificationResponseType.selectedNotificationAction,
+          payload: payload,
+          actionId: 'view_all',
+        ),
+      );
+      expect(response.actionId, 'view_all');
+      expect(response.payload, payload);
+    });
+  });
+
+  group('localizedUpdateNotificationText', () {
+    test('单条：副标题 · MM-dd HH:mm，两个按钮', () {
+      final DateTime published = DateTime(2026, 9, 10, 18, 30);
+      final UpdateNotificationText text =
+          AppModel.localizedUpdateNotificationText(
+        UpdateFeedKind.videoEpisode,
+        <UpdateFeedDraft>[
+          UpdateFeedDraft(
+            kind: UpdateFeedKind.videoEpisode,
+            targetKey: '1',
+            title: 'グロウアップショウ',
+            subtitle: 'S01E02 · 1080p',
+            publishedAt: published.millisecondsSinceEpoch,
+          ),
+        ],
+      );
+      expect(text.title, 'グロウアップショウ');
+      expect(text.body, 'S01E02 · 1080p · 09-10 18:30');
+      expect(text.openLabel, isNotEmpty);
+      expect(text.viewAllLabel, isNotEmpty);
+    });
+
+    test('单条无副标题无时刻：正文只剩空串，不留孤零零的分隔符', () {
+      final UpdateNotificationText text =
+          AppModel.localizedUpdateNotificationText(
+        UpdateFeedKind.appRelease,
+        const <UpdateFeedDraft>[
+          UpdateFeedDraft(
+            kind: UpdateFeedKind.appRelease,
+            targetKey: '2.4.0',
+            title: '2.4.0',
+          ),
+        ],
+      );
+      expect(text.body, '');
+    });
+
+    test('多条：汇总句不带时刻（时刻属于谁说不清）', () {
+      final UpdateNotificationText text =
+          AppModel.localizedUpdateNotificationText(
+        UpdateFeedKind.videoEpisode,
+        <UpdateFeedDraft>[
+          for (int i = 1; i <= 3; i++)
+            UpdateFeedDraft(
+              kind: UpdateFeedKind.videoEpisode,
+              targetKey: '$i',
+              title: 'Show',
+              subtitle: 'S01E0$i',
+              publishedAt: 1700000000000,
+            ),
+        ],
+      );
+      expect(text.body, contains('S01E01'));
+      expect(text.body, isNot(contains(':')));
+      expect(text.body, contains('2'));
+    });
+  });
+}

--- a/fushi/test/updates/update_feed_service_test.dart
+++ b/fushi/test/updates/update_feed_service_test.dart
@@ -260,6 +260,22 @@ void main() {
     );
   });
 
+  test('warmUpNotifier：启动期初始化一次；总开关关着不初始化', () async {
+    final UpdateFeedService service = await makeService();
+    await service.warmUpNotifier();
+    await service.warmUpNotifier();
+    expect(notifier.ensureReadyCalls, 1, reason: '重复 warm-up 不重复初始化');
+    await service.publishBatch(
+        UpdateFeedKind.videoEpisode, <UpdateFeedDraft>[episode('1')]);
+    expect(notifier.ensureReadyCalls, 1, reason: '发通知复用启动期的初始化');
+
+    final UpdateFeedService cold = await makeService();
+    await cold.setSystemNotificationsEnabled(false);
+    await cold.warmUpNotifier();
+    expect(notifier.ensureReadyCalls, 0,
+        reason: '关着总开关时不初始化（Android 13+ 初始化会弹权限）');
+  });
+
   test('通知 id：无组回落到域固定值；有组跨进程稳定且不与其它域撞', () {
     expect(updateNotificationId(UpdateFeedKind.videoEpisode, null), 9101);
     expect(updateNotificationId(UpdateFeedKind.appRelease, null), 9104);

--- a/fushi/test/updates/update_feed_service_test.dart
+++ b/fushi/test/updates/update_feed_service_test.dart
@@ -183,6 +183,118 @@ void main() {
     expect(counts.containsKey(UpdateFeedKind.mangaChapter), isFalse);
   });
 
+  test('通知按组拆：同域不同作品各一条，同作品多集一条；配图/时刻/按钮透传', () async {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    notifier = RecordingUpdateNotifier();
+    final UpdateFeedService service = UpdateFeedService(
+      database: db,
+      prefs: prefs,
+      notifier: notifier,
+      notificationText: (UpdateFeedKind kind, List<UpdateFeedDraft> fresh) =>
+          UpdateNotificationText(
+        title: fresh.first.title,
+        body: fresh.length == 1
+            ? fresh.first.subtitle ?? ''
+            : '+${fresh.length - 1}',
+        openLabel: 'Play',
+        viewAllLabel: 'View',
+      ),
+    );
+
+    UpdateFeedDraft grouped(String key, String group, {String? image}) =>
+        UpdateFeedDraft(
+          kind: UpdateFeedKind.videoEpisode,
+          targetKey: '$group/$key',
+          title: group,
+          subtitle: 'S01E$key',
+          imagePath: image,
+          publishedAt: 1700000000000,
+          notificationGroup: 'collection:$group',
+        );
+
+    await service.publishBatch(
+      UpdateFeedKind.videoEpisode,
+      <UpdateFeedDraft>[
+        grouped('1', 'A', image: r'C:\covers\a1.jpg'),
+        grouped('2', 'A'),
+        grouped('1', 'B'),
+      ],
+    );
+    expect(notifier.sent, hasLength(2), reason: '两部作品各占一格，同作品两集合并');
+    final UpdateNotification a = notifier.sent[0];
+    final UpdateNotification b = notifier.sent[1];
+    expect(a.id, isNot(b.id));
+    expect(
+      a.id,
+      updateNotificationId(UpdateFeedKind.videoEpisode, 'collection:A'),
+      reason: '同组恒同 id：下次 A 再更新替换而不是叠加',
+    );
+    expect(a.body, '+1');
+    expect(a.imagePath, r'C:\covers\a1.jpg', reason: '配图取组内第一条');
+    expect(a.timestamp, DateTime.fromMillisecondsSinceEpoch(1700000000000));
+    expect(
+      a.actions.map((UpdateNotificationAction x) => x.id),
+      <String>[kUpdateNotificationActionOpen, kUpdateNotificationActionViewAll],
+    );
+    expect(
+      a.actions.map((UpdateNotificationAction x) => x.label),
+      <String>['Play', 'View'],
+    );
+    final UpdateNotificationPayload? payload =
+        UpdateNotificationPayload.decode(a.payload);
+    expect(payload?.kind, UpdateFeedKind.videoEpisode);
+    expect(payload?.entryId, grouped('1', 'A').entryId,
+        reason: '载荷指向组内第一条：点通知就播那一集');
+    expect(b.imagePath, isNull);
+
+    await service.markAllSeen(kind: UpdateFeedKind.videoEpisode);
+    expect(notifier.cancelled, containsAll(<int>[a.id, b.id]),
+        reason: '标已读要撤掉本进程发过的每条分组通知');
+    expect(
+      notifier.cancelled,
+      contains(updateNotificationId(UpdateFeedKind.videoEpisode, null)),
+      reason: '域级固定 id 也撤：上个进程留下的那条不在内存账本里',
+    );
+  });
+
+  test('通知 id：无组回落到域固定值；有组跨进程稳定且不与其它域撞', () {
+    expect(updateNotificationId(UpdateFeedKind.videoEpisode, null), 9101);
+    expect(updateNotificationId(UpdateFeedKind.appRelease, null), 9104);
+    final int a1 =
+        updateNotificationId(UpdateFeedKind.videoEpisode, 'collection:1');
+    expect(
+      a1,
+      updateNotificationId(UpdateFeedKind.videoEpisode, 'collection:1'),
+    );
+    expect(
+      a1,
+      isNot(updateNotificationId(UpdateFeedKind.videoEpisode, 'collection:2')),
+    );
+    expect(
+      a1,
+      isNot(updateNotificationId(UpdateFeedKind.mangaChapter, 'collection:1')),
+    );
+    expect(a1, greaterThan(0));
+    expect(a1, lessThan(1 << 31), reason: 'Android 通知 id 是 32 位有符号 int');
+  });
+
+  test('载荷：JSON 往返；旧版裸 kind 值 / 垃圾解成 null 让调用方退到更新中心', () {
+    const UpdateNotificationPayload payload = UpdateNotificationPayload(
+      kind: UpdateFeedKind.mangaChapter,
+      entryId: 'manga_chapter:x',
+    );
+    final UpdateNotificationPayload? back =
+        UpdateNotificationPayload.decode(payload.encode());
+    expect(back?.kind, UpdateFeedKind.mangaChapter);
+    expect(back?.entryId, 'manga_chapter:x');
+    expect(UpdateNotificationPayload.decode('video_episode'), isNull);
+    expect(UpdateNotificationPayload.decode('{not json'), isNull);
+    expect(UpdateNotificationPayload.decode(null), isNull);
+  });
+
   test('混域投递直接抛错（通知按域合并，混进来会算错归属）', () async {
     final UpdateFeedService service = await makeService();
     expect(

--- a/packages/fushi_core/lib/src/database/database_update_feed.part.dart
+++ b/packages/fushi_core/lib/src/database/database_update_feed.part.dart
@@ -56,6 +56,11 @@ mixin _FushiDbUpdateFeed on _$FushiDatabase {
     return query.get();
   }
 
+  /// 按身份取一条（系统通知点击回流用：通知载荷只带 entryId，落点从这里还原）。
+  Future<UpdateFeedEntryRow?> getUpdateFeedEntry(String entryId) =>
+      (select(updateFeedEntries)..where((t) => t.entryId.equals(entryId)))
+          .getSingleOrNull();
+
   /// 把指定条目标记为已读（幂等：已读的行不再改写 seenAt，保留第一次看见的时刻）。
   Future<int> markUpdateFeedEntriesSeen(
     Iterable<String> entryIds, {

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -2203,21 +2203,21 @@ mixin _FushiDbVideoDomain
                 ]))
               .get();
 
-  /// 这条下载任务是不是某条订阅拉起来的。
+  /// 拉起这条下载任务的订阅条目；null = 手动下载。
   ///
   /// v101 更新提醒的番剧侧判据：手动下载是用户自己刚点的，下载完成再提醒一次
   /// 只是复述他刚做过的动作；订阅下载则是他没盯着的时候悄悄完成的，那一条才值
   /// 得提醒。`video_download_jobs` 本身没有来源标记，唯一的关联是订阅条目回填的
-  /// `jobId`，所以判据只能反查这张边表。
-  Future<bool> isVideoDownloadJobFromSubscription(String jobId) async {
-    final VideoDownloadSubscriptionItemRow? row =
-        await (select(videoDownloadSubscriptionItems)
-              ..where(($VideoDownloadSubscriptionItemsTable t) =>
-                  t.jobId.equals(jobId))
-              ..limit(1))
-            .getSingleOrNull();
-    return row != null;
-  }
+  /// `jobId`，所以判据只能反查这张边表。返回整行而不是 bool：提醒还要它的
+  /// `publishedAt`（资源发布时刻）。
+  Future<VideoDownloadSubscriptionItemRow?> videoDownloadSubscriptionItemForJob(
+    String jobId,
+  ) =>
+      (select(videoDownloadSubscriptionItems)
+            ..where(($VideoDownloadSubscriptionItemsTable t) =>
+                t.jobId.equals(jobId))
+            ..limit(1))
+          .getSingleOrNull();
 
   Stream<List<VideoDownloadSubscriptionItemRow>>
       watchVideoDownloadSubscriptionItems(String subscriptionId) =>

--- a/packages/fushi_engine/lib/media/video/download/video_download_pipeline_service.dart
+++ b/packages/fushi_engine/lib/media/video/download/video_download_pipeline_service.dart
@@ -45,7 +45,11 @@ import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart
 import 'package:fushi_engine/media/video/subtitle/subtitle_language_preference.dart';
 import 'package:fushi_engine/media/video/subtitle/subtitle_timing_check.dart';
 import 'package:fushi_engine/media/video/subtitle/video_subtitle_provider.dart';
+import 'package:fushi_engine/media/video/metadata/video_scrape_operation_gate.dart';
+import 'package:fushi_engine/media/video/scraper/cover_meta_store.dart';
 import 'package:fushi_engine/media/video/video_book_repository.dart';
+import 'package:fushi_engine/media/video/video_cover_extractor.dart';
+import 'package:fushi_engine/media/video/video_storage.dart';
 import 'package:fushi_engine/media/video/video_duration_probe.dart';
 import 'package:fushi_engine/media/video/video_filename_parser.dart';
 import 'package:fushi_engine/media/video/video_sidecar.dart'
@@ -799,10 +803,13 @@ class VideoDownloadPipelineService {
     this.pollInterval = const Duration(seconds: 5),
     this.leaseDuration = const Duration(minutes: 2),
     this.updateFeed,
+    VideoCoverExtractor? coverExtractor,
+    this.videoCoversDirectory,
   }) : preferredSubtitleLanguages = List<String>.unmodifiable(
          preferredSubtitleLanguages,
        ),
        workerId = workerId ?? 'video-${generateVideoDownloadInstallationId()}',
+       _coverExtractor = coverExtractor ?? extractVideoCover,
        _videoRepository = VideoBookRepository(database);
 
   final FushiDatabase database;
@@ -826,6 +833,12 @@ class VideoDownloadPipelineService {
   /// 手动任务 .torrent 元数据的落盘目录（`<jobId>.torrent`）。null 时手动
   /// 任务只接受磁力链接。
   final Directory? manualTorrentDirectory;
+
+  /// 订阅新集提醒的配图抽取（默认 [extractVideoCover]，ffmpeg 抽帧）；测试注入。
+  final VideoCoverExtractor _coverExtractor;
+
+  /// 封面来源账本（`cover_meta.json`）所在目录；null = `VideoStorage.coversDir()`。
+  final Directory? videoCoversDirectory;
   final String workerId;
   final Duration pollInterval;
   final Duration leaseDuration;
@@ -3970,6 +3983,10 @@ class VideoDownloadPipelineService {
   ///   误判成新增（BUG-1417 的形状）；
   /// * 只提醒**订阅**拉起来的任务，手动下载不提醒（用户自己刚点的）；
   /// * 挂在**入库之后**，所以提醒出现时那一集已经能点开就播。
+  ///
+  /// 提醒带三样东西：该集抽帧（[_episodeNotificationImage]，顺手就是这集的书架
+  /// 封面）、资源发布时刻（订阅条目 `publishedAt`）、发布信息（字幕组 / 分辨率，
+  /// 从资源标题里认）。通知按作品分组（`notificationGroup`）：一部番一格。
   Future<void> _publishSubscriptionEpisodeUpdates({
     required VideoDownloadJobRow job,
     required int collectionId,
@@ -3978,12 +3995,24 @@ class VideoDownloadPipelineService {
   }) async {
     final UpdateFeedPublisher? feed = updateFeed;
     if (feed == null) return;
-    if (!await database.isVideoDownloadJobFromSubscription(job.jobId)) return;
+    final VideoDownloadSubscriptionItemRow? item = await database
+        .videoDownloadSubscriptionItemForJob(job.jobId);
+    if (item == null) return;
+    final String? release = subscriptionReleaseLabel(job.resourceTitle);
     final List<UpdateFeedDraft> drafts = <UpdateFeedDraft>[];
     for (final String uid in result.createdEpisodeUids) {
       final int index = result.episodeUids.indexOf(uid);
       final VideoDownloadJobFileRow? file =
           index >= 0 && index < files.length ? files[index] : null;
+      final String? imagePath = await _episodeNotificationImage(
+        bookUid: uid,
+        videoPath: file?.finalAbsolutePath,
+        collectionId: collectionId,
+      );
+      final String subtitle = <String>[
+        if (file != null) _episodeLabel(file),
+        if (release != null) release,
+      ].join(' · ');
       drafts.add(
         UpdateFeedDraft(
           kind: UpdateFeedKind.videoEpisode,
@@ -3992,15 +4021,88 @@ class VideoDownloadPipelineService {
             episodeKey: uid,
           ),
           title: job.title,
-          subtitle: file == null ? null : _episodeLabel(file),
+          subtitle: subtitle.isEmpty ? null : subtitle,
           detailJson: jsonEncode(<String, Object?>{
             'collectionId': collectionId,
             'bookUid': uid,
+            if (imagePath != null) 'imagePath': imagePath,
+            if (item.publishedAt != null) 'publishedAt': item.publishedAt,
           }),
+          imagePath: imagePath,
+          publishedAt: item.publishedAt,
+          notificationGroup: 'collection:$collectionId',
         ),
       );
     }
     await feed.publishBatch(UpdateFeedKind.videoEpisode, drafts);
+  }
+
+  /// 新集提醒的配图：该集抽帧，并把它落成这集的书架封面（来源账本记
+  /// autoFrame，与库内导入 / 书架回填同一套准入）；抽不到（无 ffmpeg、空洞文件）
+  /// 退作品封面；都没有就纯文字。**best-effort**：任何失败只记日志，不能让
+  /// 「已入库、已能播」的事实因为一张图发不出提醒。
+  Future<String?> _episodeNotificationImage({
+    required String bookUid,
+    required String? videoPath,
+    required int collectionId,
+  }) async {
+    String? frame;
+    if (videoPath != null) {
+      try {
+        frame = await VideoCoverMutationGate.runExclusive(() async {
+          final CoverMetaStore store = CoverMetaStore(
+            videoCoversDirectory ?? await VideoStorage.coversDir(),
+          );
+          if (!await store.allowsAutoFrameWrite(bookUid)) {
+            return (await database.getVideoBookByBookUid(bookUid))?.coverPath;
+          }
+          final String? cover = await _coverExtractor(
+            videoPath: videoPath,
+            bookUid: bookUid,
+          );
+          if (cover == null || cover.isEmpty) return null;
+          await database.updateVideoBookCover(bookUid, cover);
+          if (!await store.markAutoFrameAfterWrite(bookUid)) {
+            engineLog.log(
+              'videoDownload.episodeCover.provenanceConflict',
+              StateError('封面来源在自动抽帧期间发生变化: $bookUid'),
+              StackTrace.current,
+            );
+          }
+          return cover;
+        });
+      } catch (error, stack) {
+        engineLog.log('videoDownload.episodeCover', error, stack);
+      }
+    }
+    if (frame != null && frame.isNotEmpty) return frame;
+    final MediaCollectionRow? collection = await database
+        .getMediaCollectionById(collectionId);
+    final String? poster = collection?.coverPath;
+    return poster == null || poster.isEmpty ? null : poster;
+  }
+
+  /// 从资源标题里认发布信息：`[SubsPlease] Show - 02 (1080p) [ABCD].mkv` →
+  /// `1080p · SubsPlease`。认不出任何一样返回 null——不硬凑。分辨率取第一个
+  /// `NNNNp` / `4K`；字幕组取开头第一个方括号（惯例位置），纯 hash 串不算。
+  static String? subscriptionReleaseLabel(String? resourceTitle) {
+    if (resourceTitle == null) return null;
+    final RegExpMatch? resolution = RegExp(
+      r'\b(\d{3,4}p|4K)\b',
+      caseSensitive: false,
+    ).firstMatch(resourceTitle);
+    final RegExpMatch? group = RegExp(
+      r'^\s*\[([^\]]{1,40})\]',
+    ).firstMatch(resourceTitle);
+    final String? groupName = group?.group(1)?.trim();
+    final bool groupLooksLikeHash =
+        groupName != null && RegExp(r'^[0-9A-Fa-f]{6,}$').hasMatch(groupName);
+    final List<String> parts = <String>[
+      if (resolution != null) resolution.group(1)!,
+      if (groupName != null && groupName.isNotEmpty && !groupLooksLikeHash)
+        groupName,
+    ];
+    return parts.isEmpty ? null : parts.join(' · ');
   }
 
   static String _episodeTitle(String title, VideoDownloadJobFileRow file) =>

--- a/packages/fushi_engine/lib/media/video/download/video_download_pipeline_service.dart
+++ b/packages/fushi_engine/lib/media/video/download/video_download_pipeline_service.dart
@@ -4047,7 +4047,11 @@ class VideoDownloadPipelineService {
     required int collectionId,
   }) async {
     String? frame;
-    if (videoPath != null) {
+    // 与库内导入 / host 回填同一套门：维护动作（刮削清理）持锁期间不写封面，
+    // 这轮就退作品海报。
+    final VideoScrapeOperationLease? lease =
+        videoPath == null ? null : VideoScrapeOperationGate.tryEnterOperation();
+    if (lease != null) {
       try {
         frame = await VideoCoverMutationGate.runExclusive(() async {
           final CoverMetaStore store = CoverMetaStore(
@@ -4057,7 +4061,7 @@ class VideoDownloadPipelineService {
             return (await database.getVideoBookByBookUid(bookUid))?.coverPath;
           }
           final String? cover = await _coverExtractor(
-            videoPath: videoPath,
+            videoPath: videoPath!,
             bookUid: bookUid,
           );
           if (cover == null || cover.isEmpty) return null;
@@ -4073,6 +4077,8 @@ class VideoDownloadPipelineService {
         });
       } catch (error, stack) {
         engineLog.log('videoDownload.episodeCover', error, stack);
+      } finally {
+        lease.release();
       }
     }
     if (frame != null && frame.isNotEmpty) return frame;
@@ -4095,12 +4101,16 @@ class VideoDownloadPipelineService {
       r'^\s*\[([^\]]{1,40})\]',
     ).firstMatch(resourceTitle);
     final String? groupName = group?.group(1)?.trim();
-    final bool groupLooksLikeHash =
-        groupName != null && RegExp(r'^[0-9A-Fa-f]{6,}$').hasMatch(groupName);
+    final String? resolutionLabel = resolution?.group(1);
+    // 首方括号是 hash 串（`[A1B2C3D4]`）或就是分辨率本身（`[1080p][Group]`）都
+    // 不算字幕组——后者会把「1080p · 1080p」写进副标题。
+    final bool groupIsNoise = groupName == null ||
+        groupName.isEmpty ||
+        RegExp(r'^[0-9A-Fa-f]{6,}$').hasMatch(groupName) ||
+        groupName.toLowerCase() == resolutionLabel?.toLowerCase();
     final List<String> parts = <String>[
-      if (resolution != null) resolution.group(1)!,
-      if (groupName != null && groupName.isNotEmpty && !groupLooksLikeHash)
-        groupName,
+      if (resolutionLabel != null) resolutionLabel,
+      if (!groupIsNoise) groupName,
     ];
     return parts.isEmpty ? null : parts.join(' · ');
   }

--- a/packages/fushi_engine/lib/updates/update_feed_port.dart
+++ b/packages/fushi_engine/lib/updates/update_feed_port.dart
@@ -17,6 +17,9 @@ class UpdateFeedDraft {
     required this.title,
     this.subtitle,
     this.detailJson,
+    this.imagePath,
+    this.publishedAt,
+    this.notificationGroup,
   });
 
   final UpdateFeedKind kind;
@@ -24,6 +27,19 @@ class UpdateFeedDraft {
   final String title;
   final String? subtitle;
   final String? detailJson;
+
+  /// 系统通知配图的**本机绝对路径**（番剧域：该集抽帧，退作品海报）；null =
+  /// 纯文字通知。只进通知不落库——落库的持久投影由域侧按需写进 [detailJson]。
+  final String? imagePath;
+
+  /// 事件本身的发生时刻（毫秒戳；番剧域 = 资源发布时刻）。null = 只知道本机
+  /// 发现时刻，通知按发现时刻计时。
+  final int? publishedAt;
+
+  /// 系统通知合并组：**同域同组**的一批合成一条通知、同组再来替换同一条；
+  /// null = 整个域一条（v101 原行为）。番剧域按作品分组——「A 更新 3 集」和
+  /// 「B 更新 1 集」各占一格，配图和时间才有归属；漫画/扩展/app 三域不分组。
+  final String? notificationGroup;
 
   String get entryId => updateFeedEntryId(kind, targetKey);
 }


### PR DESCRIPTION
## 背景
用户截图：Windows 上「番剧新集」toast 只有 `Fushi / 标题 / S01E02`，没有 Fushi 图标、没有视频截图、没有时间。沿真实路径查到三样在数据结构上根本没有：`WindowsInitializationSettings` 没传 `iconPath`；`UpdateFeedDraft` / `UpdateNotification` 没有图片和时间槽位；`initialize` 没挂 `onDidReceiveNotificationResponse`，点通知什么都不发生。

## 改动
- **图标**：Windows 传随包 `assets/meta/icon.png`（按 exe 目录定位，不信 cwd）。
- **截图**：番剧域入库后对新集抽帧（`extractVideoCover`，走 `CoverMetaStore` 准入 + `VideoScrapeOperationGate`），顺手落成该集书架封面；抽不到退作品海报。Windows hero 大图 / Android BigPicture / Apple attachment（先拷贝——系统会移动附件文件）/ Linux icon。
- **时间**：订阅条目 `publishedAt` → toast 时间戳 + 正文 `S01E02 · 1080p · SubsPlease · 09-10 18:30`（字幕组/分辨率从 resourceTitle 解析）。
- **点击**：载荷 `{kind, entryId}` 回流 → `openUpdateFeedEntry`，番剧新集直接 `VideoFushiPage.neutralized` 播放（带 `playlistCollectionId`）；「查看更新」进更新中心。Windows 插件把按钮 arguments 同时填进 payload/actionId，按钮参数改成 `action:<id>|<payload>` 自带载荷。启动期 `warmUpNotifier()` 初始化，重启后点旧 toast 也能响应。
- **按钮**：「播放 / 查看更新」（Windows/Android/Linux）；Windows 静音、「订阅更新」页眉。
- **按作品分组**：同作品多集一条、不同作品各一条，id 由 FNV-1a 跨进程稳定；`markAllSeen` 撤域级 + 分组 id。
- 更新中心条目显示缩略图与发布时刻。6 个 i18n key（`i18n_sync`）。

## 验证
- `flutter analyze`（含 test）绿；`test/updates`（29）、`video_download_pipeline_service_test`（55）、`test/pages` + `test/i18n`（两条并发伪红单跑 28 绿）、`fushi_engine_purity_guard` 绿。
- code-review agent 5 条发现已全部返工（第二个 commit）。
- **本机无法出真机 toast 证据**：`flutter_local_notifications_windows` 自身 `#include <atlbase.h>`，本机 VS 缺 ATL，含它的任何 Windows 构建都编不过。需 CI 包在用户机验证一次订阅入库后的 toast（图标 / 截图 / 时间 / 按钮 / 点击播放）。

https://claude.ai/code/session_01CkGrYAJLuxvftDErovjAZF
