### PR TITLE
handoff: popup kanji tap-lookup (BUG-2460) / interconnect collection download (#6) / scrape metadata sync+remote scrape (#7, BUG-2463)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2267 条。点号进各自文件。
+> 共 2268 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2460](bugs/BUG-2460-popup-kanji-card-body-tap-lookup.md) | ✅ | ✅ | 查词弹窗汉字卡片读音/释义点词无反应 |
 | [BUG-2457](bugs/BUG-2457-manga-ocr-beam-early-stopping.md) | ✅ | ✅ | 漫画 OCR beam search 按 early_stopping=false 实现与原版 generation_config 不符，退化图跑满 300 步既慢又编造 |
 | [BUG-2456](bugs/BUG-2456-dict-link-furigana-query.md) | ✅ | ✅ | 词典正文链接点击查询词混入振假名，前缀扫描退化成首字汉字 |
 | [BUG-2455](bugs/BUG-2455-interconnect-video-native-tls-trust.md) | ✅ | ✅ | 互联远端视频打不开：随包 libmpv 换 libcurl 后默认校验自签证书 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2268 条。点号进各自文件。
+> 共 2269 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2463](bugs/BUG-2463-interconnect-download-drops-host-cover-timestamps.md) | ✅ | ✅ | 互联下载登记丢失 host 封面 / importedAt / completedAt |
 | [BUG-2460](bugs/BUG-2460-popup-kanji-card-body-tap-lookup.md) | ✅ | ✅ | 查词弹窗汉字卡片读音/释义点词无反应 |
 | [BUG-2457](bugs/BUG-2457-manga-ocr-beam-early-stopping.md) | ✅ | ✅ | 漫画 OCR beam search 按 early_stopping=false 实现与原版 generation_config 不符，退化图跑满 300 步既慢又编造 |
 | [BUG-2456](bugs/BUG-2456-dict-link-furigana-query.md) | ✅ | ✅ | 词典正文链接点击查询词混入振假名，前缀扫描退化成首字汉字 |

--- a/docs/bugs/BUG-2460-popup-kanji-card-body-tap-lookup.md
+++ b/docs/bugs/BUG-2460-popup-kanji-card-body-tap-lookup.md
@@ -1,0 +1,6 @@
+## BUG-2460 · 查词弹窗汉字卡片读音/释义点词无反应
+- **报告**：2026-09-12（用户：查词弹窗顶部米黄底汉字卡片 `.kanji-card` 里的音读/训读/释义/相关词（如 JPDB Kanji 的「一軒, 軒並み, 軒先…」）点了没反应，只有大字有点击）
+- **真实性**：✅ 真 bug。根因在 document 级点击委托 `fushi/assets/popup/popup.js` `__fushiPopupClick`：`fushiSelection.selectText`（tap-to-lookup 唯一入口）只在 `closest('.glossary-content')` 分支里调；汉字卡片正文节点（`createKanjiReadingRow` 建的 `.kanji-card-value`、`.kanji-card-meanings`）不在 `.glossary-content` 内，落到 `closest('.entry') || closest('.kanji-card-section')` 卡片分支——那里只做「有子窗则 tapOutside」然后裸 `return`，从不选词。节点本身也无 onclick（只有大字 `.kanji-card-char` 直接绑 `onLinkClick`）。selection.js 对这些文本节点本来就能工作（无容器门控，`、`/`,` 在分隔符集里），Dart 两宿主（`dictionary_popup_webview.dart` / `global_lookup_controller.dart`）`textSelected` 均已注册，缺的只是委托那一句派发。
+- **[x] ① 已修复** — `.glossary-content` 分支选择器扩为 `'.glossary-content, .kanji-card-value, .kanji-card-meanings'`，卡片正文与释义正文同语义（有子窗先 tapOutside，否则 selectText）；label 列与大字不受影响。三处 popup.js 镜像同步。
+- **[x] ② 已加自动化测试** — `fushi/test/utils/misc/popup_asset_behavior_test.js` 新增 `testTapOnKanjiCardValueSelectsWord`（value/meanings → selectText 且不 tapOutside；label 列不选词）与 `testTapOnKanjiCardValueWithChildFiresTapOutside`（有子窗只 tapOutside）；`fushi/test/pages/dictionary_child_popup_close_guard_test.dart` 字面量跟进。
+- **备注**：真机验证缺口——两宿主（app 内弹窗 / galgame 悬浮窗）点读音后 `%TEMP%\hibiki_glookup.log` 出现 nested lookup 记录尚未实测。

--- a/docs/bugs/BUG-2463-interconnect-download-drops-host-cover-timestamps.md
+++ b/docs/bugs/BUG-2463-interconnect-download-drops-host-cover-timestamps.md
@@ -1,0 +1,6 @@
+## BUG-2463 · 互联下载登记丢失 host 封面 / importedAt / completedAt
+- **报告**：2026-09-12（用户：host 上刮好的元数据有的没同步到客户端——交接 #7c；本条是其中「wire 已输出但客户端未写」的三个字段，刮削元数据整块通路缺失另立 spec）
+- **真实性**：✅ 真 bug。`fushi/lib/src/pages/implementations/home_video_page.dart` `_registerDownloadedVideo`：① 封面无条件走本机 ffmpeg 抽帧 `extractVideoCover`，注释称「host 无封面文件下载原语」——但 host 早有 `GET /api/library/videos/<id>/cover`（`fushi_sync_server/video.part.dart`）且 client 已实现 `RemoteCoverFetcher.fetchRemoteCover(coverUrl)`（远端占位卡就是靠它画封面），下载后刮削封面被一帧截图顶掉；② `importedAt` 写 `DateTime.now()`，而 `RemoteVideoInfo.importedAt` 是 host 值、远端占位卡按它排序，下载后同一条目在「按导入时间」里跳位；③ `completedAt` 根本不写，远端槽按 `remote.completedAt` 画的已看完角标下载后消失。
+- **[x] ① 已修复** — 先 `_fetchHostCoverToDisk`（coverUrl + RemoteCoverFetcher → `remote_videos/<uid>.cover.jpg`），失败/无再退抽帧；`importedAt: video.importedAt ?? now`；`completedAt` 镜像 host 毫秒值。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/home_video_remote_download_register_test.dart`「下载登记镜像 host 封面（coverUrl）、importedAt 与 completedAt」（变异实测：还原修复红在 importedAt）。
+- **备注**：刮削元数据（简介/评分/分集名/external id/海报语言/lockedFields 等）在互联 wire 上整块不存在，见 `docs/specs/2026-09-12-interconnect-scrape-metadata.md`。

--- a/docs/specs/2026-09-12-interconnect-scrape-metadata.md
+++ b/docs/specs/2026-09-12-interconnect-scrape-metadata.md
@@ -78,3 +78,24 @@ host 从 DB 反向装载：新增 `loadVideoMetadataWork(db, workRow)`（`video_
 - `VideoSourceScrapeWork.source` 是非空 `SourceLibraryRow`，客户端下载的视频没有来源库；`apply` 实际不读 `source`，批 1 通过为客户端 apply 构造一个只含 collection/members 的工作单元解决（不改 `VideoSourceScrapeWork` 类型，避免波及计划器）。
 - 一个合集在计划器里可能是多个 `book:<uid>` 单元（BUG-2433）：7a 的 `candidates` / `scrape` 请求带的是 `MetadataWorkKey`，host 端按 `planScrapeWorksForCollection` 解析；多单元时返回 409 `{conflict: "ambiguousWork", works: [...]}`，客户端按本地同款 `_pickCollectionScrapeWork` 让用户选后带 `bookUid` 重发。
 - Wire 体积：全库 works 一次拉。先按 `since` 增量；images / credits 可能大，批 1 先全量，实测超 1MB 再拆端点。
+
+## 6. 落地记录（2026-09-12，批 1~3 同一 PR）
+
+- 引擎：`video_metadata_wire.dart`（codec）、`video_metadata_work_loader.dart`（DB → 模型）、`sync/video_metadata_manifest.dart`（wire DTO）、`sync/video_metadata_work_target.dart`（自然键 ↔ 本地作品单元、`applyRemoteVideoMetadata`）；`VideoSourceScrapeWork.source` 改可空（只喂 `apply` 的目标，§5 第一条最终没走「不改类型」那条路——改可空比构造假来源行干净，真刮入口 `scrapeImportedWork` 用 `ArgumentError.checkNotNull` 守住）；`searchManualCandidates` 的 `source` 可空 + 新增 `fetchWorkForLookup`。
+- host：`VideoMetadataHost` 可选能力接口（`is` 探测，老 host 404），`LocalLibraryHostService` 实现，`scrapeController` 由 app 经 `AppModel.videoScrapeControllerResolver` 借 HomePage 的控制器（不造第二个协调器）；无头服务端自动降级（无刮削链：candidates 空、scrape 409 notPlanned）。
+- 客户端：`InterconnectSyncBackend` 四个方法；`sync_orchestrator/video_metadata.part.dart` 紧跟合集同步；合集右键 / 详情页管理菜单三项：「下载远端集」（#6）「在主机上刮削」（7a）「本机刮削并回写主机」（7b）。
+- 守卫：`fushi/test/media/video/metadata/video_metadata_wire_roundtrip_test.dart`（编解码 + `apply→load→encode→decode→apply→load` 幂等）、`fushi/test/sync/interconnect_video_metadata_host_test.dart`（真 HTTP：列出 / since / 7a 降级 / 7b 身份冲突与 replace / 字段锁 / 400 / notPlanned）、`fushi/test/sync/interconnect_video_metadata_client_apply_test.dart`。
+
+### 6.1 loader 反向装载的已知不可逆差异（wire 上读回 ≠ provider 原件）
+
+**模型有字段但 DB 没列（apply 直接丢）**：`VideoMetadataWork.aliases / seasonCount / episodeCount`；`VideoMetadataPerson.id` / `VideoMetadataCharacter.id`（personKey/characterKey 是派生的）；`VideoMetadataCharacter.originalName`；`VideoMetadataImage.likes / seasonNumber / episodeNumber`；`VideoMetadataId.isDefault`（用 `isPrimary` 回填）。
+
+**apply 归一化**：id `type` 小写、`value` trim、同 type 只留最后一条；terms 按 `TitleNormalizer` 去重；credit `roleName` 写成 `roleName ?? character.name ?? ''` 并按 (person, kind, roleName) 去重，人物/角色 ids 跨作品累积；images 按 `(kind, position)` 排序、`rating ← voteAverage`、被字段锁保住的旧图行照读；extras 只落 `remoteUrl != null` 的在线附件；`provider` 靠主身份反推（作品 `ids` 里没有 `type == provider.name` 时读回的是第一条身份的 provider；`local` 骨架作品无身份直接抛、不上 wire）；credit / extra kind DB 是 snake_case，loader 反向映射，未知值域跳过。
+
+**DB 有列但模型没有（wire entry 另带或无视）**：`lockedFields / updatedAt`（entry 另带）、`VideoMetadataSeasons.endDate`、`VideoMetadataImages.width/height/sha256/localPath`、`VideoMetadataPeople.profilePath`、`VideoMetadataCharacters.imagePath`、`VideoMetadataProviderIdentities.externalUrl`、`VideoMetadataExtras.thumbnailPath/bookUid`。图片只带 `remoteUrl`，客户端沿用「无 localPath 用 remoteUrl」回落。
+
+### 6.2 未做 / 真机缺口
+
+- 真机双端（host 刮 → 客户端同步；客户端在 host 上重刮；客户端代刮回写）未实测，只有内存 DB + 真 HTTP 的端到端测试。
+- 7a/7b 入口只做了视频合集；单条目视频（`book:<uid>`）的客户端入口未加（wire 与 host 已支持 `bookUid` 键）。
+- 客户端 `updatedAt` 新旧判定用两端各自的时钟；时钟差大时 host 更新可能被跳过一轮（下一次 host 再刮会追上）。

--- a/docs/specs/2026-09-12-interconnect-scrape-metadata.md
+++ b/docs/specs/2026-09-12-interconnect-scrape-metadata.md
@@ -1,0 +1,80 @@
+# 互联刮削元数据：host → 客户端同步（7c）、客户端触发 host 刮削（7a）、客户端代刮回写（7b）
+
+日期：2026-09-12。交接编号 #7。相关：BUG-2463（wire 已输出但客户端未写的三个字段，已单独修）。
+
+## 0. 现状（沿真实代码路径核过）
+
+- 互联 wire 上视频条目只有一个 DTO `RemoteVideoInfo`（`packages/fushi_engine/lib/sync/fushi_library_host_service.dart:1504-1546`），由 host 从 `VideoBooks` 单表 materialize（`local_library_host_service/videos.part.dart:23` 只查 `allVideoBooks()`）。`packages/fushi_engine/lib/sync/` 对 `VideoScrapeMeta` / `CollectionScrapeMeta` / `MediaImages` / 13 张 `VideoMetadata*` 表 grep **零命中**；客户端 `fushi/lib/src/sync/` 同样零写入。
+- 合集清单端点 `GET/POST /api/library/collections`（`CollectionManifest`，`collection_manifest.dart:237-249`）只带 name / collectionType / members / tombstones / tagNames，**不带** `MediaCollections.coverPath` 与任何刮削字段。
+- 所以「host 刮好的元数据有的没同步」的真相是：**刮削元数据整块不在 wire 上**，不是个别列漏项。BUG-2454 / PR#1420 / PR#1423 零 schema 变更，与此无关。
+- 刮削落库的唯一入口是 `VideoMetadataDatabaseStore.apply(localWork, VideoMetadataWork)`（`video_metadata_database_store.dart:138`）：它处理 v99 字段锁、旧投影表、成员集号绑定。**客户端落库必须复用它**，不另写第二套写入。
+- 领域模型 `VideoMetadataWork`（`video_metadata_models.dart:639`，含 Season / Episode / Id / Credit / Person / Character / Image / Extra）**没有 JSON 编解码**，也没有「从 DB 行反向装载」的函数（provider 拿到模型 → apply 写库，是单向的）。
+- host 侧刮削能力面：`VideoSourceScrapeTaskController`（`video_source_scrape_task.dart:381`）的 `searchManualCandidates(source, workTitle, workStableKey, query)` 与 `rescrapeWorkWithLookup(source, workTitle, workStableKey, lookup)`；合集 → 作品单元由 `planScrapeWorksForCollection(db, collectionId)`（`video_library_scrape_sweep.dart:58`）给出，一个合集可能对应多个 `book:<uid>` 单元（BUG-2433）。
+- 身份：`VideoMetadataLookup{provider, externalId, mediaKind, episodeGroupId}`；host 已确认的主身份由 `VideoMetadataDatabaseStore.confirmedLookup(localWork)` 读 `VideoMetadataProviderIdentities.isPrimary`。
+
+## 1. 数据结构（先定这个）
+
+### 1.1 作品自然键 `MetadataWorkKey`
+
+跨端唯一、不依赖自增 id：
+
+```json
+{ "collection": { "name": "...", "collectionType": "collection" } }   // 合集级作品
+{ "bookUid": "..." }                                                   // 单条目作品
+```
+
+与 `CollectionManifestEntry` / `RemoteVideoInfo.id` 同域，客户端本地必然能解析（合集经 `/api/library/collections` 同步；bookUid 是 host 的 `VideoBooks.bookUid` = 客户端下载后的 bookUid）。
+
+### 1.2 作品 wire 形态 `MetadataWorkEntry`
+
+```json
+{
+  "key": <MetadataWorkKey>,
+  "updatedAt": 1700000000000,          // host VideoMetadataWorks.updatedAt
+  "lockedFields": ["title", "cover"],  // host 字段锁（只读镜像，客户端不据此加锁）
+  "lookup": { "provider": "mal", "externalId": "1234", "mediaKind": "tv", "episodeGroupId": null },
+  "work": <VideoMetadataWork JSON>
+}
+```
+
+`work` = `encodeVideoMetadataWork(VideoMetadataWork)`（新增 `video_metadata_wire.dart`，与 `decodeVideoMetadataWork` 互逆；`rawPayload` 不上 wire）。图片只带 `remoteUrl` / kind / language / 尺寸（host 的 `localPath` 是缓存，客户端沿用现有「无 localPath 用 remoteUrl」回落，见 `media_collection_detail_page.dart:341-344`）。
+
+host 从 DB 反向装载：新增 `loadVideoMetadataWork(db, workRow)`（`video_metadata_work_loader.dart`），逐表读 Seasons / Episodes / ProviderIdentities / Terms / Credits+People+Characters / Images / Extras 拼回 `VideoMetadataWork`。守卫：`apply → load → encode → decode → apply` 往返测试。
+
+### 1.3 端点
+
+| 方法 | 路径 | 用途 | 批次 |
+|---|---|---|---|
+| GET | `/api/library/metadata` | 全部作品 `MetadataWorkEntry[]`（`?since=<ms>` 只回 updatedAt 更新的） | 7c |
+| POST | `/api/library/metadata/candidates` | `{key, query}` → `[{lookup, work}]`（host 跑 `searchManualCandidates`） | 7a |
+| POST | `/api/library/metadata/scrape` | `{key, lookup}` → host 跑 `rescrapeWorkWithLookup`，同步返回 `{ok, entry?}` | 7a |
+| PUT | `/api/library/metadata` | `{key, lookup, work, replaceIdentity}` → host `store.apply` 落库 | 7b |
+
+`/api/capabilities` 加 `videoMetadata: true`；旧 host 404 → 客户端静默跳过（不报错、不阻塞其余同步）。
+
+## 2. 覆盖保护（7a / 7b 共用）
+
+1. **字段锁**：`store.apply` 已保留 host 锁定字段旧值，7b 回写天然受保护；7a 走 host 自己的刮削链，同理。
+2. **手动指定 ID 不静默换源**：7b `PUT` 时 host 先 `confirmedLookup(localWork)`；已有主身份且 `(provider, externalId)` 与入站 `lookup` 不同 → 除非 `replaceIdentity: true`，返回 409 `{conflict: "identity", current: <lookup>}`；客户端弹确认后重发。7a 由用户在候选里明确选身份，本身就是显式换源。
+3. **单源语义**：AniDB 身份不传兜底（沿 CLAUDE.md），wire 只搬运，不在同步层做任何换源。
+4. **7c 方向**：host 是刮削权威。客户端只在「本地无作品行」或「host `updatedAt` 大于本地 `updatedAt`」时 apply；本地字段锁照旧由 apply 保护（用户在客户端锁的字段不被 host 覆盖）。
+
+## 3. 客户端
+
+- `InterconnectSyncBackend`：`getRemoteVideoMetadata({since})` / `searchRemoteMetadataCandidates` / `requestRemoteScrape` / `putRemoteVideoMetadata`。
+- 同步编排 `sync_orchestrator/metadata.part.dart`：拉 `/api/library/metadata`，逐条按 §1.1 解析本地目标（合集按 `(name, collectionType)`；bookUid 直接查 `VideoBooks`），构造 `VideoSourceScrapeWork`（source 允许为空——见 §5 风险）并 `store.apply`。
+- 7a UI：合集右键 / 详情页管理菜单「在 host 上刮削」→ 复用 `showVideoSourceScrapeManualBindingDialog` 的候选搜索 UI，但候选来源换成远程端点；选定后 `POST /scrape`，回来触发一次 7c 拉取刷新。
+- 7b UI：「本机刮削并回写 host」→ 本地 provider registry 搜候选（沿用本地 UI）→ `fetchWork(lookup)` 拿完整 `VideoMetadataWork` → `PUT`；409 → 确认换源对话框 → `replaceIdentity: true` 重发。
+
+## 4. 分批与验证
+
+- 批 1（7c）：codec + loader + `GET /api/library/metadata` + 客户端 apply。往返守卫测试、host 端点测试（fake service）、客户端 apply 测试（内存 DB）。
+- 批 2（7a）：candidates / scrape 端点 + 客户端远程候选 UI。端点测试 + 409/404 降级测试。
+- 批 3（7b）：`PUT` + 覆盖保护 + 客户端回写 UI。字段锁 / 身份冲突测试。
+- 真机：客户端与 host 各一台，host 刮完一部，客户端同步后详情页出现简介/评分/分集名；客户端在 host 上重刮一次；客户端代刮回写一次。缺口如实记录。
+
+## 5. 风险
+
+- `VideoSourceScrapeWork.source` 是非空 `SourceLibraryRow`，客户端下载的视频没有来源库；`apply` 实际不读 `source`，批 1 通过为客户端 apply 构造一个只含 collection/members 的工作单元解决（不改 `VideoSourceScrapeWork` 类型，避免波及计划器）。
+- 一个合集在计划器里可能是多个 `book:<uid>` 单元（BUG-2433）：7a 的 `candidates` / `scrape` 请求带的是 `MetadataWorkKey`，host 端按 `planScrapeWorksForCollection` 解析；多单元时返回 409 `{conflict: "ambiguousWork", works: [...]}`，客户端按本地同款 `_pickCollectionScrapeWork` 让用户选后带 `bookUid` 重发。
+- Wire 体积：全库 works 一次拉。先按 `since` 增量；images / credits 可能大，批 1 先全量，实测超 1MB 再拆端点。

--- a/fushi/assets/browser_extension/vendor/popup.js
+++ b/fushi/assets/browser_extension/vendor/popup.js
@@ -6186,7 +6186,12 @@ function __fushiPopupClick(e) {
     // 是顶层节点，当年正是这个毛病。
     if (target?.closest('.grammar-tooltip')) return;
     if (target?.closest('summary')) return;
-    if (target?.closest('.glossary-content')) {
+    // 可点词查词的文本节点：词典释义正文 .glossary-content，以及汉字卡片的读音/stats
+    // 值（.kanji-card-value）与释义（.kanji-card-meanings）。汉字卡片正文与释义正文
+    // 同语义（点哪个字从哪个字扫词），selection.js 本就不分容器；此前它们落到下面的
+    // .kanji-card-section 卡片分支裸 return，点了没反应。大字 .kanji-card-char 自带
+    // onLinkClick + stopPropagation，不经这里。
+    if (target?.closest('.glossary-content, .kanji-card-value, .kanji-card-meanings')) {
         // BUG-767：glossary 内的锚点（MDX 原始 HTML 交叉引用/外链/发音）统一走
         // handleGlossaryAnchorClick——preventDefault 阻止默认导航（否则结果框架被导走→白屏），
         // 内部引用转 onLinkClick 重查。结构化内容链接自带 onclick + stopPropagation，永不冒泡到此。

--- a/fushi/assets/popup/popup.js
+++ b/fushi/assets/popup/popup.js
@@ -6186,7 +6186,12 @@ function __fushiPopupClick(e) {
     // 是顶层节点，当年正是这个毛病。
     if (target?.closest('.grammar-tooltip')) return;
     if (target?.closest('summary')) return;
-    if (target?.closest('.glossary-content')) {
+    // 可点词查词的文本节点：词典释义正文 .glossary-content，以及汉字卡片的读音/stats
+    // 值（.kanji-card-value）与释义（.kanji-card-meanings）。汉字卡片正文与释义正文
+    // 同语义（点哪个字从哪个字扫词），selection.js 本就不分容器；此前它们落到下面的
+    // .kanji-card-section 卡片分支裸 return，点了没反应。大字 .kanji-card-char 自带
+    // onLinkClick + stopPropagation，不经这里。
+    if (target?.closest('.glossary-content, .kanji-card-value, .kanji-card-meanings')) {
         // BUG-767：glossary 内的锚点（MDX 原始 HTML 交叉引用/外链/发音）统一走
         // handleGlossaryAnchorClick——preventDefault 阻止默认导航（否则结果框架被导走→白屏），
         // 内部引用转 onLinkClick 重查。结构化内容链接自带 onclick + stopPropagation，永不冒泡到此。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80121 (4713 per locale)
+/// Strings: 80240 (4720 per locale)
 ///
-/// Built on 2026-09-11 at 17:22 UTC
+/// Built on 2026-09-11 at 17:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6558,6 +6558,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -17656,6 +17669,26 @@ class _StringsAr extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -28982,6 +29015,26 @@ class _StringsDe extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -40362,6 +40415,26 @@ class _StringsEs extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -51776,6 +51849,26 @@ class _StringsFr extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -62992,6 +63085,26 @@ class _StringsId extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -74301,6 +74414,26 @@ class _StringsIt extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -84987,6 +85120,26 @@ class _StringsJa extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -95683,6 +95836,26 @@ class _StringsKo extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -106948,6 +107121,26 @@ class _StringsNl extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -118267,6 +118460,26 @@ class _StringsPtBr extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -129563,6 +129776,26 @@ class _StringsRu extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -140658,6 +140891,26 @@ class _StringsTh extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -151869,6 +152122,26 @@ class _StringsTr extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -163051,6 +163324,26 @@ class _StringsVi extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 // Path: <root>
@@ -173309,6 +173602,22 @@ class _StringsZhCn extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       '已下载 ${ok} 个远端集，${failed} 个失败';
+  @override
+  String get remote_collection_scrape_on_host => '在主机上刮削';
+  @override
+  String get remote_collection_scrape_push_to_host => '本机刮削并回写主机';
+  @override
+  String get remote_collection_scrape_unavailable => '对端主机不支持远程刮削';
+  @override
+  String get remote_collection_scrape_done => '已从主机更新资料';
+  @override
+  String get remote_collection_scrape_failed => '远程刮削失败：作品不在主机的刮削计划里';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      '主机上该作品已绑定 ${provider} ID ${id}，要替换吗？';
+  @override
+  String get remote_collection_scrape_pick_work => '选择要刮削的作品';
 }
 
 // Path: <root>
@@ -183677,6 +183986,26 @@ class _StringsZhHk extends _StringsEn {
   String remote_collection_download_done(
           {required Object ok, required Object failed}) =>
       'Downloaded ${ok} remote episode(s), ${failed} failed';
+  @override
+  String get remote_collection_scrape_on_host => 'Scrape on host';
+  @override
+  String get remote_collection_scrape_push_to_host =>
+      'Scrape here and send to host';
+  @override
+  String get remote_collection_scrape_unavailable =>
+      'Remote scraping is not available for this host';
+  @override
+  String get remote_collection_scrape_done => 'Metadata updated from host';
+  @override
+  String get remote_collection_scrape_failed =>
+      'Remote scrape failed: the work is not in the host library plan';
+  @override
+  String remote_collection_scrape_identity_conflict(
+          {required Object provider, required Object id}) =>
+      'The host already binds this work to ${provider} ID ${id}. Replace it?';
+  @override
+  String get remote_collection_scrape_pick_work =>
+      'Choose which work to scrape';
 }
 
 /// Flat map(s) containing all translations.
@@ -193385,6 +193714,21 @@ extension on _StringsEn {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -203088,6 +203432,21 @@ extension on _StringsAr {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -212836,6 +213195,21 @@ extension on _StringsDe {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -222575,6 +222949,21 @@ extension on _StringsEs {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -232323,6 +232712,21 @@ extension on _StringsFr {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -242042,6 +242446,21 @@ extension on _StringsId {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -251783,6 +252202,21 @@ extension on _StringsIt {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -261451,6 +261885,21 @@ extension on _StringsJa {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -271123,6 +271572,21 @@ extension on _StringsKo {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -280857,6 +281321,21 @@ extension on _StringsNl {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -290586,6 +291065,21 @@ extension on _StringsPtBr {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -300322,6 +300816,21 @@ extension on _StringsRu {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -310030,6 +310539,21 @@ extension on _StringsTh {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -319753,6 +320277,21 @@ extension on _StringsTr {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -329470,6 +330009,21 @@ extension on _StringsVi {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }
@@ -339100,6 +339654,21 @@ extension on _StringsZhCn {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             '已下载 ${ok} 个远端集，${failed} 个失败';
+      case 'remote_collection_scrape_on_host':
+        return '在主机上刮削';
+      case 'remote_collection_scrape_push_to_host':
+        return '本机刮削并回写主机';
+      case 'remote_collection_scrape_unavailable':
+        return '对端主机不支持远程刮削';
+      case 'remote_collection_scrape_done':
+        return '已从主机更新资料';
+      case 'remote_collection_scrape_failed':
+        return '远程刮削失败：作品不在主机的刮削计划里';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            '主机上该作品已绑定 ${provider} ID ${id}，要替换吗？';
+      case 'remote_collection_scrape_pick_work':
+        return '选择要刮削的作品';
       default:
         return null;
     }
@@ -348746,6 +349315,21 @@ extension on _StringsZhHk {
       case 'remote_collection_download_done':
         return ({required Object ok, required Object failed}) =>
             'Downloaded ${ok} remote episode(s), ${failed} failed';
+      case 'remote_collection_scrape_on_host':
+        return 'Scrape on host';
+      case 'remote_collection_scrape_push_to_host':
+        return 'Scrape here and send to host';
+      case 'remote_collection_scrape_unavailable':
+        return 'Remote scraping is not available for this host';
+      case 'remote_collection_scrape_done':
+        return 'Metadata updated from host';
+      case 'remote_collection_scrape_failed':
+        return 'Remote scrape failed: the work is not in the host library plan';
+      case 'remote_collection_scrape_identity_conflict':
+        return ({required Object provider, required Object id}) =>
+            'The host already binds this work to ${provider} ID ${id}. Replace it?';
+      case 'remote_collection_scrape_pick_work':
+        return 'Choose which work to scrape';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80053 (4709 per locale)
+/// Strings: 80121 (4713 per locale)
 ///
-/// Built on 2026-09-11 at 10:45 UTC
+/// Built on 2026-09-11 at 17:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6550,6 +6550,14 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_cover_cache_max_age => 'Cover cache retention';
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  String get remote_collection_download_members => 'Download remote episodes';
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -17636,6 +17644,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -28950,6 +28970,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -40318,6 +40350,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -51720,6 +51764,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -62924,6 +62980,18 @@ class _StringsId extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -74221,6 +74289,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -84895,6 +84975,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -95579,6 +95671,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -106832,6 +106936,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -118139,6 +118255,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -129423,6 +129551,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -140506,6 +140646,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -151705,6 +151857,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -162875,6 +163039,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 // Path: <root>
@@ -173122,6 +173298,17 @@ class _StringsZhCn extends _StringsEn {
   String get manga_cover_cache_max_age => '封面缓存保留时长';
   @override
   String get manga_cover_cache_max_age_subtitle => '在线源封面超过此天数后重新下载';
+  @override
+  String get remote_collection_download_members => '下载远端集';
+  @override
+  String get remote_collection_download_nothing => '没有需要下载的远端集';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      '正在后台下载 ${count} 个远端集';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      '已下载 ${ok} 个远端集，${failed} 个失败';
 }
 
 // Path: <root>
@@ -183478,6 +183665,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_cover_cache_max_age_subtitle =>
       'Online source covers are re-downloaded after this many days';
+  @override
+  String get remote_collection_download_members => 'Download remote episodes';
+  @override
+  String get remote_collection_download_nothing =>
+      'No remote episodes to download';
+  @override
+  String remote_collection_download_started({required Object count}) =>
+      'Downloading ${count} remote episode(s) in the background';
+  @override
+  String remote_collection_download_done(
+          {required Object ok, required Object failed}) =>
+      'Downloaded ${ok} remote episode(s), ${failed} failed';
 }
 
 /// Flat map(s) containing all translations.
@@ -193176,6 +193375,16 @@ extension on _StringsEn {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -202869,6 +203078,16 @@ extension on _StringsAr {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -212607,6 +212826,16 @@ extension on _StringsDe {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -222336,6 +222565,16 @@ extension on _StringsEs {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -232074,6 +232313,16 @@ extension on _StringsFr {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -241783,6 +242032,16 @@ extension on _StringsId {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -251514,6 +251773,16 @@ extension on _StringsIt {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -261172,6 +261441,16 @@ extension on _StringsJa {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -270834,6 +271113,16 @@ extension on _StringsKo {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -280558,6 +280847,16 @@ extension on _StringsNl {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -290277,6 +290576,16 @@ extension on _StringsPtBr {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -300003,6 +300312,16 @@ extension on _StringsRu {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -309701,6 +310020,16 @@ extension on _StringsTh {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -319414,6 +319743,16 @@ extension on _StringsTr {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -329121,6 +329460,16 @@ extension on _StringsVi {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }
@@ -338742,6 +339091,15 @@ extension on _StringsZhCn {
         return '封面缓存保留时长';
       case 'manga_cover_cache_max_age_subtitle':
         return '在线源封面超过此天数后重新下载';
+      case 'remote_collection_download_members':
+        return '下载远端集';
+      case 'remote_collection_download_nothing':
+        return '没有需要下载的远端集';
+      case 'remote_collection_download_started':
+        return ({required Object count}) => '正在后台下载 ${count} 个远端集';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            '已下载 ${ok} 个远端集，${failed} 个失败';
       default:
         return null;
     }
@@ -348378,6 +348736,16 @@ extension on _StringsZhHk {
         return 'Cover cache retention';
       case 'manga_cover_cache_max_age_subtitle':
         return 'Online source covers are re-downloaded after this many days';
+      case 'remote_collection_download_members':
+        return 'Download remote episodes';
+      case 'remote_collection_download_nothing':
+        return 'No remote episodes to download';
+      case 'remote_collection_download_started':
+        return ({required Object count}) =>
+            'Downloading ${count} remote episode(s) in the background';
+      case 'remote_collection_download_done':
+        return ({required Object ok, required Object failed}) =>
+            'Downloaded ${ok} remote episode(s), ${failed} failed';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "后退",
   "popup_history_forward": "前进",
   "manga_cover_cache_max_age": "封面缓存保留时长",
-  "manga_cover_cache_max_age_subtitle": "在线源封面超过此天数后重新下载"
+  "manga_cover_cache_max_age_subtitle": "在线源封面超过此天数后重新下载",
+  "remote_collection_download_members": "下载远端集",
+  "remote_collection_download_nothing": "没有需要下载的远端集",
+  "remote_collection_download_started": "正在后台下载 $count 个远端集",
+  "remote_collection_download_done": "已下载 $ok 个远端集，$failed 个失败"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "下载远端集",
   "remote_collection_download_nothing": "没有需要下载的远端集",
   "remote_collection_download_started": "正在后台下载 $count 个远端集",
-  "remote_collection_download_done": "已下载 $ok 个远端集，$failed 个失败"
+  "remote_collection_download_done": "已下载 $ok 个远端集，$failed 个失败",
+  "remote_collection_scrape_on_host": "在主机上刮削",
+  "remote_collection_scrape_push_to_host": "本机刮削并回写主机",
+  "remote_collection_scrape_unavailable": "对端主机不支持远程刮削",
+  "remote_collection_scrape_done": "已从主机更新资料",
+  "remote_collection_scrape_failed": "远程刮削失败：作品不在主机的刮削计划里",
+  "remote_collection_scrape_identity_conflict": "主机上该作品已绑定 $provider ID $id，要替换吗？",
+  "remote_collection_scrape_pick_work": "选择要刮削的作品"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4711,5 +4711,12 @@
   "remote_collection_download_members": "Download remote episodes",
   "remote_collection_download_nothing": "No remote episodes to download",
   "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
-  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed",
+  "remote_collection_scrape_on_host": "Scrape on host",
+  "remote_collection_scrape_push_to_host": "Scrape here and send to host",
+  "remote_collection_scrape_unavailable": "Remote scraping is not available for this host",
+  "remote_collection_scrape_done": "Metadata updated from host",
+  "remote_collection_scrape_failed": "Remote scrape failed: the work is not in the host library plan",
+  "remote_collection_scrape_identity_conflict": "The host already binds this work to $provider ID $id. Replace it?",
+  "remote_collection_scrape_pick_work": "Choose which work to scrape"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4707,5 +4707,9 @@
   "popup_history_back": "Back",
   "popup_history_forward": "Forward",
   "manga_cover_cache_max_age": "Cover cache retention",
-  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days"
+  "manga_cover_cache_max_age_subtitle": "Online source covers are re-downloaded after this many days",
+  "remote_collection_download_members": "Download remote episodes",
+  "remote_collection_download_nothing": "No remote episodes to download",
+  "remote_collection_download_started": "Downloading $count remote episode(s) in the background",
+  "remote_collection_download_done": "Downloaded $ok remote episode(s), $failed failed"
 }

--- a/fushi/lib/src/media/collections/collection_episode_slot.dart
+++ b/fushi/lib/src/media/collections/collection_episode_slot.dart
@@ -3,7 +3,7 @@ import 'package:fushi_engine/sync/fushi_library_host_service.dart'
     show RemoteVideoInfo;
 import 'package:fushi/src/sync/remote_cover_fetcher.dart';
 import 'package:fushi_core/fushi_core.dart'
-    show MediaCollectionItemRow, MediaKind, VideoBookRow;
+    show MediaCollectionItemRow, MediaCollectionRow, MediaKind, VideoBookRow;
 
 /// 合集的一个**成员槽**：本地视频行 [local] 或「只在对端、本机没有」的远端占位
 /// [remote]，二者恰一非空。
@@ -120,6 +120,7 @@ class CollectionRemoteContext {
     required this.loadRemoteVideos,
     required this.openEpisode,
     this.coverFetcher,
+    this.downloadMembers,
   });
 
   /// 拉对端视频清单（调用方走共享的 [RemoteLibraryCache]，TTL 内不打网络）。
@@ -135,4 +136,12 @@ class CollectionRemoteContext {
 
   /// 远端封面取数器（钉扎 HTTP 客户端）；null = 远端集只画占位图标。
   final RemoteCoverFetcher? coverFetcher;
+
+  /// 把本合集**只在对端**的成员整批下载到本机（串行排队，见
+  /// `InterconnectDownloadManager.startBatch`）。null = 该远端源不支持下载
+  /// 到本地库（详情页不出「下载远端集」入口）。
+  final Future<void> Function(
+    MediaCollectionRow collection,
+    List<RemoteVideoInfo> members,
+  )? downloadMembers;
 }

--- a/fushi/lib/src/media/collections/collection_episode_slot.dart
+++ b/fushi/lib/src/media/collections/collection_episode_slot.dart
@@ -121,6 +121,8 @@ class CollectionRemoteContext {
     required this.openEpisode,
     this.coverFetcher,
     this.downloadMembers,
+    this.scrapeOnHost,
+    this.scrapeForHost,
   });
 
   /// 拉对端视频清单（调用方走共享的 [RemoteLibraryCache]，TTL 内不打网络）。
@@ -144,4 +146,11 @@ class CollectionRemoteContext {
     MediaCollectionRow collection,
     List<RemoteVideoInfo> members,
   )? downloadMembers;
+
+  /// 7a：让 host 用户选定的身份在 host 上重刮本合集（候选搜索也打到 host）。
+  /// null = 对端不支持远程刮削。
+  final Future<void> Function(MediaCollectionRow collection)? scrapeOnHost;
+
+  /// 7b：本机刮削后把完整资料回写 host。null = 本机无刮削链或对端不支持。
+  final Future<void> Function(MediaCollectionRow collection)? scrapeForHost;
 }

--- a/fushi/lib/src/media/video/metadata/video_source_scrape_run_detail_dialog.dart
+++ b/fushi/lib/src/media/video/metadata/video_source_scrape_run_detail_dialog.dart
@@ -271,23 +271,47 @@ class _VideoSourceScrapeRunDetailDialogState
   }
 }
 
+/// 候选搜索原语：按用户输入（标题或 `mal:123` 这类身份串）返回候选。
+typedef VideoMetadataCandidateSearch
+    = Future<List<VideoSourceScrapeConfirmationCandidate>> Function(
+  String query,
+);
+
 /// 手动搜索资料源并挑一个作品（共享入口：run 详情与待确认队列都用它）。
-/// 返回选中的候选；取消返回 null。
+/// 返回选中的候选；取消返回 null。[source] 为 null = 本机没有这部作品的来源库
+/// （互联 7b 客户端代 host 刮削），provider 取全局主源。
 Future<VideoSourceScrapeConfirmationCandidate?>
     showVideoSourceScrapeManualBindingDialog({
   required BuildContext context,
   required VideoSourceScrapeTaskController controller,
-  required SourceLibraryRow source,
+  SourceLibraryRow? source,
   required String workTitle,
   String? workStableKey,
+}) =>
+        showVideoMetadataCandidateSearchDialog(
+          context: context,
+          workTitle: workTitle,
+          search: (String query) => controller.searchManualCandidates(
+            source: source,
+            workTitle: workTitle,
+            workStableKey: workStableKey,
+            query: query,
+          ),
+        );
+
+/// 同一个候选搜索 UI，但候选来源由 [search] 注入——互联 7a「在 host 上刮削」把
+/// 搜索打到对端端点，本机不需要有刮削链。
+Future<VideoSourceScrapeConfirmationCandidate?>
+    showVideoMetadataCandidateSearchDialog({
+  required BuildContext context,
+  required String workTitle,
+  required VideoMetadataCandidateSearch search,
 }) =>
         showAppDialog<VideoSourceScrapeConfirmationCandidate>(
           context: context,
           builder: (BuildContext context) => _ManualBindingDialog(
-            controller: controller,
-            source: source,
+            search: search,
             workTitle: workTitle,
-            workStableKey: workStableKey,
           ),
         );
 
@@ -295,16 +319,12 @@ Future<VideoSourceScrapeConfirmationCandidate?>
 /// [VideoSourceScrapeCandidateTile]，选中后返回同一种候选对象。
 class _ManualBindingDialog extends StatefulWidget {
   const _ManualBindingDialog({
-    required this.controller,
-    required this.source,
+    required this.search,
     required this.workTitle,
-    this.workStableKey,
   });
 
-  final VideoSourceScrapeTaskController controller;
-  final SourceLibraryRow source;
+  final VideoMetadataCandidateSearch search;
   final String workTitle;
-  final String? workStableKey;
 
   @override
   State<_ManualBindingDialog> createState() => _ManualBindingDialogState();
@@ -337,12 +357,7 @@ class _ManualBindingDialogState extends State<_ManualBindingDialog> {
     });
     try {
       final List<VideoSourceScrapeConfirmationCandidate> results =
-          await widget.controller.searchManualCandidates(
-        source: widget.source,
-        workTitle: widget.workTitle,
-        workStableKey: widget.workStableKey,
-        query: _manualQuery(),
-      );
+          await widget.search(_manualQuery());
       if (!mounted) return;
       setState(() => _results = results);
     } on Object catch (error) {

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -132,6 +132,8 @@ import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_subtitle_obscure_mode.dart';
 import 'package:fushi_engine/media/tracking/media_tracking_repository.dart';
 import 'package:fushi_engine/media/tracking/media_tracking_service.dart';
+import 'package:fushi_engine/media/video/metadata/video_source_scrape_task.dart'
+    show VideoSourceScrapeTaskController;
 import 'package:fushi_engine/sync/local_library_host_service.dart';
 import 'package:fushi/src/sync/backup_service.dart';
 import 'package:fushi/src/sync/deletion_prompt.dart';
@@ -528,6 +530,13 @@ class AppModel with ChangeNotifier {
   /// snooze + 单飞）。同步消费到远端删除标记后经 [presentDeletionCandidates] 弹出。
   final DeletionPromptPrompter syncDeletionPrompter = DeletionPromptPrompter();
 
+  /// 7a 远程刮削：host 端需要一个刮削控制器代客户端搜候选 / 重刮。控制器归
+  /// HomePage 持有并按偏好重建（它是唯一持 `VideoScrapeOperationGate` 的实例，
+  /// host 不自造第二个协调器），HomePage 在 initState 登记、dispose 清除；未登记
+  /// （弹窗词典 / 悬浮词典入口没有 HomePage）→ host 报「不支持远程刮削」。
+  Future<VideoSourceScrapeTaskController?> Function()?
+      videoScrapeControllerResolver;
+
   /// App 级 Hibiki LAN 同步服务端宿主：生命周期归 AppModel（整个会话），
   /// 不再绑在设置页 widget 上——否则切出「同步与备份」页就把服务端关了（BUG-085）。
   /// 启动时若用户启用了 host 则自动开，仅在用户关闭开关或退出 app 时停。配对批准
@@ -551,6 +560,7 @@ class AppModel with ChangeNotifier {
       db: database,
       dictionaryResourceRoot: dictionaryResourceDirectory,
       packages: SyncAssetPackageService(db: database),
+      scrapeController: () async => videoScrapeControllerResolver?.call(),
       refreshDictionaryCache: () async {
         // host 侧（互联对端上传/删除词典）直接改 DB，Dart 侧内存 cache 不会自己
         // 跟上：不先 loadFromDb，_rebuildDictPathsCacheAsync 读的还是旧列表，刚被

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -409,6 +409,10 @@ class _HomePageState extends BasePageState<HomePage>
   @override
   void initState() {
     super.initState();
+    // 7a：把本页持有的刮削控制器借给互联 host（远程候选搜索 / 重刮）。getter 按
+    // 当前偏好惰性建，所以解析器每次都返回配置正确的那一个。
+    appModelNoUpdate.videoScrapeControllerResolver =
+        () async => _videoSourceScrapeController;
 
     _currentTab = homeInitialTab(
       startupDefaultDictionaryTab: appModelNoUpdate.startupDefaultDictionaryTab,
@@ -699,6 +703,7 @@ class _HomePageState extends BasePageState<HomePage>
 
   @override
   void dispose() {
+    appModelNoUpdate.videoScrapeControllerResolver = null;
     assert(() {
       HomePage.debugSelectTab = null;
       HomePage.debugVideoDiscoveryActions = null;

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -2210,33 +2210,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ref.read(interconnectDownloadManagerProvider);
     if (manager.isRunning(video.id)) return;
 
-    final File dest = await _remoteDownloadDestination(video);
-    // TODO-2119：下载本身是所有源的共同能力，不再分派——[RemoteVideoSource] 各自
-    // 实现续传口径（互联 host live 引擎 Range + `.part` 可续；云盘整文件重下）。
-    // bookUid 用稳定的远端 video.id（与 dedupeRemoteVideos 去重键一致：upsert 同行不
-    // 撞键），故下载好的视频立即出现在列表、并从混排占位区去重隐藏。
-    Future<void> run(
-      File target, {
-      void Function(double progress)? onProgress,
-    }) =>
-        source.downloadRemoteVideo(video.id, target, onProgress: onProgress);
-    // 收尾登记仍按源分流：互联要回填外挂字幕 + host 断点，云盘要按资产名取封面、
-    // 且没有字幕/进度可回填。这是两种源**真实**的能力差异，不是样板分支。
-    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
-    final RemoteVideoClient? client = _remoteVideoClient;
-    final InterconnectDownloadComplete onComplete = client != null
-        ? (File downloaded) =>
-            _registerDownloadedVideo(client, video, downloaded)
-        : (File downloaded) =>
-            _registerDownloadedCloudVideo(cloud!, video, downloaded);
+    final Future<void> Function() start =
+        await _prepareRemoteDownload(video, source, manager);
     try {
-      await manager.startVideoDownload(
-        id: video.id,
-        title: video.title,
-        dest: dest,
-        run: run,
-        onComplete: onComplete,
-      );
+      await start();
     } catch (e) {
       debugPrint('[home-video] remote video download failed: $e');
       if (!mounted) return;
@@ -2251,6 +2228,123 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(t.remote_video_downloaded)),
     );
+  }
+
+  /// 把一条远端视频的下载装配成**可延迟启动**的启动器：目标路径、传输原语、收尾
+  /// 登记全在此刻解析，启动器本身不再碰 `ref` / 本页 State——合集批下载
+  /// （[_downloadRemoteMembers]）串行排队时，轮到后面的成员起跑时本页可能早已 dispose。
+  ///
+  /// TODO-2119：下载本身是所有源的共同能力，不再分派——[RemoteVideoSource] 各自
+  /// 实现续传口径（互联 host live 引擎 Range + `.part` 可续；云盘整文件重下）。
+  /// bookUid 用稳定的远端 video.id（与 dedupeRemoteVideos 去重键一致：upsert 同行不
+  /// 撞键），故下载好的视频立即出现在列表、并从混排占位区去重隐藏。
+  Future<Future<void> Function()> _prepareRemoteDownload(
+    RemoteVideoInfo video,
+    RemoteVideoSource source,
+    InterconnectDownloadManager manager,
+  ) async {
+    final File dest = await _remoteDownloadDestination(video);
+    Future<void> run(
+      File target, {
+      void Function(double progress)? onProgress,
+    }) =>
+        source.downloadRemoteVideo(video.id, target, onProgress: onProgress);
+    // 收尾登记仍按源分流：互联要回填外挂字幕 + host 断点，云盘要按资产名取封面、
+    // 且没有字幕/进度可回填。这是两种源**真实**的能力差异，不是样板分支。
+    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
+    final RemoteVideoClient? client = _remoteVideoClient;
+    final InterconnectDownloadComplete onComplete = client != null
+        ? (File downloaded) =>
+            _registerDownloadedVideo(client, video, downloaded)
+        : (File downloaded) =>
+            _registerDownloadedCloudVideo(cloud!, video, downloaded);
+    return () => manager.startVideoDownload(
+          id: video.id,
+          title: video.title,
+          dest: dest,
+          run: run,
+          onComplete: onComplete,
+        );
+  }
+
+  /// 合集整体下载（#6）：把 [collection] 里**只在对端**的成员 [members] 串行排进
+  /// [InterconnectDownloadManager.startBatch]。成员清单来自本地
+  /// `media_collection_items`（合集清单经 `/api/library/collections` 跨端同步，
+  /// 客户端本地必然有 host 侧成员行）+ 共享远端视频清单，不需要新 wire 端点。
+  /// 已在跑的成员跳过；没有可下载成员时明确提示而不是静默。
+  Future<void> _downloadRemoteMembers(
+    MediaCollectionRow collection,
+    List<RemoteVideoInfo> members,
+  ) async {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    if (source == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_video_unavailable)),
+      );
+      return;
+    }
+    final InterconnectDownloadManager manager =
+        ref.read(interconnectDownloadManagerProvider);
+    final String batchId =
+        InterconnectDownloadManager.collectionBatchId(collection.id);
+    if (manager.isBatchRunning(batchId)) return;
+    final List<RemoteVideoInfo> pending = <RemoteVideoInfo>[
+      for (final RemoteVideoInfo video in members)
+        if (!manager.isRunning(video.id)) video,
+    ];
+    if (pending.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_collection_download_nothing)),
+      );
+      return;
+    }
+    // 先把整批启动器解析完再起跑：启动器不依赖本页 State（见 _prepareRemoteDownload）。
+    final List<Future<void> Function()> starters = <Future<void> Function()>[
+      for (final RemoteVideoInfo video in pending)
+        await _prepareRemoteDownload(video, source, manager),
+    ];
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            t.remote_collection_download_started(count: pending.length),
+          ),
+        ),
+      );
+    }
+    final InterconnectDownloadBatch batch = await manager.startBatch(
+      id: batchId,
+      title: collection.name,
+      starters: starters,
+    );
+    if (!mounted) return;
+    _refresh();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(t.remote_collection_download_done(
+          ok: batch.completed,
+          failed: batch.failed,
+        )),
+      ),
+    );
+  }
+
+  /// 合集卡右键「下载远端集」：先按详情页同一路径解析成员槽，取远端子集交给
+  /// [_downloadRemoteMembers]。
+  Future<void> _downloadRemoteCollection(MediaCollectionRow collection) async {
+    final CollectionRemoteContext? remote = _collectionRemoteContext();
+    if (remote == null) return;
+    final List<CollectionEpisodeSlot> slots = await loadCollectionEpisodeSlots(
+      repository: widget.repo,
+      collectionId: collection.id,
+      loadRemoteVideos: remote.loadRemoteVideos,
+    );
+    await _downloadRemoteMembers(collection, <RemoteVideoInfo>[
+      for (final CollectionEpisodeSlot slot in slots)
+        if (slot.remote case final RemoteVideoInfo info) info,
+    ]);
   }
 
   /// 把刚下载到本机的对端视频 [dest] 登记成本地 [VideoBooksCompanion] 行，使其出现在
@@ -6394,7 +6488,15 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           label: t.video_jimaku_batch_title,
           icon: Icons.subtitles_outlined,
           onPressed: () => _openCollectionSubtitles(collection),
-        )
+        ),
+        // 合集整体下载（#6）：只在有远端源时出现；成员全在本机时点了会明确提示
+        // 「没有可下载的远端集」。
+        if (_collectionRemoteContext() != null)
+          DialogListAction(
+            label: t.remote_collection_download_members,
+            icon: Icons.cloud_download_outlined,
+            onPressed: () => unawaited(_downloadRemoteCollection(collection)),
+          ),
       ],
     );
   }
@@ -6597,6 +6699,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         startIndex: index,
       )),
       coverFetcher: remoteCoverFetcherFor(_remoteVideoClient),
+      downloadMembers: _downloadRemoteMembers,
     );
   }
 

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -2354,9 +2354,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   ///
   /// 字幕：host 字幕原语 [RemoteVideoClient.getRemoteVideoSubtitle] 就绪，[video]
   /// 标记 [RemoteVideoInfo.hasSubtitle] 时下载外挂字幕落地、解析成 cue 一并写入，使
-  /// 下载来的视频可查词/句导航。封面：host 无封面文件下载原语（仅 coverUrl/coverPath
-  /// 元数据），故退回本地抽帧 [extractVideoCover]（桌面 ffmpeg；移动端无则留空占位），
-  /// 与本地导入一致。
+  /// 下载来的视频可查词/句导航。封面：host 下发 [RemoteVideoInfo.coverUrl]（`/cover`
+  /// 端点，含刮削封面），client 具备 [RemoteCoverFetcher] 能力时先拉 host 封面落盘；
+  /// 无 coverUrl / 拉取失败再退回本地抽帧 [extractVideoCover]（桌面 ffmpeg；移动端
+  /// 无则留空占位）。此前这里无条件抽帧，host 上刮好的封面下载后变成一帧截图（7c）。
+  ///
+  /// `importedAt` / `completedAt` 镜像 host 值（旧 host 不带 importedAt 时才用本机
+  /// now）：远端占位卡按 host 的 importedAt 排序、按 host 的 completedAt 画已看完角标，
+  /// 下载落地后同一条目不该在「按导入时间」里跳位、也不该丢掉已看完标记。
   Future<void> _registerDownloadedVideo(
     RemoteVideoClient client,
     RemoteVideoInfo video,
@@ -2374,7 +2379,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       embeddedSubtitleTrack: subtitle.source == null
           ? const Value<int?>(0)
           : const Value<int?>(null),
-      importedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      importedAt:
+          Value(video.importedAt ?? DateTime.now().millisecondsSinceEpoch),
+      completedAt: Value<DateTime?>(
+        video.completedAt == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(video.completedAt!),
+      ),
     ));
     if (subtitle.cues.isNotEmpty) {
       await widget.repo.saveCues(bookUid: bookUid, cues: subtitle.cues);
@@ -2397,10 +2408,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         remoteTombstones: video.tagTombstones,
       );
     }
-    // 封面抽帧（extractVideoCover 走 ffmpeg 子进程，最长 30s）是慢的可选增强，绝不能
-    // 挡在建行前——否则用户「下载完」要等到抽帧结束才看到视频。这里建行已落库，封面
-    // 单独抽好后再 updateCover 回写并刷新一次（extractVideoCover 内部已吞失败返 null，
-    // 移动端无 ffmpeg 时留空占位，与本地导入一致）。
+    // 封面（先 host 封面、再抽帧）是慢的可选增强，绝不能挡在建行前——否则用户
+    // 「下载完」要等到封面结束才看到视频。这里建行已落库，封面单独落好后再
+    // updateCover 回写并刷新一次（extractVideoCover 内部已吞失败返 null，移动端无
+    // ffmpeg 时留空占位，与本地导入一致）。
     final VideoScrapeOperationLease? coverLease =
         VideoScrapeOperationGate.tryEnterOperation();
     if (coverLease == null) return;
@@ -2411,10 +2422,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             bookUid,
           );
           if (coverMetaStore == null) return false;
-          final String? coverPath = await extractVideoCover(
-            videoPath: dest.path,
-            bookUid: bookUid,
-          );
+          final String? hostCover =
+              await _fetchHostCoverToDisk(client, video, bookUid);
+          final String? coverPath = hostCover ??
+              await extractVideoCover(
+                videoPath: dest.path,
+                bookUid: bookUid,
+              );
           if (coverPath == null) return false;
           await widget.repo.updateCover(bookUid, coverPath);
           return _commitAutoFrameCover(coverMetaStore, bookUid);
@@ -2423,6 +2437,29 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       if (wroteCover && mounted) _refresh();
     } finally {
       coverLease.release();
+    }
+  }
+
+  /// 把 host 下发的封面（[RemoteVideoInfo.coverUrl]，`/cover` 端点）拉到
+  /// `remote_videos/<uid>.cover.jpg`，返回落盘路径；无 coverUrl / client 不具备
+  /// [RemoteCoverFetcher] 能力 / 拉取失败 / 空响应一律返回 null 让调用方退回抽帧。
+  Future<String?> _fetchHostCoverToDisk(
+    RemoteVideoClient client,
+    RemoteVideoInfo video,
+    String bookUid,
+  ) async {
+    final String? coverUrl = video.coverUrl;
+    final RemoteCoverFetcher? fetcher = remoteCoverFetcherFor(client);
+    if (coverUrl == null || coverUrl.isEmpty || fetcher == null) return null;
+    try {
+      final Uint8List bytes = await fetcher.fetchRemoteCover(coverUrl);
+      if (bytes.isEmpty) return null;
+      final File coverDest = await _remoteCoverDestination(bookUid);
+      await coverDest.writeAsBytes(bytes, flush: true);
+      return coverDest.path;
+    } catch (e) {
+      debugPrint('[home-video] host video cover download failed: $e');
+      return null;
     }
   }
 
@@ -2466,7 +2503,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           );
           if (coverMetaStore == null) return false;
           try {
-            final File coverDest = await _cloudCoverDestination(bookUid);
+            final File coverDest = await _remoteCoverDestination(bookUid);
             if (await cloud.getRemoteVideoCover(bookUid, coverDest)) {
               await widget.repo.updateCover(bookUid, coverDest.path);
               return _commitAutoFrameCover(coverMetaStore, bookUid);
@@ -2523,7 +2560,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 云视频封面下载落点：`<documents>/remote_videos/<safeUid>.cover.jpg`（与视频落点
   /// 同目录，重复下载覆盖同一副本）。
-  Future<File> _cloudCoverDestination(String bookUid) async {
+  /// 远端（互联 host / 云盘）封面的本机落盘路径。
+  Future<File> _remoteCoverDestination(String bookUid) async {
     final Directory dir = await AppPaths.remoteVideosDirectory();
     await dir.create(recursive: true);
     final String safeUid = safeWindowsFileName(bookUid);
@@ -2566,7 +2604,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final Directory dir = await AppPaths.videoSubtitlesDirectory();
     await dir.create(recursive: true);
     // BUG-1125：旧手写字符集漏了反斜杠（`[\/:*?"<>|]` 只转义了 `/`），id 含 `\`
-    // 时字幕会落到与封面（[_cloudCoverDestination] 走全集）不同的目录。统一走
+    // 时字幕会落到与封面（[_remoteCoverDestination] 走全集）不同的目录。统一走
     // 共享 helper 根修。
     final String safeUid = safeWindowsFileName(video.id);
     final File subDest = File(p.join(dir.path, '$safeUid.$ext'));

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -50,6 +50,10 @@ import 'package:fushi/src/media/video/video_library_overview.dart';
 import 'package:fushi/src/media/video/video_library_section.dart';
 import 'package:fushi_engine/media/video/metadata/video_scrape_operation_gate.dart';
 import 'package:fushi_engine/media/video/metadata/video_library_scrape_sweep.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
 import 'package:fushi_engine/media/video/metadata/video_source_scrape_task.dart';
 import 'package:fushi/src/media/video/video_mpv_config.dart';
 import 'package:fushi_engine/media/video/video_storage.dart';
@@ -87,6 +91,8 @@ import 'package:fushi/src/sync/deletion_prompt.dart';
 import 'package:fushi_engine/sync/deletion_propagation.dart';
 import 'package:fushi/src/sync/interconnect_sync_backend.dart';
 import 'package:fushi_engine/sync/fushi_library_host_service.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_work_target.dart';
 import 'package:fushi/src/sync/manual_sync_ui.dart';
 import 'package:fushi/src/sync/remote_download_progress_badge.dart';
 import 'package:fushi/src/sync/interconnect_download_manager.dart';
@@ -113,7 +119,9 @@ import 'package:fushi/src/media/source_library/add_local_folder_source.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:path/path.dart' as p;
 import 'package:fushi/src/media/video/metadata/video_source_scrape_run_detail_dialog.dart'
-    show showVideoSourceScrapeManualBindingDialog;
+    show
+        showVideoMetadataCandidateSearchDialog,
+        showVideoSourceScrapeManualBindingDialog;
 
 /// 顶层 helper：打开本地视频播放页的**共享路由入口**（本页 hero/卡片与首页
 /// dashboard 继续卡/活动条同一条路径），统一经 [VideoFushiPage.neutralized]
@@ -6535,6 +6543,20 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             icon: Icons.cloud_download_outlined,
             onPressed: () => unawaited(_downloadRemoteCollection(collection)),
           ),
+        // 互联刮削（7a / 7b）：只在互联源上出现。
+        if (_metadataBackend != null) ...<DialogListAction>[
+          DialogListAction(
+            label: t.remote_collection_scrape_on_host,
+            icon: Icons.cloud_sync_outlined,
+            onPressed: () => unawaited(_scrapeCollectionOnHost(collection)),
+          ),
+          if (widget.scrapeTaskController != null)
+            DialogListAction(
+              label: t.remote_collection_scrape_push_to_host,
+              icon: Icons.cloud_upload_outlined,
+              onPressed: () => unawaited(_scrapeCollectionForHost(collection)),
+            ),
+        ],
       ],
     );
   }
@@ -6738,6 +6760,214 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       )),
       coverFetcher: remoteCoverFetcherFor(_remoteVideoClient),
       downloadMembers: _downloadRemoteMembers,
+      scrapeOnHost:
+          _metadataBackend == null ? null : _scrapeCollectionOnHost,
+      scrapeForHost: _metadataBackend == null ||
+              widget.scrapeTaskController == null
+          ? null
+          : _scrapeCollectionForHost,
+    );
+  }
+
+  // ── 互联刮削元数据（7a / 7b）────────────────────────────────────────────
+  // `docs/specs/2026-09-12-interconnect-scrape-metadata.md` §3。
+
+  /// 元数据端点只在互联 backend 上有；云盘源没有。
+  InterconnectSyncBackend? get _metadataBackend {
+    final RemoteVideoClient? client = _remoteVideoClient;
+    return client is InterconnectSyncBackend ? client : null;
+  }
+
+  static VideoMetadataWorkKey _metadataKeyOf(MediaCollectionRow collection) =>
+      VideoMetadataWorkKey.collection(
+        name: collection.name,
+        collectionType: collection.collectionType,
+      );
+
+  /// 7a：候选搜索与重刮都在 host 上跑（host 自己的 provider / 主源 / 资料语言），
+  /// 客户端只负责让用户选身份，回来把 host 落好的作品条目落进本地并刷新。
+  Future<void> _scrapeCollectionOnHost(MediaCollectionRow collection) async {
+    final InterconnectSyncBackend? backend = _metadataBackend;
+    if (backend == null) return;
+    VideoMetadataWorkKey key = _metadataKeyOf(collection);
+    final VideoSourceScrapeConfirmationCandidate? candidate =
+        await showVideoMetadataCandidateSearchDialog(
+      context: context,
+      workTitle: collection.name,
+      search: (String query) async => <VideoSourceScrapeConfirmationCandidate>[
+        for (final VideoMetadataCandidateEntry c
+            in await backend.searchRemoteVideoMetadataCandidates(
+          key: key,
+          query: query,
+        ))
+          VideoSourceScrapeConfirmationCandidate(lookup: c.lookup, work: c.work),
+      ],
+    );
+    if (candidate == null || !mounted) return;
+    FushiToast.show(
+      msg: t.collection_rescrape_started,
+      severity: ToastSeverity.info,
+    );
+    try {
+      VideoMetadataWriteResult result =
+          await backend.requestRemoteVideoMetadataScrape(
+        key: key,
+        lookup: candidate.lookup,
+      );
+      // BUG-2433 同款：合集在 host 计划里是 N 个独立作品时让用户选，不默选第一个。
+      if (result.conflict == VideoMetadataConflict.ambiguousWork) {
+        if (!mounted) return;
+        final VideoMetadataWorkKey? picked =
+            await _pickRemoteWorkKey(result.ambiguousWorks);
+        if (picked == null) return;
+        key = picked;
+        result = await backend.requestRemoteVideoMetadataScrape(
+          key: key,
+          lookup: candidate.lookup,
+        );
+      }
+      await _finishRemoteMetadataWrite(result);
+    } on Object catch (e, stack) {
+      ErrorLogService.instance.log('video.scrapeCollectionOnHost', e, stack);
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.collection_rescrape_failed,
+        severity: ToastSeverity.error,
+      );
+    }
+  }
+
+  /// 7b：本机刮削链搜候选、拉完整资料，再 PUT 到 host（host 字段锁保留旧值；
+  /// host 已绑不同身份时先问用户是否替换——手动指定 ID 不静默换源）。
+  Future<void> _scrapeCollectionForHost(MediaCollectionRow collection) async {
+    final InterconnectSyncBackend? backend = _metadataBackend;
+    final VideoSourceScrapeTaskController? controller =
+        widget.scrapeTaskController;
+    if (backend == null || controller == null) return;
+    final VideoMetadataWorkKey key = _metadataKeyOf(collection);
+    final VideoSourceScrapeConfirmationCandidate? candidate =
+        await showVideoSourceScrapeManualBindingDialog(
+      context: context,
+      controller: controller,
+      workTitle: collection.name,
+    );
+    if (candidate == null || !mounted) return;
+    FushiToast.show(
+      msg: t.collection_rescrape_started,
+      severity: ToastSeverity.info,
+    );
+    try {
+      final VideoMetadataWork work =
+          await controller.fetchWorkForLookup(candidate.lookup) ??
+              candidate.work;
+      VideoMetadataWriteResult result = await backend.putRemoteVideoMetadata(
+        key: key,
+        lookup: candidate.lookup,
+        work: work,
+      );
+      if (result.conflict == VideoMetadataConflict.identity) {
+        final VideoMetadataLookup? current = result.currentLookup;
+        if (!mounted) return;
+        final bool? replace = await showAppDialog<bool>(
+          context: context,
+          builder: (BuildContext dialogContext) => AlertDialog(
+            title: Text(collection.name),
+            content: Text(t.remote_collection_scrape_identity_conflict(
+              provider: current?.provider.name.toUpperCase() ?? '?',
+              id: current?.externalId ?? '?',
+            )),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, false),
+                child: Text(t.dialog_cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(dialogContext, true),
+                child: Text(t.dialog_replace),
+              ),
+            ],
+          ),
+        );
+        if (replace != true) return;
+        result = await backend.putRemoteVideoMetadata(
+          key: key,
+          lookup: candidate.lookup,
+          work: work,
+          replaceIdentity: true,
+        );
+      }
+      await _finishRemoteMetadataWrite(result);
+    } on Object catch (e, stack) {
+      ErrorLogService.instance.log('video.scrapeCollectionForHost', e, stack);
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.collection_rescrape_failed,
+        severity: ToastSeverity.error,
+      );
+    }
+  }
+
+  /// host 写操作的收尾：成功则把 host 回传的作品条目落本地（客户端立刻看到，
+  /// 不等下一轮同步）并刷新；可解释拒绝给对应提示。
+  Future<void> _finishRemoteMetadataWrite(
+    VideoMetadataWriteResult result,
+  ) async {
+    final VideoMetadataWorkEntry? entry = result.entry;
+    if (entry != null) {
+      await applyRemoteVideoMetadata(
+        ref.read(appProvider).database,
+        <VideoMetadataWorkEntry>[entry],
+      );
+      if (!mounted) return;
+      _refresh();
+      FushiToast.show(
+        msg: t.remote_collection_scrape_done,
+        severity: ToastSeverity.info,
+      );
+      return;
+    }
+    if (!mounted) return;
+    FushiToast.show(
+      msg: result.conflict == VideoMetadataConflict.notPlanned
+          ? t.remote_collection_scrape_failed
+          : t.collection_rescrape_failed,
+      severity: ToastSeverity.error,
+    );
+  }
+
+  /// host 报合集对应多个作品单元时让用户选一个（标题取远端清单里该 bookUid 的
+  /// 标题，取不到退回 bookUid）。
+  Future<VideoMetadataWorkKey?> _pickRemoteWorkKey(
+    List<VideoMetadataWorkKey> works,
+  ) async {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    final Map<String, String> titles = <String, String>{};
+    if (source != null) {
+      try {
+        for (final RemoteVideoInfo v in await _remoteCache.read(
+          sourceId: source.remoteLibrarySourceId,
+          key: RemoteLibraryCacheKeys.videos,
+          fetch: source.listRemoteVideos,
+        )) {
+          titles[v.id] = v.title;
+        }
+      } catch (_) {
+        // 取不到标题就显示 bookUid，不阻断选择。
+      }
+    }
+    if (!mounted) return null;
+    return showAppDialog<VideoMetadataWorkKey>(
+      context: context,
+      builder: (BuildContext context) => SimpleDialog(
+        title: Text(t.remote_collection_scrape_pick_work),
+        children: <Widget>[
+          for (final VideoMetadataWorkKey k in works)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, k),
+              child: Text(titles[k.bookUid] ?? k.bookUid ?? k.toString()),
+            ),
+        ],
+      ),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/home_video_page.dart
+++ b/fushi/lib/src/pages/implementations/home_video_page.dart
@@ -6827,6 +6827,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         );
       }
       await _finishRemoteMetadataWrite(result);
+    } on RemoteVideoMetadataUnsupported {
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.remote_collection_scrape_unavailable,
+        severity: ToastSeverity.warning,
+      );
     } on Object catch (e, stack) {
       ErrorLogService.instance.log('video.scrapeCollectionOnHost', e, stack);
       if (!mounted) return;
@@ -6897,6 +6903,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         );
       }
       await _finishRemoteMetadataWrite(result);
+    } on RemoteVideoMetadataUnsupported {
+      if (!mounted) return;
+      FushiToast.show(
+        msg: t.remote_collection_scrape_unavailable,
+        severity: ToastSeverity.warning,
+      );
     } on Object catch (e, stack) {
       ErrorLogService.instance.log('video.scrapeCollectionForHost', e, stack);
       if (!mounted) return;
@@ -6914,14 +6926,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   ) async {
     final VideoMetadataWorkEntry? entry = result.entry;
     if (entry != null) {
-      await applyRemoteVideoMetadata(
+      final RemoteVideoMetadataApplyResult applied =
+          await applyRemoteVideoMetadata(
         ref.read(appProvider).database,
         <VideoMetadataWorkEntry>[entry],
       );
       if (!mounted) return;
       _refresh();
+      // 本地被跳过（本地资料不比 host 旧 / 清理中）时不谎报「已更新」。
       FushiToast.show(
-        msg: t.remote_collection_scrape_done,
+        msg: applied.applied > 0
+            ? t.remote_collection_scrape_done
+            : t.collection_rescrape_not_planned,
         severity: ToastSeverity.info,
       );
       return;

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -2516,6 +2516,12 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       case _CollectionManageAction.fillMissing:
         _fillMissingEpisodes();
         return;
+      case _CollectionManageAction.downloadRemote:
+        // 批下载在 app 级管理器里跑到底；这里只等它排完，回来重载让新落地的
+        // 本地行替换远端占位。
+        await widget.remote?.downloadMembers?.call(_collection, _remoteMembers);
+        if (mounted) await _reload();
+        return;
       case _CollectionManageAction.splitBySeason:
         await _splitBySeason();
         return;
@@ -2630,6 +2636,15 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                 Icons.playlist_add,
                 t.collection_episode_fill_missing,
                 enabled: _slots.isNotEmpty,
+              ),
+            // 合集整体下载（#6）：把只在对端的成员整批拉到本机。与「补齐缺集」
+            // （torrent 下载中心）是两条不同的路，入口分开、文案分开。
+            if (widget.remote?.downloadMembers != null)
+              _manageMenuItem(
+                _CollectionManageAction.downloadRemote,
+                Icons.cloud_download_outlined,
+                t.remote_collection_download_members,
+                enabled: _remoteMembers.isNotEmpty,
               ),
             _manageMenuItem(
               _CollectionManageAction.splitBySeason,
@@ -2751,6 +2766,7 @@ enum _CollectionManageAction {
   subtitles,
   renameEpisodes,
   fillMissing,
+  downloadRemote,
   splitBySeason,
   lockFields,
   rename,

--- a/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/fushi/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -2522,6 +2522,14 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         await widget.remote?.downloadMembers?.call(_collection, _remoteMembers);
         if (mounted) await _reload();
         return;
+      case _CollectionManageAction.scrapeOnHost:
+        await widget.remote?.scrapeOnHost?.call(_collection);
+        if (mounted) await _reload();
+        return;
+      case _CollectionManageAction.scrapeForHost:
+        await widget.remote?.scrapeForHost?.call(_collection);
+        if (mounted) await _reload();
+        return;
       case _CollectionManageAction.splitBySeason:
         await _splitBySeason();
         return;
@@ -2646,6 +2654,19 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
                 t.remote_collection_download_members,
                 enabled: _remoteMembers.isNotEmpty,
               ),
+            // 互联刮削（7a / 7b）。
+            if (widget.remote?.scrapeOnHost != null)
+              _manageMenuItem(
+                _CollectionManageAction.scrapeOnHost,
+                Icons.cloud_sync_outlined,
+                t.remote_collection_scrape_on_host,
+              ),
+            if (widget.remote?.scrapeForHost != null)
+              _manageMenuItem(
+                _CollectionManageAction.scrapeForHost,
+                Icons.cloud_upload_outlined,
+                t.remote_collection_scrape_push_to_host,
+              ),
             _manageMenuItem(
               _CollectionManageAction.splitBySeason,
               Icons.call_split,
@@ -2767,6 +2788,8 @@ enum _CollectionManageAction {
   renameEpisodes,
   fillMissing,
   downloadRemote,
+  scrapeOnHost,
+  scrapeForHost,
   splitBySeason,
   lockFields,
   rename,

--- a/fushi/lib/src/sync/interconnect_download_manager.dart
+++ b/fushi/lib/src/sync/interconnect_download_manager.dart
@@ -51,6 +51,42 @@ class InterconnectDownloadTask {
   }
 }
 
+/// 一批互联下载（合集整体下载）的进度快照。成员任务本身仍各自记在
+/// [InterconnectDownloadManager.tasks] 里；批只记「排了几个、完成几个、失败几个」。
+@immutable
+class InterconnectDownloadBatch {
+  const InterconnectDownloadBatch({
+    required this.id,
+    required this.title,
+    required this.total,
+    this.completed = 0,
+    this.failed = 0,
+  });
+
+  /// 批键（合集用 [InterconnectDownloadManager.collectionBatchId]）。
+  final String id;
+
+  /// 展示标题（合集名）。
+  final String title;
+
+  final int total;
+  final int completed;
+  final int failed;
+
+  int get finished => completed + failed;
+  bool get isRunning => finished < total;
+
+  InterconnectDownloadBatch copyWith({int? completed, int? failed}) {
+    return InterconnectDownloadBatch(
+      id: id,
+      title: title,
+      total: total,
+      completed: completed ?? this.completed,
+      failed: failed ?? this.failed,
+    );
+  }
+}
+
 /// 执行一次实际下载到 [dest] 的原语（注入，便于测试与解耦具体 client）。
 /// [onProgress] 上报 0..1 进度。
 typedef InterconnectDownloadRunner = Future<void> Function(
@@ -82,8 +118,63 @@ class InterconnectDownloadManager extends ChangeNotifier {
   /// 不同值域，再隔一个域前缀）。
   static String srtAudiobookTaskId(String identity) => 'srt:$identity';
 
+  /// 合集整体下载的批键（本地 `media_collections.id`）。
+  static String collectionBatchId(int collectionId) =>
+      'collection:$collectionId';
+
   final Map<String, InterconnectDownloadTask> _tasks =
       <String, InterconnectDownloadTask>{};
+
+  final Map<String, InterconnectDownloadBatch> _batches =
+      <String, InterconnectDownloadBatch>{};
+
+  /// 取某批快照（无则 null）。
+  InterconnectDownloadBatch? batchFor(String id) => _batches[id];
+
+  /// 某批是否还在跑（UI 决定合集卡是否显示批进度）。
+  bool isBatchRunning(String id) => _batches[id]?.isRunning ?? false;
+
+  /// **串行**跑一批下载（合集整体下载）。每个 [starters] 项自己调
+  /// [startVideoDownload] / [startBookDownload]（目标路径、传输原语、收尾登记都
+  /// 由调用方在排队前解析好，启动器不再依赖页面 State——页面 dispose 后批照跑）。
+  ///
+  /// 串行是有意的：互联 host 是单台设备、客户端多为移动端，同时开 N 条 Range 流
+  /// 只会互抢带宽并让每条都看起来卡住；成员失败不中断后续成员，失败计入批快照
+  /// （成员自己的失败原因仍在其 [InterconnectDownloadTask.error]）。
+  /// 同 [id] 已在跑则忽略重复调用，返回当前批。
+  Future<InterconnectDownloadBatch> startBatch({
+    required String id,
+    required String title,
+    required List<Future<void> Function()> starters,
+  }) async {
+    final InterconnectDownloadBatch? existing = _batches[id];
+    if (existing != null && existing.isRunning) return existing;
+    _batches[id] = InterconnectDownloadBatch(
+      id: id,
+      title: title,
+      total: starters.length,
+    );
+    _notify();
+    for (final Future<void> Function() start in starters) {
+      try {
+        await start();
+        _updateBatch(id, completed: 1);
+      } catch (_) {
+        _updateBatch(id, failed: 1);
+      }
+    }
+    return _batches[id]!;
+  }
+
+  void _updateBatch(String id, {int completed = 0, int failed = 0}) {
+    final InterconnectDownloadBatch? batch = _batches[id];
+    if (batch == null) return;
+    _batches[id] = batch.copyWith(
+      completed: batch.completed + completed,
+      failed: batch.failed + failed,
+    );
+    _notify();
+  }
 
   /// 已结束（completed/failed）任务的**完成顺序**，用于有界保留（BUG-1561）。
   /// Dart 的 Map 迭代序是首次插入序，覆写同 key 不会把它挪到末尾，所以顺序得自己记。

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -147,6 +147,14 @@ Future<bool> _defaultFushiProbe(String url, String token) async {
 /// Uses the WebDAV protocol (same as [WebDavSyncBackend]) but stores
 /// credentials in dedicated keys to avoid collision with the user's
 /// standalone WebDAV config.
+/// 对端 host 没有视频刮削元数据端点（老版本）；UI 据此提示「对端不支持远程刮削」。
+class RemoteVideoMetadataUnsupported implements Exception {
+  const RemoteVideoMetadataUnsupported();
+
+  @override
+  String toString() => 'RemoteVideoMetadataUnsupported';
+}
+
 class InterconnectSyncBackend extends SyncBackend
     with
         SyncFolderCache,
@@ -188,14 +196,25 @@ class InterconnectSyncBackend extends SyncBackend
   @visibleForTesting
   Duration requestTimeout = const Duration(seconds: 15);
 
+  /// 视频刮削元数据端点专用超时（审查 PR#1431 #1）：7a 的 scrape 是 host 同步跑完
+  /// 整条刮削链（联网取详情 + 分季分集 + 下图 + sidecar，且排在 host 手动队列后面
+  /// 接棒），candidates 是 MAL→TMDB 双形态各搜一轮，全库 GET 是几百部作品逐表装载
+  /// ——都不是 15s 量级。仍然封顶，只是量级对齐 host 侧真实耗时。
+  @visibleForTesting
+  Duration metadataRequestTimeout = const Duration(minutes: 5);
+
   /// BUG-1567：把 [req] 发出并在 [requestTimeout] 内等到响应头；超时则中止请求
   /// （释放底层连接）并抛 [TimeoutException]，让挂死 host 降级为可重试失败。
-  Future<HttpClientResponse> _sendBounded(HttpClientRequest req) {
-    return req.close().timeout(requestTimeout, onTimeout: () {
+  Future<HttpClientResponse> _sendBounded(
+    HttpClientRequest req, {
+    Duration? timeout,
+  }) {
+    final Duration limit = timeout ?? requestTimeout;
+    return req.close().timeout(limit, onTimeout: () {
       req.abort();
       throw TimeoutException(
-        'interconnect request timed out after $requestTimeout',
-        requestTimeout,
+        'interconnect request timed out after $limit',
+        limit,
       );
     });
   }
@@ -1287,7 +1306,8 @@ class InterconnectSyncBackend extends SyncBackend
       'GET',
       '$_apiBase/api/library/metadata$query',
     );
-    final HttpClientResponse res = await _sendBounded(req);
+    final HttpClientResponse res =
+        await _sendBounded(req, timeout: metadataRequestTimeout);
     if (res.statusCode == 404) {
       await res.drain<void>();
       return null;
@@ -1370,7 +1390,14 @@ class InterconnectSyncBackend extends SyncBackend
         await _ops!.buildRequest(method, '$_apiBase$path');
     req.headers.set('Content-Type', 'application/json; charset=utf-8');
     req.add(utf8.encode(jsonEncode(body)));
-    final HttpClientResponse res = await _sendBounded(req);
+    final HttpClientResponse res =
+        await _sendBounded(req, timeout: metadataRequestTimeout);
+    // 老 host 没有元数据端点：归一成一种可识别异常，UI 提示「对端不支持」而不是
+    // 一句通用错误（审查 #8：客户端不消费能力位，按 404 现场判定同样零破坏）。
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      throw const RemoteVideoMetadataUnsupported();
+    }
     if (res.statusCode != 409) {
       _ops!.checkStatus(res.statusCode, '$method $path');
     }

--- a/fushi/lib/src/sync/interconnect_sync_backend.dart
+++ b/fushi/lib/src/sync/interconnect_sync_backend.dart
@@ -3,7 +3,13 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
 import 'package:fushi_engine/sync/collection_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
 import 'package:fushi_engine/sync/deletion_propagation.dart';
 import 'package:fushi_engine/sync/fushi_library_host_service.dart';
 import 'package:fushi_engine/sync/interconnect_service_config.dart';
@@ -1265,6 +1271,110 @@ class InterconnectSyncBackend extends SyncBackend
     _ops!.checkStatus(res.statusCode, 'POST /api/library/collections');
     final String body = await _readBodyBounded(res);
     return CollectionManifest.fromJson(jsonDecode(body));
+  }
+
+  // ── Live video metadata (interconnect-only, #7) ────────────────────────
+  // `docs/specs/2026-09-12-interconnect-scrape-metadata.md`。
+
+  /// 7c：GET host 全部作品刮削元数据（[since] 非 null 只取 updatedAt 更新的）。
+  /// 老 host 无端点 404 → null（调用方跳过元数据同步，不崩）。
+  Future<List<VideoMetadataWorkEntry>?> getRemoteVideoMetadata({
+    int? since,
+  }) async {
+    await _ensureResolved();
+    final String query = since == null ? '' : '?since=$since';
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'GET',
+      '$_apiBase/api/library/metadata$query',
+    );
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      return null;
+    }
+    _ops!.checkStatus(res.statusCode, 'GET /api/library/metadata');
+    final Object? decoded = jsonDecode(await _readBodyBounded(res));
+    final List<VideoMetadataWorkEntry> out = <VideoMetadataWorkEntry>[];
+    if (decoded is Map && decoded['works'] is List) {
+      for (final Object? raw in decoded['works'] as List<Object?>) {
+        try {
+          out.add(VideoMetadataWorkEntry.fromJson(raw));
+        } on FormatException {
+          // 单条坏数据跳过，不让整份清单失效。
+        }
+      }
+    }
+    return out;
+  }
+
+  /// 7a：让 host 按 [query] 搜候选（host 自己的 provider / 主源 / 资料语言配置）。
+  Future<List<VideoMetadataCandidateEntry>> searchRemoteVideoMetadataCandidates({
+    required VideoMetadataWorkKey key,
+    required String query,
+  }) async {
+    final Object? decoded = await _postMetadataJson(
+      '/api/library/metadata/candidates',
+      <String, Object?>{'key': key.toJson(), 'query': query},
+    );
+    return <VideoMetadataCandidateEntry>[
+      if (decoded is Map && decoded['candidates'] is List)
+        for (final Object? raw in decoded['candidates'] as List<Object?>)
+          VideoMetadataCandidateEntry.fromJson(raw),
+    ];
+  }
+
+  /// 7a：让 host 用 [lookup] 重刮 [key]。200 / 409 都解成 [VideoMetadataWriteResult]。
+  Future<VideoMetadataWriteResult> requestRemoteVideoMetadataScrape({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+  }) async {
+    final Object? decoded = await _postMetadataJson(
+      '/api/library/metadata/scrape',
+      <String, Object?>{
+        'key': key.toJson(),
+        'lookup': encodeVideoMetadataLookup(lookup),
+      },
+    );
+    return VideoMetadataWriteResult.fromJson(decoded);
+  }
+
+  /// 7b：把本机刮好的 [work] 写回 host。409 identity 冲突也解成结果对象由 UI 决定。
+  Future<VideoMetadataWriteResult> putRemoteVideoMetadata({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+    required VideoMetadataWork work,
+    bool replaceIdentity = false,
+  }) async {
+    final Object? decoded = await _postMetadataJson(
+      '/api/library/metadata',
+      <String, Object?>{
+        'key': key.toJson(),
+        'lookup': encodeVideoMetadataLookup(lookup),
+        'work': encodeVideoMetadataWork(work),
+        'replaceIdentity': replaceIdentity,
+      },
+      method: 'PUT',
+    );
+    return VideoMetadataWriteResult.fromJson(decoded);
+  }
+
+  /// 元数据端点共用的 JSON 往返：409 是协议内的可解释拒绝，与 200 一样返回 body；
+  /// 其余非 2xx 走 [checkStatus] 抛错。
+  Future<Object?> _postMetadataJson(
+    String path,
+    Map<String, Object?> body, {
+    String method = 'POST',
+  }) async {
+    await _ensureResolved();
+    final HttpClientRequest req =
+        await _ops!.buildRequest(method, '$_apiBase$path');
+    req.headers.set('Content-Type', 'application/json; charset=utf-8');
+    req.add(utf8.encode(jsonEncode(body)));
+    final HttpClientResponse res = await _sendBounded(req);
+    if (res.statusCode != 409) {
+      _ops!.checkStatus(res.statusCode, '$method $path');
+    }
+    return jsonDecode(await _readBodyBounded(res));
   }
 
   /// GET 对端 host 当前删除墓碑清单（显式确认式删除传播，host→client 消费方向）。

--- a/fushi/lib/src/sync/sync_orchestrator.dart
+++ b/fushi/lib/src/sync/sync_orchestrator.dart
@@ -774,8 +774,8 @@ class SyncOrchestrator {
     final SyncRunReport report = SyncRunReport();
     final SyncBackend b = _backend;
     if (b is InterconnectSyncBackend) {
+      // 合集防抖轻量路径只同步合集；刮削元数据整库拉取留给完整 sweep（审查 #4）。
       await _syncCollectionsLive(report, b);
-      await _syncVideoMetadataLive(report, b);
     } else {
       // 云路径的 ensureNamespace 依赖同步根已解析（与 [run] 开头一致）。
       await _backend.findOrCreateRootFolder();

--- a/fushi/lib/src/sync/sync_orchestrator.dart
+++ b/fushi/lib/src/sync/sync_orchestrator.dart
@@ -7,6 +7,8 @@ import 'package:fushi_engine/media/video/video_sidecar.dart'
     show listSidecarSubtitles;
 import 'package:fushi/src/models/local_audio_manager.dart';
 import 'package:fushi_engine/sync/collection_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_work_target.dart';
 import 'package:fushi_engine/sync/manga_sync_package.dart'
     show
         hasExportableMangaContent,
@@ -37,6 +39,7 @@ import 'package:path/path.dart' as p;
 
 part 'sync_orchestrator/aggregate.part.dart';
 part 'sync_orchestrator/collections.part.dart';
+part 'sync_orchestrator/video_metadata.part.dart';
 part 'sync_orchestrator/tombstones.part.dart';
 part 'sync_orchestrator/books.part.dart';
 part 'sync_orchestrator/videos.part.dart';
@@ -244,6 +247,10 @@ class SyncRunReport {
   /// 故计入 [needsLocalLibraryRefresh]。
   int collectionsUpdated = 0;
 
+  /// 7c：本轮从互联 host 落到本地的视频刮削元数据作品数（`applyRemoteVideoMetadata`）。
+  /// >0 时合集详情页 / 视频卡的简介、评分、分集名会变，计入 [needsLocalLibraryRefresh]。
+  int videoMetadataUpdated = 0;
+
   /// Host-owned external-service preferences imported over the authenticated
   /// interconnect channel. These require an AppModel preference-cache refresh
   /// even though no media row was imported.
@@ -300,6 +307,7 @@ class SyncRunReport {
       localAudioImported > 0 ||
       localBookProgressPulled > 0 ||
       collectionsUpdated > 0 ||
+      videoMetadataUpdated > 0 ||
       serviceConfigsImported > 0;
 
   /// 合并另一条通道的报告到本报告（option B 双通道：云备份 + 互联并行各跑一轮后，
@@ -316,6 +324,7 @@ class SyncRunReport {
     localBookProgressPulled += other.localBookProgressPulled;
     rootSpillFilesRemoved += other.rootSpillFilesRemoved;
     collectionsUpdated += other.collectionsUpdated;
+    videoMetadataUpdated += other.videoMetadataUpdated;
     serviceConfigsImported += other.serviceConfigsImported;
     errors.addAll(other.errors);
     for (final SyncAuthFailure f in other.authFailures) {
@@ -706,6 +715,8 @@ class SyncOrchestrator {
     // 成员并集 + 移出/删除墓碑 + 手动序整合集 LWW，仅通道不同。
     if (isInterconnect) {
       await _syncCollectionsLive(report, b);
+      // 7c：刮削元数据紧跟合集之后（合集级作品按自然键解析刚同步出来的合集行）。
+      await _syncVideoMetadataLive(report, b);
     } else {
       await syncCollections(report);
     }
@@ -764,6 +775,7 @@ class SyncOrchestrator {
     final SyncBackend b = _backend;
     if (b is InterconnectSyncBackend) {
       await _syncCollectionsLive(report, b);
+      await _syncVideoMetadataLive(report, b);
     } else {
       // 云路径的 ensureNamespace 依赖同步根已解析（与 [run] 开头一致）。
       await _backend.findOrCreateRootFolder();
@@ -912,6 +924,14 @@ class SyncOrchestrator {
       report.noteError('collections sync', e);
     }
   }
+
+  /// 测试入口：直接调用 [_syncVideoMetadataLive]。
+  @visibleForTesting
+  Future<void> syncVideoMetadataLiveForTest(
+    SyncRunReport report,
+    InterconnectSyncBackend backend,
+  ) =>
+      _syncVideoMetadataLive(report, backend);
 
   /// 测试入口：直接调用 [_syncCollectionsLive]（private 方法对测试文件不可见）。
   @visibleForTesting

--- a/fushi/lib/src/sync/sync_orchestrator/video_metadata.part.dart
+++ b/fushi/lib/src/sync/sync_orchestrator/video_metadata.part.dart
@@ -1,0 +1,31 @@
+part of '../sync_orchestrator.dart';
+
+/// 视频刮削元数据（host → 客户端，7c）互联 live 通道。
+/// `docs/specs/2026-09-12-interconnect-scrape-metadata.md` §2/§3。
+extension _SyncOrchestratorVideoMetadata on SyncOrchestrator {
+  /// 拉 host 全部作品刮削元数据并落本地（[applyRemoteVideoMetadata]）。
+  ///
+  /// 放在合集同步**之后**：合集级作品按自然键解析本地合集行，行得先由合集清单
+  /// 同步建出来。老 host 无端点（404 → null）静默跳过——它不像合集那样是用户明
+  /// 确期待的双向数据，不往 errors 里塞噪音。单条 apply 失败记日志、不中断。
+  Future<void> _syncVideoMetadataLive(
+    SyncRunReport report,
+    InterconnectSyncBackend backend,
+  ) async {
+    try {
+      final List<VideoMetadataWorkEntry>? entries =
+          await backend.getRemoteVideoMetadata();
+      if (entries == null || entries.isEmpty) return;
+      report.videoMetadataUpdated += await applyRemoteVideoMetadata(
+        _db,
+        entries,
+        onError: (Object e, StackTrace stack) {
+          debugPrint('[sync] video metadata apply failed: $e');
+          report.noteError('video metadata apply', e);
+        },
+      );
+    } catch (e) {
+      report.noteError('video metadata live sync', e);
+    }
+  }
+}

--- a/fushi/lib/src/sync/sync_orchestrator/video_metadata.part.dart
+++ b/fushi/lib/src/sync/sync_orchestrator/video_metadata.part.dart
@@ -13,10 +13,15 @@ extension _SyncOrchestratorVideoMetadata on SyncOrchestrator {
     InterconnectSyncBackend backend,
   ) async {
     try {
+      // 增量：只拉 host updatedAt 晚于上次见过的作品（审查 #4：全库逐表装载 +
+      // 数 MB JSON 不能每轮重来）。基线按通道分槽，与合集基线同纪律。
+      final SyncRepository repo = SyncRepository(_db);
+      final int since = await repo.getVideoMetadataSyncSinceMs(_scope);
       final List<VideoMetadataWorkEntry>? entries =
-          await backend.getRemoteVideoMetadata();
+          await backend.getRemoteVideoMetadata(since: since > 0 ? since : null);
       if (entries == null || entries.isEmpty) return;
-      report.videoMetadataUpdated += await applyRemoteVideoMetadata(
+      final RemoteVideoMetadataApplyResult result =
+          await applyRemoteVideoMetadata(
         _db,
         entries,
         onError: (Object e, StackTrace stack) {
@@ -24,6 +29,17 @@ extension _SyncOrchestratorVideoMetadata on SyncOrchestrator {
           report.noteError('video metadata apply', e);
         },
       );
+      report.videoMetadataUpdated += result.applied;
+      // 有条目因本机目标缺失被延后（合集下一轮才同步到 / 视频还没下载）就不推进
+      // 基线，否则它们再也拉不到。
+      if (result.deferred > 0) return;
+      int newest = since;
+      for (final VideoMetadataWorkEntry e in entries) {
+        if (e.updatedAt > newest) newest = e.updatedAt;
+      }
+      if (newest > since) {
+        await repo.setVideoMetadataSyncSinceMs(_scope, newest);
+      }
     } catch (e) {
       report.noteError('video metadata live sync', e);
     }

--- a/fushi/lib/src/sync/sync_repository.dart
+++ b/fushi/lib/src/sync/sync_repository.dart
@@ -151,6 +151,10 @@ class SyncRepository {
   // 设备本地（[deviceLocalPrefKeys]）：随备份跨设备会让新设备把老墓碑误判为新闻反复弹。
   static const _keyDeletionTombstonesBaselineMs =
       'sync_deletion_tombstones_baseline_ms';
+  // 7c 视频刮削元数据增量拉取基线：本设备从该通道见过的最大 host updatedAt。
+  // 设备本地：随备份到新设备会让它以为已见过、永远不全量拉。
+  static const _keyVideoMetadataSyncSinceMs =
+      'sync_video_metadata_since_ms';
   // 删除墓碑**推送**的因果基线（互联通道专用，与上面的消费基线镜像对称）：描述
   // 「本设备已把删除推给对端 host 到什么时刻」。deletedAt 晚于它的墓碑才需要推。
   //
@@ -374,6 +378,17 @@ class SyncRepository {
 
   Future<void> setCollectionsSyncBaselineMs(SyncChannelScope scope, int ms) =>
       writeCollectionsSyncBaselineMs(_db, scope, ms);
+
+  /// 7c 视频刮削元数据增量拉取基线：上次从该通道见过的最大 host `updatedAt`
+  /// （毫秒）。0 = 从未拉过（全量）。设备本地、按通道分槽。
+  Future<int> getVideoMetadataSyncSinceMs(SyncChannelScope scope) async {
+    final String? s =
+        await _getStringOrNull(scope.key(_keyVideoMetadataSyncSinceMs));
+    return s == null ? 0 : int.tryParse(s) ?? 0;
+  }
+
+  Future<void> setVideoMetadataSyncSinceMs(SyncChannelScope scope, int ms) =>
+      _setString(scope.key(_keyVideoMetadataSyncSinceMs), ms.toString());
 
   /// 删除墓碑消费的因果基线（毫秒）。远端删除标记 deletedAt 晚于它才弹逐条确认；
   /// 早于它视为本设备已处理过、不再反复弹。0 = 从未消费过。设备本地
@@ -1185,6 +1200,7 @@ class SyncRepository {
   static const List<String> _perChannelDeviceLocalBases = <String>[
     _keyCollectionsBaselineMs,
     _keyDeletionTombstonesBaselineMs,
+    _keyVideoMetadataSyncSinceMs,
   ];
 
   static const List<String> _deviceLocalFixedKeys = <String>[

--- a/fushi/test/media/video/metadata/video_metadata_wire_roundtrip_test.dart
+++ b/fushi/test/media/video/metadata/video_metadata_wire_roundtrip_test.dart
@@ -1,0 +1,570 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_engine/media/source_library/source_library_row.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_database_store.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_work_loader.dart';
+import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
+
+/// 互联刮削元数据 wire（spec 2026-09-12 §1.2）三段往返：
+/// (a) encode/decode 纯编解码互逆；(b) apply → load 反向装载；(c) lookupOfWork。
+void main() {
+  group('encode / decode', () {
+    test('字段填满的作品 decode(encode(w)) 逐字段相等，rawPayload 不上 wire', () {
+      final VideoMetadataWork work =
+          _fullWork(rawPayload: const <String, Object?>{'raw': 1});
+      final Map<String, Object?> json = encodeVideoMetadataWork(work);
+      expect(json.containsKey('rawPayload'), isFalse);
+      expect(json['provider'], 'tmdb');
+      expect(json['kind'], 'tv');
+
+      final VideoMetadataWork decoded = decodeVideoMetadataWork(json);
+      expect(decoded.rawPayload, isNull);
+      // 标量逐字段。
+      expect(decoded.provider, work.provider);
+      expect(decoded.kind, work.kind);
+      expect(decoded.title, work.title);
+      expect(decoded.originalTitle, work.originalTitle);
+      expect(decoded.tagline, work.tagline);
+      expect(decoded.year, work.year);
+      expect(decoded.premiered, work.premiered);
+      expect(decoded.endDate, work.endDate);
+      expect(decoded.plot, work.plot);
+      expect(decoded.rating, work.rating);
+      expect(decoded.ratingVotes, work.ratingVotes);
+      expect(decoded.runtimeMinutes, work.runtimeMinutes);
+      expect(decoded.contentRating, work.contentRating);
+      expect(decoded.status, work.status);
+      expect(decoded.originalLanguage, work.originalLanguage);
+      expect(decoded.homepage, work.homepage);
+      expect(decoded.episodeGroupId, work.episodeGroupId);
+      expect(decoded.seasonCount, work.seasonCount);
+      expect(decoded.episodeCount, work.episodeCount);
+      // 列表逐个（模型自带值相等）。
+      expect(decoded.aliases, work.aliases);
+      expect(decoded.genres, work.genres);
+      expect(decoded.studios, work.studios);
+      expect(decoded.countries, work.countries);
+      expect(decoded.keywords, work.keywords);
+      expect(decoded.ids, work.ids);
+      expect(decoded.credits, work.credits);
+      expect(decoded.images, work.images);
+      expect(decoded.extras, work.extras);
+      expect(decoded.seasons.length, 2);
+      expect(decoded.seasons, work.seasons);
+      expect(decoded.seasons[0].episodes.length, 2);
+      expect(decoded.seasons[1].episodes.length, 1);
+      // 整体相等（copyWith 无法把 rawPayload 置回 null，重造一份不带的原件）。
+      expect(decoded, _fullWork());
+      expect(decoded, isNot(equals(work)), reason: '原件带 rawPayload');
+    });
+
+    test('缺 provider 抛 FormatException；类型错的可选字段容错为 null', () {
+      expect(
+        () => decodeVideoMetadataWork(<String, Object?>{
+          'kind': 'movie',
+          'title': 'x',
+        }),
+        throwsFormatException,
+      );
+      expect(
+        () => decodeVideoMetadataWork(<String, Object?>{
+          'provider': 'not-a-provider',
+          'kind': 'movie',
+        }),
+        throwsFormatException,
+      );
+      final VideoMetadataWork lenient =
+          decodeVideoMetadataWork(<String, Object?>{
+        'provider': 'mal',
+        'kind': 'movie',
+        'title': 'x',
+        'year': 'abc',
+        'rating': <int>[1],
+        'genres': <Object?>['a', null, 2, ' b '],
+        'ids': <Object?>[
+          <String, Object?>{'type': 'mal', 'value': '1'},
+          <String, Object?>{'type': 'imdb'},
+          'junk',
+        ],
+        'images': <Object?>[
+          <String, Object?>{'kind': 'nope', 'url': 'u', 'provider': 'mal'},
+        ],
+        'seasons': 'not-a-list',
+      });
+      expect(lenient.year, isNull);
+      expect(lenient.rating, isNull);
+      expect(lenient.genres, <String>['a', 'b']);
+      expect(lenient.ids, const <VideoMetadataId>[
+        VideoMetadataId(type: 'mal', value: '1'),
+      ]);
+      expect(lenient.images, isEmpty);
+      expect(lenient.seasons, isEmpty);
+    });
+
+    test('lookup 编解码互逆；缺必需字段返回 null', () {
+      const VideoMetadataLookup lookup = VideoMetadataLookup(
+        provider: VideoMetadataProviderKind.tmdb,
+        externalId: '1234',
+        mediaKind: VideoMetadataMediaKind.tv,
+        episodeGroupId: 'grp',
+      );
+      final VideoMetadataLookup? decoded =
+          decodeVideoMetadataLookup(encodeVideoMetadataLookup(lookup));
+      expect(decoded, isNotNull);
+      expect(decoded!.provider, lookup.provider);
+      expect(decoded.externalId, lookup.externalId);
+      expect(decoded.mediaKind, lookup.mediaKind);
+      expect(decoded.episodeGroupId, lookup.episodeGroupId);
+      expect(decodeVideoMetadataLookup(null), isNull);
+      expect(decodeVideoMetadataLookup('x'), isNull);
+      expect(
+        decodeVideoMetadataLookup(<String, Object?>{
+          'provider': 'tmdb',
+          'mediaKind': 'tv',
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('apply → load', () {
+    late FushiDatabase db;
+    late VideoMetadataDatabaseStore store;
+    late VideoSourceScrapeWork localWork;
+
+    setUp(() async {
+      db = FushiDatabase.forTesting(NativeDatabase.memory());
+      store = VideoMetadataDatabaseStore(db);
+      final int sourceId = await db.insertMediaSource(
+        MediaSourcesCompanion.insert(
+          label: 'Shows',
+          mediaKind: 'video',
+          rootPath: 'D:/Shows',
+          createdAt: 1,
+        ),
+      );
+      final List<VideoBookRow> members = <VideoBookRow>[];
+      for (final String stem in <String>[
+        'Show S01E01',
+        'Show S01E02',
+        'Show S02E01',
+      ]) {
+        await db.upsertVideoBook(
+          VideoBooksCompanion(
+            bookUid: Value<String>(stem),
+            title: Value<String>(stem),
+            videoPath: Value<String>('D:/Shows/Show/$stem.mkv'),
+            sourceId: Value<int?>(sourceId),
+          ),
+        );
+        members.add((await db.getVideoBookByBookUid(stem))!);
+      }
+      final int collectionId =
+          await db.createMediaCollection('Show', collectionType: 'playlist');
+      for (final VideoBookRow member in members) {
+        await db.addToCollection(collectionId, MediaKind.video, member.bookUid);
+      }
+      final SourceLibraryRow source = (await db.getMediaSourceById(sourceId))!;
+      final MediaCollectionRow collection =
+          (await db.getMediaCollectionById(collectionId))!;
+      localWork = VideoSourceScrapeWork(
+        source: source,
+        collection: collection,
+        title: collection.name,
+        members: members,
+      );
+    });
+
+    tearDown(() => db.close());
+
+    test('可持久化字段读回与原件一致', () async {
+      final VideoMetadataWork work = _fullWork();
+      final PersistedVideoMetadata persisted =
+          await store.apply(localWork, work);
+      final VideoMetadataWorkRow row =
+          (await db.getVideoMetadataWorkById(persisted.workId))!;
+      final VideoMetadataWork loaded = await loadVideoMetadataWork(db, row);
+
+      expect(loaded.provider, work.provider, reason: '主身份 provider');
+      expect(loaded.kind, work.kind);
+      expect(loaded.title, work.title);
+      expect(loaded.originalTitle, work.originalTitle);
+      expect(loaded.tagline, work.tagline);
+      expect(loaded.plot, work.plot);
+      expect(loaded.year, work.year);
+      expect(loaded.premiered, work.premiered);
+      expect(loaded.endDate, work.endDate);
+      expect(loaded.rating, work.rating);
+      expect(loaded.ratingVotes, work.ratingVotes);
+      expect(loaded.runtimeMinutes, work.runtimeMinutes);
+      expect(loaded.contentRating, work.contentRating);
+      expect(loaded.status, work.status);
+      expect(loaded.originalLanguage, work.originalLanguage);
+      expect(loaded.homepage, work.homepage);
+      expect(loaded.episodeGroupId, work.episodeGroupId);
+      expect(loaded.genres, work.genres);
+      expect(loaded.studios, work.studios);
+      expect(loaded.countries, work.countries);
+      expect(loaded.keywords, work.keywords);
+      // 不比 aliases / seasonCount / episodeCount：works 表没这三列。
+      expect(loaded.aliases, isEmpty);
+      expect(loaded.seasonCount, isNull);
+      expect(loaded.episodeCount, isNull);
+      expect(loaded.rawPayload, isNull);
+
+      // ids：apply 把 type 小写、按「type == provider」重算 isDefault；原件里
+      // 故意把 IMDB 写成大写且标 isDefault，读回必须是归一化后的形态。
+      expect(loaded.ids, const <VideoMetadataId>[
+        VideoMetadataId(type: 'tmdb', value: '31911', isDefault: true),
+        VideoMetadataId(type: 'imdb', value: 'tt1234567'),
+      ]);
+
+      // seasons / episodes：编号与标题、标量。
+      expect(loaded.seasons.length, 2);
+      for (int i = 0; i < 2; i++) {
+        final VideoMetadataSeason expected = work.seasons[i];
+        final VideoMetadataSeason actual = loaded.seasons[i];
+        expect(actual.seasonNumber, expected.seasonNumber);
+        expect(actual.title, expected.title);
+        expect(actual.plot, expected.plot);
+        expect(actual.airDate, expected.airDate);
+        expect(actual.year, expected.year);
+        expect(actual.episodeCount, expected.episodeCount);
+        expect(actual.rating, expected.rating);
+        expect(actual.ids, expected.ids, reason: '季 id 原件已是小写');
+        expect(actual.episodes.length, expected.episodes.length);
+        for (int j = 0; j < expected.episodes.length; j++) {
+          final VideoMetadataEpisode e = expected.episodes[j];
+          final VideoMetadataEpisode a = actual.episodes[j];
+          expect(a.seasonNumber, e.seasonNumber);
+          expect(a.episodeNumber, e.episodeNumber);
+          expect(a.title, e.title);
+          expect(a.plot, e.plot);
+          expect(a.airDate, e.airDate);
+          expect(a.absoluteNumber, e.absoluteNumber);
+          expect(a.rating, e.rating);
+          expect(a.ratingVotes, e.ratingVotes);
+          expect(a.runtimeMinutes, e.runtimeMinutes);
+          expect(a.ids, e.ids);
+        }
+      }
+      // 季图 / 集图。
+      expect(
+        loaded.seasons[0].images.map((VideoMetadataImage i) => i.url),
+        <String>['https://img.example/s1-poster.jpg'],
+      );
+      expect(
+        loaded.seasons[0].episodes[0].images
+            .map((VideoMetadataImage i) => i.url),
+        <String>['https://img.example/s1e1-thumb.jpg'],
+      );
+
+      // images：remoteUrl + kind + language。DB 按 (kind, position) 排，跨图种
+      // 顺序不保证，所以按 kind 取再比。likes 没列，不比。
+      VideoMetadataImage imageOf(VideoMetadataImageKind kind) =>
+          loaded.images.singleWhere((VideoMetadataImage i) => i.kind == kind);
+      final VideoMetadataImage cover = imageOf(VideoMetadataImageKind.cover);
+      expect(cover.url, 'https://img.example/poster-ja.jpg');
+      expect(cover.language, 'ja');
+      expect(cover.provider, VideoMetadataProviderKind.tmdb);
+      expect(cover.voteAverage, 5.5);
+      expect(cover.voteCount, 12);
+      final VideoMetadataImage backdrop =
+          imageOf(VideoMetadataImageKind.backdrop);
+      expect(backdrop.url, 'https://img.example/backdrop.jpg');
+      expect(backdrop.language, isNull);
+      expect(backdrop.provider, VideoMetadataProviderKind.fanart);
+
+      // credits：roleName 原件为 null，apply 用角色名回填；person/character 的
+      // id 没列，读回 null；character.originalName 没列，读回 null。
+      expect(loaded.credits.length, 1);
+      final VideoMetadataCredit credit = loaded.credits.single;
+      final VideoMetadataCredit original = work.credits.single;
+      expect(credit.kind, original.kind);
+      expect(credit.roleName, original.character!.name);
+      expect(credit.language, original.language);
+      expect(credit.department, original.department);
+      expect(credit.job, original.job);
+      expect(credit.providerCreditId, original.providerCreditId);
+      expect(credit.order, original.order);
+      // person：除 id 外全列持久化；ids 的 type 小写、isPrimary ← isDefault。
+      expect(credit.person.id, isNull);
+      expect(credit.person.name, original.person.name);
+      expect(credit.person.originalName, original.person.originalName);
+      expect(credit.person.biography, original.person.biography);
+      expect(credit.person.birthday, original.person.birthday);
+      expect(credit.person.deathday, original.person.deathday);
+      expect(credit.person.gender, original.person.gender);
+      expect(credit.person.placeOfBirth, original.person.placeOfBirth);
+      expect(credit.person.profileUrl, original.person.profileUrl);
+      expect(credit.person.ids, const <VideoMetadataId>[
+        VideoMetadataId(type: 'tmdb', value: '99', isDefault: true),
+      ]);
+      expect(credit.character, isNotNull);
+      expect(credit.character!.name, original.character!.name);
+      expect(credit.character!.description, original.character!.description);
+      expect(credit.character!.imageUrl, original.character!.imageUrl);
+      expect(credit.character!.originalName, isNull);
+      expect(credit.character!.ids, original.character!.ids);
+
+      // extras：原件两条，其中一条没 remoteUrl，apply 只落在线附件。
+      expect(loaded.extras.length, 1);
+      final VideoMetadataExtra extra = loaded.extras.single;
+      expect(extra.kind, VideoMetadataExtraKind.behindTheScenes,
+          reason: 'snake_case 列值映回枚举');
+      expect(extra.title, 'Making of');
+      expect(extra.provider, VideoMetadataProviderKind.tmdb);
+      expect(extra.providerVideoId, 'yt-1');
+      expect(extra.site, 'YouTube');
+      expect(extra.remoteUrl, 'https://youtu.be/yt-1');
+      expect(extra.thumbnailUrl, 'https://img.example/yt-1.jpg');
+      expect(extra.durationMs, 90000);
+      expect(extra.official, isTrue);
+      expect(extra.language, 'en');
+      expect(extra.publishedAt, '2024-01-02');
+      expect(extra.order, 3);
+    });
+
+    test('apply → load → encode → decode → apply → load 稳定（幂等）', () async {
+      final PersistedVideoMetadata first =
+          await store.apply(localWork, _fullWork());
+      final VideoMetadataWork loaded1 = await loadVideoMetadataWork(
+        db,
+        (await db.getVideoMetadataWorkById(first.workId))!,
+      );
+      final VideoMetadataWork wired =
+          decodeVideoMetadataWork(encodeVideoMetadataWork(loaded1));
+      expect(wired, loaded1, reason: 'load 结果本身应能无损上 wire');
+      final PersistedVideoMetadata second = await store.apply(localWork, wired);
+      final VideoMetadataWork loaded2 = await loadVideoMetadataWork(
+        db,
+        (await db.getVideoMetadataWorkById(second.workId))!,
+      );
+      expect(loaded2, loaded1);
+    });
+
+    test('lookupOfWork 返回主身份；没主身份 / 不存在返回 null', () async {
+      final PersistedVideoMetadata persisted =
+          await store.apply(localWork, _fullWork());
+      final VideoMetadataLookup? lookup =
+          await lookupOfWork(db, persisted.workId);
+      expect(lookup, isNotNull);
+      expect(lookup!.provider, VideoMetadataProviderKind.tmdb);
+      expect(lookup.externalId, '31911');
+      expect(lookup.mediaKind, VideoMetadataMediaKind.tv);
+      expect(lookup.episodeGroupId, 'grp-1');
+      expect(await lookupOfWork(db, persisted.workId + 1000), isNull);
+
+      // 主身份被删后 lookup 为 null；load 退回第一条身份。
+      await db.replaceVideoMetadataProviderIdentities(
+        workId: persisted.workId,
+        identities: <VideoMetadataProviderIdentitiesCompanion>[
+          VideoMetadataProviderIdentitiesCompanion.insert(
+            identityKey: 'work:${persisted.workId}:imdb',
+            provider: 'imdb',
+            externalId: 'tt1234567',
+            updatedAt: 1,
+          ),
+        ],
+      );
+      expect(await lookupOfWork(db, persisted.workId), isNull);
+      final VideoMetadataWorkRow row =
+          (await db.getVideoMetadataWorkById(persisted.workId))!;
+      expect(
+        () => loadVideoMetadataWork(db, row),
+        throwsStateError,
+        reason: 'imdb 不是 VideoMetadataProviderKind，没有可用 provider',
+      );
+    });
+
+    test('一条身份都没有的作品（local 骨架）load 抛 StateError', () async {
+      final PersistedVideoMetadata persisted = await store.apply(
+        localWork,
+        VideoMetadataWork(
+          provider: VideoMetadataProviderKind.local,
+          kind: VideoMetadataMediaKind.tv,
+          title: 'Show',
+        ),
+      );
+      final VideoMetadataWorkRow row =
+          (await db.getVideoMetadataWorkById(persisted.workId))!;
+      expect(() => loadVideoMetadataWork(db, row), throwsStateError);
+      expect(await lookupOfWork(db, persisted.workId), isNull);
+    });
+  });
+}
+
+/// 字段尽量填满：2 季 3 集、2 个 id、2 张图（一张带 language）、1 个 credit
+/// 带 person + character、2 个 extra（一个无 remoteUrl 供 DB 往返验证过滤）。
+VideoMetadataWork _fullWork({Map<String, Object?>? rawPayload}) =>
+    VideoMetadataWork(
+      provider: VideoMetadataProviderKind.tmdb,
+      kind: VideoMetadataMediaKind.tv,
+      title: 'Show',
+      originalTitle: 'ショー',
+      tagline: 'A tagline',
+      aliases: const <String>['Alias A', 'Alias B'],
+      year: 2024,
+      premiered: '2024-01-01',
+      endDate: '2024-06-30',
+      plot: 'Plot text',
+      rating: 8.25,
+      ratingVotes: 1234,
+      runtimeMinutes: 24,
+      contentRating: 'TV-14',
+      status: 'Ended',
+      originalLanguage: 'ja',
+      homepage: 'https://example.com/show',
+      episodeGroupId: 'grp-1',
+      seasonCount: 2,
+      episodeCount: 3,
+      genres: const <String>['Action', 'Drama'],
+      studios: const <String>['Studio X'],
+      countries: const <String>['JP'],
+      keywords: const <String>['kw1', 'kw2'],
+      ids: const <VideoMetadataId>[
+        VideoMetadataId(type: 'tmdb', value: '31911'),
+        VideoMetadataId(type: 'IMDB', value: 'tt1234567', isDefault: true),
+      ],
+      credits: <VideoMetadataCredit>[
+        VideoMetadataCredit(
+          kind: VideoMetadataCreditKind.voiceActor,
+          person: VideoMetadataPerson(
+            id: 'p-99',
+            name: 'Voice Person',
+            originalName: '声の人',
+            biography: 'bio',
+            birthday: '1990-01-01',
+            deathday: null,
+            gender: 2,
+            placeOfBirth: 'Tokyo',
+            profileUrl: 'https://img.example/p99.jpg',
+            ids: const <VideoMetadataId>[
+              VideoMetadataId(type: 'TMDB', value: '99', isDefault: true),
+            ],
+          ),
+          character: VideoMetadataCharacter(
+            id: 'c-7',
+            name: 'Hero',
+            originalName: '主人公',
+            description: 'the hero',
+            imageUrl: 'https://img.example/c7.jpg',
+            ids: const <VideoMetadataId>[
+              VideoMetadataId(type: 'mal', value: '7'),
+            ],
+          ),
+          language: 'ja',
+          department: 'Voice',
+          job: 'Voice Actor',
+          providerCreditId: 'cr-1',
+          order: 2,
+        ),
+      ],
+      images: const <VideoMetadataImage>[
+        VideoMetadataImage(
+          kind: VideoMetadataImageKind.cover,
+          url: 'https://img.example/poster-ja.jpg',
+          provider: VideoMetadataProviderKind.tmdb,
+          language: 'ja',
+          likes: 3,
+          voteAverage: 5.5,
+          voteCount: 12,
+        ),
+        VideoMetadataImage(
+          kind: VideoMetadataImageKind.backdrop,
+          url: 'https://img.example/backdrop.jpg',
+          provider: VideoMetadataProviderKind.fanart,
+        ),
+      ],
+      seasons: <VideoMetadataSeason>[
+        VideoMetadataSeason(
+          seasonNumber: 1,
+          title: 'Season 1',
+          plot: 'S1 plot',
+          airDate: '2024-01-01',
+          year: 2024,
+          episodeCount: 2,
+          rating: 7.5,
+          ids: const <VideoMetadataId>[
+            VideoMetadataId(type: 'tmdb', value: 's1', isDefault: true),
+          ],
+          images: const <VideoMetadataImage>[
+            VideoMetadataImage(
+              kind: VideoMetadataImageKind.cover,
+              url: 'https://img.example/s1-poster.jpg',
+              provider: VideoMetadataProviderKind.tmdb,
+              language: 'en',
+            ),
+          ],
+          episodes: <VideoMetadataEpisode>[
+            VideoMetadataEpisode(
+              seasonNumber: 1,
+              episodeNumber: 1,
+              title: 'Pilot',
+              plot: 'E1 plot',
+              airDate: '2024-01-01',
+              year: 2024,
+              absoluteNumber: 1,
+              rating: 8.0,
+              ratingVotes: 10,
+              runtimeMinutes: 24,
+              ids: const <VideoMetadataId>[
+                VideoMetadataId(type: 'tmdb', value: 'e1', isDefault: true),
+              ],
+              images: const <VideoMetadataImage>[
+                VideoMetadataImage(
+                  kind: VideoMetadataImageKind.thumb,
+                  url: 'https://img.example/s1e1-thumb.jpg',
+                  provider: VideoMetadataProviderKind.tmdb,
+                ),
+              ],
+            ),
+            VideoMetadataEpisode(
+              seasonNumber: 1,
+              episodeNumber: 2,
+              title: 'Second',
+              absoluteNumber: 2,
+            ),
+          ],
+        ),
+        VideoMetadataSeason(
+          seasonNumber: 2,
+          title: 'Season 2',
+          episodeCount: 1,
+          episodes: <VideoMetadataEpisode>[
+            VideoMetadataEpisode(
+              seasonNumber: 2,
+              episodeNumber: 1,
+              title: 'Return',
+              absoluteNumber: 3,
+            ),
+          ],
+        ),
+      ],
+      extras: const <VideoMetadataExtra>[
+        VideoMetadataExtra(
+          kind: VideoMetadataExtraKind.behindTheScenes,
+          title: 'Making of',
+          provider: VideoMetadataProviderKind.tmdb,
+          providerVideoId: 'yt-1',
+          site: 'YouTube',
+          remoteUrl: 'https://youtu.be/yt-1',
+          thumbnailUrl: 'https://img.example/yt-1.jpg',
+          durationMs: 90000,
+          official: true,
+          language: 'en',
+          publishedAt: '2024-01-02',
+          order: 3,
+        ),
+        VideoMetadataExtra(
+          kind: VideoMetadataExtraKind.trailer,
+          title: 'No url trailer',
+        ),
+      ],
+      rawPayload: rawPayload,
+    );

--- a/fushi/test/media/video/metadata/video_source_scrape_task_test.dart
+++ b/fushi/test/media/video/metadata/video_source_scrape_task_test.dart
@@ -476,12 +476,16 @@ class _ManualRunner
 
   @override
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
   }) async =>
       const <VideoSourceScrapeConfirmationCandidate>[];
+
+  @override
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup) =>
+      Future<VideoMetadataWork?>.value(null);
 
   @override
   Future<SourceScrapeReport> rescrapeWorkWithLookup({

--- a/fushi/test/pages/dictionary_child_popup_close_guard_test.dart
+++ b/fushi/test/pages/dictionary_child_popup_close_guard_test.dart
@@ -345,8 +345,9 @@ void main() {
         () {
       final String js = read('assets/popup/popup.js');
       // 取 .glossary-content 分支体（到下一个分支 .entry 卡片判定之前）。
-      final int start =
-          js.indexOf("if (target?.closest('.glossary-content')) {");
+      // BUG-2460 起该分支也覆盖汉字卡片正文（.kanji-card-value / -meanings）。
+      final int start = js.indexOf(
+          "if (target?.closest('.glossary-content, .kanji-card-value, .kanji-card-meanings')) {");
       expect(start, greaterThanOrEqualTo(0),
           reason: 'glossary-content branch present');
       final int end = js.indexOf("if (target?.closest('.entry')", start);

--- a/fushi/test/pages/home_video_remote_download_register_test.dart
+++ b/fushi/test/pages/home_video_remote_download_register_test.dart
@@ -14,6 +14,7 @@ import 'package:fushi/src/models/preferences_repository.dart';
 import 'package:fushi/src/pages/implementations/home_video_page.dart';
 import 'package:fushi_engine/sync/fushi_library_host_service.dart';
 import 'package:fushi/src/sync/interconnect_download_manager.dart';
+import 'package:fushi/src/sync/remote_cover_fetcher.dart';
 import 'package:fushi/src/sync/remote_library_source.dart';
 import 'package:fushi/src/sync/remote_video_client.dart';
 import 'package:fushi_core/fushi_core.dart';
@@ -210,6 +211,57 @@ void main() {
     final List<dynamic> cues = await repo.loadCues('remote-clip');
     expect(cues, isNotEmpty);
   });
+
+  // 7c：host 已刮好的封面 / importedAt / completedAt 此前下载后全部丢失（无条件抽帧、
+  // importedAt 写本机 now、completedAt 不写）。
+  testWidgets('下载登记镜像 host 封面（coverUrl）、importedAt 与 completedAt',
+      (WidgetTester tester) async {
+    final _FakeCoverRemoteVideoClient client = _FakeCoverRemoteVideoClient(
+      videos: <RemoteVideoInfo>[
+        const RemoteVideoInfo(
+          id: 'remote-clip',
+          title: 'Remote Clip',
+          coverUrl: 'http://x/videos/remote-clip/cover',
+          importedAt: 1700000000000,
+          completedAt: 1700000500000,
+        ),
+      ],
+      coverBytes: <int>[0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3],
+    );
+    await tester.pumpWidget(buildApp(client: client));
+    await tester.pumpAndSettle();
+
+    await tapDownloadAwaitRow(tester);
+
+    final VideoBookRow? row = await repo.getByBookUid('remote-clip');
+    expect(row, isNotNull);
+    expect(row!.importedAt, 1700000000000,
+        reason: 'importedAt 镜像 host 值，下载后不该在「按导入时间」里跳位');
+    expect(row.completedAt?.millisecondsSinceEpoch, 1700000500000,
+        reason: 'completedAt 镜像 host 值，已看完角标不丢');
+    expect(client.coverFetches, <String>['http://x/videos/remote-clip/cover'],
+        reason: 'host 有 coverUrl 时先拉 host 封面');
+    expect(row.coverPath, isNotNull);
+    expect(File(row.coverPath!).readAsBytesSync(),
+        <int>[0xFF, 0xD8, 0xFF, 0xE0, 1, 2, 3]);
+  });
+}
+
+class _FakeCoverRemoteVideoClient extends _FakeRemoteVideoClient
+    implements RemoteCoverFetcher {
+  _FakeCoverRemoteVideoClient({required super.videos, required this.coverBytes});
+
+  final List<int> coverBytes;
+  final List<String> coverFetches = <String>[];
+
+  @override
+  String get coverCacheNamespace => 'test';
+
+  @override
+  Future<Uint8List> fetchRemoteCover(String coverUrl) async {
+    coverFetches.add(coverUrl);
+    return Uint8List.fromList(coverBytes);
+  }
 }
 
 class _FakeRemoteVideoClient implements RemoteVideoClient {

--- a/fushi/test/pages/video_manual_binding_ui_test.dart
+++ b/fushi/test/pages/video_manual_binding_ui_test.dart
@@ -31,7 +31,7 @@ class _ManualBindingRunner
 
   @override
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
@@ -40,6 +40,10 @@ class _ManualBindingRunner
     searchedKeys.add(workStableKey);
     return results;
   }
+
+  @override
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup) =>
+      Future<VideoMetadataWork?>.value(null);
 
   @override
   Future<SourceScrapeReport> rescrapeWorkWithLookup({

--- a/fushi/test/pages/video_source_scrape_ui_test.dart
+++ b/fushi/test/pages/video_source_scrape_ui_test.dart
@@ -132,7 +132,7 @@ class _ManualBindingRunner
 
   @override
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
@@ -140,6 +140,10 @@ class _ManualBindingRunner
     queries.add(query);
     return results;
   }
+
+  @override
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup) =>
+      Future<VideoMetadataWork?>.value(null);
 
   @override
   Future<SourceScrapeReport> rescrapeWorkWithLookup({

--- a/fushi/test/sync/interconnect_download_manager_test.dart
+++ b/fushi/test/sync/interconnect_download_manager_test.dart
@@ -156,5 +156,85 @@ void main() {
       gate.complete();
       await running;
     });
+
+    // #6 合集整体下载：串行批。
+    group('startBatch (collection download)', () {
+      test('runs starters strictly one after another and counts results',
+          () async {
+        final List<String> order = <String>[];
+        final Completer<void> firstGate = Completer<void>();
+        Future<void> Function() starter(String id, {bool fail = false}) =>
+            () => manager.startVideoDownload(
+                  id: id,
+                  title: id,
+                  dest: dest('$id.mp4'),
+                  run: (File target,
+                      {void Function(double progress)? onProgress}) async {
+                    order.add('start:$id');
+                    if (id == 'a') await firstGate.future;
+                    if (fail) throw StateError('boom $id');
+                    order.add('end:$id');
+                  },
+                );
+
+        final Future<InterconnectDownloadBatch> done = manager.startBatch(
+          id: InterconnectDownloadManager.collectionBatchId(7),
+          title: 'Series',
+          starters: <Future<void> Function()>[
+            starter('a'),
+            starter('b', fail: true),
+            starter('c'),
+          ],
+        );
+        await Future<void>.delayed(Duration.zero);
+        // a 还卡着时 b 绝不能起跑（串行）。
+        expect(order, <String>['start:a']);
+        expect(manager.isBatchRunning('collection:7'), isTrue);
+        expect(manager.batchFor('collection:7')!.total, 3);
+        firstGate.complete();
+
+        final InterconnectDownloadBatch batch = await done;
+        expect(order, <String>[
+          'start:a',
+          'end:a',
+          'start:b',
+          'start:c',
+          'end:c',
+        ]);
+        expect(batch.completed, 2);
+        expect(batch.failed, 1);
+        expect(batch.isRunning, isFalse);
+        // 成员失败原因仍在其自己的任务快照里，批不吞。
+        expect(manager.taskFor('b')!.status, InterconnectDownloadStatus.failed);
+        expect(manager.taskFor('b')!.error, isNotNull);
+        expect(
+            manager.taskFor('c')!.status, InterconnectDownloadStatus.completed);
+      });
+
+      test('duplicate startBatch while running returns the live batch',
+          () async {
+        final Completer<void> gate = Completer<void>();
+        var starts = 0;
+        Future<void> Function() blocked() => () async {
+              starts += 1;
+              await gate.future;
+            };
+        final Future<InterconnectDownloadBatch> first = manager.startBatch(
+          id: 'collection:1',
+          title: 'S',
+          starters: <Future<void> Function()>[blocked()],
+        );
+        await Future<void>.delayed(Duration.zero);
+        final InterconnectDownloadBatch again = await manager.startBatch(
+          id: 'collection:1',
+          title: 'S',
+          starters: <Future<void> Function()>[blocked(), blocked()],
+        );
+        expect(again.total, 1, reason: '重复调用拿到的是正在跑的那批，不是新批');
+        expect(starts, 1);
+        gate.complete();
+        await first;
+      });
+    });
   });
 }

--- a/fushi/test/sync/interconnect_video_metadata_client_apply_test.dart
+++ b/fushi/test/sync/interconnect_video_metadata_client_apply_test.dart
@@ -57,11 +57,12 @@ void main() {
   tearDown(() => db.close());
 
   test('合集在本机 → 落作品行并带上 host 主身份；只在 host 的成员不阻断', () async {
-    final int applied = await applyRemoteVideoMetadata(
+    final RemoteVideoMetadataApplyResult applied =
+        await applyRemoteVideoMetadata(
       db,
       <VideoMetadataWorkEntry>[entry()],
     );
-    expect(applied, 1);
+    expect(applied.applied, 1);
     final VideoMetadataWorkRow row =
         (await db.getVideoMetadataWorkByCollection(collectionId))!;
     expect(row.overview, 'host plot');
@@ -75,25 +76,26 @@ void main() {
     final VideoMetadataWorkRow local =
         (await db.getVideoMetadataWorkByCollection(collectionId))!;
     // host 的 updatedAt 比本地落库时刻早：跳过。
-    final int skipped = await applyRemoteVideoMetadata(
+    final RemoteVideoMetadataApplyResult skipped =
+        await applyRemoteVideoMetadata(
       db,
       <VideoMetadataWorkEntry>[
         entry(plot: 'stale', updatedAt: local.updatedAt - 1),
       ],
     );
-    expect(skipped, 0);
+    expect(skipped.applied, 0);
     expect(
       (await db.getVideoMetadataWorkByCollection(collectionId))!.overview,
       'host plot',
     );
     // host 更新了：覆盖。
-    final int fresh = await applyRemoteVideoMetadata(
+    final RemoteVideoMetadataApplyResult fresh = await applyRemoteVideoMetadata(
       db,
       <VideoMetadataWorkEntry>[
         entry(plot: 'newer', updatedAt: local.updatedAt + 1),
       ],
     );
-    expect(fresh, 1);
+    expect(fresh.applied, 1);
     expect(
       (await db.getVideoMetadataWorkByCollection(collectionId))!.overview,
       'newer',
@@ -101,7 +103,8 @@ void main() {
   });
 
   test('本机没有的合集 / 单条目跳过，不抛', () async {
-    final int applied = await applyRemoteVideoMetadata(
+    final RemoteVideoMetadataApplyResult applied =
+        await applyRemoteVideoMetadata(
       db,
       <VideoMetadataWorkEntry>[
         entry(
@@ -113,7 +116,8 @@ void main() {
         entry(key: const VideoMetadataWorkKey.book('not-downloaded')),
       ],
     );
-    expect(applied, 0);
+    expect(applied.applied, 0);
+    expect(applied.deferred, 2, reason: '目标缺失计入 deferred，基线不得推进');
   });
 
   test('客户端自己锁的字段不被 host 覆盖', () async {

--- a/fushi/test/sync/interconnect_video_metadata_client_apply_test.dart
+++ b/fushi/test/sync/interconnect_video_metadata_client_apply_test.dart
@@ -1,0 +1,140 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_locked_fields.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_work_loader.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_work_target.dart';
+
+/// 7c 客户端落库：`applyRemoteVideoMetadata` 的目标解析 / 新旧判定 / 本地字段锁。
+void main() {
+  late FushiDatabase db;
+  late int collectionId;
+
+  VideoMetadataWorkEntry entry({
+    String plot = 'host plot',
+    int updatedAt = 1000,
+    VideoMetadataWorkKey key = const VideoMetadataWorkKey.collection(
+      name: 'Show',
+      collectionType: 'collection',
+    ),
+  }) =>
+      VideoMetadataWorkEntry(
+        key: key,
+        updatedAt: updatedAt,
+        lockedFields: const <String>[],
+        lookup: const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '7',
+          mediaKind: VideoMetadataMediaKind.tv,
+        ),
+        work: VideoMetadataWork(
+          provider: VideoMetadataProviderKind.mal,
+          kind: VideoMetadataMediaKind.tv,
+          title: 'Show',
+          plot: plot,
+          // 故意不带 id：wire 上 lookup 才是身份真相，apply 前须补齐。
+        ),
+      );
+
+  setUp(() async {
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    // 客户端典型形态：合集经清单同步建出来，成员一个在本机、一个只在 host。
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value<String>('Show S01E01'),
+      title: Value<String>('Show S01E01'),
+      videoPath: Value<String>('D:/dl/Show S01E01.mkv'),
+    ));
+    collectionId =
+        await db.createMediaCollection('Show', collectionType: 'collection');
+    await db.addToCollection(collectionId, MediaKind.video, 'Show S01E01');
+    await db.addToCollection(collectionId, MediaKind.video, 'Show S01E02');
+  });
+
+  tearDown(() => db.close());
+
+  test('合集在本机 → 落作品行并带上 host 主身份；只在 host 的成员不阻断', () async {
+    final int applied = await applyRemoteVideoMetadata(
+      db,
+      <VideoMetadataWorkEntry>[entry()],
+    );
+    expect(applied, 1);
+    final VideoMetadataWorkRow row =
+        (await db.getVideoMetadataWorkByCollection(collectionId))!;
+    expect(row.overview, 'host plot');
+    final VideoMetadataLookup? lookup = await lookupOfWork(db, row.id);
+    expect(lookup?.provider, VideoMetadataProviderKind.mal);
+    expect(lookup?.externalId, '7');
+  });
+
+  test('本地作品行不比 host 旧则跳过（不重放旧数据）', () async {
+    await applyRemoteVideoMetadata(db, <VideoMetadataWorkEntry>[entry()]);
+    final VideoMetadataWorkRow local =
+        (await db.getVideoMetadataWorkByCollection(collectionId))!;
+    // host 的 updatedAt 比本地落库时刻早：跳过。
+    final int skipped = await applyRemoteVideoMetadata(
+      db,
+      <VideoMetadataWorkEntry>[
+        entry(plot: 'stale', updatedAt: local.updatedAt - 1),
+      ],
+    );
+    expect(skipped, 0);
+    expect(
+      (await db.getVideoMetadataWorkByCollection(collectionId))!.overview,
+      'host plot',
+    );
+    // host 更新了：覆盖。
+    final int fresh = await applyRemoteVideoMetadata(
+      db,
+      <VideoMetadataWorkEntry>[
+        entry(plot: 'newer', updatedAt: local.updatedAt + 1),
+      ],
+    );
+    expect(fresh, 1);
+    expect(
+      (await db.getVideoMetadataWorkByCollection(collectionId))!.overview,
+      'newer',
+    );
+  });
+
+  test('本机没有的合集 / 单条目跳过，不抛', () async {
+    final int applied = await applyRemoteVideoMetadata(
+      db,
+      <VideoMetadataWorkEntry>[
+        entry(
+          key: const VideoMetadataWorkKey.collection(
+            name: 'Elsewhere',
+            collectionType: 'collection',
+          ),
+        ),
+        entry(key: const VideoMetadataWorkKey.book('not-downloaded')),
+      ],
+    );
+    expect(applied, 0);
+  });
+
+  test('客户端自己锁的字段不被 host 覆盖', () async {
+    await applyRemoteVideoMetadata(db, <VideoMetadataWorkEntry>[entry()]);
+    final VideoMetadataWorkRow local =
+        (await db.getVideoMetadataWorkByCollection(collectionId))!;
+    await db.setVideoMetadataWorkLockedFields(
+      local.id,
+      encodeLockedFields(<VideoMetadataLockableField>{
+        VideoMetadataLockableField.overview,
+      }),
+    );
+    await applyRemoteVideoMetadata(
+      db,
+      <VideoMetadataWorkEntry>[
+        entry(plot: 'host overwrite', updatedAt: local.updatedAt + 1),
+      ],
+    );
+    expect(
+      (await db.getVideoMetadataWorkByCollection(collectionId))!.overview,
+      'host plot',
+    );
+  });
+}

--- a/fushi/test/sync/interconnect_video_metadata_host_test.dart
+++ b/fushi/test/sync/interconnect_video_metadata_host_test.dart
@@ -10,6 +10,7 @@ import 'package:fushi_engine/media/video/metadata/video_metadata_locked_fields.d
 import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
 import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
 import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
+import 'package:fushi_engine/media/source_library/source_library_row.dart';
 import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
 import 'package:fushi_engine/sync/fushi_sync_server.dart';
 import 'package:fushi_engine/sync/local_library_host_service.dart';
@@ -311,6 +312,93 @@ void main() {
       VideoMetadataWriteResult.fromJson(res.json).entry!.lockedFields,
       <String>['overview'],
     );
+  });
+
+  // 审查 PR#1431 #2：合集在计划器里是 N 个成员级作品（无集号的电影合集）时，
+  // 7b 不得按合集单元 apply——那会新建合集级作品并物理删掉全部成员作品行。
+  test('7b PUT 到多作品单元的合集 → 409 ambiguousWork，成员作品行一条不少', () async {
+    final int sourceId = (await db.getMediaSourcesByKind('video')).single.id;
+    final SourceLibraryRow source = (await db.getMediaSourceById(sourceId))!;
+    final List<VideoBookRow> films = <VideoBookRow>[];
+    for (final String stem in <String>['Movie A', 'Movie B']) {
+      await db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value<String>(stem),
+        title: Value<String>(stem),
+        videoPath: Value<String>('D:/Shows/Films/$stem.mkv'),
+        sourceId: Value<int?>(sourceId),
+      ));
+      films.add((await db.getVideoBookByBookUid(stem))!);
+    }
+    final int filmsId =
+        await db.createMediaCollection('Films', collectionType: 'collection');
+    for (final VideoBookRow m in films) {
+      await db.addToCollection(filmsId, MediaKind.video, m.bookUid);
+    }
+    final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(db);
+    for (final VideoBookRow m in films) {
+      await store.apply(
+        VideoSourceScrapeWork(
+          source: source,
+          title: m.title,
+          members: <VideoBookRow>[m],
+        ),
+        work(title: m.title, externalId: m.bookUid.hashCode.toString())
+            .copyWith(kind: VideoMetadataMediaKind.movie),
+      );
+    }
+    expect(await db.getVideoMetadataWorkByBook('Movie A'), isNotNull);
+
+    final ({int status, Object? json}) res = await call(
+      'PUT',
+      '/api/library/metadata',
+      body: <String, Object?>{
+        'key': const VideoMetadataWorkKey.collection(
+          name: 'Films',
+          collectionType: 'collection',
+        ).toJson(),
+        'lookup': encodeVideoMetadataLookup(const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '9',
+          mediaKind: VideoMetadataMediaKind.movie,
+        )),
+        'work': encodeVideoMetadataWork(work(title: 'Films', externalId: '9')),
+      },
+    );
+    expect(res.status, 409);
+    final VideoMetadataWriteResult result =
+        VideoMetadataWriteResult.fromJson(res.json);
+    expect(result.conflict, VideoMetadataConflict.ambiguousWork);
+    expect(
+      result.ambiguousWorks.map((VideoMetadataWorkKey k) => k.bookUid),
+      unorderedEquals(<String>['Movie A', 'Movie B']),
+    );
+    expect(await db.getVideoMetadataWorkByBook('Movie A'), isNotNull,
+        reason: '成员作品行不得被合集级 apply 删掉');
+    expect(await db.getVideoMetadataWorkByBook('Movie B'), isNotNull);
+    expect(await db.getVideoMetadataWorkByCollection(filmsId), isNull);
+
+    // 客户端按 ambiguousWorks 用 bookUid 重发 → 只动那一部。
+    final ({int status, Object? json}) one = await call(
+      'PUT',
+      '/api/library/metadata',
+      body: <String, Object?>{
+        'key': const VideoMetadataWorkKey.book('Movie A').toJson(),
+        'lookup': encodeVideoMetadataLookup(const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '9',
+          mediaKind: VideoMetadataMediaKind.movie,
+        )),
+        'work': encodeVideoMetadataWork(
+          work(title: 'Movie A', plot: 'client', externalId: '9')
+              .copyWith(kind: VideoMetadataMediaKind.movie),
+        ),
+        'replaceIdentity': true,
+      },
+    );
+    expect(one.status, 200);
+    expect(
+        (await db.getVideoMetadataWorkByBook('Movie A'))!.overview, 'client');
+    expect((await db.getVideoMetadataWorkByBook('Movie B'))!.overview, 'plot');
   });
 
   test('坏请求：缺 key / 缺 lookup → 400；未知作品 → 409 notPlanned', () async {

--- a/fushi/test/sync/interconnect_video_metadata_host_test.dart
+++ b/fushi/test/sync/interconnect_video_metadata_host_test.dart
@@ -1,0 +1,341 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_database_store.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_locked_fields.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
+import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
+import 'package:fushi_engine/sync/fushi_sync_server.dart';
+import 'package:fushi_engine/sync/local_library_host_service.dart';
+import 'package:fushi_engine/sync/sync_asset_package_service.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+import 'package:path/path.dart' as p;
+
+/// 互联视频刮削元数据 host 端（7c 列出 / 7a 无刮削链降级 / 7b 回写与覆盖保护），
+/// 走真 HTTP + 真 `LocalLibraryHostService` + 内存 DB。
+/// `docs/specs/2026-09-12-interconnect-scrape-metadata.md`。
+void main() {
+  late Directory tmp;
+  late FushiDatabase db;
+  late FushiSyncServer server;
+  late String base;
+  late MediaCollectionRow collection;
+  late VideoSourceScrapeWork localWork;
+  const String token = 'test-token-meta';
+  String authHeader() => 'Basic ${base64Encode(utf8.encode('hibiki:$token'))}';
+
+  Future<({int status, Object? json})> call(
+    String method,
+    String path, {
+    Object? body,
+  }) async {
+    final HttpClient c = HttpClient();
+    try {
+      final HttpClientRequest req =
+          await c.openUrl(method, Uri.parse('$base$path'));
+      req.headers.set('authorization', authHeader());
+      if (body != null) {
+        req.headers.set('content-type', 'application/json; charset=utf-8');
+        req.add(utf8.encode(jsonEncode(body)));
+      }
+      final HttpClientResponse res = await req.close();
+      final String text = await res.transform(utf8.decoder).join();
+      // 400 的 body 是纯文本错误说明，不是 JSON。
+      Object? json;
+      try {
+        json = text.isEmpty ? null : jsonDecode(text);
+      } on FormatException {
+        json = text;
+      }
+      return (status: res.statusCode, json: json);
+    } finally {
+      c.close();
+    }
+  }
+
+  VideoMetadataWork work({
+    String title = 'Show',
+    String plot = 'plot',
+    String externalId = '100',
+    VideoMetadataProviderKind provider = VideoMetadataProviderKind.mal,
+  }) =>
+      VideoMetadataWork(
+        provider: provider,
+        kind: VideoMetadataMediaKind.tv,
+        title: title,
+        plot: plot,
+        year: 2020,
+        ids: <VideoMetadataId>[
+          VideoMetadataId(type: provider.name, value: externalId),
+        ],
+      );
+
+  setUp(() async {
+    tmp = Directory.systemTemp.createTempSync('hbk_meta_host');
+    db = FushiDatabase.forTesting(NativeDatabase.memory());
+    final int sourceId = await db.insertMediaSource(
+      MediaSourcesCompanion.insert(
+        label: 'Shows',
+        mediaKind: 'video',
+        rootPath: 'D:/Shows',
+        createdAt: 1,
+      ),
+    );
+    final List<VideoBookRow> members = <VideoBookRow>[];
+    for (final String stem in <String>['Show S01E01', 'Show S01E02']) {
+      await db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value<String>(stem),
+        title: Value<String>(stem),
+        videoPath: Value<String>('D:/Shows/Show/$stem.mkv'),
+        sourceId: Value<int?>(sourceId),
+      ));
+      members.add((await db.getVideoBookByBookUid(stem))!);
+    }
+    final int collectionId =
+        await db.createMediaCollection('Show', collectionType: 'playlist');
+    for (final VideoBookRow m in members) {
+      await db.addToCollection(collectionId, MediaKind.video, m.bookUid);
+    }
+    collection = (await db.getMediaCollectionById(collectionId))!;
+    localWork = VideoSourceScrapeWork(
+      source: (await db.getMediaSourceById(sourceId))!,
+      collection: collection,
+      title: collection.name,
+      members: members,
+    );
+    final Directory dictRoot = Directory(p.join(tmp.path, 'dicts'))
+      ..createSync(recursive: true);
+    server = FushiSyncServer(
+      syncDataDir: tmp.path,
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: LocalLibraryHostService(
+        db: db,
+        dictionaryResourceRoot: dictRoot,
+        packages: SyncAssetPackageService(db: db),
+        refreshDictionaryCache: () async {},
+        runExclusive: (Future<void> Function() body) => body(),
+        // 无刮削控制器：7a 端点必须降级而不是 500。
+        scrapeController: () async => null,
+      ),
+    );
+    await server.start();
+    base = 'http://127.0.0.1:${server.port}';
+  });
+
+  tearDown(() async {
+    await server.stop();
+    await db.close();
+    try {
+      tmp.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  test('capabilities.liveLibrary.videoMetadata == true', () async {
+    final ({int status, Object? json}) res =
+        await call('GET', '/api/capabilities');
+    expect(res.status, 200);
+    final Map<dynamic, dynamic> live =
+        (res.json as Map<dynamic, dynamic>)['liveLibrary'] as Map;
+    expect(live['videoMetadata'], true);
+  });
+
+  test('7c GET /api/library/metadata 列出 host 作品（自然键 + 模型 + 主身份）', () async {
+    final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(db);
+    await store.apply(localWork, work(plot: 'from host'));
+
+    final ({int status, Object? json}) res =
+        await call('GET', '/api/library/metadata');
+    expect(res.status, 200);
+    final List<Object?> works =
+        (res.json as Map<dynamic, dynamic>)['works'] as List<Object?>;
+    expect(works, hasLength(1));
+    final VideoMetadataWorkEntry entry =
+        VideoMetadataWorkEntry.fromJson(works.single);
+    expect(entry.key.isCollection, isTrue);
+    expect(entry.key.collectionName, 'Show');
+    expect(entry.key.collectionType, 'playlist');
+    expect(entry.work.plot, 'from host');
+    expect(entry.lookup?.provider, VideoMetadataProviderKind.mal);
+    expect(entry.lookup?.externalId, '100');
+    expect(entry.updatedAt, greaterThan(0));
+
+    // since 过滤：晚于 updatedAt 的 since 什么都不回。
+    final ({int status, Object? json}) later = await call(
+      'GET',
+      '/api/library/metadata?since=${entry.updatedAt}',
+    );
+    expect(
+      ((later.json as Map<dynamic, dynamic>)['works'] as List<Object?>),
+      isEmpty,
+    );
+  });
+
+  test('7a 无刮削控制器：candidates 回空、scrape 回 409 notPlanned', () async {
+    final Map<String, Object?> key = const VideoMetadataWorkKey.collection(
+      name: 'Show',
+      collectionType: 'playlist',
+    ).toJson();
+    final ({int status, Object? json}) cands = await call(
+      'POST',
+      '/api/library/metadata/candidates',
+      body: <String, Object?>{'key': key, 'query': 'Show'},
+    );
+    expect(cands.status, 200);
+    expect(
+      (cands.json as Map<dynamic, dynamic>)['candidates'],
+      isEmpty,
+    );
+    final ({int status, Object? json}) scrape = await call(
+      'POST',
+      '/api/library/metadata/scrape',
+      body: <String, Object?>{
+        'key': key,
+        'lookup': encodeVideoMetadataLookup(const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '100',
+          mediaKind: VideoMetadataMediaKind.tv,
+        )),
+      },
+    );
+    expect(scrape.status, 409);
+    expect(
+      VideoMetadataWriteResult.fromJson(scrape.json).conflict,
+      VideoMetadataConflict.notPlanned,
+    );
+  });
+
+  test('7b PUT 落库；host 已绑不同身份时 409 identity，replaceIdentity 才换', () async {
+    final Map<String, Object?> key = const VideoMetadataWorkKey.collection(
+      name: 'Show',
+      collectionType: 'playlist',
+    ).toJson();
+    Map<String, Object?> body(String externalId, {bool replace = false}) =>
+        <String, Object?>{
+          'key': key,
+          'lookup': encodeVideoMetadataLookup(VideoMetadataLookup(
+            provider: VideoMetadataProviderKind.mal,
+            externalId: externalId,
+            mediaKind: VideoMetadataMediaKind.tv,
+          )),
+          'work': encodeVideoMetadataWork(
+            work(plot: 'from client $externalId', externalId: externalId),
+          ),
+          'replaceIdentity': replace,
+        };
+
+    final ({int status, Object? json}) first =
+        await call('PUT', '/api/library/metadata', body: body('100'));
+    expect(first.status, 200);
+    final VideoMetadataWorkRow row =
+        (await db.getVideoMetadataWorkByCollection(collection.id))!;
+    expect(row.overview, 'from client 100');
+
+    // 同身份重写：不冲突。
+    final ({int status, Object? json}) same =
+        await call('PUT', '/api/library/metadata', body: body('100'));
+    expect(same.status, 200);
+
+    // 换身份且未显式确认：409 + 现身份。
+    final ({int status, Object? json}) conflict =
+        await call('PUT', '/api/library/metadata', body: body('200'));
+    expect(conflict.status, 409);
+    final VideoMetadataWriteResult result =
+        VideoMetadataWriteResult.fromJson(conflict.json);
+    expect(result.conflict, VideoMetadataConflict.identity);
+    expect(result.currentLookup?.externalId, '100');
+    expect(
+      (await db.getVideoMetadataWorkByCollection(collection.id))!.overview,
+      'from client 100',
+      reason: '被拒的写入不得动库',
+    );
+
+    // 显式替换。
+    final ({int status, Object? json}) replaced = await call(
+      'PUT',
+      '/api/library/metadata',
+      body: body('200', replace: true),
+    );
+    expect(replaced.status, 200);
+    expect(
+      (await db.getVideoMetadataWorkByCollection(collection.id))!.overview,
+      'from client 200',
+    );
+    final VideoMetadataWorkEntry entry = VideoMetadataWriteResult.fromJson(
+      replaced.json,
+    ).entry!;
+    expect(entry.lookup?.externalId, '200');
+  });
+
+  test('7b PUT 尊重 host 字段锁（锁住的 overview 保留旧值）', () async {
+    final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(db);
+    final PersistedVideoMetadata persisted =
+        await store.apply(localWork, work(plot: 'host locked'));
+    await db.setVideoMetadataWorkLockedFields(
+      persisted.workId,
+      encodeLockedFields(<VideoMetadataLockableField>{
+        VideoMetadataLockableField.overview,
+      }),
+    );
+    final ({int status, Object? json}) res = await call(
+      'PUT',
+      '/api/library/metadata',
+      body: <String, Object?>{
+        'key': const VideoMetadataWorkKey.collection(
+          name: 'Show',
+          collectionType: 'playlist',
+        ).toJson(),
+        'lookup': encodeVideoMetadataLookup(const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '100',
+          mediaKind: VideoMetadataMediaKind.tv,
+        )),
+        'work': encodeVideoMetadataWork(
+          work(title: 'Show (client)', plot: 'client overwrite'),
+        ),
+      },
+    );
+    expect(res.status, 200);
+    final VideoMetadataWorkRow row =
+        (await db.getVideoMetadataWorkByCollection(collection.id))!;
+    expect(row.overview, 'host locked', reason: '锁住的字段不被客户端覆盖');
+    expect(row.title, 'Show (client)', reason: '未锁字段照常更新');
+    expect(
+      VideoMetadataWriteResult.fromJson(res.json).entry!.lockedFields,
+      <String>['overview'],
+    );
+  });
+
+  test('坏请求：缺 key / 缺 lookup → 400；未知作品 → 409 notPlanned', () async {
+    expect(
+      (await call('PUT', '/api/library/metadata', body: <String, Object?>{}))
+          .status,
+      400,
+    );
+    final ({int status, Object? json}) unknown = await call(
+      'PUT',
+      '/api/library/metadata',
+      body: <String, Object?>{
+        'key': const VideoMetadataWorkKey.book('nope').toJson(),
+        'lookup': encodeVideoMetadataLookup(const VideoMetadataLookup(
+          provider: VideoMetadataProviderKind.mal,
+          externalId: '1',
+          mediaKind: VideoMetadataMediaKind.tv,
+        )),
+        'work': encodeVideoMetadataWork(work()),
+      },
+    );
+    expect(unknown.status, 409);
+    expect(
+      VideoMetadataWriteResult.fromJson(unknown.json).conflict,
+      VideoMetadataConflict.notPlanned,
+    );
+  });
+}

--- a/fushi/test/utils/misc/popup_asset_behavior_test.js
+++ b/fushi/test/utils/misc/popup_asset_behavior_test.js
@@ -263,13 +263,14 @@ class FakeElement {
   }
 
   closest(selector) {
-    if (!selector.startsWith('.')) {
+    // Supports a comma-separated list of simple class selectors only.
+    const classNames = selector.split(',').map((s) => s.trim());
+    if (classNames.some((s) => !s.startsWith('.'))) {
       return null;
     }
-    const className = selector.slice(1);
     let element = this;
     while (element) {
-      if (element.classList?.contains(className)) {
+      if (classNames.some((s) => element.classList?.contains(s.slice(1)))) {
         return element;
       }
       element = element.parentElement;
@@ -970,6 +971,62 @@ function testTapInKanjiSectionGapKeepsLayer() {
   const result = fireDocumentClick(context, sectionGap);
   assert.equal(result.tapOutsideCalls, 0,
     'tapping the kanji-card-section gap/margin must NOT fire tapOutside (layer kept)');
+}
+
+// (6) Kanji card BODY text (readings / stats values / meanings) is lookup text
+// with the same semantics as .glossary-content: tapping it must select a word
+// (fushiSelection.selectText → textSelected), not drop into the card-root
+// branch that only keeps the layer. DOM mirrors createKanjiReadingRow and
+// buildKanjiCards: body > .kanji-card-section > .kanji-card > .kanji-card-row >
+// .kanji-card-value, and .kanji-card > .kanji-card-meanings.
+function buildKanjiCardBody(context) {
+  const section = new FakeElement('div');
+  section.classList.add('kanji-card-section');
+  const kanjiCard = new FakeElement('div');
+  kanjiCard.classList.add('kanji-card');
+  const row = new FakeElement('div');
+  row.classList.add('kanji-card-row');
+  const label = new FakeElement('span');
+  label.classList.add('kanji-card-label');
+  const value = new FakeElement('span');
+  value.classList.add('kanji-card-value');
+  const meanings = new FakeElement('div');
+  meanings.classList.add('kanji-card-meanings');
+  context.document.body.appendChild(section);
+  section.appendChild(kanjiCard);
+  kanjiCard.appendChild(row);
+  row.appendChild(label);
+  row.appendChild(value);
+  kanjiCard.appendChild(meanings);
+  return {label, value, meanings};
+}
+
+function testTapOnKanjiCardValueSelectsWord() {
+  const context = loadPopup();
+  const {value, meanings, label} = buildKanjiCardBody(context);
+  for (const node of [value, meanings]) {
+    const result = fireDocumentClick(context, node);
+    assert.equal(result.selectCalls, 1,
+      'tapping kanji card reading/meaning text must call selectText (tap-to-lookup)');
+    assert.equal(result.tapOutsideCalls, 0,
+      'kanji card body text is inside the card: no tapOutside');
+  }
+  // The label column ("On", "Kun", ...) is UI chrome, not lookup text.
+  const labelResult = fireDocumentClick(context, label);
+  assert.equal(labelResult.selectCalls, 0,
+    'kanji card label column must not select text');
+  assert.equal(labelResult.tapOutsideCalls, 0,
+    'kanji card label is still inside the card root: layer kept');
+}
+
+function testTapOnKanjiCardValueWithChildFiresTapOutside() {
+  const context = loadPopup();
+  const {value} = buildKanjiCardBody(context);
+  const result = fireDocumentClick(context, value, 50, 50, {hasChild: true});
+  assert.equal(result.tapOutsideCalls, 1,
+    'with a child popup, tapping kanji card text closes descendants first');
+  assert.equal(result.selectCalls, 0,
+    'with a child popup, kanji card text must not also select a word');
 }
 
 // ── TODO-869：父弹窗有子弹窗时，点卡片本体也得发 tapOutside 关后代层 ───────────
@@ -2349,6 +2406,8 @@ testTapOnEntryCardWhitespaceKeepsLayer();
 testTapOnPopupBackgroundFiresTapOutside();
 testTapInsideKanjiCardKeepsLayer();
 testTapInKanjiSectionGapKeepsLayer();
+testTapOnKanjiCardValueSelectsWord();
+testTapOnKanjiCardValueWithChildFiresTapOutside();
 testEntryWhitespaceWithChildFiresTapOutside();
 testEntryWhitespaceWithoutChildKeepsLayer();
 testKanjiSectionWhitespaceWithChildFiresTapOutside();

--- a/packages/fushi_core/lib/src/database/database_video_domain.part.dart
+++ b/packages/fushi_core/lib/src/database/database_video_domain.part.dart
@@ -281,6 +281,14 @@ mixin _FushiDbVideoDomain
             ..where(($VideoMetadataWorksTable t) => t.bookUid.equals(bookUid)))
           .getSingleOrNull();
 
+  /// 把作品行的 `updatedAt` 钉成远端给的戳（互联 7c 客户端落库后用 host 的
+  /// updatedAt 覆盖 apply 写的本机 now，新旧判定才能跨设备成立）。
+  Future<void> setVideoMetadataWorkUpdatedAt(int workId, int updatedAt) async {
+    await (update(videoMetadataWorks)
+          ..where(($VideoMetadataWorksTable t) => t.id.equals(workId)))
+        .write(VideoMetadataWorksCompanion(updatedAt: Value<int>(updatedAt)));
+  }
+
   /// 写作品级字段锁（schema v99）。`null` = 清空全部锁。锁是纯用户意图，独立于
   /// 刮削产物，所以是自己的原语而不是 `upsertVideoMetadataWork` 的一个字段。
   Future<void> setVideoMetadataWorkLockedFields(

--- a/packages/fushi_engine/lib/media/video/metadata/video_metadata_wire.dart
+++ b/packages/fushi_engine/lib/media/video/metadata/video_metadata_wire.dart
@@ -1,0 +1,404 @@
+/// [VideoMetadataWork] / [VideoMetadataLookup] 的 JSON wire 编解码。
+///
+/// 供互联同步把 host 刮好的作品资料整块搬到客户端（spec
+/// `docs/specs/2026-09-12-interconnect-scrape-metadata.md` §1.2）。
+///
+/// 约定：
+/// - 枚举一律用 `.name` 上 wire；解码认不出的枚举值按「缺失」处理（可空字段置
+///   null、列表元素丢弃），只有 [VideoMetadataWork.provider] / `kind` 这两个必需
+///   字段缺失或非法时抛 [FormatException]。
+/// - [VideoMetadataWork.rawPayload] 不上 wire：encode 忽略，decode 置 null。
+/// - 解码对缺失 / 类型错误的字段容错，走 `video_metadata_json.dart` 的 helper。
+library;
+
+import 'package:fushi_engine/media/video/metadata/video_metadata_json.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
+
+// ─── 作品 ────────────────────────────────────────────────────────────
+
+Map<String, Object?> encodeVideoMetadataWork(VideoMetadataWork work) =>
+    <String, Object?>{
+      'provider': work.provider.name,
+      'kind': work.kind.name,
+      'title': work.title,
+      'originalTitle': work.originalTitle,
+      'tagline': work.tagline,
+      'aliases': work.aliases,
+      'year': work.year,
+      'premiered': work.premiered,
+      'endDate': work.endDate,
+      'plot': work.plot,
+      'rating': work.rating,
+      'ratingVotes': work.ratingVotes,
+      'runtimeMinutes': work.runtimeMinutes,
+      'contentRating': work.contentRating,
+      'status': work.status,
+      'originalLanguage': work.originalLanguage,
+      'homepage': work.homepage,
+      'episodeGroupId': work.episodeGroupId,
+      'seasonCount': work.seasonCount,
+      'episodeCount': work.episodeCount,
+      'genres': work.genres,
+      'studios': work.studios,
+      'countries': work.countries,
+      'keywords': work.keywords,
+      'ids': work.ids.map(_encodeId).toList(),
+      'credits': work.credits.map(_encodeCredit).toList(),
+      'images': work.images.map(_encodeImage).toList(),
+      'seasons': work.seasons.map(_encodeSeason).toList(),
+      'extras': work.extras.map(_encodeExtra).toList(),
+    };
+
+/// 解码作品。`provider` / `kind` 缺失或不是合法枚举名时抛 [FormatException]。
+VideoMetadataWork decodeVideoMetadataWork(Map<String, Object?> json) {
+  final VideoMetadataProviderKind? provider =
+      _providerKind(metadataString(json['provider']));
+  if (provider == null) {
+    throw FormatException(
+      'VideoMetadataWork wire: provider 缺失或非法: ${json['provider']}',
+    );
+  }
+  final VideoMetadataMediaKind? kind = VideoMetadataMediaKind.values
+      .asNameMap()[metadataString(json['kind']) ?? ''];
+  if (kind == null) {
+    throw FormatException(
+      'VideoMetadataWork wire: kind 缺失或非法: ${json['kind']}',
+    );
+  }
+  return VideoMetadataWork(
+    provider: provider,
+    kind: kind,
+    title: metadataString(json['title']) ?? '',
+    originalTitle: metadataString(json['originalTitle']),
+    tagline: metadataString(json['tagline']),
+    aliases: _stringList(json['aliases']),
+    year: metadataInt(json['year']),
+    premiered: metadataString(json['premiered']),
+    endDate: metadataString(json['endDate']),
+    plot: metadataString(json['plot']),
+    rating: metadataDouble(json['rating']),
+    ratingVotes: metadataInt(json['ratingVotes']),
+    runtimeMinutes: metadataInt(json['runtimeMinutes']),
+    contentRating: metadataString(json['contentRating']),
+    status: metadataString(json['status']),
+    originalLanguage: metadataString(json['originalLanguage']),
+    homepage: metadataString(json['homepage']),
+    episodeGroupId: metadataString(json['episodeGroupId']),
+    seasonCount: metadataInt(json['seasonCount']),
+    episodeCount: metadataInt(json['episodeCount']),
+    genres: _stringList(json['genres']),
+    studios: _stringList(json['studios']),
+    countries: _stringList(json['countries']),
+    keywords: _stringList(json['keywords']),
+    ids: _decodeIds(json['ids']),
+    credits: _decodeCredits(json['credits']),
+    images: _decodeImages(json['images']),
+    seasons: _objects(json['seasons']).map(_decodeSeason).toList(),
+    extras: _objects(json['extras']).map(_decodeExtra).nonNulls.toList(),
+    rawPayload: null,
+  );
+}
+
+// ─── lookup ──────────────────────────────────────────────────────────
+
+Map<String, Object?> encodeVideoMetadataLookup(VideoMetadataLookup lookup) =>
+    <String, Object?>{
+      'provider': lookup.provider.name,
+      'externalId': lookup.externalId,
+      'mediaKind': lookup.mediaKind.name,
+      'episodeGroupId': lookup.episodeGroupId,
+    };
+
+/// 不是对象、或 provider / externalId / mediaKind 任一缺失非法时返回 null。
+VideoMetadataLookup? decodeVideoMetadataLookup(Object? json) {
+  final Map<String, Object?>? map = metadataObject(json);
+  if (map == null) return null;
+  final VideoMetadataProviderKind? provider =
+      _providerKind(metadataString(map['provider']));
+  final String? externalId = metadataString(map['externalId']);
+  final VideoMetadataMediaKind? mediaKind = VideoMetadataMediaKind.values
+      .asNameMap()[metadataString(map['mediaKind']) ?? ''];
+  if (provider == null || externalId == null || mediaKind == null) {
+    return null;
+  }
+  return VideoMetadataLookup(
+    provider: provider,
+    externalId: externalId,
+    mediaKind: mediaKind,
+    episodeGroupId: metadataString(map['episodeGroupId']),
+  );
+}
+
+// ─── 季 / 集 ─────────────────────────────────────────────────────────
+
+Map<String, Object?> _encodeSeason(VideoMetadataSeason season) =>
+    <String, Object?>{
+      'seasonNumber': season.seasonNumber,
+      'title': season.title,
+      'plot': season.plot,
+      'airDate': season.airDate,
+      'year': season.year,
+      'episodeCount': season.episodeCount,
+      'rating': season.rating,
+      'ids': season.ids.map(_encodeId).toList(),
+      'images': season.images.map(_encodeImage).toList(),
+      'episodes': season.episodes.map(_encodeEpisode).toList(),
+    };
+
+VideoMetadataSeason _decodeSeason(Map<String, Object?> json) =>
+    VideoMetadataSeason(
+      seasonNumber: metadataInt(json['seasonNumber']) ?? 0,
+      title: metadataString(json['title']) ?? '',
+      plot: metadataString(json['plot']),
+      airDate: metadataString(json['airDate']),
+      year: metadataInt(json['year']),
+      episodeCount: metadataInt(json['episodeCount']),
+      rating: metadataDouble(json['rating']),
+      ids: _decodeIds(json['ids']),
+      images: _decodeImages(json['images']),
+      episodes: _objects(json['episodes']).map(_decodeEpisode).toList(),
+    );
+
+Map<String, Object?> _encodeEpisode(VideoMetadataEpisode episode) =>
+    <String, Object?>{
+      'seasonNumber': episode.seasonNumber,
+      'episodeNumber': episode.episodeNumber,
+      'title': episode.title,
+      'plot': episode.plot,
+      'airDate': episode.airDate,
+      'year': episode.year,
+      'absoluteNumber': episode.absoluteNumber,
+      'rating': episode.rating,
+      'ratingVotes': episode.ratingVotes,
+      'runtimeMinutes': episode.runtimeMinutes,
+      'ids': episode.ids.map(_encodeId).toList(),
+      'credits': episode.credits.map(_encodeCredit).toList(),
+      'images': episode.images.map(_encodeImage).toList(),
+    };
+
+VideoMetadataEpisode _decodeEpisode(Map<String, Object?> json) =>
+    VideoMetadataEpisode(
+      seasonNumber: metadataInt(json['seasonNumber']) ?? 0,
+      episodeNumber: metadataInt(json['episodeNumber']) ?? 0,
+      title: metadataString(json['title']) ?? '',
+      plot: metadataString(json['plot']),
+      airDate: metadataString(json['airDate']),
+      year: metadataInt(json['year']),
+      absoluteNumber: metadataInt(json['absoluteNumber']),
+      rating: metadataDouble(json['rating']),
+      ratingVotes: metadataInt(json['ratingVotes']),
+      runtimeMinutes: metadataInt(json['runtimeMinutes']),
+      ids: _decodeIds(json['ids']),
+      credits: _decodeCredits(json['credits']),
+      images: _decodeImages(json['images']),
+    );
+
+// ─── 身份 ────────────────────────────────────────────────────────────
+
+Map<String, Object?> _encodeId(VideoMetadataId id) => <String, Object?>{
+      'type': id.type,
+      'value': id.value,
+      'isDefault': id.isDefault,
+    };
+
+/// type / value 任一缺失的条目丢弃。
+VideoMetadataId? _decodeId(Map<String, Object?> json) {
+  final String? type = metadataString(json['type']);
+  final String? value = metadataString(json['value']);
+  if (type == null || value == null) return null;
+  return VideoMetadataId(
+    type: type,
+    value: value,
+    isDefault: metadataBool(json['isDefault']) ?? false,
+  );
+}
+
+List<VideoMetadataId> _decodeIds(Object? json) =>
+    _objects(json).map(_decodeId).nonNulls.toList();
+
+// ─── 职员 / 人物 / 角色 ──────────────────────────────────────────────
+
+Map<String, Object?> _encodeCredit(VideoMetadataCredit credit) =>
+    <String, Object?>{
+      'kind': credit.kind.name,
+      'person': _encodePerson(credit.person),
+      'character':
+          credit.character == null ? null : _encodeCharacter(credit.character!),
+      'language': credit.language,
+      'roleName': credit.roleName,
+      'department': credit.department,
+      'job': credit.job,
+      'providerCreditId': credit.providerCreditId,
+      'order': credit.order,
+    };
+
+/// kind 非法或 person 缺失（人名都没有）的条目丢弃。
+VideoMetadataCredit? _decodeCredit(Map<String, Object?> json) {
+  final VideoMetadataCreditKind? kind = VideoMetadataCreditKind.values
+      .asNameMap()[metadataString(json['kind']) ?? ''];
+  final Map<String, Object?>? personJson = metadataObject(json['person']);
+  if (kind == null || personJson == null) return null;
+  final VideoMetadataPerson? person = _decodePerson(personJson);
+  if (person == null) return null;
+  final Map<String, Object?>? characterJson = metadataObject(json['character']);
+  return VideoMetadataCredit(
+    kind: kind,
+    person: person,
+    character: characterJson == null ? null : _decodeCharacter(characterJson),
+    language: metadataString(json['language']),
+    roleName: metadataString(json['roleName']),
+    department: metadataString(json['department']),
+    job: metadataString(json['job']),
+    providerCreditId: metadataString(json['providerCreditId']),
+    order: metadataInt(json['order']) ?? 0,
+  );
+}
+
+List<VideoMetadataCredit> _decodeCredits(Object? json) =>
+    _objects(json).map(_decodeCredit).nonNulls.toList();
+
+Map<String, Object?> _encodePerson(VideoMetadataPerson person) =>
+    <String, Object?>{
+      'id': person.id,
+      'name': person.name,
+      'originalName': person.originalName,
+      'biography': person.biography,
+      'birthday': person.birthday,
+      'deathday': person.deathday,
+      'gender': person.gender,
+      'placeOfBirth': person.placeOfBirth,
+      'profileUrl': person.profileUrl,
+      'ids': person.ids.map(_encodeId).toList(),
+    };
+
+VideoMetadataPerson? _decodePerson(Map<String, Object?> json) {
+  final String? name = metadataString(json['name']);
+  if (name == null) return null;
+  return VideoMetadataPerson(
+    id: metadataString(json['id']),
+    name: name,
+    originalName: metadataString(json['originalName']),
+    biography: metadataString(json['biography']),
+    birthday: metadataString(json['birthday']),
+    deathday: metadataString(json['deathday']),
+    gender: metadataInt(json['gender']),
+    placeOfBirth: metadataString(json['placeOfBirth']),
+    profileUrl: metadataString(json['profileUrl']),
+    ids: _decodeIds(json['ids']),
+  );
+}
+
+Map<String, Object?> _encodeCharacter(VideoMetadataCharacter character) =>
+    <String, Object?>{
+      'id': character.id,
+      'name': character.name,
+      'originalName': character.originalName,
+      'description': character.description,
+      'imageUrl': character.imageUrl,
+      'ids': character.ids.map(_encodeId).toList(),
+    };
+
+VideoMetadataCharacter? _decodeCharacter(Map<String, Object?> json) {
+  final String? name = metadataString(json['name']);
+  if (name == null) return null;
+  return VideoMetadataCharacter(
+    id: metadataString(json['id']),
+    name: name,
+    originalName: metadataString(json['originalName']),
+    description: metadataString(json['description']),
+    imageUrl: metadataString(json['imageUrl']),
+    ids: _decodeIds(json['ids']),
+  );
+}
+
+// ─── 图片 ────────────────────────────────────────────────────────────
+
+Map<String, Object?> _encodeImage(VideoMetadataImage image) =>
+    <String, Object?>{
+      'kind': image.kind.name,
+      'url': image.url,
+      'provider': image.provider.name,
+      'language': image.language,
+      'likes': image.likes,
+      'voteAverage': image.voteAverage,
+      'voteCount': image.voteCount,
+      'seasonNumber': image.seasonNumber,
+      'episodeNumber': image.episodeNumber,
+    };
+
+/// kind / provider 非法或 url 缺失的条目丢弃。
+VideoMetadataImage? _decodeImage(Map<String, Object?> json) {
+  final VideoMetadataImageKind? kind = VideoMetadataImageKind.values
+      .asNameMap()[metadataString(json['kind']) ?? ''];
+  final VideoMetadataProviderKind? provider =
+      _providerKind(metadataString(json['provider']));
+  final String? url = metadataString(json['url']);
+  if (kind == null || provider == null || url == null) return null;
+  return VideoMetadataImage(
+    kind: kind,
+    url: url,
+    provider: provider,
+    language: metadataString(json['language']),
+    likes: metadataInt(json['likes']),
+    voteAverage: metadataDouble(json['voteAverage']),
+    voteCount: metadataInt(json['voteCount']),
+    seasonNumber: metadataInt(json['seasonNumber']),
+    episodeNumber: metadataInt(json['episodeNumber']),
+  );
+}
+
+List<VideoMetadataImage> _decodeImages(Object? json) =>
+    _objects(json).map(_decodeImage).nonNulls.toList();
+
+// ─── 附件 ────────────────────────────────────────────────────────────
+
+Map<String, Object?> _encodeExtra(VideoMetadataExtra extra) =>
+    <String, Object?>{
+      'kind': extra.kind.name,
+      'title': extra.title,
+      'provider': extra.provider?.name,
+      'providerVideoId': extra.providerVideoId,
+      'site': extra.site,
+      'remoteUrl': extra.remoteUrl,
+      'thumbnailUrl': extra.thumbnailUrl,
+      'durationMs': extra.durationMs,
+      'official': extra.official,
+      'language': extra.language,
+      'publishedAt': extra.publishedAt,
+      'order': extra.order,
+    };
+
+/// kind 非法的条目丢弃；title 缺失按空串。
+VideoMetadataExtra? _decodeExtra(Map<String, Object?> json) {
+  final VideoMetadataExtraKind? kind = VideoMetadataExtraKind.values
+      .asNameMap()[metadataString(json['kind']) ?? ''];
+  if (kind == null) return null;
+  return VideoMetadataExtra(
+    kind: kind,
+    title: metadataString(json['title']) ?? '',
+    provider: _providerKind(metadataString(json['provider'])),
+    providerVideoId: metadataString(json['providerVideoId']),
+    site: metadataString(json['site']),
+    remoteUrl: metadataString(json['remoteUrl']),
+    thumbnailUrl: metadataString(json['thumbnailUrl']),
+    durationMs: metadataInt(json['durationMs']),
+    official: metadataBool(json['official']) ?? false,
+    language: metadataString(json['language']),
+    publishedAt: metadataString(json['publishedAt']),
+    order: metadataInt(json['order']) ?? 0,
+  );
+}
+
+// ─── 基础 helper ─────────────────────────────────────────────────────
+
+VideoMetadataProviderKind? _providerKind(String? name) =>
+    VideoMetadataProviderKind.values.asNameMap()[name ?? ''];
+
+/// 只保留对象元素；非对象元素（null / 标量）丢弃。
+Iterable<Map<String, Object?>> _objects(Object? json) =>
+    metadataList(json).map(metadataObject).nonNulls;
+
+/// 只保留非空字符串元素（去首尾空白）。
+List<String> _stringList(Object? json) =>
+    metadataList(json).map(metadataString).nonNulls.toList();

--- a/packages/fushi_engine/lib/media/video/metadata/video_metadata_work_loader.dart
+++ b/packages/fushi_engine/lib/media/video/metadata/video_metadata_work_loader.dart
@@ -1,0 +1,349 @@
+/// 从 Drift 表反向装载 [VideoMetadataWork]。
+///
+/// 这是 `VideoMetadataDatabaseStore.apply` 的逆操作：apply 把领域模型拆进
+/// works / seasons / episodes / provider_identities / terms / credits+people+
+/// characters / images / extras 九张表，这里逐表读回拼成一个作品。互联 host 用它
+/// 把已刮好的资料整块搬上 wire（spec `2026-09-12-interconnect-scrape-metadata.md`
+/// §1.2）。
+///
+/// 已知不可逆之处（apply 写了但读不回来、或模型有字段而 DB 没列）集中记在
+/// [loadVideoMetadataWork] 的文档里，改 schema 前先看那份清单。
+library;
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart';
+
+/// 把 [row] 及其全部子表装载成领域模型。
+///
+/// - `provider`：取 work 级主身份（`isPrimary`）的 provider；没有主身份取第一条
+///   身份；一条身份都没有（例如扫描器写的 `local` 骨架作品）抛 [StateError]——
+///   调用方先用 [lookupOfWork] 过滤，别拿它当探测手段。
+/// - `kind`：`row.mediaType`；非法值抛 [StateError]。
+///
+/// 与 apply 的差异清单（读回来的东西和当初写进去的不一样）：
+/// 1. `aliases` / `seasonCount` / `episodeCount`：`VideoMetadataWorks` 没这三列，
+///    读回恒为空 / null（`episodeCount` 只进了旧投影 `collection_scrape_meta`）。
+/// 2. `rawPayload`：进的是 `video_metadata_raw_snapshots`，这里不读（本来就不
+///    上 wire）。
+/// 3. `VideoMetadataId.isDefault`：apply 不存它，存的是「type == 主 provider」
+///    算出来的 `isPrimary`；读回用 `isPrimary` 回填。id 的 type 被 apply 小写、
+///    value 被 trim。
+/// 4. terms：apply 按 `TitleNormalizer` 归一化去重，同一种类里归一化后相同的词
+///    只剩第一条；`name` 保留原文。
+/// 5. credits：apply 把 `roleName ?? character.name ?? ''` 写进 `roleName` 列，
+///    所以原本 null 的 roleName 读回变成角色名；按 (person, kind, roleName) 去重。
+///    `VideoMetadataPerson.id` / `VideoMetadataCharacter.id` 没列，读回 null；
+///    `VideoMetadataCharacter.originalName` 没列，读回 null。人物 / 角色的 ids
+///    是跨作品累积合并的（`_mergeEntityIdentities`），可能比当初这一部作品给
+///    的多。
+/// 6. images：`likes` / `seasonNumber` / `episodeNumber` 没列，读回 null；
+///    `rating` ← `voteAverage`。DB 按 (kind, position) 排序，所以跨图种的原始
+///    交错顺序丢失、同图种内顺序保留。被字段锁保住的旧图行会照读出来。
+/// 7. extras：只有 `remoteUrl != null` 的在线附件进了库；本地附件
+///    （`sourceKind == 'local'`，绑 host 自己的 bookUid）对客户端没意义，这里
+///    不读。
+/// 8. seasons / episodes：DB 的 `title` 可空，模型必填——读回 `?? ''`；
+///    `VideoMetadataSeasons.endDate` 列模型没有，读不回。
+/// 9. `lockedFields` / `updatedAt`：模型没有，由 wire entry 另行携带。
+Future<VideoMetadataWork> loadVideoMetadataWork(
+  FushiDatabase db,
+  VideoMetadataWorkRow row,
+) async {
+  final VideoMetadataMediaKind? kind =
+      VideoMetadataMediaKind.values.asNameMap()[row.mediaType];
+  if (kind == null) {
+    throw StateError('work ${row.id} 的 mediaType 非法: ${row.mediaType}');
+  }
+  final List<VideoMetadataProviderIdentityRow> identities =
+      await db.getVideoMetadataProviderIdentities(workId: row.id);
+  // getVideoMetadataProviderIdentities 已按 isPrimary DESC 排：主身份在最前。
+  final VideoMetadataProviderIdentityRow? primary = identities.firstOrNull;
+  final VideoMetadataProviderKind? provider = primary == null
+      ? null
+      : VideoMetadataProviderKind.values.asNameMap()[primary.provider];
+  if (provider == null) {
+    throw StateError(
+      'work ${row.id} 没有可用的 provider 身份（${primary?.provider}）',
+    );
+  }
+  final Map<String, List<String>> terms = await _termsByKind(db, row.id);
+  return VideoMetadataWork(
+    provider: provider,
+    kind: kind,
+    title: row.title,
+    originalTitle: row.originalTitle,
+    tagline: row.tagline,
+    year: row.year,
+    premiered: row.premiereDate,
+    endDate: row.endDate,
+    plot: row.overview,
+    rating: row.rating,
+    ratingVotes: row.ratingCount,
+    runtimeMinutes: row.runtimeMinutes,
+    contentRating: row.contentRating,
+    status: row.status,
+    originalLanguage: row.originalLanguage,
+    homepage: row.homepage,
+    episodeGroupId: row.episodeGroupId,
+    genres: terms['genre'] ?? const <String>[],
+    studios: terms['studio'] ?? const <String>[],
+    countries: terms['country'] ?? const <String>[],
+    keywords: terms['keyword'] ?? const <String>[],
+    ids: identities.map(_idOf).toList(),
+    credits: await _loadCredits(db, workId: row.id),
+    images: _imagesOf(await db.getVideoMetadataImages(workId: row.id)),
+    seasons: await _loadSeasons(db, row.id),
+    extras: _extrasOf(await db.getVideoMetadataExtras(row.id)),
+  );
+}
+
+/// 按 workId 取主身份对应的 lookup。语义与
+/// `VideoMetadataDatabaseStore.confirmedLookup` 一致：没有主身份、provider 非法
+/// 或为 `fanart`、mediaType 非法都返回 null。
+Future<VideoMetadataLookup?> lookupOfWork(FushiDatabase db, int workId) async {
+  final VideoMetadataWorkRow? row = await db.getVideoMetadataWorkById(workId);
+  if (row == null) return null;
+  final List<VideoMetadataProviderIdentityRow> identities =
+      await db.getVideoMetadataProviderIdentities(workId: workId);
+  final VideoMetadataProviderIdentityRow? identity = identities
+      .where((VideoMetadataProviderIdentityRow value) => value.isPrimary)
+      .firstOrNull;
+  if (identity == null) return null;
+  final VideoMetadataProviderKind? provider =
+      VideoMetadataProviderKind.values.asNameMap()[identity.provider];
+  final VideoMetadataMediaKind? kind =
+      VideoMetadataMediaKind.values.asNameMap()[row.mediaType];
+  if (provider == null ||
+      provider == VideoMetadataProviderKind.fanart ||
+      kind == null) {
+    return null;
+  }
+  return VideoMetadataLookup(
+    provider: provider,
+    externalId: identity.externalId,
+    mediaKind: kind,
+    episodeGroupId: row.episodeGroupId,
+  );
+}
+
+// ─── 子表 ────────────────────────────────────────────────────────────
+
+Future<Map<String, List<String>>> _termsByKind(
+  FushiDatabase db,
+  int workId,
+) async {
+  final Map<String, List<String>> out = <String, List<String>>{};
+  for (final VideoMetadataTermRow term
+      in await db.getVideoMetadataTermsForWork(workId)) {
+    out.putIfAbsent(term.kind, () => <String>[]).add(term.name);
+  }
+  return out;
+}
+
+Future<List<VideoMetadataSeason>> _loadSeasons(
+  FushiDatabase db,
+  int workId,
+) async {
+  final List<VideoMetadataSeason> seasons = <VideoMetadataSeason>[];
+  for (final VideoMetadataSeasonRow season
+      in await db.getVideoMetadataSeasons(workId)) {
+    seasons.add(VideoMetadataSeason(
+      seasonNumber: season.seasonNumber,
+      title: season.title ?? '',
+      plot: season.overview,
+      airDate: season.premiereDate,
+      year: season.year,
+      episodeCount: season.episodeCount,
+      rating: season.rating,
+      ids: (await db.getVideoMetadataProviderIdentities(seasonId: season.id))
+          .map(_idOf)
+          .toList(),
+      images: _imagesOf(await db.getVideoMetadataImages(seasonId: season.id)),
+      episodes: await _loadEpisodes(db, season),
+    ));
+  }
+  return seasons;
+}
+
+Future<List<VideoMetadataEpisode>> _loadEpisodes(
+  FushiDatabase db,
+  VideoMetadataSeasonRow season,
+) async {
+  final List<VideoMetadataEpisode> episodes = <VideoMetadataEpisode>[];
+  for (final VideoMetadataEpisodeRow episode
+      in await db.getVideoMetadataEpisodes(season.id)) {
+    episodes.add(VideoMetadataEpisode(
+      seasonNumber: season.seasonNumber,
+      episodeNumber: episode.episodeNumber,
+      title: episode.title ?? '',
+      plot: episode.overview,
+      airDate: episode.airDate,
+      year: episode.year,
+      absoluteNumber: episode.absoluteNumber,
+      rating: episode.rating,
+      ratingVotes: episode.ratingCount,
+      runtimeMinutes: episode.runtimeMinutes,
+      ids: (await db.getVideoMetadataProviderIdentities(episodeId: episode.id))
+          .map(_idOf)
+          .toList(),
+      credits: await _loadCredits(db, episodeId: episode.id),
+      images: _imagesOf(await db.getVideoMetadataImages(episodeId: episode.id)),
+    ));
+  }
+  return episodes;
+}
+
+/// 读一个 owner（work 或 episode）的职员表，顺带把人物 / 角色及其身份读齐。
+/// 人物 / 角色行被级联删掉（理论上不会——credits 引用它们）的条目跳过。
+Future<List<VideoMetadataCredit>> _loadCredits(
+  FushiDatabase db, {
+  int? workId,
+  int? episodeId,
+}) async {
+  final List<VideoMetadataCredit> credits = <VideoMetadataCredit>[];
+  final Map<String, VideoMetadataPerson> people =
+      <String, VideoMetadataPerson>{};
+  final Map<String, VideoMetadataCharacter> characters =
+      <String, VideoMetadataCharacter>{};
+  for (final VideoMetadataCreditRow credit in await db.getVideoMetadataCredits(
+    workId: workId,
+    episodeId: episodeId,
+  )) {
+    final VideoMetadataCreditKind? kind = _creditKindOf(credit.creditKind);
+    if (kind == null) continue;
+    VideoMetadataPerson? person = people[credit.personKey];
+    if (person == null) {
+      person = await _loadPerson(db, credit.personKey);
+      if (person == null) continue;
+      people[credit.personKey] = person;
+    }
+    VideoMetadataCharacter? character;
+    if (credit.characterKey case final String characterKey) {
+      character =
+          characters[characterKey] ?? await _loadCharacter(db, characterKey);
+      if (character != null) characters[characterKey] = character;
+    }
+    credits.add(VideoMetadataCredit(
+      kind: kind,
+      person: person,
+      character: character,
+      language: credit.language,
+      roleName: credit.roleName.isEmpty ? null : credit.roleName,
+      department: credit.department,
+      job: credit.job,
+      providerCreditId: credit.providerCreditId,
+      order: credit.sortOrder,
+    ));
+  }
+  return credits;
+}
+
+Future<VideoMetadataPerson?> _loadPerson(
+  FushiDatabase db,
+  String personKey,
+) async {
+  final VideoMetadataPersonRow? row =
+      await db.getVideoMetadataPerson(personKey);
+  if (row == null) return null;
+  return VideoMetadataPerson(
+    name: row.name,
+    originalName: row.originalName,
+    biography: row.biography,
+    birthday: row.birthday,
+    deathday: row.deathday,
+    gender: row.gender,
+    placeOfBirth: row.placeOfBirth,
+    profileUrl: row.profileUrl,
+    ids: (await db.getVideoMetadataProviderIdentities(personKey: personKey))
+        .map(_idOf)
+        .toList(),
+  );
+}
+
+Future<VideoMetadataCharacter?> _loadCharacter(
+  FushiDatabase db,
+  String characterKey,
+) async {
+  final VideoMetadataCharacterRow? row =
+      await db.getVideoMetadataCharacter(characterKey);
+  if (row == null) return null;
+  return VideoMetadataCharacter(
+    name: row.name,
+    description: row.description,
+    imageUrl: row.imageUrl,
+    ids: (await db.getVideoMetadataProviderIdentities(
+      characterKey: characterKey,
+    ))
+        .map(_idOf)
+        .toList(),
+  );
+}
+
+// ─── 行 → 模型 ───────────────────────────────────────────────────────
+
+VideoMetadataId _idOf(VideoMetadataProviderIdentityRow row) => VideoMetadataId(
+      type: row.provider,
+      value: row.externalId,
+      isDefault: row.isPrimary,
+    );
+
+/// provider / kind 列值不在枚举内的图行跳过（历史 provider 只读兼容）。
+List<VideoMetadataImage> _imagesOf(List<VideoMetadataImageRow> rows) =>
+    <VideoMetadataImage>[
+      for (final VideoMetadataImageRow row in rows)
+        if ((
+          VideoMetadataImageKind.values.asNameMap()[row.kind],
+          VideoMetadataProviderKind.values.asNameMap()[row.provider],
+        )
+            case (
+              final VideoMetadataImageKind kind,
+              final VideoMetadataProviderKind provider,
+            ))
+          VideoMetadataImage(
+            kind: kind,
+            url: row.remoteUrl,
+            provider: provider,
+            language: row.language,
+            voteAverage: row.rating,
+            voteCount: row.voteCount,
+          ),
+    ];
+
+/// 只读在线附件；kind 列值不在枚举内的行跳过。
+List<VideoMetadataExtra> _extrasOf(List<VideoMetadataExtraRow> rows) =>
+    <VideoMetadataExtra>[
+      for (final VideoMetadataExtraRow row in rows)
+        if (row.sourceKind == 'online')
+          if (_extraKindOf(row.kind) case final VideoMetadataExtraKind kind)
+            VideoMetadataExtra(
+              kind: kind,
+              title: row.title,
+              provider: row.provider == null
+                  ? null
+                  : VideoMetadataProviderKind.values.asNameMap()[row.provider!],
+              providerVideoId: row.providerVideoId,
+              site: row.site,
+              remoteUrl: row.remoteUrl,
+              thumbnailUrl: row.thumbnailUrl,
+              durationMs: row.durationMs,
+              official: row.official,
+              language: row.language,
+              publishedAt: row.publishedAt,
+              order: row.sortOrder,
+            ),
+    ];
+
+/// `_creditKind` 的逆：`voice_actor` → [VideoMetadataCreditKind.voiceActor]，
+/// 其余按枚举名。
+VideoMetadataCreditKind? _creditKindOf(String value) => switch (value) {
+      'voice_actor' => VideoMetadataCreditKind.voiceActor,
+      _ => VideoMetadataCreditKind.values.asNameMap()[value],
+    };
+
+/// `_extraKind` 的逆：snake_case 的两个值映回枚举，其余按枚举名。
+VideoMetadataExtraKind? _extraKindOf(String value) => switch (value) {
+      'behind_the_scenes' => VideoMetadataExtraKind.behindTheScenes,
+      'deleted_scene' => VideoMetadataExtraKind.deletedScene,
+      _ => VideoMetadataExtraKind.values.asNameMap()[value],
+    };

--- a/packages/fushi_engine/lib/media/video/metadata/video_source_scrape_coordinator.dart
+++ b/packages/fushi_engine/lib/media/video/metadata/video_source_scrape_coordinator.dart
@@ -172,7 +172,8 @@ class VideoSourceScrapeCoordinator
     VideoSourceScrapeProgressCallback? onProgress,
   }) =>
       scrapeSource(
-        work.source,
+        // 下载导入器给的单元恒带来源；无来源的元数据写入目标不该走到真刮这里。
+        ArgumentError.checkNotNull(work.source, 'work.source'),
         cancellationToken:
             cancellationToken ?? VideoSourceScrapeCancellationToken(),
         onProgress: onProgress ?? (_) {},
@@ -185,7 +186,7 @@ class VideoSourceScrapeCoordinator
 
   @override
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
@@ -197,9 +198,12 @@ class VideoSourceScrapeCoordinator
     // 作品可能已不在当前计划里（文件改名/移动/删除后标题漂移，BUG-1998）。
     // 搜索只需要「电影还是剧集」这一个参数：拿不到就双形态各搜一次再按身份
     // 去重合并，绝不让只读的候选搜索因为计划回查失败而整个抛异常。
-    final VideoSourceScrapeWork? work = await _plannedWorkOrNull(
-        source, workTitle,
-        workStableKey: workStableKey);
+    // [source] 为 null（互联客户端代 host 刮削，7b：本机没有这部作品的来源库）
+    // 时同样走双形态搜索，provider 取全局主源。
+    final VideoSourceScrapeWork? work = source == null
+        ? null
+        : await _plannedWorkOrNull(source, workTitle,
+            workStableKey: workStableKey);
     final List<VideoMetadataLookup> explicit = parseExplicitVideoMetadataIds(
       <String>[trimmed],
       fallbackMediaKind:
@@ -210,7 +214,8 @@ class VideoSourceScrapeCoordinator
         RegExp(r'^(?:mal|myanimelist|tmdb|anidb|aid)\s*[:=]',
                 caseSensitive: false)
             .hasMatch(trimmed);
-    final VideoMetadataProviderKind selected = await _sourceProvider(source);
+    final VideoMetadataProviderKind selected =
+        source == null ? primaryProvider : await _sourceProvider(source);
     final List<VideoMetadataProviderKind> chain = _providerChain(selected);
     if (identityInput) {
       final VideoMetadataLookup? lookup =
@@ -281,6 +286,14 @@ class VideoSourceScrapeCoordinator
       if (candidates.isNotEmpty) break;
     }
     return candidates;
+  }
+
+  @override
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup) {
+    final VideoMetadataProvider? provider =
+        _manualSearchProvider(lookup.provider);
+    if (provider == null) return Future<VideoMetadataWork?>.value(null);
+    return provider.fetchWork(lookup);
   }
 
   @override

--- a/packages/fushi_engine/lib/media/video/metadata/video_source_scrape_task.dart
+++ b/packages/fushi_engine/lib/media/video/metadata/video_source_scrape_task.dart
@@ -325,11 +325,15 @@ abstract interface class VideoSourceScrapeManualBinding {
   /// 按用户输入的标题在资料源里搜索候选。作品的剧集/电影形态由来源计划决定，
   /// 调用方不需要（也不应该）自己猜。
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
   });
+
+  /// 拉取 [lookup] 指向作品的完整资料（候选搜索结果只是摘要）。provider 不可用
+  /// 返回 null。互联 7b「客户端代 host 刮削」用它拿到要回写的完整模型。
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup);
 
   /// 按 [lookup] 重刮 [workTitle] 这一个作品。作品不在当前来源计划里时抛
   /// [VideoSourceScrapeWorkNotFound]。
@@ -493,7 +497,7 @@ class VideoSourceScrapeTaskController extends EngineChangeNotifier {
 
   /// 只读的候选搜索：不写库、不抢刮削互斥门，用户可以在批次跑着时先查。
   Future<List<VideoSourceScrapeConfirmationCandidate>> searchManualCandidates({
-    required SourceLibraryRow source,
+    SourceLibraryRow? source,
     required String workTitle,
     String? workStableKey,
     required String query,
@@ -509,6 +513,15 @@ class VideoSourceScrapeTaskController extends EngineChangeNotifier {
       workStableKey: workStableKey,
       query: query,
     );
+  }
+
+  /// 拉取 [lookup] 的完整作品资料（7b 回写用）；实现不支持手动绑定时返回 null。
+  Future<VideoMetadataWork?> fetchWorkForLookup(VideoMetadataLookup lookup) {
+    if (_disposed || _runner is! VideoSourceScrapeManualBinding) {
+      return Future<VideoMetadataWork?>.value(null);
+    }
+    return (_runner as VideoSourceScrapeManualBinding)
+        .fetchWorkForLookup(lookup);
   }
 
   /// 按用户手动选中的身份重刮单个作品。

--- a/packages/fushi_engine/lib/media/video/metadata/video_source_work_planner.dart
+++ b/packages/fushi_engine/lib/media/video/metadata/video_source_work_planner.dart
@@ -19,7 +19,11 @@ class VideoSourceScrapeWork {
     this.collection,
   });
 
-  final SourceLibraryRow source;
+  /// 作品所属的扫描来源。计划器产出的单元恒非 null；**null 只出现在不经计划器
+  /// 的元数据写入目标**（互联 7b 回写 / 7c 客户端同步，`resolveMetadataWorkTarget`）
+  /// ——那条路只走 `VideoMetadataDatabaseStore.apply`，它不读来源；任何要真的去
+  /// 刮（`scrapeSource`）的入口都要求非 null。
+  final SourceLibraryRow? source;
   final MediaCollectionRow? collection;
   final String title;
   final List<VideoBookRow> members;

--- a/packages/fushi_engine/lib/sync/fushi_library_host_service.dart
+++ b/packages/fushi_engine/lib/sync/fushi_library_host_service.dart
@@ -2,6 +2,11 @@ import 'dart:io';
 
 import 'package:fushi_engine/sync/aggregate_snapshot.dart';
 import 'package:fushi_engine/sync/collection_manifest.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:path/path.dart' as p;
 
@@ -2087,6 +2092,43 @@ abstract interface class VideoDeletionHost {
   ///
   /// 幂等：[id] 不存在时静默返回。[id] 含路径穿越字符时抛 [ArgumentError]。
   Future<void> deleteVideo(String id);
+}
+
+/// host 端「视频刮削元数据」的**可选**能力（`docs/specs/2026-09-12-interconnect-scrape-metadata.md`）。
+///
+/// 与 [DeletionTombstoneHost] 同范式：主接口有十余个测试 fake 全量 implements，
+/// 新能力不扩大那个面。server 用 `is` 探测，不实现 → `/api/library/metadata*` 404，
+/// 能力位 `liveLibrary.videoMetadata=false`，client 静默跳过。
+abstract interface class VideoMetadataHost {
+  /// 7c：host 全部作品的刮削元数据（`VideoMetadataWorks` + 从属表反向装载）。
+  /// [since] 非 null 时只回 `updatedAt > since` 的作品。纯读。
+  Future<List<VideoMetadataWorkEntry>> listVideoMetadata({int? since});
+
+  /// 7a：在 host 上按 [query] 搜候选（host 自己的 provider 配置 / 主源选择 / 资料
+  /// 语言）。[key] 用来定作品形态（电影 / 剧集）与来源设置；host 无刮削链或作品
+  /// 不在任何本地来源的计划里时返回空列表。
+  Future<List<VideoMetadataCandidateEntry>> searchVideoMetadataCandidates({
+    required VideoMetadataWorkKey key,
+    required String query,
+  });
+
+  /// 7a：让 host 用用户选定的 [lookup] 重刮 [key] 对应作品（等价于 host 用户本地
+  /// 「手动指定身份重刮」），同步等到落库。合集对应多个作品单元时回
+  /// [VideoMetadataConflict.ambiguousWork]。
+  Future<VideoMetadataWriteResult> scrapeVideoMetadata({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+  });
+
+  /// 7b：把客户端本地刮好的 [work] 写进 host（`VideoMetadataDatabaseStore.apply`，
+  /// host 字段锁保留旧值）。host 已有与 [lookup] 不同的主身份且 [replaceIdentity]
+  /// 为 false → [VideoMetadataConflict.identity]，不动库。
+  Future<VideoMetadataWriteResult> putVideoMetadata({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+    required VideoMetadataWork work,
+    bool replaceIdentity = false,
+  });
 }
 
 /// host 端「视频播放偏好跨设备同步」的**可选**能力（BUG-1620 调轴起步，播放偏好

--- a/packages/fushi_engine/lib/sync/fushi_sync_server.dart
+++ b/packages/fushi_engine/lib/sync/fushi_sync_server.dart
@@ -14,6 +14,12 @@ import 'package:fushi_engine/media/video/video_subtitle_source.dart'
         subtitleFormatForCodec;
 import 'package:fushi_engine/sync/aggregate_snapshot.dart';
 import 'package:fushi_engine/sync/collection_manifest.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
 import 'package:fushi_engine/sync/fushi_library_host_service.dart';
 import 'package:fushi_engine/sync/interconnect_profile_transfer.dart';
 import 'package:fushi_engine/sync/interconnect_service_config.dart';
@@ -40,6 +46,7 @@ part 'fushi_sync_server/pairing.part.dart';
 part 'fushi_sync_server/lookup.part.dart';
 part 'fushi_sync_server/library.part.dart';
 part 'fushi_sync_server/video.part.dart';
+part 'fushi_sync_server/video_metadata.part.dart';
 part 'fushi_sync_server/sync_state.part.dart';
 part 'fushi_sync_server/webdav.part.dart';
 
@@ -547,6 +554,12 @@ class FushiSyncServer {
     if (reqPath == '/api/library/audiobooks' ||
         reqPath.startsWith('/api/library/audiobooks/')) {
       return _handleLibraryAudiobooks(request, method, reqPath);
+    }
+    // 视频刮削元数据（7c/7a/7b），必须排在 videos 前缀判定之前（互不为前缀，但
+    // 放一起读）；host 不实现 VideoMetadataHost → 404。
+    if (reqPath == '/api/library/metadata' ||
+        reqPath.startsWith('/api/library/metadata/')) {
+      return _handleLibraryVideoMetadata(request, method, reqPath);
     }
     if (reqPath == '/api/library/videos' ||
         reqPath.startsWith('/api/library/videos/')) {

--- a/packages/fushi_engine/lib/sync/fushi_sync_server/pairing.part.dart
+++ b/packages/fushi_engine/lib/sync/fushi_sync_server/pairing.part.dart
@@ -360,6 +360,9 @@ extension _FushiSyncServerPairing on FushiSyncServer {
         // client 的漫画「来源」页把这一行标成「对端版本过低」，而不是让用户点进去
         // 对着一屏 404 反复重试。与既有 `mangaOcr` 能力位同一范式。
         'manga': _libraryService is MangaLibraryHost,
+        // 视频刮削元数据同步 / 远程刮削 / 代刮回写（`/api/library/metadata*`）。老
+        // host 无此字段 → client 跳过元数据同步并隐藏远程刮削入口。
+        'videoMetadata': _libraryService is VideoMetadataHost,
         'serviceConfig': _securityContext != null &&
             _libraryService is InterconnectServiceConfigHost,
         // 互联「配置文件」（Profile）双向搬运：与 serviceConfig 同门槛（必须 TLS）。

--- a/packages/fushi_engine/lib/sync/fushi_sync_server/video_metadata.part.dart
+++ b/packages/fushi_engine/lib/sync/fushi_sync_server/video_metadata.part.dart
@@ -1,0 +1,126 @@
+part of '../fushi_sync_server.dart';
+
+/// 视频刮削元数据端点（`docs/specs/2026-09-12-interconnect-scrape-metadata.md` §1.3）。
+///
+/// | 方法 | 路径 | 语义 |
+/// |---|---|---|
+/// | GET  | `/api/library/metadata?since=<ms>` | 7c：host 全部作品（增量按 updatedAt） |
+/// | POST | `/api/library/metadata/candidates` | 7a：`{key, query}` → 候选列表 |
+/// | POST | `/api/library/metadata/scrape` | 7a：`{key, lookup}` → host 重刮 |
+/// | PUT  | `/api/library/metadata` | 7b：`{key, lookup, work, replaceIdentity}` → host 落库 |
+///
+/// 鉴权走中间件（无豁免）。host 不实现 [VideoMetadataHost] → 404（老 host 天然如此，
+/// client 静默跳过）。可解释拒绝回 409 + [VideoMetadataWriteResult] JSON；坏 JSON /
+/// 缺字段 400。
+extension _FushiSyncServerVideoMetadata on FushiSyncServer {
+  Future<shelf.Response> _handleLibraryVideoMetadata(
+    shelf.Request request,
+    String method,
+    String reqPath,
+  ) async {
+    final Object? svc = _libraryService;
+    if (svc is! VideoMetadataHost) {
+      return shelf.Response.notFound('Video metadata host off');
+    }
+    final VideoMetadataHost host = svc;
+
+    if (reqPath == '/api/library/metadata') {
+      switch (method) {
+        case 'GET':
+          final int? since =
+              int.tryParse(request.url.queryParameters['since'] ?? '');
+          final List<VideoMetadataWorkEntry> entries =
+              await host.listVideoMetadata(since: since);
+          return jsonResponse(<String, Object?>{
+            'works': <Object?>[
+              for (final VideoMetadataWorkEntry e in entries) e.toJson(),
+            ],
+          });
+        case 'PUT':
+          final Map<String, dynamic>? json = await readJsonObjectBody(request);
+          if (json == null) return shelf.Response(400, body: 'Invalid JSON');
+          final VideoMetadataWorkKey key;
+          final VideoMetadataLookup? lookup;
+          final VideoMetadataWork work;
+          try {
+            key = VideoMetadataWorkKey.fromJson(json['key']);
+            lookup = decodeVideoMetadataLookup(json['lookup']);
+            final Object? rawWork = json['work'];
+            if (rawWork is! Map) throw const FormatException('work missing');
+            work = decodeVideoMetadataWork(rawWork.cast<String, Object?>());
+          } on FormatException catch (e) {
+            return shelf.Response(400, body: 'Invalid body: $e');
+          }
+          if (lookup == null) {
+            return shelf.Response(400, body: 'Invalid body: lookup missing');
+          }
+          final VideoMetadataWriteResult result = await host.putVideoMetadata(
+            key: key,
+            lookup: lookup,
+            work: work,
+            replaceIdentity: json['replaceIdentity'] == true,
+          );
+          return _writeResultResponse(result);
+        default:
+          return shelf.Response(405);
+      }
+    }
+
+    if (reqPath == '/api/library/metadata/candidates') {
+      if (method != 'POST') return shelf.Response(405);
+      final Map<String, dynamic>? json = await readJsonObjectBody(request);
+      if (json == null) return shelf.Response(400, body: 'Invalid JSON');
+      final VideoMetadataWorkKey key;
+      try {
+        key = VideoMetadataWorkKey.fromJson(json['key']);
+      } on FormatException catch (e) {
+        return shelf.Response(400, body: 'Invalid body: $e');
+      }
+      final Object? query = json['query'];
+      if (query is! String) {
+        return shelf.Response(400, body: 'Invalid body: query missing');
+      }
+      final List<VideoMetadataCandidateEntry> candidates =
+          await host.searchVideoMetadataCandidates(key: key, query: query);
+      return jsonResponse(<String, Object?>{
+        'candidates': <Object?>[
+          for (final VideoMetadataCandidateEntry c in candidates) c.toJson(),
+        ],
+      });
+    }
+
+    if (reqPath == '/api/library/metadata/scrape') {
+      if (method != 'POST') return shelf.Response(405);
+      final Map<String, dynamic>? json = await readJsonObjectBody(request);
+      if (json == null) return shelf.Response(400, body: 'Invalid JSON');
+      final VideoMetadataWorkKey key;
+      final VideoMetadataLookup? lookup;
+      try {
+        key = VideoMetadataWorkKey.fromJson(json['key']);
+        lookup = decodeVideoMetadataLookup(json['lookup']);
+      } on FormatException catch (e) {
+        return shelf.Response(400, body: 'Invalid body: $e');
+      }
+      if (lookup == null) {
+        return shelf.Response(400, body: 'Invalid body: lookup missing');
+      }
+      final VideoMetadataWriteResult result =
+          await host.scrapeVideoMetadata(key: key, lookup: lookup);
+      return _writeResultResponse(result);
+    }
+
+    return shelf.Response.notFound('Not found');
+  }
+
+  /// 成功 200、可解释拒绝 409，body 都是 [VideoMetadataWriteResult.toJson]。
+  shelf.Response _writeResultResponse(VideoMetadataWriteResult result) {
+    final String body = jsonEncode(result.toJson());
+    return shelf.Response(
+      result.isOk ? 200 : 409,
+      body: body,
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+    );
+  }
+}

--- a/packages/fushi_engine/lib/sync/local_library_host_service.dart
+++ b/packages/fushi_engine/lib/sync/local_library_host_service.dart
@@ -24,7 +24,10 @@ import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
 import 'package:fushi_engine/media/video/metadata/video_metadata_work_loader.dart';
 import 'package:fushi_engine/media/video/metadata/video_scrape_operation_gate.dart';
 import 'package:fushi_engine/media/video/metadata/video_source_scrape_task.dart'
-    show VideoSourceScrapeConfirmationCandidate, VideoSourceScrapeTaskController;
+    show
+        SourceScrapeReport,
+        VideoSourceScrapeConfirmationCandidate,
+        VideoSourceScrapeTaskController;
 import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
 import 'package:fushi_engine/media/source_library/source_library_row.dart'
     show SourceLibraryRow;

--- a/packages/fushi_engine/lib/sync/local_library_host_service.dart
+++ b/packages/fushi_engine/lib/sync/local_library_host_service.dart
@@ -13,7 +13,23 @@ import 'package:fushi_audio/fushi_audio_core.dart'
 import 'package:fushi_engine/media/media_pref_keys.dart';
 import 'package:fushi_engine/media/video/m3u8_playlist.dart'
     show PlaylistEntry;
+import 'package:fushi_engine/media/video/metadata/video_library_scrape_sweep.dart'
+    show VideoPendingScrapeWork, planScrapeWorksForCollection;
+import 'package:fushi_engine/media/video/metadata/video_metadata_database_store.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_locked_fields.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_metadata_work_loader.dart';
 import 'package:fushi_engine/media/video/metadata/video_scrape_operation_gate.dart';
+import 'package:fushi_engine/media/video/metadata/video_source_scrape_task.dart'
+    show VideoSourceScrapeConfirmationCandidate, VideoSourceScrapeTaskController;
+import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
+import 'package:fushi_engine/media/source_library/source_library_row.dart'
+    show SourceLibraryRow;
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+import 'package:fushi_engine/sync/video_metadata_work_target.dart';
 import 'package:fushi_engine/media/video/scraper/cover_meta_store.dart';
 import 'package:fushi_engine/media/video/video_book_repository.dart';
 import 'package:fushi_engine/media/video/video_storage.dart';
@@ -53,6 +69,7 @@ part 'local_library_host_service/manga.part.dart';
 part 'local_library_host_service/local_audio.part.dart';
 part 'local_library_host_service/audiobooks.part.dart';
 part 'local_library_host_service/videos.part.dart';
+part 'local_library_host_service/video_metadata.part.dart';
 part 'local_library_host_service/sync_state.part.dart';
 
 // ── 跨域共享的顶层 helper（原 LocalLibraryHostService 的 private static；mixin 体内看不到宿主类
@@ -88,7 +105,8 @@ abstract class _LocalLibraryHostBase
         VideoPlaybackSyncHost,
         AudiobookDelayHost,
         InterconnectServiceConfigHost,
-        InterconnectProfileHost {
+        InterconnectProfileHost,
+        VideoMetadataHost {
   FushiDatabase get _db;
   Directory get _dictionaryResourceRoot;
   SyncAssetPackageService get _packages;
@@ -115,6 +133,7 @@ abstract class _LocalLibraryHostBase
   Future<String?> Function(
       {required String videoPath,
       required String bookUid})? get _extractVideoCover;
+  Future<VideoSourceScrapeTaskController?> Function()? get _scrapeController;
 }
 
 /// 用真实 Hibiki 库（Drift DB + [SyncAssetPackageService]）实现 host 库服务。
@@ -145,6 +164,7 @@ class LocalLibraryHostService extends _LocalLibraryHostBase
         _LocalLibraryHostLocalAudio,
         _LocalLibraryHostAudiobooks,
         _LocalLibraryHostVideos,
+        _LocalLibraryHostVideoMetadata,
         _LocalLibraryHostSyncState {
   LocalLibraryHostService({
     required FushiDatabase db,
@@ -174,6 +194,7 @@ class LocalLibraryHostService extends _LocalLibraryHostBase
       required String videoPath,
       required String bookUid,
     })? extractVideoCover,
+    Future<VideoSourceScrapeTaskController?> Function()? scrapeController,
   })  : _db = db,
         _dictionaryResourceRoot = dictionaryResourceRoot,
         _packages = packages,
@@ -193,7 +214,8 @@ class LocalLibraryHostService extends _LocalLibraryHostBase
         _videoSubtitleLangCode = videoSubtitleLangCode,
         _uploadedVideoRoot = uploadedVideoRoot,
         _videoCoversDirectory = videoCoversDirectory,
-        _extractVideoCover = extractVideoCover;
+        _extractVideoCover = extractVideoCover,
+        _scrapeController = scrapeController;
 
   @override
   final FushiDatabase _db;
@@ -285,6 +307,13 @@ class LocalLibraryHostService extends _LocalLibraryHostBase
   @override
   final Future<String?> Function(
       {required String videoPath, required String bookUid})? _extractVideoCover;
+
+  /// 7a 远程刮削用的 host 刮削控制器解析器（可选）。控制器归 UI 层（HomePage）
+  /// 持有并按偏好重建，host 不自造第二个协调器（两个协调器会各自抢
+  /// `VideoScrapeOperationGate`），只在请求到来时取一次。null / 解析出 null →
+  /// candidates 回空、scrape 回 notPlanned。
+  @override
+  final Future<VideoSourceScrapeTaskController?> Function()? _scrapeController;
 }
 
 /// 跨域共享的查询 helper（书 / 视频 / 有声书都用）：主合集归属一趟映射、可导出有声书键集。

--- a/packages/fushi_engine/lib/sync/local_library_host_service/video_metadata.part.dart
+++ b/packages/fushi_engine/lib/sync/local_library_host_service/video_metadata.part.dart
@@ -1,0 +1,226 @@
+part of '../local_library_host_service.dart';
+
+/// 视频刮削元数据域（`docs/specs/2026-09-12-interconnect-scrape-metadata.md`）：
+/// 7c 列出 host 作品、7a 代客户端搜候选 / 重刮、7b 接收客户端代刮结果落库。
+///
+/// 落库只有一条路：`VideoMetadataDatabaseStore.apply`（字段锁、旧投影、成员集号
+/// 绑定全在那里），本文件不写任何元数据表。
+mixin _LocalLibraryHostVideoMetadata on _LocalLibraryHostBase {
+  // ── 7c：列出 ──────────────────────────────────────────────────────────────
+
+  @override
+  Future<List<VideoMetadataWorkEntry>> listVideoMetadata({int? since}) async {
+    final List<VideoMetadataWorkEntry> entries = <VideoMetadataWorkEntry>[];
+    for (final VideoMetadataWorkRow row
+        in await _db.getAllVideoMetadataWorks()) {
+      if (since != null && row.updatedAt <= since) continue;
+      final VideoMetadataWorkEntry? entry = await _entryForWorkRow(row);
+      if (entry != null) entries.add(entry);
+    }
+    return entries;
+  }
+
+  /// 作品行 → wire 条目；键解析不到（悬空合集 / 无 bookUid）或装载失败（无任何
+  /// 身份行的残缺作品）→ null，跳过而不是让整份清单 500。
+  Future<VideoMetadataWorkEntry?> _entryForWorkRow(
+    VideoMetadataWorkRow row,
+  ) async {
+    final VideoMetadataWorkKey? key = await metadataWorkKeyOf(_db, row);
+    if (key == null) return null;
+    final VideoMetadataWork work;
+    try {
+      work = await loadVideoMetadataWork(_db, row);
+    } on StateError catch (e, stack) {
+      engineLog.log('sync.videoMetadata.load', e, stack);
+      return null;
+    }
+    return VideoMetadataWorkEntry(
+      key: key,
+      updatedAt: row.updatedAt,
+      lockedFields: <String>[
+        for (final VideoMetadataLockableField f
+            in parseLockedFields(row.lockedFields))
+          f.name,
+      ],
+      lookup: await lookupOfWork(_db, row.id),
+      work: work,
+    );
+  }
+
+  Future<VideoMetadataWorkEntry?> _entryForTarget(
+    VideoSourceScrapeWork target,
+  ) async {
+    final VideoMetadataWorkRow? row = target.collection == null
+        ? await _db.getVideoMetadataWorkByBook(target.members.single.bookUid)
+        : await _db.getVideoMetadataWorkByCollection(target.collection!.id);
+    return row == null ? null : _entryForWorkRow(row);
+  }
+
+  // ── 7a：在 host 上搜候选 / 重刮 ───────────────────────────────────────────
+
+  @override
+  Future<List<VideoMetadataCandidateEntry>> searchVideoMetadataCandidates({
+    required VideoMetadataWorkKey key,
+    required String query,
+  }) async {
+    final VideoSourceScrapeTaskController? controller =
+        await _scrapeController?.call();
+    if (controller == null) return const <VideoMetadataCandidateEntry>[];
+    final _PlannedUnitResolution resolved = await _plannedUnitForKey(key);
+    final VideoPendingScrapeWork? unit = resolved.unit;
+    // 多单元时候选搜索只需要作品形态，取第一个单元的来源设置即可；真正写身份的
+    // scrape 才要求唯一。
+    final VideoPendingScrapeWork? seed = unit ?? resolved.ambiguous.firstOrNull;
+    if (seed == null) return const <VideoMetadataCandidateEntry>[];
+    final List<VideoSourceScrapeConfirmationCandidate> candidates =
+        await controller.searchManualCandidates(
+      source: seed.source,
+      workTitle: seed.work.title,
+      workStableKey: seed.work.stableKey,
+      query: query,
+    );
+    return <VideoMetadataCandidateEntry>[
+      for (final VideoSourceScrapeConfirmationCandidate c in candidates)
+        VideoMetadataCandidateEntry(lookup: c.lookup, work: c.work),
+    ];
+  }
+
+  @override
+  Future<VideoMetadataWriteResult> scrapeVideoMetadata({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+  }) async {
+    final VideoSourceScrapeTaskController? controller =
+        await _scrapeController?.call();
+    if (controller == null) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.notPlanned,
+      );
+    }
+    final _PlannedUnitResolution resolved = await _plannedUnitForKey(key);
+    if (resolved.ambiguous.isNotEmpty) {
+      return VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.ambiguousWork,
+        ambiguousWorks: <VideoMetadataWorkKey>[
+          for (final VideoPendingScrapeWork u in resolved.ambiguous)
+            VideoMetadataWorkKey.book(u.work.members.single.bookUid),
+        ],
+      );
+    }
+    final VideoPendingScrapeWork? unit = resolved.unit;
+    if (unit == null) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.notPlanned,
+      );
+    }
+    await controller.rescrapeWorkWithLookup(
+      source: unit.source,
+      workTitle: unit.work.title,
+      workStableKey: unit.work.stableKey,
+      lookup: lookup,
+    );
+    final VideoMetadataWorkEntry? entry = await _entryForTarget(unit.work);
+    if (entry == null) {
+      // 刮完却没有作品行 = 刮削链自己判失败（候选被类型门拒等），如实报未落库。
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.notPlanned,
+      );
+    }
+    return VideoMetadataWriteResult.ok(entry);
+  }
+
+  /// 自然键 → 计划器里的作品单元。
+  ///
+  /// 合集键走 `planScrapeWorksForCollection`（BUG-2433：可能是一个合集级单元，
+  /// 也可能是 N 个成员级单元）；单条目键在全部本地视频来源的计划里找
+  /// `book:<uid>`。
+  Future<_PlannedUnitResolution> _plannedUnitForKey(
+    VideoMetadataWorkKey key,
+  ) async {
+    if (key.isCollection) {
+      final MediaCollectionRow? collection =
+          await _db.getMediaCollectionByNaturalKey(
+        key.collectionName!,
+        key.collectionType!,
+      );
+      if (collection == null) return const _PlannedUnitResolution.none();
+      final List<VideoPendingScrapeWork> planned =
+          await planScrapeWorksForCollection(_db, collection.id);
+      if (planned.isEmpty) return const _PlannedUnitResolution.none();
+      if (planned.length == 1) {
+        return _PlannedUnitResolution.single(planned.single);
+      }
+      return _PlannedUnitResolution.ambiguous(planned);
+    }
+    final String stableKey = 'book:${key.bookUid}';
+    final List<SourceLibraryRow> sources =
+        (await _db.getMediaSourcesByKind('video'))
+            .where((SourceLibraryRow s) => s.transport == 'local')
+            .toList(growable: false);
+    for (final SourceLibraryRow source in sources) {
+      for (final VideoSourceScrapeWork work
+          in await VideoSourceWorkPlanner(_db).plan(source)) {
+        if (work.stableKey == stableKey) {
+          return _PlannedUnitResolution.single(
+            VideoPendingScrapeWork(source: source, work: work),
+          );
+        }
+      }
+    }
+    return const _PlannedUnitResolution.none();
+  }
+
+  // ── 7b：接收客户端代刮结果 ────────────────────────────────────────────────
+
+  @override
+  Future<VideoMetadataWriteResult> putVideoMetadata({
+    required VideoMetadataWorkKey key,
+    required VideoMetadataLookup lookup,
+    required VideoMetadataWork work,
+    bool replaceIdentity = false,
+  }) async {
+    final VideoSourceScrapeWork? target =
+        await resolveMetadataWorkTarget(_db, key);
+    if (target == null) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.notPlanned,
+      );
+    }
+    final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(_db);
+    // 手动指定的 MAL/TMDB ID 不得静默换源：host 已有主身份且与入站不同，必须由
+    // 客户端用户明确说「换」。
+    final VideoMetadataLookup? current = await store.confirmedLookup(target);
+    if (current != null &&
+        !replaceIdentity &&
+        (current.provider != lookup.provider ||
+            current.externalId != lookup.externalId)) {
+      return VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.identity,
+        currentLookup: current,
+      );
+    }
+    await _runExclusive(() async {
+      await store.apply(target, withLookupIdentity(work, lookup));
+    });
+    final VideoMetadataWorkEntry? entry = await _entryForTarget(target);
+    if (entry == null) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.notPlanned,
+      );
+    }
+    return VideoMetadataWriteResult.ok(entry);
+  }
+}
+
+/// [_LocalLibraryHostVideoMetadata._plannedUnitForKey] 的三态结果。
+class _PlannedUnitResolution {
+  const _PlannedUnitResolution.none()
+      : unit = null,
+        ambiguous = const <VideoPendingScrapeWork>[];
+  const _PlannedUnitResolution.single(VideoPendingScrapeWork this.unit)
+      : ambiguous = const <VideoPendingScrapeWork>[];
+  const _PlannedUnitResolution.ambiguous(this.ambiguous) : unit = null;
+
+  final VideoPendingScrapeWork? unit;
+  final List<VideoPendingScrapeWork> ambiguous;
+}

--- a/packages/fushi_engine/lib/sync/local_library_host_service/video_metadata.part.dart
+++ b/packages/fushi_engine/lib/sync/local_library_host_service/video_metadata.part.dart
@@ -113,17 +113,26 @@ mixin _LocalLibraryHostVideoMetadata on _LocalLibraryHostBase {
         VideoMetadataConflict.notPlanned,
       );
     }
-    await controller.rescrapeWorkWithLookup(
+    final SourceScrapeReport scrapeReport =
+        await controller.rescrapeWorkWithLookup(
       source: unit.source,
       workTitle: unit.work.title,
       workStableKey: unit.work.stableKey,
       lookup: lookup,
     );
+    // 刮削链的失败不抛、进 report（provider 挂 / 封禁 / 候选被类型门拒）；不能
+    // 因为库里还躺着上次的旧行就回 ok（审查 PR#1431 #5）。
+    if (scrapeReport.failedWorks > 0 ||
+        scrapeReport.errors.isNotEmpty ||
+        scrapeReport.succeededWorks == 0) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.scrapeFailed,
+      );
+    }
     final VideoMetadataWorkEntry? entry = await _entryForTarget(unit.work);
     if (entry == null) {
-      // 刮完却没有作品行 = 刮削链自己判失败（候选被类型门拒等），如实报未落库。
       return const VideoMetadataWriteResult.conflict(
-        VideoMetadataConflict.notPlanned,
+        VideoMetadataConflict.scrapeFailed,
       );
     }
     return VideoMetadataWriteResult.ok(entry);
@@ -179,8 +188,23 @@ mixin _LocalLibraryHostVideoMetadata on _LocalLibraryHostBase {
     required VideoMetadataWork work,
     bool replaceIdentity = false,
   }) async {
-    final VideoSourceScrapeWork? target =
-        await resolveMetadataWorkTarget(_db, key);
+    // 作品形态必须与计划器一致（BUG-2433 / 审查 PR#1431 #2）：一个合集在计划里
+    // 可能是 N 个成员级作品，直接按合集单元 apply 会新建合集级作品并**物理删掉**
+    // 全部成员作品行。所以先问计划器；多单元 → ambiguousWork 让客户端用户选；
+    // 单条目键没进计划（例如 host 上传的散片）才退回按行解析——单条目 apply
+    // 只动它自己的作品行。
+    final _PlannedUnitResolution resolved = await _plannedUnitForKey(key);
+    if (resolved.ambiguous.isNotEmpty) {
+      return VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.ambiguousWork,
+        ambiguousWorks: <VideoMetadataWorkKey>[
+          for (final VideoPendingScrapeWork u in resolved.ambiguous)
+            VideoMetadataWorkKey.book(u.work.members.single.bookUid),
+        ],
+      );
+    }
+    final VideoSourceScrapeWork? target = resolved.unit?.work ??
+        (key.isCollection ? null : await resolveMetadataWorkTarget(_db, key));
     if (target == null) {
       return const VideoMetadataWriteResult.conflict(
         VideoMetadataConflict.notPlanned,
@@ -199,9 +223,21 @@ mixin _LocalLibraryHostVideoMetadata on _LocalLibraryHostBase {
         currentLookup: current,
       );
     }
-    await _runExclusive(() async {
-      await store.apply(target, withLookupIdentity(work, lookup));
-    });
+    // 与 host 本地刮削同一道门：清理刮削资料期间拒绝新写入（审查 #7）。
+    final VideoScrapeOperationLease? lease =
+        VideoScrapeOperationGate.tryEnterOperation();
+    if (lease == null) {
+      return const VideoMetadataWriteResult.conflict(
+        VideoMetadataConflict.scrapeFailed,
+      );
+    }
+    try {
+      await _runExclusive(() async {
+        await store.apply(target, withLookupIdentity(work, lookup));
+      });
+    } finally {
+      lease.release();
+    }
     final VideoMetadataWorkEntry? entry = await _entryForTarget(target);
     if (entry == null) {
       return const VideoMetadataWriteResult.conflict(

--- a/packages/fushi_engine/lib/sync/video_metadata_manifest.dart
+++ b/packages/fushi_engine/lib/sync/video_metadata_manifest.dart
@@ -1,0 +1,225 @@
+/// 互联视频刮削元数据的 wire 形态（`docs/specs/2026-09-12-interconnect-scrape-metadata.md` §1）。
+///
+/// 只做「作品自然键 + 领域模型 JSON」的搬运，不含任何合并/换源语义——覆盖保护在
+/// host 的 [VideoMetadataHost] 实现与 `VideoMetadataDatabaseStore.apply` 里。
+library;
+
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_metadata_wire.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataWork;
+
+/// 作品自然键：合集级 `(name, collectionType)` 或单条目 `bookUid`。跨端唯一，不依赖
+/// 自增 id（与 `CollectionManifestEntry` / `RemoteVideoInfo.id` 同域）。
+class VideoMetadataWorkKey {
+  const VideoMetadataWorkKey.collection({
+    required String name,
+    required this.collectionType,
+  })  : collectionName = name,
+        bookUid = null;
+
+  const VideoMetadataWorkKey.book(String this.bookUid)
+      : collectionName = null,
+        collectionType = null;
+
+  final String? collectionName;
+  final String? collectionType;
+  final String? bookUid;
+
+  bool get isCollection => bookUid == null;
+
+  Map<String, Object?> toJson() => isCollection
+      ? <String, Object?>{
+          'collection': <String, Object?>{
+            'name': collectionName,
+            'collectionType': collectionType,
+          },
+        }
+      : <String, Object?>{'bookUid': bookUid};
+
+  /// 缺键 / 形态不对抛 [FormatException]（端点回 400）。
+  static VideoMetadataWorkKey fromJson(Object? json) {
+    if (json is! Map) throw const FormatException('work key must be an object');
+    final Object? bookUid = json['bookUid'];
+    if (bookUid is String && bookUid.isNotEmpty) {
+      return VideoMetadataWorkKey.book(bookUid);
+    }
+    final Object? collection = json['collection'];
+    if (collection is Map) {
+      final Object? name = collection['name'];
+      final Object? type = collection['collectionType'];
+      if (name is String && name.isNotEmpty && type is String) {
+        return VideoMetadataWorkKey.collection(
+            name: name, collectionType: type);
+      }
+    }
+    throw const FormatException('work key needs bookUid or collection');
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is VideoMetadataWorkKey &&
+      other.collectionName == collectionName &&
+      other.collectionType == collectionType &&
+      other.bookUid == bookUid;
+
+  @override
+  int get hashCode => Object.hash(collectionName, collectionType, bookUid);
+
+  @override
+  String toString() => isCollection
+      ? 'collection:$collectionName/$collectionType'
+      : 'book:$bookUid';
+}
+
+/// 一个作品在 wire 上的完整形态。
+class VideoMetadataWorkEntry {
+  const VideoMetadataWorkEntry({
+    required this.key,
+    required this.updatedAt,
+    required this.lockedFields,
+    required this.lookup,
+    required this.work,
+  });
+
+  final VideoMetadataWorkKey key;
+
+  /// host `VideoMetadataWorks.updatedAt`（epoch 毫秒）；客户端据此判新旧。
+  final int updatedAt;
+
+  /// host 字段锁名单（只读镜像，客户端不据此加锁）。
+  final List<String> lockedFields;
+
+  /// host 已确认的主身份；无主身份为 null。
+  final VideoMetadataLookup? lookup;
+
+  final VideoMetadataWork work;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'key': key.toJson(),
+        'updatedAt': updatedAt,
+        'lockedFields': lockedFields,
+        if (lookup != null) 'lookup': encodeVideoMetadataLookup(lookup!),
+        'work': encodeVideoMetadataWork(work),
+      };
+
+  static VideoMetadataWorkEntry fromJson(Object? json) {
+    if (json is! Map) throw const FormatException('entry must be an object');
+    final Object? work = json['work'];
+    if (work is! Map) throw const FormatException('entry.work missing');
+    return VideoMetadataWorkEntry(
+      key: VideoMetadataWorkKey.fromJson(json['key']),
+      updatedAt: switch (json['updatedAt']) {
+        final num v => v.toInt(),
+        _ => 0,
+      },
+      lockedFields: <String>[
+        if (json['lockedFields'] case final List<Object?> list)
+          for (final Object? v in list)
+            if (v is String) v,
+      ],
+      lookup: decodeVideoMetadataLookup(json['lookup']),
+      work: decodeVideoMetadataWork(work.cast<String, Object?>()),
+    );
+  }
+}
+
+/// 远程候选（7a）：host 跑 `searchManualCandidates` 的一条结果。
+class VideoMetadataCandidateEntry {
+  const VideoMetadataCandidateEntry({required this.lookup, required this.work});
+
+  final VideoMetadataLookup lookup;
+  final VideoMetadataWork work;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'lookup': encodeVideoMetadataLookup(lookup),
+        'work': encodeVideoMetadataWork(work),
+      };
+
+  static VideoMetadataCandidateEntry fromJson(Object? json) {
+    if (json is! Map) {
+      throw const FormatException('candidate must be an object');
+    }
+    final VideoMetadataLookup? lookup =
+        decodeVideoMetadataLookup(json['lookup']);
+    final Object? work = json['work'];
+    if (lookup == null || work is! Map) {
+      throw const FormatException('candidate needs lookup and work');
+    }
+    return VideoMetadataCandidateEntry(
+      lookup: lookup,
+      work: decodeVideoMetadataWork(work.cast<String, Object?>()),
+    );
+  }
+}
+
+/// host 对 7a / 7b 请求的三种可解释拒绝（端点回 409，body 带 `conflict`）。
+enum VideoMetadataConflict {
+  /// 一个合集在计划器里对应多个 `book:<uid>` 作品单元（BUG-2433），客户端须让
+  /// 用户选后带 `bookUid` 重发。`works` 列出候选单元键。
+  ambiguousWork,
+
+  /// host 已有与入站不同的主身份，且请求未带 `replaceIdentity: true`
+  /// （手动指定 ID 不静默换源）。`current` 为 host 现身份。
+  identity,
+
+  /// 作品在 host 上没有可刮削的本地来源（成员全是远端占位 / 来源已删）。
+  notPlanned,
+}
+
+/// [VideoMetadataHost] 写操作的结果：成功带 entry；拒绝带 conflict + 附加信息。
+class VideoMetadataWriteResult {
+  const VideoMetadataWriteResult.ok(VideoMetadataWorkEntry this.entry)
+      : conflict = null,
+        currentLookup = null,
+        ambiguousWorks = const <VideoMetadataWorkKey>[];
+
+  const VideoMetadataWriteResult.conflict(
+    VideoMetadataConflict this.conflict, {
+    this.currentLookup,
+    this.ambiguousWorks = const <VideoMetadataWorkKey>[],
+  }) : entry = null;
+
+  final VideoMetadataWorkEntry? entry;
+  final VideoMetadataConflict? conflict;
+  final VideoMetadataLookup? currentLookup;
+  final List<VideoMetadataWorkKey> ambiguousWorks;
+
+  bool get isOk => conflict == null;
+
+  Map<String, Object?> toJson() => isOk
+      ? <String, Object?>{'ok': true, 'entry': entry!.toJson()}
+      : <String, Object?>{
+          'ok': false,
+          'conflict': conflict!.name,
+          if (currentLookup != null)
+            'current': encodeVideoMetadataLookup(currentLookup!),
+          if (ambiguousWorks.isNotEmpty)
+            'works': <Object?>[
+              for (final VideoMetadataWorkKey k in ambiguousWorks) k.toJson(),
+            ],
+        };
+
+  static VideoMetadataWriteResult fromJson(Object? json) {
+    if (json is! Map) throw const FormatException('result must be an object');
+    if (json['ok'] == true) {
+      return VideoMetadataWriteResult.ok(
+        VideoMetadataWorkEntry.fromJson(json['entry']),
+      );
+    }
+    final VideoMetadataConflict? conflict =
+        VideoMetadataConflict.values.asNameMap()[json['conflict']];
+    if (conflict == null) {
+      throw FormatException('unknown conflict ${json['conflict']}');
+    }
+    return VideoMetadataWriteResult.conflict(
+      conflict,
+      currentLookup: decodeVideoMetadataLookup(json['current']),
+      ambiguousWorks: <VideoMetadataWorkKey>[
+        if (json['works'] case final List<Object?> list)
+          for (final Object? v in list) VideoMetadataWorkKey.fromJson(v),
+      ],
+    );
+  }
+}

--- a/packages/fushi_engine/lib/sync/video_metadata_manifest.dart
+++ b/packages/fushi_engine/lib/sync/video_metadata_manifest.dart
@@ -166,6 +166,10 @@ enum VideoMetadataConflict {
 
   /// 作品在 host 上没有可刮削的本地来源（成员全是远端占位 / 来源已删）。
   notPlanned,
+
+  /// host 跑了刮削链但失败（provider 挂 / 封禁 / 候选被类型门拒 / 资料清理中），
+  /// 库里没有新资料。
+  scrapeFailed,
 }
 
 /// [VideoMetadataHost] 写操作的结果：成功带 entry；拒绝带 conflict + 附加信息。

--- a/packages/fushi_engine/lib/sync/video_metadata_work_target.dart
+++ b/packages/fushi_engine/lib/sync/video_metadata_work_target.dart
@@ -1,0 +1,131 @@
+/// 把互联 wire 上的作品自然键解析成 `VideoMetadataDatabaseStore.apply` 需要的本地
+/// 作品单元，以及反方向（DB 作品行 → 自然键）。host（7a/7b）与客户端（7c）共用。
+///
+/// **不经计划器**：这里只回答「这个键在本机对应哪条合集行 / 哪些本地成员行」，不
+/// 判断作品形态、不找来源库——所以 [VideoSourceScrapeWork.source] 为 null，只能喂
+/// `apply`，不能喂 `scrapeSource`。真的要在本机刮（7a host 侧）走
+/// `planScrapeWorksForCollection`。
+library;
+
+import 'package:fushi_core/fushi_core.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_database_store.dart';
+import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
+    show VideoMetadataId, VideoMetadataWork;
+import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
+    show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
+import 'package:fushi_engine/sync/video_metadata_manifest.dart';
+
+/// 自然键 → 本地作品单元；合集不存在 / 单条目不在库 → null。
+///
+/// 合集单元的成员只含**本机有行**的成员（客户端上「只在 host」的成员没有
+/// `VideoBooks` 行，`apply` 对它们只写作品级与分季/分集行，不绑 bookUid）。
+Future<VideoSourceScrapeWork?> resolveMetadataWorkTarget(
+  FushiDatabase db,
+  VideoMetadataWorkKey key,
+) async {
+  if (key.isCollection) {
+    final MediaCollectionRow? collection =
+        await db.getMediaCollectionByNaturalKey(
+            key.collectionName!, key.collectionType!);
+    if (collection == null) return null;
+    final List<VideoBookRow> members = <VideoBookRow>[];
+    for (final MediaCollectionItemRow item
+        in await db.getCollectionItems(collection.id)) {
+      if (item.mediaType != MediaKind.video.dbValue) continue;
+      final VideoBookRow? row = await db.getVideoBookByBookUid(item.entryKey);
+      if (row != null) members.add(row);
+    }
+    return VideoSourceScrapeWork(
+      source: null,
+      collection: collection,
+      title: collection.name,
+      members: members,
+    );
+  }
+  final VideoBookRow? row = await db.getVideoBookByBookUid(key.bookUid!);
+  if (row == null) return null;
+  return VideoSourceScrapeWork(
+    source: null,
+    title: row.title,
+    members: <VideoBookRow>[row],
+  );
+}
+
+/// DB 作品行 → 自然键；合集行已不存在（悬空 collectionId）或作品既无合集也无
+/// bookUid → null（这种行不上 wire）。
+Future<VideoMetadataWorkKey?> metadataWorkKeyOf(
+  FushiDatabase db,
+  VideoMetadataWorkRow row,
+) async {
+  final int? collectionId = row.collectionId;
+  if (collectionId != null) {
+    final MediaCollectionRow? collection =
+        await db.getMediaCollectionById(collectionId);
+    if (collection == null) return null;
+    return VideoMetadataWorkKey.collection(
+      name: collection.name,
+      collectionType: collection.collectionType,
+    );
+  }
+  final String? bookUid = row.bookUid;
+  if (bookUid == null || bookUid.isEmpty) return null;
+  return VideoMetadataWorkKey.book(bookUid);
+}
+
+/// 让 [work] 的主身份与 [lookup] 一致：`apply` 按 `work.provider` 选主身份行、按
+/// `work.ids` 写身份表，客户端送来的模型若缺这条 id（或 provider 不同）就补齐，
+/// 否则 host 落库后 `confirmedLookup` 读不回客户端选定的身份。
+VideoMetadataWork withLookupIdentity(
+  VideoMetadataWork work,
+  VideoMetadataLookup lookup,
+) {
+  final String type = lookup.provider.name;
+  final bool hasId = work.ids.any(
+    (VideoMetadataId id) =>
+        id.type.toLowerCase() == type && id.value == lookup.externalId,
+  );
+  if (hasId && work.provider == lookup.provider) return work;
+  return work.copyWith(
+    provider: lookup.provider,
+    ids: <VideoMetadataId>[
+      if (!hasId) VideoMetadataId(type: type, value: lookup.externalId),
+      ...work.ids,
+    ],
+  );
+}
+
+/// 7c 客户端侧：把 host 下发的作品条目落进本地 DB，返回实际写入条数。
+///
+/// 每条：解析本地目标（合集不在本机 / 单条目未下载 → 跳过）→ 本地已有作品行且
+/// `updatedAt >= host.updatedAt` → 跳过（host 是刮削权威，但不重放旧数据）→
+/// `VideoMetadataDatabaseStore.apply`（本地字段锁照旧保护用户在客户端锁的字段）。
+/// 单条失败记日志不中断其余条目。
+Future<int> applyRemoteVideoMetadata(
+  FushiDatabase db,
+  List<VideoMetadataWorkEntry> entries, {
+  void Function(Object error, StackTrace stack)? onError,
+}) async {
+  final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(db);
+  int applied = 0;
+  for (final VideoMetadataWorkEntry entry in entries) {
+    try {
+      final VideoSourceScrapeWork? target =
+          await resolveMetadataWorkTarget(db, entry.key);
+      if (target == null) continue;
+      final VideoMetadataWorkRow? existing = target.collection == null
+          ? await db.getVideoMetadataWorkByBook(target.members.single.bookUid)
+          : await db.getVideoMetadataWorkByCollection(target.collection!.id);
+      if (existing != null && existing.updatedAt >= entry.updatedAt) continue;
+      final VideoMetadataLookup? lookup = entry.lookup;
+      await store.apply(
+        target,
+        lookup == null ? entry.work : withLookupIdentity(entry.work, lookup),
+      );
+      applied += 1;
+    } catch (e, stack) {
+      onError?.call(e, stack);
+    }
+  }
+  return applied;
+}

--- a/packages/fushi_engine/lib/sync/video_metadata_work_target.dart
+++ b/packages/fushi_engine/lib/sync/video_metadata_work_target.dart
@@ -13,6 +13,9 @@ import 'package:fushi_engine/media/video/metadata/video_metadata_models.dart'
     show VideoMetadataId, VideoMetadataWork;
 import 'package:fushi_engine/media/video/metadata/video_metadata_provider.dart'
     show VideoMetadataLookup;
+import 'package:fushi_engine/media/video/metadata/video_metadata_work_loader.dart'
+    show lookupOfWork;
+import 'package:fushi_engine/media/video/metadata/video_scrape_operation_gate.dart';
 import 'package:fushi_engine/media/video/metadata/video_source_work_planner.dart';
 import 'package:fushi_engine/sync/video_metadata_manifest.dart';
 
@@ -86,46 +89,85 @@ VideoMetadataWork withLookupIdentity(
         id.type.toLowerCase() == type && id.value == lookup.externalId,
   );
   if (hasId && work.provider == lookup.provider) return work;
+  // 追加到末尾：`_uniqueIds` 同 type 取**最后**一条，前插会被 work 自带的同 type
+  // 旧 id 盖掉（审查 #6）。
   return work.copyWith(
     provider: lookup.provider,
     ids: <VideoMetadataId>[
-      if (!hasId) VideoMetadataId(type: type, value: lookup.externalId),
       ...work.ids,
+      if (!hasId) VideoMetadataId(type: type, value: lookup.externalId),
     ],
   );
 }
 
-/// 7c 客户端侧：把 host 下发的作品条目落进本地 DB，返回实际写入条数。
+/// [applyRemoteVideoMetadata] 的结果：[applied] 实际落库条数；[deferred] 因本机
+/// 还没有目标（合集未同步到 / 单条目未下载）而跳过的条数——调用方据此**不推进**
+/// 增量基线，下轮再拉一遍这些作品。
+class RemoteVideoMetadataApplyResult {
+  const RemoteVideoMetadataApplyResult({
+    required this.applied,
+    required this.deferred,
+  });
+
+  final int applied;
+  final int deferred;
+}
+
+/// 7c 客户端侧：把 host 下发的作品条目落进本地 DB。
 ///
-/// 每条：解析本地目标（合集不在本机 / 单条目未下载 → 跳过）→ 本地已有作品行且
-/// `updatedAt >= host.updatedAt` → 跳过（host 是刮削权威，但不重放旧数据）→
-/// `VideoMetadataDatabaseStore.apply`（本地字段锁照旧保护用户在客户端锁的字段）。
-/// 单条失败记日志不中断其余条目。
-Future<int> applyRemoteVideoMetadata(
+/// 每条：解析本地目标（合集不在本机 / 单条目未下载 → 延后）→ 本地已有**真刮过**
+/// 的作品行且 `updatedAt >= host.updatedAt` → 跳过（host 是刮削权威，但不重放旧
+/// 数据）→ `VideoMetadataDatabaseStore.apply`（本地字段锁照旧保护用户在客户端锁的
+/// 字段）→ 把 `updatedAt` 钉成 host 的戳。单条失败记日志不中断其余条目。
+Future<RemoteVideoMetadataApplyResult> applyRemoteVideoMetadata(
   FushiDatabase db,
   List<VideoMetadataWorkEntry> entries, {
   void Function(Object error, StackTrace stack)? onError,
 }) async {
   final VideoMetadataDatabaseStore store = VideoMetadataDatabaseStore(db);
   int applied = 0;
+  int deferred = 0;
   for (final VideoMetadataWorkEntry entry in entries) {
     try {
       final VideoSourceScrapeWork? target =
           await resolveMetadataWorkTarget(db, entry.key);
-      if (target == null) continue;
+      if (target == null) {
+        deferred += 1;
+        continue;
+      }
       final VideoMetadataWorkRow? existing = target.collection == null
           ? await db.getVideoMetadataWorkByBook(target.members.single.bookUid)
           : await db.getVideoMetadataWorkByCollection(target.collection!.id);
-      if (existing != null && existing.updatedAt >= entry.updatedAt) continue;
+      // 新旧判定只对「真刮过」的本地行成立：扫描器写的 provider=local 骨架行不算
+      // 资料，不能挡住 host（审查 PR#1431 #3）。
+      if (existing != null &&
+          existing.updatedAt >= entry.updatedAt &&
+          await lookupOfWork(db, existing.id) != null) {
+        continue;
+      }
       final VideoMetadataLookup? lookup = entry.lookup;
-      await store.apply(
-        target,
-        lookup == null ? entry.work : withLookupIdentity(entry.work, lookup),
-      );
+      final VideoScrapeOperationLease? lease =
+          VideoScrapeOperationGate.tryEnterOperation();
+      if (lease == null) {
+        onError?.call(StateError('视频刮削资料正在清理'), StackTrace.current);
+        break;
+      }
+      try {
+        final PersistedVideoMetadata persisted = await store.apply(
+          target,
+          lookup == null ? entry.work : withLookupIdentity(entry.work, lookup),
+        );
+        // 落库后把 updatedAt 钉成 host 的戳：apply 写的是本机 now，会让两台互为
+        // host 的设备无限乒乓、也让 host 下一次更新被误判为旧（审查 #3）。
+        await db.setVideoMetadataWorkUpdatedAt(
+            persisted.workId, entry.updatedAt);
+      } finally {
+        lease.release();
+      }
       applied += 1;
     } catch (e, stack) {
       onError?.call(e, stack);
     }
   }
-  return applied;
+  return RemoteVideoMetadataApplyResult(applied: applied, deferred: deferred);
 }

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -6186,7 +6186,12 @@ function __fushiPopupClick(e) {
     // 是顶层节点，当年正是这个毛病。
     if (target?.closest('.grammar-tooltip')) return;
     if (target?.closest('summary')) return;
-    if (target?.closest('.glossary-content')) {
+    // 可点词查词的文本节点：词典释义正文 .glossary-content，以及汉字卡片的读音/stats
+    // 值（.kanji-card-value）与释义（.kanji-card-meanings）。汉字卡片正文与释义正文
+    // 同语义（点哪个字从哪个字扫词），selection.js 本就不分容器；此前它们落到下面的
+    // .kanji-card-section 卡片分支裸 return，点了没反应。大字 .kanji-card-char 自带
+    // onLinkClick + stopPropagation，不经这里。
+    if (target?.closest('.glossary-content, .kanji-card-value, .kanji-card-meanings')) {
         // BUG-767：glossary 内的锚点（MDX 原始 HTML 交叉引用/外链/发音）统一走
         // handleGlossaryAnchorClick——preventDefault 阻止默认导航（否则结果框架被导走→白屏），
         // 内部引用转 onLinkClick 重查。结构化内容链接自带 onclick + stopPropagation，永不冒泡到此。


### PR DESCRIPTION
交接 #8 / #6 / #7 四项一起落地（5 个提交，可按提交分开审）。

## #8 查词弹窗汉字卡片点词（BUG-2460）
- 根因：`popup.js` 点击委托只在 `.glossary-content` 分支调 `selectText`，`.kanji-card-value / .kanji-card-meanings` 落到卡片根分支裸 `return`。
- 修法：该分支选择器扩为三类文本节点；三处 popup.js 镜像同步；node 行为测试加正/负向用例（变异实测：撤掉修复红）。Dart 零改动。

## #6 互联合集整体下载
- `InterconnectDownloadManager.startBatch`：串行跑一批启动器（host 单机、并发只互抢带宽），批快照记完成/失败。
- `home_video_page` 把单条下载装配抽成 `_prepareRemoteDownload`（启动器不依赖页面 State，页面 dispose 后批照跑）；合集右键与详情页管理菜单加「下载远端集」。成员来自本地 `media_collection_items` + 远端清单，不改 wire。

## 7c 小漏项（BUG-2463）
- 下载登记此前无条件本机抽帧（host 早有 `/cover` + `RemoteCoverFetcher`）、`importedAt` 写本机 now、`completedAt` 不写。改为镜像 host 值，封面失败再退抽帧。

## 7c 主体 + 7a + 7b（spec：`docs/specs/2026-09-12-interconnect-scrape-metadata.md`）
- 调查结论修正交接前提：刮削元数据在互联 wire 上**整块不存在**，不是个别列漏项。
- 引擎：`VideoMetadataWork` JSON codec + DB 反向装载 loader（往返 + 幂等守卫）；`VideoSourceScrapeWork.source` 改可空（只喂 `apply` 的目标）。
- host：`VideoMetadataHost` 可选能力接口；`GET /api/library/metadata`、`POST /candidates`、`POST /scrape`、`PUT`；覆盖保护：字段锁走 `store.apply`，手动 ID 不静默换源（409 identity，需 `replaceIdentity`），合集多作品单元 409 ambiguousWork。
- 客户端：同步编排紧跟合集之后落库；合集右键 / 详情页「在主机上刮削」「本机刮削并回写主机」。
- 老 host 404 → 客户端静默跳过；无头服务端无刮削链自动降级。

## 验证
- `flutter analyze` 全量 0 issue；`dart analyze packages/fushi_server packages/fushi_engine` 0 issue。
- 定向：popup 守卫 70 条、#6 相邻 68 条、登记测试 7 条、#7 新增 + 相邻 138 条、`test/build` + `test/i18n` 529 条，全绿（退出码 0）。
- 真机缺口：#8 两宿主点读音看 `hibiki_glookup.log`；#7 双端真机三条路径。均未做，spec §6.2 / BUG 文件已如实记。

https://claude.ai/code/session_016s3XTCXiP7ZYkKGp7FBhZ2
