### PR TITLE
feat(reader): 振假名开关改成三态 Off / Toggle / Hidden；修 WebKit 首行注音撑高（BUG-2472）；行盒探针与 -Ios runner

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2275 条。点号进各自文件。
+> 共 2276 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2472](bugs/BUG-2472-webkit-ruby-paragraph-first-line-growth.md) | ✅ | ✅ | WebKit 上首行含振假名的段落被撑高一截 |
 | [BUG-2466](bugs/BUG-2466-reader-continuous-reveal-smooth-scroll-inflates-ledger.md) | ✅ | ✅ | 连续模式听书长距离平滑跟随滚动把途中视口计入阅读账本 |
 | [BUG-2465](bugs/BUG-2465-reader-reanchor-frozen-when-page-hidden.md) | ✅ | ✅ | 页面隐藏时阅读器重锚旗永不清（rAF 冻结）位置与进度不落库 |
 | [BUG-2464](bugs/BUG-2464-manga-online-download-first.md) | ✅ | ✅ | 在线漫画改为强制下载后才能看，删除在线直读与阅读期页图缓存 |

--- a/docs/agent/integration-testing.md
+++ b/docs/agent/integration-testing.md
@@ -63,6 +63,8 @@ flutter test integration_test/<t>_test.dart -d emulator-<port>     # 或 ci/inte
 #   ↑ 隐藏窗口下 WKWebView 页面常报 document.hidden=true、requestAnimationFrame 不跑（2026-09-12 探针多次 raf=0，
 #   非每次）。重锚落定已改经 _reanchorFrame（隐藏页走 setTimeout），位置 / 进度 / 账本在 Mac runner 上照常落地；
 #   若某测试仍卡 pending，给它加 WebView 探针（见 audiobook_resume_align_itest）打 raf/hidden 再判
+# iOS 模拟器（同一台 Mac 上的 iPhone 模拟器；WebKit + 真安全区 34pt；不传 -IosDevice 取第一台可用 iPhone）
+.\tool\run_mac_itest.ps1 integration_test/<t>_test.dart -Ios [-IosDevice <udid>]
 ```
 
 `reader_computer_use_flow` 在 Windows runner 下还会把可见验收证据（function-matrix、flutter-ui-tree、截图）写进 `.codex-test/windows-itest/<run-id>/computer-use/...`——产物清单、判读规则、「截图缺失≠功能失败」见 [computer-use-testing.md](computer-use-testing.md)。

--- a/docs/bugs/BUG-2472-webkit-ruby-paragraph-first-line-growth.md
+++ b/docs/bugs/BUG-2472-webkit-ruby-paragraph-first-line-growth.md
@@ -1,0 +1,9 @@
+## BUG-2472 · WebKit 上首行含振假名的段落被撑高一截
+- **报告**：2026-09-11（用户：「振假名的显示有问题，会改变 epub 的行高；只有 WebKit（mac / iOS）有问题，Blink 没有」）
+- **真实性**：✅ 真 bug（WebKit 专属）。根因是引擎行为差异，落点 `fushi/lib/src/reader/reader_content_styles.dart:474`（`html { … }` 规则此前对所有引擎都只留默认 line-box 行为，BUG-611 把 `-webkit-line-box-contain` 整个删掉了）。
+  - 机制：`<rt>` 注音盒 = 0.45em × line-height normal ≈ 0.54em，超出根行盒上半 leading（(1.65−1)/2 = 0.325em）约 0.215em。Blink 让注音悬在 leading 里、行盒不动；WebKit 把段落**首行**往下推，段落块轴（横排=高、竖排=宽）多出 ≈0.215em，**行距不变**。竖排下即「首列有注音的段落更宽」，段落间距忽宽忽窄。
+  - Mac 真机（macOS 27.0，WebKit 605.1.15，`~/dev/hibiki` 隔离数据根）数据：合成素材四轮（横/竖 × 22/43）带注音段落块轴多出 4.73px（22 号）/ 6.05px（43 号），纯文本段 0；真书 無職転生 21 第 10 节（272 处注音）横/竖 × 22/46：首行含注音的段落中位多出 4.73 / 6.25px，纯文本段 0；Blink（Windows WebView2 153）同一探针全 0。相邻行行距在两端、所有轮次都相等（delta 0）——用户说的「行高」实际是段落首行/块高，不是逐行行距。
+  - 候选实测（Mac）：`ruby, rt { line-height: 1 }` 反而把行距撑大 4.9~6px；`block glyphs replaced`（BUG-611 删掉的那条）撑大 6~9px；抬 body 行高到 1.9 全局变疏；`rt { line-height: 1 }` 单独无效；**`html { -webkit-line-box-contain: block replaced }`** 四轮 + 真书全部归 0、行距不变、注音位置不变（截图 `observe-b-v43-C2-webview.png` / `observe-b-h43-C2-webview.png`）。
+- **[x] ① 已修复** — `1376273f4b`：`_webKitLineBoxCss()` 按 `defaultTargetPlatform` 只在 iOS / macOS 发出 `-webkit-line-box-contain: block replaced !important`，不带 `glyphs`；Android / Windows / Linux 一律不发（Blink 不解析；旧 Android WebView 解析且 BUG-611 实证 `glyphs` 会把竖排注音塌进基字列）。已知代价：WebKit 上比段落字号大的 inline 片段不再撑高所在行。
+- **[x] ② 已加自动化测试** — `fushi/test/reader/vertical_ruby_line_box_contain_guard_test.dart`：iOS / macOS 生成的 CSS 必含 `block replaced` 且不含 `glyphs`；android / windows / linux 必不含该属性（BUG-611 守卫保留）。真渲染：`fushi/integration_test/reader_ruby_line_box_probe_itest.dart`（合成，量行距 + 段落块轴多出量，五个候选）与 `reader_ruby_line_box_realbook_itest.dart`（真书，按段落分桶），Mac 上用 `tool/run_mac_itest.ps1` 跑，读 `[ruby-line-box]` / `[ruby-realbook]` 行。
+- **备注**：探针设计：横排按行 top 聚类、竖排按列 left 聚类，逐字符 `Range.getClientRects()`；「多出量」= 段落块轴尺寸 − 行数 × 行距中位数。

--- a/fushi/CLAUDE.md
+++ b/fushi/CLAUDE.md
@@ -102,7 +102,7 @@ Hibiki 的 Flutter 多平台主应用：日语 EPUB 阅读器，集成划词查�
   - **WebView 架构**: `InAppWebView` + `fushi.local` 虚拟域名拦截（`shouldInterceptRequest`），EPUB HTML/CSS/字体/图片全部经过安全校验后在拦截器中提供。
   - **分页系统**: JS 端 `fushiReader` 分页引擎 + Dart 端 `ReaderPaginationScripts`，支持分页/连续两种模式。
   - **文本选择**: JS `onTextSelected` → Dart `ReaderSelectionData` → 词典查询 → 浮层展示。
-  - **手势系统**: 触摸/指针/滚轮统一处理（滑动翻页、点击高亮、双击振假名切换、图片点击查看）。
+  - **手势系统**: 触摸/指针/滚轮统一处理（滑动翻页、点击高亮、振假名三态 off/toggle/hidden（toggle 态点隐藏注音的 ruby 揭示、不查词）、图片点击查看）。
   - **有声书集成**: `AudiobookPlayerController` + `AudiobookBridge` + `HighlightBridge`，支持 cue 同步高亮、跨章节追踪、音量键句子导航。
   - **歌词模式**: 独立 HTML 页面（`LyricsModeHtml`），支持收藏句子高亮、实时样式更新。
   - **位置保存**: section + normCharOffset (0-10000) 双维度，debounce 写入 DB。

--- a/fushi/integration_test/reader_dblclick_context_menu_verify_itest.dart
+++ b/fushi/integration_test/reader_dblclick_context_menu_verify_itest.dart
@@ -23,9 +23,9 @@ import 'test_helpers.dart';
 /// 引擎渲染的真 EPUB）里驱动原生双击，断言修复真生效：
 ///
 /// TODO-1028：双击建立的原生框选必须被 capture 阶段的 `dblclick → removeAllRanges`
-///   清掉——否则它盖住单击查词、并绊住振假名整页切换。断言双击后
-///   `getSelection().isCollapsed === true`（选区清）且 `show-all-rt` 被 toggle
-///   （振假名切换恢复正常）。这是**真引擎行为级**证据，不是源码 grep。
+///   清掉——否则它盖住单击查词。断言双击后 `getSelection().isCollapsed === true`
+///   （选区清）。这是**真引擎行为级**证据，不是源码 grep。（历史上还断言
+///   `show-all-rt` 被 toggle；振假名三态改造后 dblclick 不再切整页，已删。）
 ///
 /// TODO-994：`InAppWebViewSettings.disableContextMenu` 在 Windows 上必须为真
 ///   （关掉 WebView2 原生右键菜单，只留 Hibiki Flutter 菜单）。原生菜单是 OS 级
@@ -41,7 +41,7 @@ void main() {
       IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'TODO-1028: native double-click clears selection + toggles furigana; '
+    'TODO-1028: native double-click clears selection; '
     'TODO-994: native context menu disabled on Windows',
     timeout: const Timeout(Duration(minutes: 8)),
     (WidgetTester tester) async {
@@ -67,13 +67,11 @@ void main() {
         expect(appModel.isInitialised, isTrue,
             reason: 'AppModel must finish initialising');
 
-        // 分页模式 + 振假名 toggle 模式：让双击既能触发原生选词，又能验证振假名切换。
+        // 分页模式：让双击能触发原生选词。
         await appModel.database
             .setPref('src:reader_fushi:view_mode', 'pagination');
         await appModel.database
             .setPref('src:reader_fushi:writing_mode', 'horizontal-tb');
-        await appModel.database
-            .setPref('src:reader_fushi:furigana_mode', 'toggle');
         await ReaderFushiSource.readerSettings?.refreshFromDb();
 
         final String bookKey = await EpubImporter.import(
@@ -146,11 +144,9 @@ void main() {
                 'stops hijacking single-tap lookup (getSelection().isCollapsed)');
         expect(dbl['selectionTextAfter'], '',
             reason: 'no residual native selection text after double-click');
-        // 振假名整页切换在双击后仍生效（capture clear 先跑 → toggle 守卫不被绊住）。
-        expect(dbl['showAllRtToggled'], isTrue,
-            reason:
-                'TODO-1028: furigana whole-page toggle (show-all-rt) must still '
-                'fire on double-click once the capture clear runs first');
+        // 振假名三态后 dblclick 不再切整页揭示。
+        expect(dbl['showAllRtToggled'], isFalse,
+            reason: 'dblclick must not flip show-all-rt any more');
 
         // ── TODO-994: fork 引擎在真渲染；右键 DOM 可派发；选区路径可用 ──
         final dynamic rawCtx = await runInWebView(_contextMenuProbeJs());

--- a/fushi/integration_test/reader_furigana_three_state_itest.dart
+++ b/fushi/integration_test/reader_furigana_three_state_itest.dart
@@ -1,0 +1,548 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:fushi/src/media/sources/reader_fushi_source.dart'
+    show ReaderFushiSource;
+import 'package:fushi/src/models/app_model.dart' show AppModel;
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart'
+    show ReaderFushiPage;
+import 'package:fushi_engine/epub/epub_importer.dart' show EpubImporter;
+
+import 'helpers/library_fixture.dart'
+    show openBookViaProductionPath, readyAppModel, showBooksTab;
+import 'helpers/observe_capture.dart';
+import 'support/itest_startup_guard.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+/// 振假名三态（`src:reader_fushi:furigana_mode` = `off` / `toggle` / `hidden`）
+/// 真 app 证据（Windows 离屏 runner，真 WebView2 + 真分页 JS + 真 CSS 注入）。
+///
+/// 被测契约（`ReaderContentStyles._furiganaCss` + `fushiSelection.selectText`）：
+///  1. `toggle`：未揭示 `<ruby>` 的 `rt` 是 `visibility:hidden`、ruby 带灰色虚线下划线
+///     （`text-decoration-style: dotted`）、无 `furigana-revealed` class；
+///  2. 点该 ruby（`selectText(x, y, 50, false)`）只揭示：class 加上、rt 变 `visible`，
+///     **不查词**——判据是 JS 侧 `window.flutter_inappwebview.callHandler` 的探针
+///     计数（`onTextSelected` / `onTapEmpty` 都为 0）加 `fushiSelection.selection`
+///     仍为 null；Dart 侧 `_handleTextSelected` 是私有方法、查词弹窗也没有稳定 key，
+///     而 `callHandler('onTextSelected')` 正是 JS→Dart 唯一的查词入口，探针计数是
+///     最贴近真实路径的可观察点；
+///  3. 再点同一点走正常查词：`onTextSelected` 计数 +1、`selection.text` 非空；
+///  4. 热切到 `hidden`（`setReaderFuriganaMode` → `onSettingsChangedLive`，与设置页
+///     `notifyReaderSettingsChanged` 同一条路）：rt `display:none`；再热切到 `off`：
+///     rt `visibility:visible` 且 ruby 无虚线下划线；
+///  5. 偏好在 `finally` 还原。
+///
+/// 素材是本文件现生成的一本**横排分页**单章 EPUB，正文前几段混有 `<ruby>…<rt>…</rt>
+/// </ruby>`（首屏即可命中，不依赖任何章节导航）。全程不点控件：开书走
+/// [openBookViaProductionPath]，其余经 debug 钩子 / JS。
+///
+/// Run (PowerShell, from fushi/):
+///   powershell -ExecutionPolicy Bypass -File tool/run_windows_itest.ps1 \
+///       integration_test/reader_furigana_three_state_itest.dart
+
+const Key _kWebViewKey = ValueKey<String>('fushi_webview');
+const Key _kContentReadyKey = ValueKey<String>('fushi_content_ready');
+
+bool _webViewShown() => find.byKey(_kWebViewKey).evaluate().isNotEmpty;
+
+bool _contentReady() => find.byKey(_kContentReadyKey).evaluate().isNotEmpty;
+
+bool _readerPageGone() => find.byType(ReaderFushiPage).evaluate().isEmpty;
+
+Future<void> _waitFor(
+  WidgetTester tester,
+  bool Function() ready,
+  String label, {
+  int maxPolls = 120,
+  Duration step = const Duration(milliseconds: 500),
+}) async {
+  for (int i = 0; i < maxPolls; i++) {
+    await tester.pump(step);
+    if (ready()) {
+      debugPrint('[furigana3] $label ready after ${i * step.inMilliseconds}ms');
+      return;
+    }
+  }
+  fail('$label did not become ready within '
+      '${maxPolls * step.inMilliseconds}ms');
+}
+
+/// 让 fire-and-forget 的偏好 setter 落地。
+Future<void> _pumpForPref(WidgetTester tester) async {
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 150));
+  }
+}
+
+// ── 素材：横排分页单章 EPUB，段首混 ruby ────────────────────────────────
+
+const List<String> _rubyParagraphs = <String>[
+  '「<ruby>漢字<rt>かんじ</rt></ruby>の<ruby>勉強<rt>べんきょう</rt></ruby>は'
+      '<ruby>楽<rt>たの</rt></ruby>しい。」と<ruby>少年<rt>しょうねん</rt></ruby>は'
+      '言った。桜の花が咲き始めた頃、少年は初めてその図書館を訪れた。',
+  '古い木の扉を押し開けると、<ruby>埃<rt>ほこり</rt></ruby>の匂いと'
+      '<ruby>紙<rt>かみ</rt></ruby>の香りが混ざり合った空気が流れ出てきた。'
+      '窓から差し込む午後の光が、本棚の間を縫うように伸びていた。',
+  '<ruby>図書館<rt>としょかん</rt></ruby>の奥には、誰も近寄らない古びた書架が'
+      'あった。そこには、<ruby>背表紙<rt>せびょうし</rt></ruby>の文字も読めない'
+      'ほど古い本が並んでいた。',
+  '少年が一冊の本を手に取ると、ページの間から小さな<ruby>鍵<rt>かぎ</rt></ruby>'
+      'が落ちた。銀色に光るその鍵は、どこかの扉を開けるもののようだった。',
+  '彼は鍵を握りしめ、図書館の中を探索し始めた。廊下の突き当たりに、見覚えの'
+      'ない<ruby>扉<rt>とびら</rt></ruby>を見つけた。',
+  '扉の向こうには、想像もしなかった世界が広がっていた。空は紫色で、二つの'
+      '<ruby>月<rt>つき</rt></ruby>が浮かんでいた。',
+];
+
+Uint8List _utf8(String s) => Uint8List.fromList(utf8.encode(s));
+
+Uint8List _buildFuriganaEpub() {
+  final StringBuffer body = StringBuffer();
+  for (int i = 0; i < _rubyParagraphs.length; i++) {
+    body.writeln('  <p id="p${i + 1}">${_rubyParagraphs[i]}</p>');
+  }
+  const String title = '振り仮名三態テスト';
+  final String chapter = '''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
+<head>
+  <meta charset="UTF-8"/>
+  <title>$title</title>
+</head>
+<body>
+  <h1>$title</h1>
+$body</body>
+</html>''';
+  const String opf = '''<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">urn:uuid:furigana-three-state-itest-001</dc:identifier>
+    <dc:title>Furigana Three State Book</dc:title>
+    <dc:language>ja</dc:language>
+    <dc:creator>Hibiki Test Suite</dc:creator>
+    <meta property="dcterms:modified">2026-01-01T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="ch1" href="chapter_01.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="ch1"/>
+  </spine>
+</package>''';
+  const String ncx = '''<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:uid" content="urn:uuid:furigana-three-state-itest-001"/>
+  </head>
+  <docTitle><text>Furigana Three State Book</text></docTitle>
+  <navMap>
+    <navPoint id="nav1" playOrder="1">
+      <navLabel><text>$title</text></navLabel>
+      <content src="chapter_01.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>''';
+  const String container = '''<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>''';
+
+  final Archive archive = Archive();
+  void add(String name, String content, {bool compress = true}) {
+    final Uint8List bytes = _utf8(content);
+    archive.addFile(
+      ArchiveFile(name, bytes.length, bytes)..compress = compress,
+    );
+  }
+
+  add('mimetype', 'application/epub+zip', compress: false);
+  add('META-INF/container.xml', container);
+  add('OEBPS/content.opf', opf);
+  add('OEBPS/toc.ncx', ncx);
+  add('OEBPS/chapter_01.xhtml', chapter);
+  return Uint8List.fromList(ZipEncoder().encode(archive)!);
+}
+
+Future<String> _seedFuriganaBook(WidgetTester tester) async {
+  final AppModel appModel = await readyAppModel(tester);
+  await showBooksTab(tester);
+  final String bookKey = await EpubImporter.import(
+    db: appModel.database,
+    bytes: _buildFuriganaEpub(),
+    fileName: 'furigana_three_state.epub',
+  );
+  debugPrint('[furigana3] seeded book key=$bookKey');
+  await tester.pump(const Duration(seconds: 1));
+  return bookKey;
+}
+
+// ── JS 探针 ─────────────────────────────────────────────────────────────
+
+typedef _RunJs = Future<dynamic> Function(String source);
+
+/// 一次性包一层 `flutter_inappwebview.callHandler`，按 handler 名计数——
+/// `onTextSelected` 是 JS→Dart 唯一的查词入口，`onTapEmpty` 是「点空白」入口。
+const String _installSpyJs = r'''
+(function () {
+  if (window.__furiganaSpy) return 'already';
+  var spy = { onTextSelected: 0, onTapEmpty: 0, other: 0 };
+  window.__furiganaSpy = spy;
+  var bridge = window.flutter_inappwebview;
+  if (!bridge || typeof bridge.callHandler !== 'function') return 'no-bridge';
+  var orig = bridge.callHandler;
+  bridge.callHandler = function () {
+    var name = arguments[0];
+    if (name === 'onTextSelected' || name === 'onTapEmpty') spy[name]++;
+    else spy.other++;
+    return orig.apply(bridge, arguments);
+  };
+  return 'installed';
+})()
+''';
+
+/// 采样第 [index] 个带 `<rt>` 的 ruby（DOM 顺序）：rt/ruby 计算样式、揭示 class、
+/// 基字文本节点的视口矩形中心（点击坐标用基字而不是整个 ruby 盒的中心：ruby 盒
+/// 含注音轨，其几何中心可能落在 rt 与基字的交界上）、探针计数与 JS 选区。
+String _probeJs(int index) => '''
+(function () {
+  var rubies = Array.prototype.filter.call(
+      document.querySelectorAll('ruby'),
+      function (r) { return r.querySelector('rt') !== null; });
+  var ruby = rubies[$index] || null;
+  if (!ruby) return JSON.stringify({ found: false, rubyCount: rubies.length });
+  var rt = ruby.querySelector('rt');
+  var baseNode = null;
+  for (var i = 0; i < ruby.childNodes.length; i++) {
+    var n = ruby.childNodes[i];
+    if (n.nodeType === 3 && n.textContent.trim()) { baseNode = n; break; }
+  }
+  var range = document.createRange();
+  if (baseNode) range.selectNodeContents(baseNode); else range.selectNode(ruby);
+  var br = range.getBoundingClientRect();
+  var rr = ruby.getBoundingClientRect();
+  var rtCs = getComputedStyle(rt);
+  var rubyCs = getComputedStyle(ruby);
+  var sel = window.fushiSelection ? window.fushiSelection.selection : undefined;
+  return JSON.stringify({
+    found: true,
+    rubyCount: rubies.length,
+    baseText: baseNode ? baseNode.textContent : ruby.textContent,
+    rtText: rt.textContent,
+    revealed: ruby.classList.contains('furigana-revealed'),
+    rtVisibility: rtCs.visibility,
+    rtDisplay: rtCs.display,
+    rubyDecorationLine: rubyCs.textDecorationLine,
+    rubyDecorationStyle: rubyCs.textDecorationStyle,
+    baseCx: (br.left + br.right) / 2,
+    baseCy: (br.top + br.bottom) / 2,
+    baseRect: [br.left, br.top, br.width, br.height],
+    rubyRect: [rr.left, rr.top, rr.width, rr.height],
+    inViewport: br.width > 0 && br.height > 0 && br.left >= 0 && br.top >= 0 &&
+        br.right <= window.innerWidth && br.bottom <= window.innerHeight,
+    spy: window.__furiganaSpy || null,
+    selectionText: sel ? sel.text : null,
+    hasSelection: !!sel,
+    styleHasToggleRule: (function () {
+      var el = document.getElementById('fushi-reader-style');
+      return !!(el && el.textContent.indexOf('furigana-revealed') >= 0);
+    })()
+  });
+})()
+''';
+
+class _RubyProbe {
+  const _RubyProbe(this.raw);
+
+  factory _RubyProbe.fromRaw(Object? raw) {
+    final Map<String, dynamic> m = raw is Map
+        ? Map<String, dynamic>.from(raw)
+        : jsonDecode(raw.toString()) as Map<String, dynamic>;
+    return _RubyProbe(m);
+  }
+
+  final Map<String, dynamic> raw;
+
+  bool get found => raw['found'] == true;
+  int get rubyCount => (raw['rubyCount'] as num?)?.toInt() ?? 0;
+  String get baseText => raw['baseText']?.toString() ?? '';
+  String get rtText => raw['rtText']?.toString() ?? '';
+  bool get revealed => raw['revealed'] == true;
+  String get rtVisibility => raw['rtVisibility']?.toString() ?? '';
+  String get rtDisplay => raw['rtDisplay']?.toString() ?? '';
+  String get rubyDecorationLine => raw['rubyDecorationLine']?.toString() ?? '';
+  String get rubyDecorationStyle =>
+      raw['rubyDecorationStyle']?.toString() ?? '';
+  double get baseCx => (raw['baseCx'] as num?)?.toDouble() ?? 0;
+  double get baseCy => (raw['baseCy'] as num?)?.toDouble() ?? 0;
+  bool get inViewport => raw['inViewport'] == true;
+  int get spyTextSelected =>
+      ((raw['spy'] as Map?)?['onTextSelected'] as num?)?.toInt() ?? -1;
+  int get spyTapEmpty =>
+      ((raw['spy'] as Map?)?['onTapEmpty'] as num?)?.toInt() ?? -1;
+  bool get hasSelection => raw['hasSelection'] == true;
+  String? get selectionText => raw['selectionText']?.toString();
+  bool get styleHasToggleRule => raw['styleHasToggleRule'] == true;
+
+  @override
+  String toString() => 'base="$baseText" rt="$rtText" revealed=$revealed '
+      'rtVisibility=$rtVisibility rtDisplay=$rtDisplay '
+      'rubyDecoration=$rubyDecorationLine/$rubyDecorationStyle '
+      'baseCenter=(${_f(baseCx)},${_f(baseCy)}) inViewport=$inViewport '
+      'baseRect=${raw['baseRect']} rubyRect=${raw['rubyRect']} '
+      'spy(onTextSelected=$spyTextSelected onTapEmpty=$spyTapEmpty) '
+      'selection=${hasSelection ? '"$selectionText"' : 'null'} '
+      'toggleCssPresent=$styleHasToggleRule rubyCount=$rubyCount';
+}
+
+Future<_RubyProbe> _probe(_RunJs runJs, int index) async =>
+    _RubyProbe.fromRaw(await runJs(_probeJs(index)));
+
+/// 轮询到 [accept] 成立（设置热切换 → CSS 换入 → 重锚是异步链，采样过渡态会把真值
+/// 误判成红）。超时返回最后一次采样，由调用方断言给出真实读数。
+Future<_RubyProbe> _probeUntil(
+  WidgetTester tester,
+  _RunJs runJs,
+  int index,
+  bool Function(_RubyProbe p) accept,
+  String label, {
+  int maxPolls = 40,
+}) async {
+  _RubyProbe? last;
+  for (int i = 0; i < maxPolls; i++) {
+    last = await _probe(runJs, index);
+    if (accept(last)) {
+      debugPrint('[furigana3] $label (after ${i * 250}ms): $last');
+      return last;
+    }
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+  debugPrint('[furigana3] $label (NOT settled after ${maxPolls * 250}ms): '
+      '$last');
+  return last!;
+}
+
+Future<void> _openSeededBook(WidgetTester tester, String bookKey) async {
+  await openBookViaProductionPath(tester, bookKey);
+  await _waitFor(tester, _webViewShown, 'reader WebView');
+  await _waitFor(tester, _contentReady, 'reader content');
+  await _waitFor(tester, readerWebViewReady, 'reader debug hooks',
+      maxPolls: 20);
+}
+
+Future<void> _closeReader(WidgetTester tester) async {
+  if (_readerPageGone()) return;
+  final NavigatorState nav =
+      Navigator.of(tester.element(find.byType(ReaderFushiPage)));
+  nav.pop();
+  await _waitFor(tester, _readerPageGone, 'reader closed', maxPolls: 40);
+  await tester.pump(const Duration(seconds: 1));
+}
+
+Future<void> _captureWeb(String name) async {
+  final ObserveShot web = await captureReaderWebView(name);
+  debugPrint('[furigana3] webview $name saved=${web.saved} '
+      'nonBlank=${web.nonBlank} path=${web.path}');
+  expect(web.saved, isTrue, reason: 'WebView capture $name must be saved');
+}
+
+Future<void> _captureFrame(WidgetTester tester, String name) async {
+  final ObserveShot frame = await captureFlutterFrame(tester, name);
+  debugPrint('[furigana3] frame $name saved=${frame.saved} '
+      'nonBlank=${frame.nonBlank} path=${frame.path}');
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'furigana_mode three-state: toggle hides rt + dotted underline, first tap '
+    'reveals without lookup, second tap looks up; hidden/off hot-switch',
+    timeout: const Timeout(Duration(minutes: 12)),
+    (WidgetTester tester) async {
+      await runFushiItest(
+        label: 'furigana3',
+        body: () async {
+          await launchFushiTestApp();
+          expect(await waitForHome(tester), isTrue,
+              reason: 'home (nav bar) must render');
+          await tester.pump(const Duration(seconds: 2));
+          await readyAppModel(tester);
+
+          final ReaderFushiSource source = ReaderFushiSource.instance;
+          final String originalMode = source.readerFuriganaMode;
+          final String originalWritingMode = source.readerWritingMode;
+          final String originalViewMode = source.readerViewMode;
+          debugPrint('[furigana3] original prefs: furigana_mode=$originalMode '
+              'writing_mode=$originalWritingMode view_mode=$originalViewMode');
+
+          try {
+            // 前置：横排分页 + toggle 态，都在开书前写好。
+            await source.setReaderWritingMode('horizontal-tb');
+            await source.setReaderViewMode('paginated');
+            await source.setReaderFuriganaMode('toggle');
+            await _pumpForPref(tester);
+            expect(source.readerFuriganaMode, 'toggle');
+
+            final String bookKey = await _seedFuriganaBook(tester);
+            await _openSeededBook(tester, bookKey);
+            await tester.pump(const Duration(seconds: 2));
+
+            final _RunJs? runJs = ReaderFushiPage.debugEvaluateJavascript;
+            expect(runJs, isNotNull,
+                reason: 'reader must expose debugEvaluateJavascript');
+            expect(ReaderFushiSource.readerSettings?.furiganaMode, 'toggle',
+                reason: 'live ReaderSettings must carry the toggle mode');
+            expect(ReaderFushiSource.readerSettings?.isContinuousMode, isFalse,
+                reason: 'must run paginated');
+            final Object? wm =
+                await runJs!('getComputedStyle(document.body).writingMode');
+            debugPrint('[furigana3] body writingMode=$wm');
+            expect(wm.toString(), 'horizontal-tb');
+
+            final Object? spy = await runJs(_installSpyJs);
+            debugPrint('[furigana3] callHandler spy: $spy');
+            expect(spy.toString(), 'installed');
+
+            // ── 1. toggle 态基线 ────────────────────────────────────────
+            final _RubyProbe s1 = await _probeUntil(
+                tester, runJs, 0, (p) => p.found && p.inViewport, '1 toggle');
+            expect(s1.found, isTrue,
+                reason: 'book must contain <ruby> with <rt>');
+            expect(s1.inViewport, isTrue,
+                reason: 'first ruby must be on the first page (needed for '
+                    'elementFromPoint): ${s1.raw['baseRect']}');
+            expect(s1.styleHasToggleRule, isTrue,
+                reason: 'injected #fushi-reader-style must carry the toggle '
+                    'CSS');
+            expect(s1.rtVisibility, 'hidden',
+                reason: '1. toggle: unrevealed rt must be visibility:hidden');
+            expect(s1.rtDisplay, 'ruby-text',
+                reason:
+                    '1. toggle keeps the annotation lane (not display:none)');
+            expect(s1.rubyDecorationStyle, 'dotted',
+                reason: '1. toggle: unrevealed ruby gets a dotted underline');
+            expect(s1.rubyDecorationLine, contains('underline'));
+            expect(s1.revealed, isFalse,
+                reason: '1. no furigana-revealed class before tapping');
+            await _captureWeb('observe-a1-toggle-hidden-webview');
+            await _captureFrame(tester, 'observe-a1-toggle-hidden');
+
+            // ── 2. 点该 ruby：只揭示、不查词 ──────────────────────────
+            final double cx = s1.baseCx;
+            final double cy = s1.baseCy;
+            final Object? hit = await runJs(
+                "(document.elementFromPoint($cx, $cy) || {}).tagName || 'none'");
+            debugPrint('[furigana3] 2. elementFromPoint($cx,$cy) → $hit');
+            final Object? r2 = await runJs(
+                'String(window.fushiSelection.selectText($cx, $cy, 50, false))');
+            debugPrint('[furigana3] 2. selectText returned $r2');
+            final _RubyProbe s2 = await _probeUntil(tester, runJs, 0,
+                (p) => p.revealed && p.rtVisibility == 'visible', '2 revealed');
+            expect(s2.revealed, isTrue,
+                reason: '2. tapping a hidden-furigana ruby must add '
+                    'furigana-revealed');
+            expect(s2.rtVisibility, 'visible',
+                reason: '2. revealed rt must become visible');
+            expect(s2.rubyDecorationLine, isNot(contains('underline')),
+                reason: '2. revealed ruby drops the dotted underline');
+            expect(s2.spyTextSelected, 0,
+                reason: '2. reveal tap must NOT fire onTextSelected (lookup)');
+            expect(s2.spyTapEmpty, 0,
+                reason: '2. reveal tap must NOT fire onTapEmpty either');
+            expect(s2.hasSelection, isFalse,
+                reason: '2. fushiSelection.selection stays null after reveal');
+            await _captureWeb('observe-a2-revealed-webview');
+
+            // ── 3. 再点同一点：正常查词 ──────────────────────────────
+            final Object? r3 = await runJs(
+                'String(window.fushiSelection.selectText($cx, $cy, 50, false))');
+            debugPrint('[furigana3] 3. selectText returned $r3');
+            final _RubyProbe s3 = await _probeUntil(tester, runJs, 0,
+                (p) => p.spyTextSelected >= 1 && p.hasSelection, '3 lookup');
+            expect(s3.spyTextSelected, 1,
+                reason: '3. second tap on the revealed ruby must go through '
+                    'the normal lookup path (onTextSelected fired once)');
+            expect(s3.hasSelection, isTrue,
+                reason: '3. fushiSelection.selection must be populated');
+            expect(s3.selectionText, isNotEmpty);
+            expect(s3.spyTapEmpty, 0);
+            expect(s3.revealed, isTrue, reason: '3. reveal state persists');
+            await tester.pump(const Duration(seconds: 1));
+            await _captureWeb('observe-a3-lookup-webview');
+            await _captureFrame(tester, 'observe-a3-lookup');
+
+            // ── 4a. 热切 hidden：rt display:none ───────────────────────
+            await source.setReaderFuriganaMode('hidden');
+            await _pumpForPref(tester);
+            expect(ReaderFushiSource.readerSettings?.furiganaMode, 'hidden');
+            // 第 1 个 ruby 已揭示（class 仍在）；第 2 个从未揭示——两者在 hidden
+            // 态都必须 display:none（hidden 的 CSS 不看 furigana-revealed）。
+            final _RubyProbe s4a0 = await _probeUntil(
+                tester, runJs, 0, (p) => p.rtDisplay == 'none', '4a hidden #0');
+            final _RubyProbe s4a1 = await _probeUntil(
+                tester, runJs, 1, (p) => p.rtDisplay == 'none', '4a hidden #1');
+            expect(s4a0.rtDisplay, 'none',
+                reason: '4a. hidden: rt must be display:none (revealed ruby)');
+            expect(s4a1.rtDisplay, 'none',
+                reason:
+                    '4a. hidden: rt must be display:none (unrevealed ruby)');
+            expect(s4a1.styleHasToggleRule, isFalse,
+                reason: '4a. hidden CSS must not carry the toggle rules');
+            await _captureWeb('observe-a4-hidden-webview');
+
+            // ── 4b. 热切 off：rt visible、无虚线 ─────────────────────
+            await source.setReaderFuriganaMode('off');
+            await _pumpForPref(tester);
+            expect(ReaderFushiSource.readerSettings?.furiganaMode, 'off');
+            final _RubyProbe s4b1 = await _probeUntil(
+                tester,
+                runJs,
+                1,
+                (p) =>
+                    p.rtDisplay == 'ruby-text' && p.rtVisibility == 'visible',
+                '4b off #1');
+            final _RubyProbe s4b0 = await _probe(runJs, 0);
+            debugPrint('[furigana3] 4b off #0: $s4b0');
+            expect(s4b1.rtVisibility, 'visible',
+                reason: '4b. off: unrevealed ruby rt must be visible');
+            expect(s4b1.rtDisplay, 'ruby-text');
+            expect(s4b1.rubyDecorationStyle, isNot('dotted'),
+                reason: '4b. off: no dotted underline on ruby');
+            expect(s4b1.rubyDecorationLine, isNot(contains('underline')));
+            expect(s4b1.revealed, isFalse, reason: 'ruby #1 was never tapped');
+            expect(s4b0.rtVisibility, 'visible');
+            expect(s4b0.rtDisplay, 'ruby-text');
+            await _captureWeb('observe-a5-off-webview');
+
+            debugPrint('[furigana3] PASS: toggle(hidden rt, dotted) → tap '
+                'reveals w/o lookup → tap looks up → hidden(display:none) → '
+                'off(visible, no underline)');
+          } finally {
+            await _closeReader(tester);
+            await source.setReaderFuriganaMode(originalMode);
+            await source.setReaderWritingMode(originalWritingMode);
+            await source.setReaderViewMode(originalViewMode);
+            await _pumpForPref(tester);
+            debugPrint('[furigana3] restored prefs: furigana_mode='
+                '${source.readerFuriganaMode} writing_mode='
+                '${source.readerWritingMode} view_mode=${source.readerViewMode}');
+          }
+        },
+      );
+    },
+  );
+}
+
+String _f(dynamic v) {
+  if (v is num) return v.toStringAsFixed(2);
+  return v.toString();
+}

--- a/fushi/integration_test/reader_ruby_line_box_probe_itest.dart
+++ b/fushi/integration_test/reader_ruby_line_box_probe_itest.dart
@@ -1,0 +1,587 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:fushi/src/media/sources/reader_fushi_source.dart'
+    show ReaderFushiSource;
+import 'package:fushi/src/models/app_model.dart' show AppModel;
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart'
+    show ReaderFushiPage;
+import 'package:fushi_engine/epub/epub_importer.dart' show EpubImporter;
+
+import 'helpers/library_fixture.dart'
+    show openBookViaProductionPath, readyAppModel, showBooksTab;
+import 'helpers/observe_capture.dart';
+import 'support/itest_startup_guard.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+/// 振假名行盒高度探针（跨引擎：Blink 基线 / WebKit 复现）。
+///
+/// 用户反馈：macOS / iOS 的 WKWebView（WebKit）上，带振假名的行比纯正文行更高，
+/// 行距忽大忽小；Windows / Android（Blink）正常。本探针在**真阅读器**（真 CSS
+/// 注入、真分页 shell、`furigana_mode=off`、`line_height=1.65`、分页，横排 / 竖排 ×
+/// 字号 22 / 43 四轮，用户报的场景是竖排 + 43）里：
+///
+///  1. 开一本正文交替「纯文本段落」与「带 ruby 段落」（每段 3~4 行）的 EPUB；
+///  2. JS 对每个段落逐字符 `Range.getClientRects()`，横排按 top 聚类得行盒，行距 =
+///     相邻行 top 之差；竖排按 left 聚类得列，行距 = 前一列 left − 本列 left（跨栏的
+///     负跳变丢弃），取段落中位数；再按段落种类取中位数；
+///  3. 依次向 `<head>` 追加 `<style id="probe">`（每个候选换掉上一个）再量一遍：
+///       * baseline —— 不注入；
+///       * C1 `ruby, rt { line-height: 1 !important; }`
+///       * C2 `html { -webkit-line-box-contain: block replaced !important; }`
+///       * C3 `html { -webkit-line-box-contain: block glyphs replaced !important; }`
+///       * C4 `rt { line-height: 1 !important; } ruby { line-height: 1 !important; }
+///             body { line-height: 1.9 !important; }`
+///  4. 每个 case 打一行
+///     `[ruby-line-box] engine=<UA 摘要> pass=<h22|h43|v22|v43> case=<名> plain=<px> ruby=<px> delta=<px>`
+///     并抓一张 WebView 截图（`observe-b-<pass>-<case>-webview.png`，Mac 抓不到时只记
+///     saved=false、不判红）。
+///
+/// 断言只做「探针跑通、每个 case 都量到了数值、基线两类段落都至少 2 行」——**不断言
+/// WebKit 结论**：本机（Windows/Blink）只能证明 Blink 基线 delta，WebKit 数值要在
+/// Mac 上跑同一份文件读日志。改过的偏好在 `finally` 还原，`#probe` 样式在退出前移除。
+///
+/// Run on Windows (PowerShell, from fushi/):
+///   powershell -ExecutionPolicy Bypass -File tool/run_windows_itest.ps1 \
+///       integration_test/reader_ruby_line_box_probe_itest.dart
+///
+/// Run on the Mac (PowerShell, from the repo root; the target must be COMMITTED
+/// first —— run_mac_itest.ps1 把已提交历史同步到 Mac 并 ff 到 origin/develop，
+/// 所以本文件所在提交要先能被 Mac 拿到）：
+///   .\tool\run_mac_itest.ps1 integration_test/reader_ruby_line_box_probe_itest.dart
+/// 然后在输出里 grep `[ruby-line-box]`。
+
+const Key _kWebViewKey = ValueKey<String>('fushi_webview');
+const Key _kContentReadyKey = ValueKey<String>('fushi_content_ready');
+
+bool _webViewShown() => find.byKey(_kWebViewKey).evaluate().isNotEmpty;
+
+bool _contentReady() => find.byKey(_kContentReadyKey).evaluate().isNotEmpty;
+
+bool _readerPageGone() => find.byType(ReaderFushiPage).evaluate().isEmpty;
+
+Future<void> _waitFor(
+  WidgetTester tester,
+  bool Function() ready,
+  String label, {
+  int maxPolls = 120,
+  Duration step = const Duration(milliseconds: 500),
+}) async {
+  for (int i = 0; i < maxPolls; i++) {
+    await tester.pump(step);
+    if (ready()) {
+      debugPrint(
+          '[ruby-line-box] $label ready after ${i * step.inMilliseconds}ms');
+      return;
+    }
+  }
+  fail('$label did not become ready within '
+      '${maxPolls * step.inMilliseconds}ms');
+}
+
+Future<void> _pumpForPref(WidgetTester tester) async {
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 150));
+  }
+}
+
+// ── 素材：纯文本段 / ruby 段交替 ────────────────────────────────────────
+
+const String _plainA = '桜の花が咲き始めた頃、少年は初めてその図書館を訪れた。古い木の扉を押し開けると、'
+    '埃の匂いと紙の香りが混ざり合った空気が流れ出てきた。窓から差し込む午後の光が、'
+    '本棚の間を縫うように伸びていた。少年は息を殺して、その光の道を辿った。図書館の'
+    '奥には、誰も近寄らない古びた書架があった。そこには、背表紙の文字も読めないほど'
+    '古い本が並んでいた。少年が一冊の本を手に取ると、ページの間から小さな鍵が落ちた。';
+
+const String _rubyA =
+    '<ruby>桜<rt>さくら</rt></ruby>の<ruby>花<rt>はな</rt></ruby>が咲き始めた頃、'
+    '<ruby>少年<rt>しょうねん</rt></ruby>は初めてその<ruby>図書館<rt>としょかん</rt>'
+    '</ruby>を訪れた。古い<ruby>木<rt>き</rt></ruby>の<ruby>扉<rt>とびら</rt></ruby>'
+    'を押し開けると、<ruby>埃<rt>ほこり</rt></ruby>の匂いと<ruby>紙<rt>かみ</rt>'
+    '</ruby>の香りが混ざり合った<ruby>空気<rt>くうき</rt></ruby>が流れ出てきた。'
+    '<ruby>窓<rt>まど</rt></ruby>から差し込む<ruby>午後<rt>ごご</rt></ruby>の'
+    '<ruby>光<rt>ひかり</rt></ruby>が、<ruby>本棚<rt>ほんだな</rt></ruby>の間を'
+    '縫うように伸びていた。<ruby>少年<rt>しょうねん</rt></ruby>は<ruby>息<rt>いき'
+    '</rt></ruby>を殺して、その光の<ruby>道<rt>みち</rt></ruby>を辿った。'
+    '<ruby>図書館<rt>としょかん</rt></ruby>の<ruby>奥<rt>おく</rt></ruby>には、'
+    '誰も近寄らない古びた<ruby>書架<rt>しょか</rt></ruby>があった。そこには、'
+    '<ruby>背表紙<rt>せびょうし</rt></ruby>の<ruby>文字<rt>もじ</rt></ruby>も'
+    '読めないほど古い<ruby>本<rt>ほん</rt></ruby>が並んでいた。';
+
+const String _plainB = '彼は鍵を握りしめ、図書館の中を探索し始めた。廊下の突き当たりに、見覚えのない'
+    '扉を見つけた。扉の向こうには、想像もしなかった世界が広がっていた。空は紫色で、'
+    '二つの月が浮かんでいた。風が吹くたびに、木々の葉が音楽を奏でた。まるで森全体が'
+    '一つの楽器のようだった。小さな川のほとりに座って、少年は持ってきた本を開いた。'
+    '物語の中の世界と、今いる世界が重なって見えた。日が暮れ始めると、森の中に小さな'
+    '灯りが点り始めた。';
+
+const String _rubyB =
+    '<ruby>彼<rt>かれ</rt></ruby>は<ruby>鍵<rt>かぎ</rt></ruby>を握りしめ、'
+    '<ruby>図書館<rt>としょかん</rt></ruby>の中を<ruby>探索<rt>たんさく</rt></ruby>'
+    'し始めた。<ruby>廊下<rt>ろうか</rt></ruby>の突き当たりに、見覚えのない'
+    '<ruby>扉<rt>とびら</rt></ruby>を見つけた。扉の向こうには、<ruby>想像<rt>そうぞう'
+    '</rt></ruby>もしなかった<ruby>世界<rt>せかい</rt></ruby>が広がっていた。'
+    '<ruby>空<rt>そら</rt></ruby>は<ruby>紫色<rt>むらさきいろ</rt></ruby>で、二つの'
+    '<ruby>月<rt>つき</rt></ruby>が浮かんでいた。<ruby>風<rt>かぜ</rt></ruby>が吹く'
+    'たびに、<ruby>木々<rt>きぎ</rt></ruby>の<ruby>葉<rt>は</rt></ruby>が'
+    '<ruby>音楽<rt>おんがく</rt></ruby>を奏でた。まるで<ruby>森全体<rt>もりぜんたい'
+    '</rt></ruby>が一つの<ruby>楽器<rt>がっき</rt></ruby>のようだった。小さな'
+    '<ruby>川<rt>かわ</rt></ruby>のほとりに座って、<ruby>少年<rt>しょうねん</rt>'
+    '</ruby>は持ってきた<ruby>本<rt>ほん</rt></ruby>を開いた。';
+
+Uint8List _utf8(String s) => Uint8List.fromList(utf8.encode(s));
+
+Uint8List _buildProbeEpub() {
+  const String title = '行盒高さ探針';
+  final StringBuffer body = StringBuffer();
+  // ruby 段放最前：每轮截图只抓首屏，首屏必须看得到注音（C2 等候选在竖排下
+  // 是否把注音塌进基字列要靠截图判）。
+  const List<List<String>> paragraphs = <List<String>>[
+    <String>['ruby', _rubyA],
+    <String>['plain', _plainA],
+    <String>['ruby', _rubyB],
+    <String>['plain', _plainB],
+    <String>['ruby', _rubyA],
+    <String>['plain', _plainA],
+    <String>['ruby', _rubyB],
+    <String>['plain', _plainB],
+  ];
+  for (int i = 0; i < paragraphs.length; i++) {
+    body.writeln('  <p id="lb${i + 1}" data-kind="${paragraphs[i][0]}">'
+        '${paragraphs[i][1]}</p>');
+  }
+  final String chapter = '''<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
+<head>
+  <meta charset="UTF-8"/>
+  <title>$title</title>
+</head>
+<body>
+  <h1>$title</h1>
+$body</body>
+</html>''';
+  const String opf = '''<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="uid">urn:uuid:ruby-line-box-probe-itest-001</dc:identifier>
+    <dc:title>Ruby Line Box Probe Book</dc:title>
+    <dc:language>ja</dc:language>
+    <dc:creator>Hibiki Test Suite</dc:creator>
+    <meta property="dcterms:modified">2026-01-01T00:00:00Z</meta>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="ch1" href="chapter_01.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="ch1"/>
+  </spine>
+</package>''';
+  const String ncx = '''<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:uid" content="urn:uuid:ruby-line-box-probe-itest-001"/>
+  </head>
+  <docTitle><text>Ruby Line Box Probe Book</text></docTitle>
+  <navMap>
+    <navPoint id="nav1" playOrder="1">
+      <navLabel><text>$title</text></navLabel>
+      <content src="chapter_01.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>''';
+  const String container = '''<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>''';
+
+  final Archive archive = Archive();
+  void add(String name, String content, {bool compress = true}) {
+    final Uint8List bytes = _utf8(content);
+    archive.addFile(
+      ArchiveFile(name, bytes.length, bytes)..compress = compress,
+    );
+  }
+
+  add('mimetype', 'application/epub+zip', compress: false);
+  add('META-INF/container.xml', container);
+  add('OEBPS/content.opf', opf);
+  add('OEBPS/toc.ncx', ncx);
+  add('OEBPS/chapter_01.xhtml', chapter);
+  return Uint8List.fromList(ZipEncoder().encode(archive)!);
+}
+
+Future<String> _seedProbeBook(WidgetTester tester) async {
+  final AppModel appModel = await readyAppModel(tester);
+  await showBooksTab(tester);
+  final String bookKey = await EpubImporter.import(
+    db: appModel.database,
+    bytes: _buildProbeEpub(),
+    fileName: 'ruby_line_box_probe.epub',
+  );
+  debugPrint('[ruby-line-box] seeded book key=$bookKey');
+  await tester.pump(const Duration(seconds: 1));
+  return bookKey;
+}
+
+// ── JS 量测 ─────────────────────────────────────────────────────────────
+
+typedef _RunJs = Future<dynamic> Function(String source);
+
+/// 逐段落逐字符量行盒：`p[data-kind]` 里跳过 rt/rp 的文本节点，每个字符一个
+/// Range → `getClientRects()[0]`，按 top（±2px）聚类成行；行距 = 相邻行 top 之差，
+/// 丢弃负跳变（分页跨栏）与超过 4×fontSize 的异常值；段落取中位数。
+const String _measureJs = r'''
+(function () {
+  function median(a) {
+    if (!a.length) return 0;
+    var s = a.slice().sort(function (x, y) { return x - y; });
+    var m = s.length >> 1;
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+  }
+  function ua() {
+    var u = navigator.userAgent || '';
+    var m;
+    if ((m = /Chrome\/([\d.]+)/.exec(u))) return 'Blink Chrome/' + m[1];
+    if ((m = /AppleWebKit\/([\d.]+)/.exec(u))) {
+      var v = /Version\/([\d.]+)/.exec(u);
+      return 'WebKit AppleWebKit/' + m[1] + (v ? ' Version/' + v[1] : '');
+    }
+    return u.slice(0, 60);
+  }
+  var bodyCs = getComputedStyle(document.body);
+  var fontSize = parseFloat(bodyCs.fontSize) || 16;
+  // 竖排：一「行」是一列（同 left），行距沿 x 轴（vertical-rl 向左推进，取
+  // 前一列 left − 本列 left 为正）；横排：一行同 top，行距沿 y 轴。
+  var vertical = /^vertical/.test(bodyCs.writingMode || '');
+  var out = { engine: ua(), ua: navigator.userAgent,
+              bodyFontSize: bodyCs.fontSize, bodyLineHeight: bodyCs.lineHeight,
+              bodyWritingMode: bodyCs.writingMode,
+              probeCss: (document.getElementById('probe') || {}).textContent || '',
+              paragraphs: [] };
+  var firstRt = document.querySelector('rt');
+  if (firstRt) {
+    var rc = getComputedStyle(firstRt);
+    out.rtCss = { display: rc.display, fontSize: rc.fontSize, lineHeight: rc.lineHeight };
+    var ru = getComputedStyle(firstRt.parentNode);
+    out.rubyCss = { display: ru.display, lineHeight: ru.lineHeight,
+                    rubyPosition: ru.rubyPosition || ru.webkitRubyPosition || '' };
+  }
+  var ps = document.querySelectorAll('p[data-kind]');
+  for (var i = 0; i < ps.length; i++) {
+    var p = ps[i];
+    var walker = document.createTreeWalker(p, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        var e = n.parentNode;
+        while (e && e !== p) {
+          var t = e.tagName;
+          if (t === 'RT' || t === 'RP' || t === 'RTC') return NodeFilter.FILTER_REJECT;
+          e = e.parentNode;
+        }
+        return n.textContent.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+      }
+    });
+    var lines = []; // { top, bottom, left }
+    var node;
+    while ((node = walker.nextNode())) {
+      var len = node.textContent.length;
+      for (var k = 0; k < len; k++) {
+        var r = document.createRange();
+        r.setStart(node, k); r.setEnd(node, k + 1);
+        var rects = r.getClientRects();
+        if (!rects.length) continue;
+        var cr = rects[0];
+        if (cr.width <= 0 || cr.height <= 0) continue;
+        var found = null;
+        for (var L = 0; L < lines.length; L++) {
+          var same = vertical
+            ? (Math.abs(lines[L].left - cr.left) <= 2 && Math.abs(lines[L].top - cr.top) < 4000)
+            : (Math.abs(lines[L].top - cr.top) <= 2 && Math.abs(lines[L].left - cr.left) < 4000);
+          if (same) { found = lines[L]; break; }
+        }
+        if (found) {
+          found.bottom = Math.max(found.bottom, cr.bottom);
+          found.top = Math.min(found.top, cr.top);
+          found.right = Math.max(found.right, cr.right);
+          found.left = Math.min(found.left, cr.left);
+          found.chars++;
+        } else {
+          lines.push({ top: cr.top, bottom: cr.bottom, left: cr.left, right: cr.right, chars: 1 });
+        }
+      }
+    }
+    // 文档序 = 出现序；相邻行 top 差为行距（同栏内为正）。
+    var pitches = [];
+    for (var L2 = 1; L2 < lines.length; L2++) {
+      var d = vertical
+        ? (lines[L2 - 1].left - lines[L2].left)
+        : (lines[L2].top - lines[L2 - 1].top);
+      if (d > 0 && d < fontSize * 4) pitches.push(d);
+    }
+    var glyphHeights = lines.map(function (l) {
+      return vertical ? (l.right - l.left) : (l.bottom - l.top);
+    });
+    // 块轴尺寸（横排=高、竖排=宽）减去 行数×行距 = 段落里多出来的空间。WebKit 会把
+    // 首行注音溢出的部分加在段落块首（首行变高），行距不变但段落更长——这就是
+    // 「带振假名的段落更高」的落点；Blink 为 0。
+    var pr = p.getBoundingClientRect();
+    var blockSize = vertical ? pr.width : pr.height;
+    var mp = median(pitches);
+    var extra = mp > 0 ? (blockSize - lines.length * mp) : 0;
+    out.paragraphs.push({
+      id: p.id, kind: p.getAttribute('data-kind'),
+      lineCount: lines.length,
+      pitches: pitches.map(function (v) { return Math.round(v * 100) / 100; }),
+      medianPitch: Math.round(median(pitches) * 100) / 100,
+      medianGlyphHeight: Math.round(median(glyphHeights) * 100) / 100,
+      pRectHeight: Math.round(pr.height * 100) / 100,
+      blockSize: Math.round(blockSize * 100) / 100,
+      extra: Math.round(extra * 100) / 100
+    });
+  }
+  function kindMedian(kind) {
+    var v = [];
+    out.paragraphs.forEach(function (q) { if (q.kind === kind && q.medianPitch > 0) v.push(q.medianPitch); });
+    return Math.round(median(v) * 100) / 100;
+  }
+  out.plain = kindMedian('plain');
+  out.ruby = kindMedian('ruby');
+  out.delta = Math.round((out.ruby - out.plain) * 100) / 100;
+  function kindExtra(kind) {
+    var v = [];
+    out.paragraphs.forEach(function (q) { if (q.kind === kind && q.medianPitch > 0) v.push(q.extra); });
+    return Math.round(median(v) * 100) / 100;
+  }
+  out.plainExtra = kindExtra('plain');
+  out.rubyExtra = kindExtra('ruby');
+  return JSON.stringify(out);
+})()
+''';
+
+String _setProbeCssJs(String css) => '''
+(function () {
+  var el = document.getElementById('probe');
+  if (!el) {
+    el = document.createElement('style');
+    el.id = 'probe';
+    document.head.appendChild(el);
+  }
+  el.textContent = ${jsonEncode(css)};
+  void document.body.offsetHeight;
+  return el.textContent.length;
+})()
+''';
+
+const String _removeProbeCssJs = r'''
+(function () {
+  var el = document.getElementById('probe');
+  if (el) el.parentNode.removeChild(el);
+  void document.body.offsetHeight;
+  return !document.getElementById('probe');
+})()
+''';
+
+class _LineBoxResult {
+  const _LineBoxResult(this.raw);
+
+  factory _LineBoxResult.fromRaw(Object? raw) {
+    final Map<String, dynamic> m = raw is Map
+        ? Map<String, dynamic>.from(raw)
+        : jsonDecode(raw.toString()) as Map<String, dynamic>;
+    return _LineBoxResult(m);
+  }
+
+  final Map<String, dynamic> raw;
+
+  String get engine => raw['engine']?.toString() ?? '?';
+  double get plain => (raw['plain'] as num?)?.toDouble() ?? 0;
+  double get ruby => (raw['ruby'] as num?)?.toDouble() ?? 0;
+  double get delta => (raw['delta'] as num?)?.toDouble() ?? 0;
+  List<Map<String, dynamic>> get paragraphs => (raw['paragraphs'] as List)
+      .map((dynamic e) => Map<String, dynamic>.from(e as Map))
+      .toList();
+  int minLines(String kind) => paragraphs
+      .where((Map<String, dynamic> p) => p['kind'] == kind)
+      .map((Map<String, dynamic> p) => (p['lineCount'] as num).toInt())
+      .fold<int>(1 << 30, (int a, int b) => a < b ? a : b);
+}
+
+const List<MapEntry<String, String>> _cases = <MapEntry<String, String>>[
+  MapEntry<String, String>('baseline', ''),
+  MapEntry<String, String>('C1', 'ruby, rt { line-height: 1 !important; }'),
+  MapEntry<String, String>(
+      'C2', 'html { -webkit-line-box-contain: block replaced !important; }'),
+  MapEntry<String, String>('C3',
+      'html { -webkit-line-box-contain: block glyphs replaced !important; }'),
+  MapEntry<String, String>(
+      'C4',
+      'rt { line-height: 1 !important; } '
+          'ruby { line-height: 1 !important; } '
+          'body { line-height: 1.9 !important; }'),
+  MapEntry<String, String>('C5', 'rt { line-height: 1 !important; }'),
+];
+
+Future<void> _openSeededBook(WidgetTester tester, String bookKey) async {
+  await openBookViaProductionPath(tester, bookKey);
+  await _waitFor(tester, _webViewShown, 'reader WebView');
+  await _waitFor(tester, _contentReady, 'reader content');
+  await _waitFor(tester, readerWebViewReady, 'reader debug hooks',
+      maxPolls: 20);
+}
+
+Future<void> _closeReader(WidgetTester tester) async {
+  if (_readerPageGone()) return;
+  final NavigatorState nav =
+      Navigator.of(tester.element(find.byType(ReaderFushiPage)));
+  nav.pop();
+  await _waitFor(tester, _readerPageGone, 'reader closed', maxPolls: 40);
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'ruby line-box probe: plain vs ruby line pitch under baseline and four '
+    'candidate CSS overrides (engine-tagged, no WebKit assertion)',
+    timeout: const Timeout(Duration(minutes: 25)),
+    (WidgetTester tester) async {
+      await runFushiItest(
+        label: 'ruby-line-box',
+        body: () async {
+          await launchFushiTestApp();
+          expect(await waitForHome(tester), isTrue,
+              reason: 'home (nav bar) must render');
+          await tester.pump(const Duration(seconds: 2));
+          await readyAppModel(tester);
+
+          final ReaderFushiSource source = ReaderFushiSource.instance;
+          final String originalMode = source.readerFuriganaMode;
+          final String originalWritingMode = source.readerWritingMode;
+          final String originalViewMode = source.readerViewMode;
+          final double originalLineHeight = source.readerLineHeight;
+          final double originalFontSize = source.readerFontSize;
+          debugPrint('[ruby-line-box] original prefs: furigana_mode='
+              '$originalMode writing_mode=$originalWritingMode '
+              'view_mode=$originalViewMode line_height=$originalLineHeight '
+              'font_size=$originalFontSize');
+
+          _RunJs? runJs;
+          try {
+            await source.setReaderViewMode('paginated');
+            await source.setReaderFuriganaMode('off');
+            await source.setReaderLineHeight(1.65);
+            await _pumpForPref(tester);
+
+            final String bookKey = await _seedProbeBook(tester);
+            final List<String> summary = <String>[];
+            // 双写向 × 双字号：用户报的场景是竖排 + 字号 43，横排 22 是 Blink 基线。
+            for (final String wm in <String>['horizontal-tb', 'vertical-rl']) {
+              for (final double fs in <double>[22, 43]) {
+                final String pass =
+                    '${wm == 'vertical-rl' ? 'v' : 'h'}${fs.round()}';
+                await source.setReaderWritingMode(wm);
+                await source.setReaderFontSize(fs);
+                await _pumpForPref(tester);
+                await _openSeededBook(tester, bookKey);
+                await tester.pump(const Duration(seconds: 2));
+
+                runJs = ReaderFushiPage.debugEvaluateJavascript;
+                expect(runJs, isNotNull,
+                    reason: 'reader must expose debugEvaluateJavascript');
+                expect(ReaderFushiSource.readerSettings?.furiganaMode, 'off');
+                expect(ReaderFushiSource.readerSettings?.lineHeight, 1.65);
+                expect(ReaderFushiSource.readerSettings?.isContinuousMode,
+                    isFalse);
+                expect(ReaderFushiSource.readerSettings?.writingMode, wm);
+
+                for (final MapEntry<String, String> c in _cases) {
+                  if (c.value.isEmpty) {
+                    await runJs!(_removeProbeCssJs);
+                  } else {
+                    final Object? len = await runJs!(_setProbeCssJs(c.value));
+                    debugPrint('[ruby-line-box] case=${c.key} probe css set '
+                        '(len=$len): ${c.value}');
+                  }
+                  await tester.pump(const Duration(milliseconds: 500));
+                  final _LineBoxResult r =
+                      _LineBoxResult.fromRaw(await runJs(_measureJs));
+                  final String line = '[ruby-line-box] engine=${r.engine} '
+                      'pass=$pass case=${c.key} plain=${r.plain} ruby=${r.ruby} '
+                      'delta=${r.delta} blockExtra plain=${r.raw['plainExtra']} '
+                      'ruby=${r.raw['rubyExtra']}';
+                  debugPrint(line);
+                  summary.add(line);
+                  debugPrint(
+                      '[ruby-line-box]   body font=${r.raw['bodyFontSize']} '
+                      'lineHeight=${r.raw['bodyLineHeight']} '
+                      'writingMode=${r.raw['bodyWritingMode']} '
+                      'rt=${r.raw['rtCss']} ruby=${r.raw['rubyCss']}');
+                  for (final Map<String, dynamic> p in r.paragraphs) {
+                    debugPrint('[ruby-line-box]   ${p['id']} ${p['kind']} '
+                        'lines=${p['lineCount']} medianPitch=${p['medianPitch']} '
+                        'glyphH=${p['medianGlyphHeight']} '
+                        'block=${p['blockSize']} extra=${p['extra']} '
+                        'pitches=${p['pitches']}');
+                  }
+                  final ObserveShot web = await captureReaderWebView(
+                      'observe-b-$pass-${c.key}-webview');
+                  debugPrint(
+                      '[ruby-line-box]   webview ${c.key} saved=${web.saved} '
+                      'nonBlank=${web.nonBlank} path=${web.path}');
+
+                  expect(r.plain, greaterThan(0),
+                      reason:
+                          'case ${c.key}: plain paragraphs must yield a pitch');
+                  expect(r.ruby, greaterThan(0),
+                      reason:
+                          'case ${c.key}: ruby paragraphs must yield a pitch');
+                  if (c.key == 'baseline') {
+                    expect(r.minLines('plain'), greaterThanOrEqualTo(2),
+                        reason: 'every plain paragraph must wrap to ≥2 lines '
+                            '(pitch needs two line tops)');
+                    expect(r.minLines('ruby'), greaterThanOrEqualTo(2),
+                        reason: 'every ruby paragraph must wrap to ≥2 lines');
+                  }
+                }
+                await runJs!(_removeProbeCssJs);
+                debugPrint('[ruby-line-box] UA=${(await runJs(
+                  'navigator.userAgent',
+                ))}');
+                await _closeReader(tester);
+              }
+            }
+            debugPrint('[ruby-line-box] SUMMARY\n${summary.join('\n')}');
+          } finally {
+            try {
+              await runJs?.call(_removeProbeCssJs);
+            } catch (e) {
+              debugPrint('[ruby-line-box] probe css removal skipped: $e');
+            }
+            await _closeReader(tester);
+            await source.setReaderFuriganaMode(originalMode);
+            await source.setReaderWritingMode(originalWritingMode);
+            await source.setReaderViewMode(originalViewMode);
+            await source.setReaderLineHeight(originalLineHeight);
+            await source.setReaderFontSize(originalFontSize);
+            await _pumpForPref(tester);
+            debugPrint('[ruby-line-box] restored prefs: furigana_mode='
+                '${source.readerFuriganaMode} writing_mode='
+                '${source.readerWritingMode} view_mode=${source.readerViewMode} '
+                'line_height=${source.readerLineHeight} '
+                'font_size=${source.readerFontSize}');
+          }
+        },
+      );
+    },
+  );
+}

--- a/fushi/integration_test/reader_ruby_line_box_realbook_itest.dart
+++ b/fushi/integration_test/reader_ruby_line_box_realbook_itest.dart
@@ -1,0 +1,371 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:fushi/src/media/sources/reader_fushi_source.dart'
+    show ReaderFushiSource;
+import 'package:fushi/src/models/app_model.dart' show AppModel;
+import 'package:fushi/src/pages/implementations/reader_fushi_page.dart'
+    show ReaderFushiPage;
+import 'package:fushi_engine/epub/epub_importer.dart' show EpubImporter;
+
+import 'helpers/library_fixture.dart'
+    show openBookViaProductionPath, readyAppModel, showBooksTab;
+import 'helpers/observe_capture.dart';
+import 'support/itest_startup_guard.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+/// 真书版振假名行盒探针（跨引擎：Blink 基线 / WebKit 复现）。
+///
+/// 合成素材探针（`reader_ruby_line_box_probe_itest.dart`）在 macOS WebKit 上四轮
+/// （横/竖 × 22/43）delta 全 0，复现不了用户报的「带振假名的行更高」。本探针改用
+/// **用户的真书**（EPUB 路径经 `--dart-define=FUSHI_PROBE_EPUB=...` 传入）：
+///
+///  1. 用生产导入路径导入该 EPUB，解压树里逐章数 `<rt`，把阅读位置钉到注音最多的
+///     那一章（`upsertReaderPosition`，阅读器开书按保存位置恢复章节）；
+///  2. 竖排 / 横排 × 字号 22 / 46（用户 Mac 上的真实字号 46）四轮开书，JS 对正文
+///     每个块级元素逐字符 `Range.getClientRects()` 聚类成行（横排按 top、竖排按
+///     left），每行标记「是否含 ruby 字符」，相邻行行距按「两行都不含 ruby」/
+///     「至少一行含 ruby」分桶取中位数，输出
+///     `[ruby-realbook] engine=<UA> pass=<h22|h46|v22|v46> plain=<px> ruby=<px> delta=<px>`
+///     以及每行的 hasRuby / pitch 明细（前 40 行）；
+///  3. 每轮抓一张 WebView 截图 `observe-rb-<pass>-webview.png`。
+///
+/// 断言只做「探针跑通、量到数值」，不断言引擎结论。偏好在 `finally` 还原。
+///
+/// Run on Windows（fushi/ 下）：
+///   powershell -ExecutionPolicy Bypass -File tool/run_windows_itest.ps1 \
+///     integration_test/reader_ruby_line_box_realbook_itest.dart \
+///     -DartDefine FUSHI_PROBE_EPUB=D:/path/to/book.epub
+/// Run on the Mac（ssh 到 Mac，fushi/ 下）：
+///   FUSHI_TEST_HIDDEN=1 flutter test integration_test/reader_ruby_line_box_realbook_itest.dart \
+///     -d macos --no-pub --dart-define=FUSHI_TEST_ROOT=$HOME/dev/fushi-test-root \
+///     --dart-define=FUSHI_PROBE_EPUB=$HOME/dev/probe-books/book.epub
+
+const String _epubPath = String.fromEnvironment('FUSHI_PROBE_EPUB');
+
+const Key _kWebViewKey = ValueKey<String>('fushi_webview');
+const Key _kContentReadyKey = ValueKey<String>('fushi_content_ready');
+
+bool _webViewShown() => find.byKey(_kWebViewKey).evaluate().isNotEmpty;
+
+bool _contentReady() => find.byKey(_kContentReadyKey).evaluate().isNotEmpty;
+
+bool _readerPageGone() => find.byType(ReaderFushiPage).evaluate().isEmpty;
+
+Future<void> _waitFor(
+  WidgetTester tester,
+  bool Function() ready,
+  String label, {
+  int maxPolls = 120,
+  Duration step = const Duration(milliseconds: 500),
+}) async {
+  for (int i = 0; i < maxPolls; i++) {
+    await tester.pump(step);
+    if (ready()) {
+      debugPrint(
+          '[ruby-realbook] $label ready after ${i * step.inMilliseconds}ms');
+      return;
+    }
+  }
+  fail('$label did not become ready within '
+      '${maxPolls * step.inMilliseconds}ms');
+}
+
+Future<void> _pumpForPref(WidgetTester tester) async {
+  for (int i = 0; i < 8; i++) {
+    await tester.pump(const Duration(milliseconds: 150));
+  }
+}
+
+Future<void> _openBook(WidgetTester tester, String bookKey) async {
+  await openBookViaProductionPath(tester, bookKey);
+  await _waitFor(tester, _webViewShown, 'reader WebView');
+  await _waitFor(tester, _contentReady, 'reader content', maxPolls: 240);
+  await _waitFor(tester, readerWebViewReady, 'reader debug hooks',
+      maxPolls: 20);
+}
+
+Future<void> _closeReader(WidgetTester tester) async {
+  if (_readerPageGone()) return;
+  final NavigatorState nav =
+      Navigator.of(tester.element(find.byType(ReaderFushiPage)));
+  nav.pop();
+  await _waitFor(tester, _readerPageGone, 'reader closed', maxPolls: 40);
+  await tester.pump(const Duration(seconds: 1));
+}
+
+/// 逐章数 `<rt`（解压树 + chaptersJson 的 href），返回注音最多的章下标。
+Future<int> _sectionWithMostRuby(EpubBookRow book) async {
+  final List<dynamic> chapters = jsonDecode(book.chaptersJson) as List<dynamic>;
+  int best = 0;
+  int bestCount = -1;
+  for (int i = 0; i < chapters.length; i++) {
+    final String href = (chapters[i] as Map<String, dynamic>)['href'] as String;
+    final File f = File('${book.extractDir}${Platform.pathSeparator}$href');
+    int count = 0;
+    if (f.existsSync()) {
+      final String html = f.readAsStringSync();
+      count = '<rt'.allMatches(html).length;
+    }
+    debugPrint('[ruby-realbook] section $i href=$href rt=$count');
+    if (count > bestCount) {
+      bestCount = count;
+      best = i;
+    }
+  }
+  debugPrint('[ruby-realbook] pinned section=$best (rt=$bestCount)');
+  return best;
+}
+
+const String _measureJs = r'''
+(function () {
+  function median(a) {
+    if (!a.length) return 0;
+    var s = a.slice().sort(function (x, y) { return x - y; });
+    var m = s.length >> 1;
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+  }
+  function ua() {
+    var u = navigator.userAgent || '';
+    var m;
+    if ((m = /Chrome\/([\d.]+)/.exec(u))) return 'Blink Chrome/' + m[1];
+    if ((m = /AppleWebKit\/([\d.]+)/.exec(u))) return 'WebKit AppleWebKit/' + m[1];
+    return u.slice(0, 60);
+  }
+  var bodyCs = getComputedStyle(document.body);
+  var fontSize = parseFloat(bodyCs.fontSize) || 16;
+  var vertical = /^vertical/.test(bodyCs.writingMode || '');
+  var out = { engine: ua(), bodyFontSize: bodyCs.fontSize, bodyLineHeight: bodyCs.lineHeight,
+              bodyWritingMode: bodyCs.writingMode, blocks: 0, lines: [] };
+  var firstRt = document.querySelector('rt');
+  if (firstRt) {
+    var rc = getComputedStyle(firstRt);
+    out.rtCss = { display: rc.display, fontSize: rc.fontSize, lineHeight: rc.lineHeight };
+    var ru = getComputedStyle(firstRt.parentNode);
+    out.rubyCss = { display: ru.display, lineHeight: ru.lineHeight,
+                    rubyPosition: ru.rubyPosition || ru.webkitRubyPosition || '' };
+  }
+  out.rubyCount = document.querySelectorAll('ruby').length;
+  var blocks = document.querySelectorAll('p, div, li, h1, h2, h3');
+  var plainPitches = [], rubyPitches = [];
+  var plainExtras = [], rubyExtras = [], firstRubyExtras = [];
+  var detail = [];
+  for (var i = 0; i < blocks.length; i++) {
+    var p = blocks[i];
+    // 只取叶子块（不含子块级元素），避免同一文本被父块重复量。
+    if (p.querySelector('p, div, li, h1, h2, h3')) continue;
+    var walker = document.createTreeWalker(p, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        var e = n.parentNode;
+        while (e && e !== p) {
+          var t = e.tagName;
+          if (t === 'RT' || t === 'RP' || t === 'RTC') return NodeFilter.FILTER_REJECT;
+          e = e.parentNode;
+        }
+        return n.textContent.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
+      }
+    });
+    var lines = [];
+    var node;
+    while ((node = walker.nextNode())) {
+      var inRuby = !!(node.parentNode && node.parentNode.closest && node.parentNode.closest('ruby'));
+      var len = node.textContent.length;
+      for (var k = 0; k < len; k++) {
+        if (!node.textContent[k].trim()) continue;
+        var r = document.createRange();
+        r.setStart(node, k); r.setEnd(node, k + 1);
+        var rects = r.getClientRects();
+        if (!rects.length) continue;
+        var cr = rects[0];
+        if (cr.width <= 0 || cr.height <= 0) continue;
+        var found = null;
+        for (var L = 0; L < lines.length; L++) {
+          var same = vertical
+            ? (Math.abs(lines[L].left - cr.left) <= 2)
+            : (Math.abs(lines[L].top - cr.top) <= 2);
+          if (same) { found = lines[L]; break; }
+        }
+        if (found) {
+          found.top = Math.min(found.top, cr.top); found.bottom = Math.max(found.bottom, cr.bottom);
+          found.left = Math.min(found.left, cr.left); found.right = Math.max(found.right, cr.right);
+          found.chars++; if (inRuby) found.ruby++;
+        } else {
+          lines.push({ top: cr.top, bottom: cr.bottom, left: cr.left, right: cr.right, chars: 1, ruby: inRuby ? 1 : 0 });
+        }
+      }
+    }
+    if (lines.length < 2) continue;
+    out.blocks++;
+    // 段落块轴尺寸 − 行数×本段行距中位数 = 段落多出的空间（首行被注音撑高会落在这里）。
+    (function () {
+      var ps = [];
+      for (var q = 1; q < lines.length; q++) {
+        var dq = vertical ? (lines[q - 1].left - lines[q].left) : (lines[q].top - lines[q - 1].top);
+        if (dq > 0 && dq < fontSize * 4) ps.push(dq);
+      }
+      if (!ps.length) return;
+      var pr = p.getBoundingClientRect();
+      var blockSize = vertical ? pr.width : pr.height;
+      var extra = blockSize - lines.length * median(ps);
+      var hasRuby = lines.some(function (l) { return l.ruby > 0; });
+      var firstRuby = lines[0].ruby > 0;
+      (hasRuby ? rubyExtras : plainExtras).push(extra);
+      if (firstRuby) firstRubyExtras.push(extra);
+    })();
+    for (var L2 = 1; L2 < lines.length; L2++) {
+      var a = lines[L2 - 1], b = lines[L2];
+      var d = vertical ? (a.left - b.left) : (b.top - a.top);
+      if (!(d > 0 && d < fontSize * 4)) continue;
+      var anyRuby = a.ruby > 0 || b.ruby > 0;
+      (anyRuby ? rubyPitches : plainPitches).push(d);
+      if (detail.length < 40) {
+        detail.push({ block: i, pitch: Math.round(d * 100) / 100, aRuby: a.ruby, bRuby: b.ruby,
+                      aChars: a.chars, bChars: b.chars });
+      }
+    }
+  }
+  out.plain = Math.round(median(plainPitches) * 100) / 100;
+  out.ruby = Math.round(median(rubyPitches) * 100) / 100;
+  out.plainN = plainPitches.length; out.rubyN = rubyPitches.length;
+  out.plainMax = Math.round(Math.max.apply(null, plainPitches.concat([0])) * 100) / 100;
+  out.rubyMax = Math.round(Math.max.apply(null, rubyPitches.concat([0])) * 100) / 100;
+  out.delta = Math.round((out.ruby - out.plain) * 100) / 100;
+  out.plainExtra = Math.round(median(plainExtras) * 100) / 100;
+  out.rubyExtra = Math.round(median(rubyExtras) * 100) / 100;
+  out.firstRubyExtra = Math.round(median(firstRubyExtras) * 100) / 100;
+  out.plainExtraN = plainExtras.length; out.rubyExtraN = rubyExtras.length;
+  out.firstRubyExtraN = firstRubyExtras.length;
+  out.lines = detail;
+  return JSON.stringify(out);
+})()
+''';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'real-book ruby line-box probe: plain vs ruby-adjacent line pitch on the '
+    'user\'s EPUB across writing modes and font sizes (engine-tagged)',
+    timeout: const Timeout(Duration(minutes: 25)),
+    (WidgetTester tester) async {
+      expect(_epubPath, isNotEmpty,
+          reason: 'pass --dart-define=FUSHI_PROBE_EPUB=<path to epub>');
+      final File epub = File(_epubPath);
+      expect(epub.existsSync(), isTrue, reason: 'epub not found: $_epubPath');
+
+      await runFushiItest(
+        label: 'ruby-realbook',
+        body: () async {
+          await launchFushiTestApp();
+          expect(await waitForHome(tester), isTrue,
+              reason: 'home (nav bar) must render');
+          await tester.pump(const Duration(seconds: 2));
+          final AppModel appModel = await readyAppModel(tester);
+
+          final ReaderFushiSource source = ReaderFushiSource.instance;
+          final String originalMode = source.readerFuriganaMode;
+          final String originalWritingMode = source.readerWritingMode;
+          final String originalViewMode = source.readerViewMode;
+          final double originalLineHeight = source.readerLineHeight;
+          final double originalFontSize = source.readerFontSize;
+          debugPrint('[ruby-realbook] original prefs: furigana_mode='
+              '$originalMode writing_mode=$originalWritingMode '
+              'view_mode=$originalViewMode line_height=$originalLineHeight '
+              'font_size=$originalFontSize');
+
+          try {
+            await source.setReaderViewMode('paginated');
+            await source.setReaderFuriganaMode('off');
+            await source.setReaderLineHeight(1.65);
+            await _pumpForPref(tester);
+
+            await showBooksTab(tester);
+            final String bookKey = await EpubImporter.import(
+              db: appModel.database,
+              bytes: epub.readAsBytesSync(),
+              fileName: epub.uri.pathSegments.last,
+            );
+            debugPrint('[ruby-realbook] imported key=$bookKey');
+            final EpubBookRow? row =
+                await appModel.database.getEpubBook(bookKey);
+            expect(row, isNotNull);
+            final int section = await _sectionWithMostRuby(row!);
+            await appModel.database.upsertReaderPosition(
+              ReaderPositionsCompanion(
+                bookUid: Value<String>(row.uid),
+                sectionIndex: Value<int>(section),
+                normCharOffset: const Value<int>(0),
+                charOffset: const Value<int>(-1),
+                updatedAt: Value<int>(DateTime.now().millisecondsSinceEpoch),
+              ),
+            );
+            await tester.pump(const Duration(seconds: 1));
+
+            final List<String> summary = <String>[];
+            for (final String wm in <String>['vertical-rl', 'horizontal-tb']) {
+              for (final double fs in <double>[46, 22]) {
+                final String pass =
+                    '${wm == 'vertical-rl' ? 'v' : 'h'}${fs.round()}';
+                await source.setReaderWritingMode(wm);
+                await source.setReaderFontSize(fs);
+                await _pumpForPref(tester);
+                await _openBook(tester, bookKey);
+                await tester.pump(const Duration(seconds: 3));
+
+                final Future<dynamic> Function(String)? runJs =
+                    ReaderFushiPage.debugEvaluateJavascript;
+                expect(runJs, isNotNull);
+                final Map<String, dynamic> r =
+                    jsonDecode((await runJs!(_measureJs)) as String)
+                        as Map<String, dynamic>;
+                final String line = '[ruby-realbook] engine=${r['engine']} '
+                    'pass=$pass plain=${r['plain']} (n=${r['plainN']}, '
+                    'max=${r['plainMax']}) ruby=${r['ruby']} (n=${r['rubyN']}, '
+                    'max=${r['rubyMax']}) delta=${r['delta']} '
+                    'blocks=${r['blocks']} rubies=${r['rubyCount']} '
+                    'blockExtra plain=${r['plainExtra']} (n=${r['plainExtraN']}) '
+                    'ruby=${r['rubyExtra']} (n=${r['rubyExtraN']}) '
+                    'firstLineRuby=${r['firstRubyExtra']} '
+                    '(n=${r['firstRubyExtraN']})';
+                debugPrint(line);
+                summary.add(line);
+                debugPrint('[ruby-realbook]   body font=${r['bodyFontSize']} '
+                    'lineHeight=${r['bodyLineHeight']} '
+                    'writingMode=${r['bodyWritingMode']} rt=${r['rtCss']} '
+                    'ruby=${r['rubyCss']}');
+                for (final dynamic d in r['lines'] as List<dynamic>) {
+                  debugPrint('[ruby-realbook]   $d');
+                }
+                final ObserveShot web =
+                    await captureReaderWebView('observe-rb-$pass-webview');
+                debugPrint('[ruby-realbook]   webview $pass saved=${web.saved} '
+                    'nonBlank=${web.nonBlank} path=${web.path}');
+                expect(
+                    (r['plainN'] as num) + (r['rubyN'] as num), greaterThan(0),
+                    reason: 'pass $pass must measure some line pitches');
+                await _closeReader(tester);
+              }
+            }
+            debugPrint('[ruby-realbook] SUMMARY\n${summary.join('\n')}');
+          } finally {
+            await _closeReader(tester);
+            await source.setReaderFuriganaMode(originalMode);
+            await source.setReaderWritingMode(originalWritingMode);
+            await source.setReaderViewMode(originalViewMode);
+            await source.setReaderLineHeight(originalLineHeight);
+            await source.setReaderFontSize(originalFontSize);
+            await _pumpForPref(tester);
+            debugPrint('[ruby-realbook] restored prefs');
+          }
+        },
+      );
+    },
+  );
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80291 (4723 per locale)
+/// Strings: 80274 (4722 per locale)
 ///
-/// Built on 2026-09-11 at 21:29 UTC
+/// Built on 2026-09-11 at 22:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3922,12 +3922,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get reader_font_size => 'Font size';
   String get reader_font_vpal => 'VPAL (vertical alt)';
   String get reader_font_weight => 'Font weight';
-  String get reader_furigana_hide => 'Hide';
   String get reader_furigana_mode => 'Furigana';
   String get reader_furigana_mode_hint => '';
-  String get reader_furigana_partial => 'Partial';
-  String get reader_furigana_show => 'Show';
-  String get reader_furigana_toggle => 'Toggle';
   String get reader_gallery => 'Gallery';
   String get reader_gallery_current => 'Reading here';
   String get reader_gallery_empty => 'No illustrations in this book';
@@ -6570,6 +6566,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get settings_study_diag_export_hint =>
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  String get reader_furigana_off => 'Off';
+  String get reader_furigana_toggle => 'Toggle';
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -13063,17 +13062,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get reader_font_weight => 'وزن الخط';
   @override
-  String get reader_furigana_hide => 'إخفاء';
-  @override
   String get reader_furigana_mode => 'فوريغانا';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'جزئي';
-  @override
-  String get reader_furigana_show => 'عرض';
-  @override
-  String get reader_furigana_toggle => 'تبديل';
   @override
   String get reader_gallery => 'المعرض';
   @override
@@ -17691,6 +17682,12 @@ class _StringsAr extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -24322,17 +24319,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get reader_font_weight => 'Schriftstärke';
   @override
-  String get reader_furigana_hide => 'Ausblenden';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Teilweise';
-  @override
-  String get reader_furigana_show => 'Anzeigen';
-  @override
-  String get reader_furigana_toggle => 'Umschalten';
   @override
   String get reader_gallery => 'Galerie';
   @override
@@ -29038,6 +29027,12 @@ class _StringsDe extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -35689,17 +35684,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get reader_font_weight => 'Grosor de fuente';
   @override
-  String get reader_furigana_hide => 'Ocultar';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Parcial';
-  @override
-  String get reader_furigana_show => 'Mostrar';
-  @override
-  String get reader_furigana_toggle => 'Alternar';
   @override
   String get reader_gallery => 'Galería';
   @override
@@ -40439,6 +40426,12 @@ class _StringsEs extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -47110,17 +47103,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get reader_font_weight => 'Graisse de police';
   @override
-  String get reader_furigana_hide => 'Masquer';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Partiel';
-  @override
-  String get reader_furigana_show => 'Afficher';
-  @override
-  String get reader_furigana_toggle => 'Basculer';
   @override
   String get reader_gallery => 'Galerie';
   @override
@@ -51873,6 +51858,12 @@ class _StringsFr extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -58431,17 +58422,9 @@ class _StringsId extends _StringsEn {
   @override
   String get reader_font_weight => 'Ketebalan font';
   @override
-  String get reader_furigana_hide => 'Sembunyikan';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Sebagian';
-  @override
-  String get reader_furigana_show => 'Tampilkan';
-  @override
-  String get reader_furigana_toggle => 'Alihkan';
   @override
   String get reader_gallery => 'Galeri';
   @override
@@ -63111,6 +63094,12 @@ class _StringsId extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -69720,17 +69709,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get reader_font_weight => 'Spessore carattere';
   @override
-  String get reader_furigana_hide => 'Nascondi';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Parziale';
-  @override
-  String get reader_furigana_show => 'Mostra';
-  @override
-  String get reader_furigana_toggle => 'Alterna';
   @override
   String get reader_gallery => 'Galleria';
   @override
@@ -74440,6 +74421,12 @@ class _StringsIt extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -80691,17 +80678,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get reader_font_weight => 'フォントの太さ';
   @override
-  String get reader_furigana_hide => '非表示';
-  @override
   String get reader_furigana_mode => 'ふりがな';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => '一部';
-  @override
-  String get reader_furigana_show => '表示';
-  @override
-  String get reader_furigana_toggle => '切替';
   @override
   String get reader_gallery => 'ギャラリー';
   @override
@@ -85151,6 +85130,12 @@ class _StringsJa extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -91406,17 +91391,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get reader_font_weight => '글꼴 굵기';
   @override
-  String get reader_furigana_hide => '숨기기';
-  @override
   String get reader_furigana_mode => '후리가나';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => '부분';
-  @override
-  String get reader_furigana_show => '표시';
-  @override
-  String get reader_furigana_toggle => '전환';
   @override
   String get reader_gallery => '갤러리';
   @override
@@ -95872,6 +95849,12 @@ class _StringsKo extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -102457,17 +102440,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get reader_font_weight => 'Letterdikte';
   @override
-  String get reader_furigana_hide => 'Verbergen';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Gedeeltelijk';
-  @override
-  String get reader_furigana_show => 'Tonen';
-  @override
-  String get reader_furigana_toggle => 'Wisselen';
   @override
   String get reader_gallery => 'Galerij';
   @override
@@ -107159,6 +107134,12 @@ class _StringsNl extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -113776,17 +113757,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get reader_font_weight => 'Espessura da fonte';
   @override
-  String get reader_furigana_hide => 'Ocultar';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Parcial';
-  @override
-  String get reader_furigana_show => 'Mostrar';
-  @override
-  String get reader_furigana_toggle => 'Alternar';
   @override
   String get reader_gallery => 'Galeria';
   @override
@@ -118499,6 +118472,12 @@ class _StringsPtBr extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -125097,17 +125076,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get reader_font_weight => 'Насыщенность шрифта';
   @override
-  String get reader_furigana_hide => 'Скрыть';
-  @override
   String get reader_furigana_mode => 'Фуригана';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Частично';
-  @override
-  String get reader_furigana_show => 'Показать';
-  @override
-  String get reader_furigana_toggle => 'Переключить';
   @override
   String get reader_gallery => 'Галерея';
   @override
@@ -129816,6 +129787,12 @@ class _StringsRu extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -136300,17 +136277,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get reader_font_weight => 'น้ำหนักฟอนต์';
   @override
-  String get reader_furigana_hide => 'ซ่อน';
-  @override
   String get reader_furigana_mode => 'ฟุริงานะ';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'บางส่วน';
-  @override
-  String get reader_furigana_show => 'แสดง';
-  @override
-  String get reader_furigana_toggle => 'สลับ';
   @override
   String get reader_gallery => 'แกลเลอรี';
   @override
@@ -140934,6 +140903,12 @@ class _StringsTh extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -147494,17 +147469,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get reader_font_weight => 'Yazı tipi kalınlığı';
   @override
-  String get reader_furigana_hide => 'Gizle';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Kısmi';
-  @override
-  String get reader_furigana_show => 'Göster';
-  @override
-  String get reader_furigana_toggle => 'Değiştir';
   @override
   String get reader_gallery => 'Galeri';
   @override
@@ -152167,6 +152134,12 @@ class _StringsTr extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -158713,17 +158686,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get reader_font_weight => 'Độ đậm phông chữ';
   @override
-  String get reader_furigana_hide => 'Ẩn';
-  @override
   String get reader_furigana_mode => 'Furigana';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => 'Một phần';
-  @override
-  String get reader_furigana_show => 'Hiện';
-  @override
-  String get reader_furigana_toggle => 'Chuyển đổi';
   @override
   String get reader_gallery => 'Bộ sưu tập';
   @override
@@ -163370,6 +163335,12 @@ class _StringsVi extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 // Path: <root>
@@ -169372,17 +169343,9 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get reader_font_weight => '字体粗细';
   @override
-  String get reader_furigana_hide => '隐藏';
-  @override
   String get reader_furigana_mode => '振假名';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => '部分';
-  @override
-  String get reader_furigana_show => '显示';
-  @override
-  String get reader_furigana_toggle => '切换';
   @override
   String get reader_gallery => '插图';
   @override
@@ -173650,6 +173613,12 @@ class _StringsZhCn extends _StringsEn {
       '翻页入账、段开封、有声书恢复与跳页流水，用于排查阅读速度异常。保存为文本文件。';
   @override
   String get study_diag_share_subject => 'Fushi 统计诊断日志';
+  @override
+  String get reader_furigana_off => '关闭';
+  @override
+  String get reader_furigana_toggle => '点击显示';
+  @override
+  String get reader_furigana_hidden => '隐藏';
 }
 
 // Path: <root>
@@ -179698,17 +179667,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get reader_font_weight => '字型粗細';
   @override
-  String get reader_furigana_hide => '隱藏';
-  @override
   String get reader_furigana_mode => '振假名';
   @override
   String get reader_furigana_mode_hint => '';
-  @override
-  String get reader_furigana_partial => '部分';
-  @override
-  String get reader_furigana_show => '顯示';
-  @override
-  String get reader_furigana_toggle => '切換';
   @override
   String get reader_gallery => '插圖';
   @override
@@ -184045,6 +184006,12 @@ class _StringsZhHk extends _StringsEn {
       'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
   @override
   String get study_diag_share_subject => 'Fushi study diagnostics';
+  @override
+  String get reader_furigana_off => 'Off';
+  @override
+  String get reader_furigana_toggle => 'Toggle';
+  @override
+  String get reader_furigana_hidden => 'Hidden';
 }
 
 /// Flat map(s) containing all translations.
@@ -189698,18 +189665,10 @@ extension on _StringsEn {
         return 'VPAL (vertical alt)';
       case 'reader_font_weight':
         return 'Font weight';
-      case 'reader_furigana_hide':
-        return 'Hide';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Partial';
-      case 'reader_furigana_show':
-        return 'Show';
-      case 'reader_furigana_toggle':
-        return 'Toggle';
       case 'reader_gallery':
         return 'Gallery';
       case 'reader_gallery_current':
@@ -193775,6 +193734,12 @@ extension on _StringsEn {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -199426,18 +199391,10 @@ extension on _StringsAr {
         return 'VPAL (بديل عمودي)';
       case 'reader_font_weight':
         return 'وزن الخط';
-      case 'reader_furigana_hide':
-        return 'إخفاء';
       case 'reader_furigana_mode':
         return 'فوريغانا';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'جزئي';
-      case 'reader_furigana_show':
-        return 'عرض';
-      case 'reader_furigana_toggle':
-        return 'تبديل';
       case 'reader_gallery':
         return 'المعرض';
       case 'reader_gallery_current':
@@ -203500,6 +203457,12 @@ extension on _StringsAr {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -209180,18 +209143,10 @@ extension on _StringsDe {
         return 'VPAL (Vertikale Alt.)';
       case 'reader_font_weight':
         return 'Schriftstärke';
-      case 'reader_furigana_hide':
-        return 'Ausblenden';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Teilweise';
-      case 'reader_furigana_show':
-        return 'Anzeigen';
-      case 'reader_furigana_toggle':
-        return 'Umschalten';
       case 'reader_gallery':
         return 'Galerie';
       case 'reader_gallery_current':
@@ -213270,6 +213225,12 @@ extension on _StringsDe {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -218943,18 +218904,10 @@ extension on _StringsEs {
         return 'VPAL (alt. vertical)';
       case 'reader_font_weight':
         return 'Grosor de fuente';
-      case 'reader_furigana_hide':
-        return 'Ocultar';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Parcial';
-      case 'reader_furigana_show':
-        return 'Mostrar';
-      case 'reader_furigana_toggle':
-        return 'Alternar';
       case 'reader_gallery':
         return 'Galería';
       case 'reader_gallery_current':
@@ -223031,6 +222984,12 @@ extension on _StringsEs {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -228711,18 +228670,10 @@ extension on _StringsFr {
         return 'VPAL (alt. vertical)';
       case 'reader_font_weight':
         return 'Graisse de police';
-      case 'reader_furigana_hide':
-        return 'Masquer';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Partiel';
-      case 'reader_furigana_show':
-        return 'Afficher';
-      case 'reader_furigana_toggle':
-        return 'Basculer';
       case 'reader_gallery':
         return 'Galerie';
       case 'reader_gallery_current':
@@ -232801,6 +232752,12 @@ extension on _StringsFr {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -238462,18 +238419,10 @@ extension on _StringsId {
         return 'VPAL (Alt Vertikal)';
       case 'reader_font_weight':
         return 'Ketebalan font';
-      case 'reader_furigana_hide':
-        return 'Sembunyikan';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Sebagian';
-      case 'reader_furigana_show':
-        return 'Tampilkan';
-      case 'reader_furigana_toggle':
-        return 'Alihkan';
       case 'reader_gallery':
         return 'Galeri';
       case 'reader_gallery_current':
@@ -242542,6 +242491,12 @@ extension on _StringsId {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -248212,18 +248167,10 @@ extension on _StringsIt {
         return 'VPAL (alt. verticale)';
       case 'reader_font_weight':
         return 'Spessore carattere';
-      case 'reader_furigana_hide':
-        return 'Nascondi';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Parziale';
-      case 'reader_furigana_show':
-        return 'Mostra';
-      case 'reader_furigana_toggle':
-        return 'Alterna';
       case 'reader_gallery':
         return 'Galleria';
       case 'reader_gallery_current':
@@ -252305,6 +252252,12 @@ extension on _StringsIt {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -257940,18 +257893,10 @@ extension on _StringsJa {
         return 'VPAL（縦書き代替）';
       case 'reader_font_weight':
         return 'フォントの太さ';
-      case 'reader_furigana_hide':
-        return '非表示';
       case 'reader_furigana_mode':
         return 'ふりがな';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return '一部';
-      case 'reader_furigana_show':
-        return '表示';
-      case 'reader_furigana_toggle':
-        return '切替';
       case 'reader_gallery':
         return 'ギャラリー';
       case 'reader_gallery_current':
@@ -261995,6 +261940,12 @@ extension on _StringsJa {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -267631,18 +267582,10 @@ extension on _StringsKo {
         return 'VPAL (세로 대체)';
       case 'reader_font_weight':
         return '글꼴 굵기';
-      case 'reader_furigana_hide':
-        return '숨기기';
       case 'reader_furigana_mode':
         return '후리가나';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return '부분';
-      case 'reader_furigana_show':
-        return '표시';
-      case 'reader_furigana_toggle':
-        return '전환';
       case 'reader_gallery':
         return '갤러리';
       case 'reader_gallery_current':
@@ -271689,6 +271632,12 @@ extension on _StringsKo {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -277358,18 +277307,10 @@ extension on _StringsNl {
         return 'VPAL (vert. alt.)';
       case 'reader_font_weight':
         return 'Letterdikte';
-      case 'reader_furigana_hide':
-        return 'Verbergen';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Gedeeltelijk';
-      case 'reader_furigana_show':
-        return 'Tonen';
-      case 'reader_furigana_toggle':
-        return 'Wisselen';
       case 'reader_gallery':
         return 'Galerij';
       case 'reader_gallery_current':
@@ -281445,6 +281386,12 @@ extension on _StringsNl {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -287113,18 +287060,10 @@ extension on _StringsPtBr {
         return 'VPAL (alt. vertical)';
       case 'reader_font_weight':
         return 'Espessura da fonte';
-      case 'reader_furigana_hide':
-        return 'Ocultar';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Parcial';
-      case 'reader_furigana_show':
-        return 'Mostrar';
-      case 'reader_furigana_toggle':
-        return 'Alternar';
       case 'reader_gallery':
         return 'Galeria';
       case 'reader_gallery_current':
@@ -291196,6 +291135,12 @@ extension on _StringsPtBr {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -296871,18 +296816,10 @@ extension on _StringsRu {
         return 'VPAL (верт. альт.)';
       case 'reader_font_weight':
         return 'Насыщенность шрифта';
-      case 'reader_furigana_hide':
-        return 'Скрыть';
       case 'reader_furigana_mode':
         return 'Фуригана';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Частично';
-      case 'reader_furigana_show':
-        return 'Показать';
-      case 'reader_furigana_toggle':
-        return 'Переключить';
       case 'reader_gallery':
         return 'Галерея';
       case 'reader_gallery_current':
@@ -300954,6 +300891,12 @@ extension on _StringsRu {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -306608,18 +306551,10 @@ extension on _StringsTh {
         return 'VPAL (ตัวอักษรทดแทน)';
       case 'reader_font_weight':
         return 'น้ำหนักฟอนต์';
-      case 'reader_furigana_hide':
-        return 'ซ่อน';
       case 'reader_furigana_mode':
         return 'ฟุริงานะ';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'บางส่วน';
-      case 'reader_furigana_show':
-        return 'แสดง';
-      case 'reader_furigana_toggle':
-        return 'สลับ';
       case 'reader_gallery':
         return 'แกลเลอรี';
       case 'reader_gallery_current':
@@ -310684,6 +310619,12 @@ extension on _StringsTh {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -316348,18 +316289,10 @@ extension on _StringsTr {
         return 'VPAL (dikey alt.)';
       case 'reader_font_weight':
         return 'Yazı tipi kalınlığı';
-      case 'reader_furigana_hide':
-        return 'Gizle';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Kısmi';
-      case 'reader_furigana_show':
-        return 'Göster';
-      case 'reader_furigana_toggle':
-        return 'Değiştir';
       case 'reader_gallery':
         return 'Galeri';
       case 'reader_gallery_current':
@@ -320429,6 +320362,12 @@ extension on _StringsTr {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -326089,18 +326028,10 @@ extension on _StringsVi {
         return 'VPAL (thay thế dọc)';
       case 'reader_font_weight':
         return 'Độ đậm phông chữ';
-      case 'reader_furigana_hide':
-        return 'Ẩn';
       case 'reader_furigana_mode':
         return 'Furigana';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return 'Một phần';
-      case 'reader_furigana_show':
-        return 'Hiện';
-      case 'reader_furigana_toggle':
-        return 'Chuyển đổi';
       case 'reader_gallery':
         return 'Bộ sưu tập';
       case 'reader_gallery_current':
@@ -330168,6 +330099,12 @@ extension on _StringsVi {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }
@@ -335785,18 +335722,10 @@ extension on _StringsZhCn {
         return 'VPAL 纵排替代';
       case 'reader_font_weight':
         return '字体粗细';
-      case 'reader_furigana_hide':
-        return '隐藏';
       case 'reader_furigana_mode':
         return '振假名';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return '部分';
-      case 'reader_furigana_show':
-        return '显示';
-      case 'reader_furigana_toggle':
-        return '切换';
       case 'reader_gallery':
         return '插图';
       case 'reader_gallery_current':
@@ -339820,6 +339749,12 @@ extension on _StringsZhCn {
         return '翻页入账、段开封、有声书恢复与跳页流水，用于排查阅读速度异常。保存为文本文件。';
       case 'study_diag_share_subject':
         return 'Fushi 统计诊断日志';
+      case 'reader_furigana_off':
+        return '关闭';
+      case 'reader_furigana_toggle':
+        return '点击显示';
+      case 'reader_furigana_hidden':
+        return '隐藏';
       default:
         return null;
     }
@@ -345444,18 +345379,10 @@ extension on _StringsZhHk {
         return 'VPAL 直排替代';
       case 'reader_font_weight':
         return '字型粗細';
-      case 'reader_furigana_hide':
-        return '隱藏';
       case 'reader_furigana_mode':
         return '振假名';
       case 'reader_furigana_mode_hint':
         return '';
-      case 'reader_furigana_partial':
-        return '部分';
-      case 'reader_furigana_show':
-        return '顯示';
-      case 'reader_furigana_toggle':
-        return '切換';
       case 'reader_gallery':
         return '插圖';
       case 'reader_gallery_current':
@@ -349488,6 +349415,12 @@ extension on _StringsZhHk {
         return 'Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.';
       case 'study_diag_share_subject':
         return 'Fushi study diagnostics';
+      case 'reader_furigana_off':
+        return 'Off';
+      case 'reader_furigana_toggle':
+        return 'Toggle';
+      case 'reader_furigana_hidden':
+        return 'Hidden';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Font size",
   "reader_font_vpal": "VPAL (vertical alt)",
   "reader_font_weight": "Font weight",
-  "reader_furigana_hide": "Hide",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Partial",
-  "reader_furigana_show": "Show",
-  "reader_furigana_toggle": "Toggle",
   "reader_gallery": "Gallery",
   "reader_gallery_current": "Reading here",
   "reader_gallery_empty": "No illustrations in this book",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "حجم الخط",
   "reader_font_vpal": "VPAL (بديل عمودي)",
   "reader_font_weight": "وزن الخط",
-  "reader_furigana_hide": "إخفاء",
   "reader_furigana_mode": "فوريغانا",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "جزئي",
-  "reader_furigana_show": "عرض",
-  "reader_furigana_toggle": "تبديل",
   "reader_gallery": "المعرض",
   "reader_gallery_current": "تقرأ هنا",
   "reader_gallery_empty": "لا توجد رسوم توضيحية في هذا الكتاب",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Schriftgröße",
   "reader_font_vpal": "VPAL (Vertikale Alt.)",
   "reader_font_weight": "Schriftstärke",
-  "reader_furigana_hide": "Ausblenden",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Teilweise",
-  "reader_furigana_show": "Anzeigen",
-  "reader_furigana_toggle": "Umschalten",
   "reader_gallery": "Galerie",
   "reader_gallery_current": "Aktuelle Leseposition",
   "reader_gallery_empty": "Keine Illustrationen in diesem Buch",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Tamaño de fuente",
   "reader_font_vpal": "VPAL (alt. vertical)",
   "reader_font_weight": "Grosor de fuente",
-  "reader_furigana_hide": "Ocultar",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Parcial",
-  "reader_furigana_show": "Mostrar",
-  "reader_furigana_toggle": "Alternar",
   "reader_gallery": "Galería",
   "reader_gallery_current": "Leyendo aquí",
   "reader_gallery_empty": "No hay ilustraciones en este libro",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Taille de police",
   "reader_font_vpal": "VPAL (alt. vertical)",
   "reader_font_weight": "Graisse de police",
-  "reader_furigana_hide": "Masquer",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Partiel",
-  "reader_furigana_show": "Afficher",
-  "reader_furigana_toggle": "Basculer",
   "reader_gallery": "Galerie",
   "reader_gallery_current": "Lecture ici",
   "reader_gallery_empty": "Aucune illustration dans ce livre",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Ukuran Font",
   "reader_font_vpal": "VPAL (Alt Vertikal)",
   "reader_font_weight": "Ketebalan font",
-  "reader_furigana_hide": "Sembunyikan",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Sebagian",
-  "reader_furigana_show": "Tampilkan",
-  "reader_furigana_toggle": "Alihkan",
   "reader_gallery": "Galeri",
   "reader_gallery_current": "Sedang membaca di sini",
   "reader_gallery_empty": "Tidak ada ilustrasi di buku ini",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Dimensione carattere",
   "reader_font_vpal": "VPAL (alt. verticale)",
   "reader_font_weight": "Spessore carattere",
-  "reader_furigana_hide": "Nascondi",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Parziale",
-  "reader_furigana_show": "Mostra",
-  "reader_furigana_toggle": "Alterna",
   "reader_gallery": "Galleria",
   "reader_gallery_current": "Stai leggendo qui",
   "reader_gallery_empty": "Nessuna illustrazione in questo libro",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "フォントサイズ",
   "reader_font_vpal": "VPAL（縦書き代替）",
   "reader_font_weight": "フォントの太さ",
-  "reader_furigana_hide": "非表示",
   "reader_furigana_mode": "ふりがな",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "一部",
-  "reader_furigana_show": "表示",
-  "reader_furigana_toggle": "切替",
   "reader_gallery": "ギャラリー",
   "reader_gallery_current": "現在の閲覧位置",
   "reader_gallery_empty": "この本にはイラストがありません",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "글꼴 크기",
   "reader_font_vpal": "VPAL (세로 대체)",
   "reader_font_weight": "글꼴 굵기",
-  "reader_furigana_hide": "숨기기",
   "reader_furigana_mode": "후리가나",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "부분",
-  "reader_furigana_show": "표시",
-  "reader_furigana_toggle": "전환",
   "reader_gallery": "갤러리",
   "reader_gallery_current": "현재 읽는 위치",
   "reader_gallery_empty": "이 책에 삽화가 없습니다",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Lettergrootte",
   "reader_font_vpal": "VPAL (vert. alt.)",
   "reader_font_weight": "Letterdikte",
-  "reader_furigana_hide": "Verbergen",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Gedeeltelijk",
-  "reader_furigana_show": "Tonen",
-  "reader_furigana_toggle": "Wisselen",
   "reader_gallery": "Galerij",
   "reader_gallery_current": "Hier aan het lezen",
   "reader_gallery_empty": "Geen illustraties in dit boek",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Tamanho da Fonte",
   "reader_font_vpal": "VPAL (alt. vertical)",
   "reader_font_weight": "Espessura da fonte",
-  "reader_furigana_hide": "Ocultar",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Parcial",
-  "reader_furigana_show": "Mostrar",
-  "reader_furigana_toggle": "Alternar",
   "reader_gallery": "Galeria",
   "reader_gallery_current": "Lendo aqui",
   "reader_gallery_empty": "Sem ilustrações neste livro",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Размер шрифта",
   "reader_font_vpal": "VPAL (верт. альт.)",
   "reader_font_weight": "Насыщенность шрифта",
-  "reader_furigana_hide": "Скрыть",
   "reader_furigana_mode": "Фуригана",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Частично",
-  "reader_furigana_show": "Показать",
-  "reader_furigana_toggle": "Переключить",
   "reader_gallery": "Галерея",
   "reader_gallery_current": "Вы читаете здесь",
   "reader_gallery_empty": "В этой книге нет иллюстраций",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "ขนาดฟอนต์",
   "reader_font_vpal": "VPAL (ตัวอักษรทดแทน)",
   "reader_font_weight": "น้ำหนักฟอนต์",
-  "reader_furigana_hide": "ซ่อน",
   "reader_furigana_mode": "ฟุริงานะ",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "บางส่วน",
-  "reader_furigana_show": "แสดง",
-  "reader_furigana_toggle": "สลับ",
   "reader_gallery": "แกลเลอรี",
   "reader_gallery_current": "กำลังอ่านที่นี่",
   "reader_gallery_empty": "ไม่มีภาพประกอบในหนังสือเล่มนี้",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Yazı tipi boyutu",
   "reader_font_vpal": "VPAL (dikey alt.)",
   "reader_font_weight": "Yazı tipi kalınlığı",
-  "reader_furigana_hide": "Gizle",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Kısmi",
-  "reader_furigana_show": "Göster",
-  "reader_furigana_toggle": "Değiştir",
   "reader_gallery": "Galeri",
   "reader_gallery_current": "Burada okunuyor",
   "reader_gallery_empty": "Bu kitapta illüstrasyon yok",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "Cỡ chữ",
   "reader_font_vpal": "VPAL (thay thế dọc)",
   "reader_font_weight": "Độ đậm phông chữ",
-  "reader_furigana_hide": "Ẩn",
   "reader_furigana_mode": "Furigana",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "Một phần",
-  "reader_furigana_show": "Hiện",
-  "reader_furigana_toggle": "Chuyển đổi",
   "reader_gallery": "Bộ sưu tập",
   "reader_gallery_current": "Đang đọc tại đây",
   "reader_gallery_empty": "Không có hình minh họa trong sách này",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "字体大小",
   "reader_font_vpal": "VPAL 纵排替代",
   "reader_font_weight": "字体粗细",
-  "reader_furigana_hide": "隐藏",
   "reader_furigana_mode": "振假名",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "部分",
-  "reader_furigana_show": "显示",
-  "reader_furigana_toggle": "切换",
   "reader_gallery": "插图",
   "reader_gallery_current": "正在阅读",
   "reader_gallery_empty": "本书没有插图",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "阅读速度",
   "settings_study_diag_export": "导出统计诊断日志",
   "settings_study_diag_export_hint": "翻页入账、段开封、有声书恢复与跳页流水，用于排查阅读速度异常。保存为文本文件。",
-  "study_diag_share_subject": "Fushi 统计诊断日志"
+  "study_diag_share_subject": "Fushi 统计诊断日志",
+  "reader_furigana_off": "关闭",
+  "reader_furigana_toggle": "点击显示",
+  "reader_furigana_hidden": "隐藏"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -2739,12 +2739,8 @@
   "reader_font_size": "字型大小",
   "reader_font_vpal": "VPAL 直排替代",
   "reader_font_weight": "字型粗細",
-  "reader_furigana_hide": "隱藏",
   "reader_furigana_mode": "振假名",
   "reader_furigana_mode_hint": "",
-  "reader_furigana_partial": "部分",
-  "reader_furigana_show": "顯示",
-  "reader_furigana_toggle": "切換",
   "reader_gallery": "插圖",
   "reader_gallery_current": "正在閱讀",
   "reader_gallery_empty": "本書沒有插圖",
@@ -4721,5 +4717,8 @@
   "stat_reading_speed": "Reading speed",
   "settings_study_diag_export": "Export study diagnostics log",
   "settings_study_diag_export_hint": "Page credits, segment open/close, audiobook resume and jump trace, for troubleshooting reading-speed anomalies. Saved as a text file.",
-  "study_diag_share_subject": "Fushi study diagnostics"
+  "study_diag_share_subject": "Fushi study diagnostics",
+  "reader_furigana_off": "Off",
+  "reader_furigana_toggle": "Toggle",
+  "reader_furigana_hidden": "Hidden"
 }

--- a/fushi/lib/src/media/audiobook/reader_quick_settings_sheet.dart
+++ b/fushi/lib/src/media/audiobook/reader_quick_settings_sheet.dart
@@ -277,7 +277,9 @@ class _ReaderQuickSettingsSheetState extends State<ReaderQuickSettingsSheet>
       case 'theme':
         await src.setReaderTheme(value as String);
       case 'hideFurigana':
-        await src.setReaderFuriganaMode((value as bool) ? 'hide' : 'toggle');
+        // 布尔开关只能表达两态：开 = hidden，关 = off（旧实现关掉落到 toggle，
+        // 永远回不到显示态）。
+        await src.setReaderFuriganaMode((value as bool) ? 'hidden' : 'off');
       case 'textIndentation':
         await src.setReaderTextIndentation((value as num).toDouble());
       case 'marginTop':

--- a/fushi/lib/src/media/sources/reader_fushi_source.dart
+++ b/fushi/lib/src/media/sources/reader_fushi_source.dart
@@ -1754,7 +1754,7 @@ class ReaderFushiSource extends ReaderMediaSource {
         getPreference<bool?>(key: 'hide_furigana', defaultValue: null);
     if (legacy != null) {
       final String oldStyle = _legacyFuriganaStyle;
-      final String mode = (legacy as bool) ? 'hide' : 'show';
+      final String mode = (legacy as bool) ? 'hidden' : 'off';
       final String merged = normalizeFuriganaMode(
         (legacy && (oldStyle == 'partial' || oldStyle == 'toggle'))
             ? oldStyle
@@ -1769,7 +1769,7 @@ class ReaderFushiSource extends ReaderMediaSource {
       return merged;
     }
     return normalizeFuriganaMode(
-      getPreference<String>(key: 'furigana_mode', defaultValue: 'show'),
+      getPreference<String>(key: 'furigana_mode', defaultValue: 'off'),
     );
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
@@ -687,8 +687,9 @@ extension _ReaderCaret on _ReaderFushiPageState {
         }
         return KeyEventResult.handled;
       case ShortcutAction.readerToggleFurigana:
-        // Mirror the double-tap furigana toggle so a gamepad (R3) can show/hide
-        // furigana without a pointer double-tap the WebView can't synthesise.
+        // 振假名 toggle 态的整页揭示 / 收回（CSS `body.show-all-rt`）：键盘 / 手柄
+        // (R3) 没有「点一个揭示一个」的指针，这颗键一次揭示全页；off / hidden 态
+        // 没有对应 CSS，按下是 no-op。
         _controller?.evaluateJavascript(
           source: "document.body.classList.toggle('show-all-rt');",
         );

--- a/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
@@ -11,7 +11,7 @@ part of '../reader_fushi_page.dart';
 ///   (d) `_buildWebView` 里调 @protected 的 `prunePopupStack` / `topPopupState`
 ///       改走主壳新增的 `_webviewPrunePopupStack` / `_webviewTopPopupState` 转发器
 ///       （扩展不能直接读写基类 @protected 成员），与 caret 域的 `_caret*` 转发同款。
-///   (e) `_notFound` / `_forbidden` / `_isValidFontData` / `_buildFuriganaJs` /
+///   (e) `_notFound` / `_forbidden` / `_isValidFontData` /
 ///       `_stripScriptTags` 五个 static 连同其唯一调用者一起搬来，作扩展 static 保留
 ///       （裸名可解析）。
 /// 样式/主题域（`_buildStyleTag` / `_computeStyleTag` / `_applyStylesLive` 等）被
@@ -589,35 +589,10 @@ extension _ReaderWebView on _ReaderFushiPageState {
 
   static bool _isValidFontData(Uint8List data) => isValidFontData(data);
 
-  /// BUG-1140 第二阶段①：三种 furigana 模式的监听器全部随引擎发一份，运行时按
-  /// `C.furiganaMode` 选一个装（旧实现在 Dart 侧按 `s.furiganaMode` 三选一插值，
-  /// 那会让引擎源码随设置变化 → 外链缓存与编译复用同时失效）。
-  ///
-  /// 值域与分支判据逐条对齐旧的 `switch (mode)`：`partial` 装 click 切换单个 ruby、
-  /// `toggle` 装 dblclick 切换整页、其余（含 `off`）什么都不装。
-  static String _buildFuriganaJs() {
-    return '''
-  if (C.furiganaMode === 'partial') {
-    document.addEventListener('click', function(e) {
-      var sel = window.getSelection();
-      if (sel && !sel.isCollapsed) return;
-      var node = e.target;
-      while (node && node !== document.body) {
-        if (node.tagName === 'RUBY') {
-          node.classList.toggle('show-rt');
-          return;
-        }
-        node = node.parentElement;
-      }
-    }, true);
-  } else if (C.furiganaMode === 'toggle') {
-    document.addEventListener('dblclick', function() {
-      var sel = window.getSelection();
-      if (sel && !sel.isCollapsed) return;
-      document.body.classList.toggle('show-all-rt');
-    });
-  }''';
-  }
+  // 振假名三态（off / toggle / hidden）不再装任何 JS 监听器：隐藏由 CSS 承担，
+  // toggle 态的「点一个揭示一个」收进 fushiSelection.selectText（查词入口，
+  // 命中隐藏注音的 ruby 只揭示、不查词），整页揭示走 readerToggleFurigana 快捷键。
+  // 旧 `_buildFuriganaJs`（partial 的 click 切换 / toggle 的 dblclick 整页切换）已删。
 
   // ── Single IIFE setup script (mirrors Hoshi Android's readerSetupScript) ──
 
@@ -737,9 +712,6 @@ extension _ReaderWebView on _ReaderFushiPageState {
       ),
     );
 
-    // 三种 furigana 模式的监听器全部随引擎发，运行时按 C.furiganaMode 选一个装。
-    final String furiganaJs = _buildFuriganaJs();
-
     final String caretJs = ReaderCaretScripts.source();
 
     return '''
@@ -786,7 +758,6 @@ install: function(C) {
     insetBottom: C.caretInsetBottom,
     scopeSelector: null
   });
-  $furiganaJs
   // BUG-239: 连续模式不让 _gestureEnd 回传 onSwipe（交给原生滚动 + 边界 IIFE），
   // 消除横向滑动 90% 跳页与原生滚动的轴向冲突；分页模式照旧水平滑动翻页。
   var fushiContinuousMode = C.continuousMode;
@@ -1374,7 +1345,8 @@ install: function(C) {
     if (hasStart && !_fushiReaderMouseNativeTextStart && (Date.now() - startTime) < 400) e.preventDefault();
   });
   // TODO-1028: 砍掉双击建立的原生框选——它会盖住单击查词、并绊住振假名 dblclick
-  // 切换（_buildFuriganaJs 'toggle' 分支带 `!sel.isCollapsed` 守卫）。原生双击选词在
+  // 切换（历史上 'toggle' 分支的 dblclick 整页切换带 `!sel.isCollapsed` 守卫，
+  // 该分支已随三态改造删除，本 capture 清选区仍是单击查词不被双击框选盖住的前提）。原生双击选词在
   // mousedown/selectstart 阶段已发生，dblclick 只是结果，preventDefault 拦不住，故改
   // removeAllRanges 清掉既成选区。用 capture 让它先于振假名 handler（bubble 阶段）跑，
   // 从而振假名切换反而恢复正常（守卫不再被双击选区绊住）。单击查词走 onTap/_selectTextAt

--- a/fushi/lib/src/reader/reader_content_styles.dart
+++ b/fushi/lib/src/reader/reader_content_styles.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart' show defaultTargetPlatform;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:fushi/src/models/cjk_font_families.dart';
 import 'package:fushi/src/models/content_font_chain.dart';
 import 'package:fushi/src/reader/reader_settings.dart';
@@ -173,6 +174,28 @@ class ReaderContentStyles {
   /// 中文字形渲染。接上 [contentFontFamilyCss] 后，语言已知就给该语言的衬线链；
   /// 语言未知（[language] 为 null 或非 CJK）时链为空，退回原来的 `serif`，与改造
   /// 前逐字节一致——不知道语言就不猜，理由见 `content_font_chain.dart`。
+  /// BUG-2472：WebKit（macOS / iOS WKWebView）把**首行含振假名的段落**整体撑高一截：
+  /// `<rt>` 注音盒（0.45em × line-height normal ≈ 0.54em）超出根行盒上半 leading
+  /// （(1.65−1)/2 = 0.325em）的部分，WebKit 不是像 Blink 那样让它悬在 leading 里，
+  /// 而是把段落首行往下推，段落块轴多出 ≈ 0.215em（22 号 4.73px、46 号 6.25px；
+  /// 行距本身不变，Blink 恒为 0）。竖排下就是「有注音的段落列更宽」，段落间距忽宽忽窄。
+  ///
+  /// 修法：只在 WebKit 上声明 `-webkit-line-box-contain: block replaced`——行盒高只由
+  /// 块的 line-height（strut）与替换元素决定，不再被 inline 盒（注音）撑开，注音照旧画
+  /// 在 leading 里；Mac 真机四轮（横/竖 × 22/43）与真书（無職転生 21，横/竖 × 22/46）
+  /// 实测段落多出量归 0、行距不变、注音位置不变。Blink 早已不解析该属性（BUG-611 记录
+  /// 的 `CSS.supports === false`），但旧版 Android WebView 仍解析且 BUG-611 实证
+  /// `block glyphs replaced` 会把竖排注音塌进基字列，故**按平台门控**只发给 Apple 端，
+  /// 且不带 `glyphs`（C3 实测反而把行距撑大 6~9px）。代价：WebKit 上比段落字号大的
+  /// inline 片段（如 `<span style="font-size:1.5em">`）不再撑高所在行；Blink 会撑。
+  static String _webKitLineBoxCss() => switch (defaultTargetPlatform) {
+        TargetPlatform.iOS ||
+        TargetPlatform.macOS =>
+          '  /* BUG-2472: WebKit only — see _webKitLineBoxCss. */\n'
+              '  -webkit-line-box-contain: block replaced !important;\n',
+        _ => '',
+      };
+
   static String _bodyFontFamily(String? customCssFamilies, String? language) {
     final String chain = contentFontFamilyCss(
       languageTag: language,
@@ -467,8 +490,12 @@ html {
      default line-box behaviour (which reserves ruby space) on every engine —
      exactly what current Blink already does correctly (zero regression there),
      and the BUG-108 lesson that Blink WebViews do not add ruby leading unless
-     the line box is allowed to grow. */
-  /* Themed scrollbar: the track stays transparent so it shows the page
+     the line box is allowed to grow.
+     BUG-2472 addendum: on WebKit (macOS / iOS) the SAME reserve is what makes a
+     paragraph whose first line carries furigana taller than its neighbours, so
+     `block replaced` (no `glyphs`) is emitted there and only there — see
+     _webKitLineBoxCss. */
+${_webKitLineBoxCss()}  /* Themed scrollbar: the track stays transparent so it shows the page
      background, and the thumb takes the theme text colour (already alpha<1),
      so dark themes get a light thumb and light themes a dark one. The standard
      props cover Firefox/Chromium 121+; the -webkit pseudo-elements below cover

--- a/fushi/lib/src/reader/reader_content_styles.dart
+++ b/fushi/lib/src/reader/reader_content_styles.dart
@@ -1175,29 +1175,32 @@ body::after {
     // still wins for hidden furigana. The shown modes also own <rtc> (see
     // _rtcAnnotationCss); `hide` hides rtc together with rt so a hidden
     // annotation container cannot keep reserving lane space.
+    // 三态对齐 Hoshi Reader iOS `FuriganaMode { off, toggle, hidden }`（值域见
+    // ReaderSettings.furiganaMode）。`toggle` 的隐藏纯由 CSS 承担，不再靠装载时 JS
+    // 给 ruby 打 class：正文动态换章 / 设置热更新都只重发 CSS，JS 标记会漏掉新
+    // 内容或在热切换后残留。揭示 = 点击那个 ruby 加 `furigana-revealed`
+    // （fushiSelection.selectText 入口，命中隐藏注音的 ruby 只揭示、不查词）；
+    // `body.show-all-rt` 是 readerToggleFurigana 快捷键（手柄 R3）的整页揭示。
     switch (mode) {
-      case 'hide':
+      case 'hidden':
         return 'rt, rtc { display: none !important; }';
-      case 'partial':
-        return '''
-rt {
-  display: ruby-text !important;
-  font-size: 0.45em;
-  visibility: hidden;
-}
-$_rtcAnnotationCss
-ruby.show-rt rt {
-  visibility: visible;
-}''';
       case 'toggle':
         return '''
-rt {
-  display: ruby-text !important;
-  font-size: 0.45em;
-  visibility: hidden;
-}
+rt { display: ruby-text !important; font-size: 0.45em; }
 $_rtcAnnotationCss
-body.show-all-rt rt {
+ruby:not(.furigana-revealed) > rt,
+ruby:not(.furigana-revealed) > rtc,
+ruby:not(.furigana-revealed) > rp {
+  visibility: hidden !important;
+}
+ruby:not(.furigana-revealed):has(rt) {
+  text-decoration-line: underline !important;
+  text-decoration-style: dotted !important;
+  text-decoration-color: rgba(160, 160, 160, 0.8) !important;
+  text-underline-offset: 0.05em !important;
+}
+body.show-all-rt ruby > rt,
+body.show-all-rt ruby > rtc {
   visibility: visible !important;
 }''';
       default:
@@ -1216,7 +1219,7 @@ $_rtcAnnotationCss''';
   /// the annotation into the base column as its own character slot (the
   /// 貫(かん)禄(ろく) screenshot: かん inline between 貫/禄, ろく below the
   /// word). `rtc > rt` is MORE specific than the bare `rt` rule, so it must
-  /// only be emitted in shown modes — in `hide` it would defeat
+  /// only be emitted in shown modes — in `hidden` it would defeat
   /// `rt { display: none !important }` and un-hide rtc furigana.
   static const String _rtcAnnotationCss = '''
 rtc {

--- a/fushi/lib/src/reader/reader_engine_config.dart
+++ b/fushi/lib/src/reader/reader_engine_config.dart
@@ -77,7 +77,8 @@ class ReaderEngineConfig {
   final int swipeFastDistThreshold;
   final int wheelGestureQuietMs;
 
-  /// `off` / `partial` / `toggle`（`ReaderSettings.furiganaMode` 的值域）。
+  /// `off` / `toggle` / `hidden`（`ReaderSettings.furiganaMode` 的值域）。JS 侧
+  /// 现已不按它分支（隐藏由 CSS 承担），仍随 config 下发供探针 / 日志读。
   final String furiganaMode;
 
   // ── caret ─────────────────────────────────────────────────────────

--- a/fushi/lib/src/reader/reader_selection_scripts.dart
+++ b/fushi/lib/src/reader/reader_selection_scripts.dart
@@ -1136,9 +1136,33 @@ window.fushiSelection = {
     }
     return null;
   },
+  // 振假名 toggle 态（ReaderSettings.furiganaMode == 'toggle'，CSS 把未揭示 ruby 的
+  // rt 设成 visibility:hidden）：命中这样的 ruby 时返回它，调用方只揭示不查词。
+  // 判据读注音的**计算样式**而不是某个模式旗——设置热切换只重发 CSS，读旗会过期；
+  // hidden 态 rt 是 display:none（不算），快捷键 show-all-rt 揭示后 visible（不算）。
+  _hiddenFuriganaRubyAt: function(x, y) {
+    var el = document.elementFromPoint(x, y);
+    var ruby = el && el.closest ? el.closest('ruby') : null;
+    if (!ruby || ruby.classList.contains('furigana-revealed')) return null;
+    var rt = ruby.querySelector('rt');
+    if (!rt) return null;
+    var cs = getComputedStyle(rt);
+    if (cs.display === 'none' || cs.visibility !== 'hidden') return null;
+    return ruby;
+  },
   selectText: function(x, y, maxLength, fromHover) {
     if (document.elementFromPoint(x, y)?.closest('a')) {
       return null;
+    }
+    // Hoshi Reader iOS Toggle 语义：点隐藏注音的 ruby = 揭示它，这一下不查词、
+    // 也不算点空白（不 fire onTapEmpty）；悬停查词（fromHover）不揭示。
+    if (!fromHover) {
+      var hiddenRuby = this._hiddenFuriganaRubyAt(x, y);
+      if (hiddenRuby) {
+        hiddenRuby.classList.add('furigana-revealed');
+        this.clearSelection();
+        return null;
+      }
     }
     var hit = this.getCharacterAtPoint(x, y);
     if (!hit) {

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -305,13 +305,21 @@ class ReaderSettings {
   String get theme => _get<String>('theme', 'light-theme');
   Future<void> setTheme(String v) => _set<String>('theme', v);
 
+  /// 振假名显示形态，三态对齐 Hoshi Reader iOS `FuriganaMode`（2026-09-11 用户拍板）：
+  ///  * `off`    —— 原样显示（历史值 `show`）；
+  ///  * `toggle` —— 默认隐藏（`visibility:hidden`，注音轨占位保留、行高不抖），
+  ///                点一个 `<ruby>` 揭示一个，且那一下不查词（历史值 `partial`；
+  ///                历史 `toggle` 是「双击整页切换」，并入此态，整页揭示改由
+  ///                `readerToggleFurigana` 快捷键承担）；
+  ///  * `hidden` —— `display:none`（历史值 `hide`）。
+  /// 持久化键 `furigana_mode` 不变，旧值经 [normalizeFuriganaMode] 归一化。
   String get furiganaMode {
     final dynamic raw = _cache['hide_furigana'];
     final bool? legacy = raw is bool ? raw : null;
     if (legacy != null) {
       final String oldStyle =
           _get<String>('furigana_style', 'partial').toLowerCase();
-      final String mode = legacy ? 'hide' : 'show';
+      final String mode = legacy ? 'hidden' : 'off';
       final String merged = normalizeFuriganaMode(
         (legacy && (oldStyle == 'partial' || oldStyle == 'toggle'))
             ? oldStyle
@@ -324,7 +332,7 @@ class ReaderSettings {
       return merged;
     }
     return normalizeFuriganaMode(
-      _get<String>('furigana_mode', 'show'),
+      _get<String>('furigana_mode', 'off'),
     );
   }
 
@@ -859,16 +867,20 @@ class ReaderSettings {
   ({String fontFamily, String fontFaces}) buildCustomFontCss() =>
       customFontCssForEntries(customFonts);
 
+  /// 三态 `off` / `toggle` / `hidden`（见 [furiganaMode]）。历史四态映射：
+  /// `show`→`off`、`partial`→`toggle`、`toggle`→`toggle`、`hide`→`hidden`；
+  /// 其余一律 `off`。
   static String normalizeFuriganaMode(String mode) =>
-      switch (mode.toLowerCase()) {
-        'show' || 'hide' || 'partial' || 'toggle' => mode.toLowerCase(),
-        _ => 'show',
+      switch (mode.toLowerCase().trim()) {
+        'off' || 'show' => 'off',
+        'toggle' || 'partial' => 'toggle',
+        'hidden' || 'hide' => 'hidden',
+        _ => 'off',
       };
 
   static String furiganaModeToStyle(String mode) =>
       switch (normalizeFuriganaMode(mode)) {
-        'hide' => 'Hide',
-        'partial' => 'Partial',
+        'hidden' => 'Hide',
         'toggle' => 'Toggle',
         _ => 'Show',
       };

--- a/fushi/lib/src/settings/settings_schema_reading.dart
+++ b/fushi/lib/src/settings/settings_schema_reading.dart
@@ -185,26 +185,22 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.translate_outlined,
             controlBelow: true,
             reader: const ReaderPlacement(group: ReaderGroup.layout, order: 13),
+            // 三态对齐 Hoshi Reader iOS：Off / Toggle / Hidden。
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
-                value: 'show',
-                label: t.reader_furigana_show,
-                tooltip: t.reader_furigana_show,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'hide',
-                label: t.reader_furigana_hide,
-                tooltip: t.reader_furigana_hide,
-              ),
-              SettingsSegmentOption<String>(
-                value: 'partial',
-                label: t.reader_furigana_partial,
-                tooltip: t.reader_furigana_partial,
+                value: 'off',
+                label: t.reader_furigana_off,
+                tooltip: t.reader_furigana_off,
               ),
               SettingsSegmentOption<String>(
                 value: 'toggle',
                 label: t.reader_furigana_toggle,
                 tooltip: t.reader_furigana_toggle,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'hidden',
+                label: t.reader_furigana_hidden,
+                tooltip: t.reader_furigana_hidden,
               ),
             ],
             selected: (SettingsContext c) => c.readerSource.readerFuriganaMode,

--- a/fushi/test/i18n/strings_test.dart
+++ b/fushi/test/i18n/strings_test.dart
@@ -6,8 +6,9 @@ void main() {
     test('uses compact labels for furigana modes', () {
       final strings = AppLocale.zhCn.translations;
 
-      expect(strings.reader_furigana_partial, '部分');
-      expect(strings.reader_furigana_toggle, '切换');
+      expect(strings.reader_furigana_off, '关闭');
+      expect(strings.reader_furigana_toggle, '点击显示');
+      expect(strings.reader_furigana_hidden, '隐藏');
       expect(
         strings.reader_furigana_mode_hint,
         '',

--- a/fushi/test/reader/furigana_mode_dedup_test.dart
+++ b/fushi/test/reader/furigana_mode_dedup_test.dart
@@ -10,10 +10,12 @@ import 'package:fushi/src/reader/reader_settings.dart';
 /// 并用源码守卫确认 source 端不再保留重复的 switch 分支。
 void main() {
   const inputs = <String>[
+    'off',
+    'toggle',
+    'hidden',
     'show',
     'hide',
     'partial',
-    'toggle',
     'SHOW',
     'Hide',
     'PARTIAL',
@@ -41,6 +43,69 @@ void main() {
         expect(
           ReaderFushiSource.furiganaModeToStyle(m),
           ReaderSettings.furiganaModeToStyle(m),
+          reason: 'input="$m"',
+        );
+      }
+    });
+
+    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
+      expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
+      // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
+      expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hide'), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
+      // 只剩三个规范值。
+      for (final m in inputs) {
+        expect(
+          <String>['off', 'toggle', 'hidden'],
+          contains(ReaderSettings.normalizeFuriganaMode(m)),
+          reason: 'input="$m"',
+        );
+      }
+    });
+
+    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
+      expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
+      // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
+      expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hide'), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
+      // 只剩三个规范值。
+      for (final m in inputs) {
+        expect(
+          <String>['off', 'toggle', 'hidden'],
+          contains(ReaderSettings.normalizeFuriganaMode(m)),
+          reason: 'input="$m"',
+        );
+      }
+    });
+
+    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
+      expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
+      // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
+      expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
+      expect(ReaderSettings.normalizeFuriganaMode('hide'), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
+      expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
+      expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
+      // 只剩三个规范值。
+      for (final m in inputs) {
+        expect(
+          <String>['off', 'toggle', 'hidden'],
+          contains(ReaderSettings.normalizeFuriganaMode(m)),
           reason: 'input="$m"',
         );
       }

--- a/fushi/test/reader/reader_content_styles_test.dart
+++ b/fushi/test/reader/reader_content_styles_test.dart
@@ -300,26 +300,63 @@ void main() {
   });
 
   group('ReaderContentStyles furigana modes', () {
-    test('default mode shows furigana', () async {
+    test('default mode (off) shows furigana', () async {
       final ReaderSettings settings = await _defaultSettings();
+      expect(settings.furiganaMode, 'off');
       final String css = ReaderContentStyles.css(settings: settings);
-      // Default furigana mode is 'show' → rt { font-size: 0.45em; }
+      // Default furigana mode is 'off' → rt { font-size: 0.45em; }, nothing hidden.
       expect(css, contains('rt'));
       expect(css, contains('0.45em'));
+      expect(css, isNot(contains('furigana-revealed')));
+      expect(css, isNot(contains('rt, rtc { display: none !important; }')));
     });
 
-    test('hide furigana mode via themeOverride still renders rt rule',
+    test('hidden mode renders display:none for rt/rtc (legacy value "hide" too)',
         () async {
       final FushiDatabase db =
           FushiDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final ReaderSettings settings = ReaderSettings(db);
       await settings.refreshFromDb();
+      await settings.setFuriganaMode('hidden');
+      expect(ReaderContentStyles.css(settings: settings),
+          contains('rt, rtc { display: none !important; }'));
       await settings.setFuriganaMode('hide');
+      expect(settings.furiganaMode, 'hidden');
+      expect(ReaderContentStyles.css(settings: settings),
+          contains('rt, rtc { display: none !important; }'));
+    });
 
+    test('toggle mode: CSS-owned hide + per-ruby reveal + dotted hint + '
+        'whole-page reveal (Hoshi Reader iOS Toggle)', () async {
+      final FushiDatabase db =
+          FushiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      await settings.setFuriganaMode('toggle');
       final String css = ReaderContentStyles.css(settings: settings);
-      expect(css, contains('rt'));
-      expect(css, contains('display: none'));
+      // 未揭示的 ruby：注音 visibility:hidden（占位保留，行高不抖），不是 display:none。
+      expect(
+          css,
+          contains('ruby:not(.furigana-revealed) > rt,\n'
+              'ruby:not(.furigana-revealed) > rtc,\n'
+              'ruby:not(.furigana-revealed) > rp {\n'
+              '  visibility: hidden !important;\n}'));
+      expect(css, isNot(contains('rt, rtc { display: none !important; }')));
+      // 显示态仍强制 rt 为 ruby-text（TODO-1308），rtc 接管照旧。
+      expect(css, contains('rt { display: ruby-text !important; font-size: 0.45em; }'));
+      // 灰色虚线下划线提示可点（与 Hoshi iOS 同款）。
+      expect(css, contains('ruby:not(.furigana-revealed):has(rt) {'));
+      expect(css, contains('text-decoration-style: dotted !important;'));
+      expect(css, contains('text-decoration-color: rgba(160, 160, 160, 0.8) !important;'));
+      // readerToggleFurigana 快捷键的整页揭示。
+      expect(css, contains('body.show-all-rt ruby > rt,\nbody.show-all-rt ruby > rtc {\n  visibility: visible !important;\n}'));
+      // 旧四态残留不得复活。
+      expect(css, isNot(contains('show-rt rt')));
+      // 历史值 partial 归到 toggle。
+      await settings.setFuriganaMode('partial');
+      expect(settings.furiganaMode, 'toggle');
     });
   });
 

--- a/fushi/test/reader/reader_dblclick_clear_selection_behavior_test.js
+++ b/fushi/test/reader/reader_dblclick_clear_selection_behavior_test.js
@@ -42,13 +42,17 @@ const captureMatch = source.match(
 assert.ok(captureMatch, 'missing TODO-1028 capture-phase clear-selection dblclick listener');
 const captureListener = captureMatch[0];
 
-// (2) Extract the furigana 'toggle' dblclick handler from _buildFuriganaJs. It is
-// inside a Dart triple-quoted string; grab the addEventListener statement only.
-const toggleMatch = source.match(
-  /document\.addEventListener\('dblclick',\s*function\(\)\s*\{\s*var sel = window\.getSelection\(\);\s*if \(sel && !sel\.isCollapsed\) return;\s*document\.body\.classList\.toggle\('show-all-rt'\);\s*\}\);/,
-);
-assert.ok(toggleMatch, "missing _buildFuriganaJs 'toggle' dblclick handler");
-const furiganaListener = toggleMatch[0];
+// (2) The furigana whole-page dblclick toggle was removed with the three-state
+// furigana rework (whole-page reveal moved to the readerToggleFurigana
+// shortcut). The harness keeps a stand-in bubble-phase listener that mirrors the
+// old guard so the test still proves the ORDER contract: the capture clear runs
+// first, so a bubble listener guarded by `!sel.isCollapsed` is not tripped.
+const furiganaListener =
+  "document.addEventListener('dblclick', function() {" +
+  ' var sel = window.getSelection();' +
+  ' if (sel && !sel.isCollapsed) return;' +
+  " document.body.classList.toggle('show-all-rt');" +
+  ' });';
 
 function makeHarness() {
   // capture-phase listeners run before bubble-phase ones (browser order). The

--- a/fushi/test/reader/reader_dblclick_clear_selection_guard_test.dart
+++ b/fushi/test/reader/reader_dblclick_clear_selection_guard_test.dart
@@ -61,21 +61,14 @@ void main() {
     );
   });
 
-  test('furigana whole-page double-click toggle is preserved', () {
+  test('furigana dblclick whole-page toggle stays removed (three-state)', () {
+    // 振假名三态改造：整页揭示改走 readerToggleFurigana 快捷键，dblclick 不再
+    // 切 show-all-rt；否则双击选词又会顺带翻振假名。
     final String src = webview.readAsStringSync();
-    final RegExp furiganaToggle = RegExp(
-      r"document\.addEventListener\('dblclick',\s*function\(\)\s*\{\s*"
-      r'var sel = window\.getSelection\(\);\s*'
-      r'if \(sel && !sel\.isCollapsed\) return;\s*'
-      r"document\.body\.classList\.toggle\('show-all-rt'\);\s*"
-      r'\}\);',
-    );
     expect(
-      furiganaToggle.hasMatch(src),
-      isTrue,
-      reason: 'the furigana whole-page toggle dblclick handler '
-          '(show-all-rt) must remain intact and must NOT be confused with the '
-          'TODO-1028 clear-selection listener',
+      src.contains("document.body.classList.toggle('show-all-rt')"),
+      isFalse,
+      reason: 'no dblclick furigana toggle in the engine setup script',
     );
   });
 }

--- a/fushi/test/reader/reader_engine_static_source_guard_test.dart
+++ b/fushi/test/reader/reader_engine_static_source_guard_test.dart
@@ -168,8 +168,11 @@ void main() {
       final String engine = readerFushiEngineSource();
       expect(engine.contains('window.fushiCaret.init({'), isTrue);
       expect(engine.contains('color: C.caretColor,'), isTrue);
-      expect(engine.contains("C.furiganaMode === 'partial'"), isTrue);
-      expect(engine.contains("C.furiganaMode === 'toggle'"), isTrue);
+      // 振假名三态后 JS 不再按 C.furiganaMode 分支（隐藏由 CSS 承担，揭示在
+      // fushiSelection.selectText）；旧的 partial click / toggle dblclick 监听器
+      // 不得复活。
+      expect(engine.contains("C.furiganaMode === 'partial'"), isFalse);
+      expect(engine.contains("classList.toggle('show-rt')"), isFalse);
     });
   });
 

--- a/fushi/test/reader/reader_furigana_toggle_reveal_behavior_test.dart
+++ b/fushi/test/reader/reader_furigana_toggle_reveal_behavior_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 振假名三态 `toggle`（对齐 Hoshi Reader iOS FuriganaMode.toggle）的行为级守卫：
+/// 用 node 执行 `reader_furigana_toggle_reveal_behavior_test.js`，它从
+/// `reader_selection_scripts.dart` 原样切出生产的 `_hiddenFuriganaRubyAt` /
+/// `selectText`，断言「点隐藏注音的 ruby = 只揭示、不查词、不算点空白」，以及
+/// hidden 态 / 已揭示 / 注音可见 / 悬停查词四种情况照常查词。
+///
+/// 当本机/CI 没有 node 时自动 skip；有 node 的环境真跑。
+void main() {
+  test(
+      'tapping a hidden-furigana ruby reveals it without lookup '
+      '(executes fushiSelection.selectText via node)', () async {
+    final String? nodeExe = _resolveNode();
+    if (nodeExe == null) {
+      markTestSkipped('node not found on PATH; skipping JS behavior execution');
+      return;
+    }
+
+    final File jsTest = File(
+      'test/reader/reader_furigana_toggle_reveal_behavior_test.js',
+    );
+    expect(jsTest.existsSync(), isTrue,
+        reason: 'behavior harness ${jsTest.path} must exist');
+
+    final ProcessResult result = await Process.run(
+      nodeExe,
+      <String>[jsTest.path],
+      workingDirectory: Directory.current.path,
+    );
+
+    expect(
+      result.exitCode,
+      0,
+      reason: 'furigana toggle reveal JS behavior test failed.\n'
+          'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+    );
+    expect(
+      result.stdout.toString(),
+      contains('all assertions passed'),
+      reason: 'behavior harness must reach its success marker',
+    );
+  });
+
+  test('selectText reveals before lookup and never for hover (source guard)',
+      () {
+    final String src =
+        File('lib/src/reader/reader_selection_scripts.dart').readAsStringSync();
+    final int reveal =
+        src.indexOf('var hiddenRuby = this._hiddenFuriganaRubyAt(x, y);');
+    final int lookup = src.indexOf('var hit = this.getCharacterAtPoint(x, y);');
+    expect(reveal, greaterThanOrEqualTo(0));
+    expect(lookup, greaterThan(reveal), reason: '揭示判断必须在取字查词之前');
+    final String between = src.substring(reveal - 40, lookup);
+    expect(between, contains('if (!fromHover) {'), reason: '悬停查词不得揭示振假名');
+    expect(between, contains("classList.add('furigana-revealed')"));
+  });
+}
+
+/// Resolve a usable `node` executable, returning null when none is on PATH.
+String? _resolveNode() {
+  final List<String> candidates =
+      Platform.isWindows ? <String>['node.exe', 'node'] : <String>['node'];
+  for (final String name in candidates) {
+    try {
+      final ProcessResult probe = Process.runSync(name, <String>['--version']);
+      if (probe.exitCode == 0) {
+        return name;
+      }
+    } on ProcessException {
+      // Not found; try next candidate.
+    }
+  }
+  return null;
+}

--- a/fushi/test/reader/reader_furigana_toggle_reveal_behavior_test.js
+++ b/fushi/test/reader/reader_furigana_toggle_reveal_behavior_test.js
@@ -1,0 +1,142 @@
+// 振假名三态 `toggle`（对齐 Hoshi Reader iOS FuriganaMode.toggle）的行为测试：
+// 点到「注音被 CSS 藏起来」的 <ruby> 时，fushiSelection.selectText 必须只揭示它
+// （加 `furigana-revealed`）、清选区、**不查词**（不调 getCharacterAtPoint /
+// selectFromPosition）、也不当作点空白（不 fire onTapEmpty）；而 hidden 态
+// （rt display:none）、已揭示、注音本就可见、悬停查词（fromHover）四种情况都照常走
+// 查词路径。
+//
+// 本测试从 reader_selection_scripts.dart 原样切出生产的 `_hiddenFuriganaRubyAt`
+// 与 `selectText` 两个方法在 node vm 里执行，配一个最小假 DOM。
+//
+// Run: node fushi/test/reader/reader_furigana_toggle_reveal_behavior_test.js
+// (also driven from reader_furigana_toggle_reveal_behavior_test.dart so it runs
+//  inside `flutter test`).
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const scriptsPath = path.resolve(
+  __dirname,
+  '../../lib/src/reader/reader_selection_scripts.dart',
+);
+const source = fs.readFileSync(scriptsPath, 'utf8').replace(/\r\n/g, '\n');
+
+function extractMethod(name) {
+  const start = source.indexOf(`\n  ${name}: function(`);
+  assert.ok(start >= 0, `missing ${name} in reader_selection_scripts.dart`);
+  const end = source.indexOf('\n  },\n', start);
+  assert.ok(end > start, `unterminated ${name}`);
+  // "  name: function(...) { ... }" (without the trailing comma).
+  return source.slice(start + 1, end + 4);
+}
+
+const hiddenRubyAt = extractMethod('_hiddenFuriganaRubyAt');
+const selectText = extractMethod('selectText');
+
+function makeClassList(initial) {
+  const set = new Set(initial || []);
+  return {
+    add(n) { set.add(n); },
+    contains(n) { return set.has(n); },
+    has(n) { return set.has(n); },
+  };
+}
+
+// scenario: { rtDisplay, rtVisibility, revealed, hasRt, hitTextNode }
+function makeHarness(sc) {
+  const rt = sc.hasRt === false ? null : { tag: 'rt' };
+  const ruby = {
+    classList: makeClassList(sc.revealed ? ['furigana-revealed'] : []),
+    querySelector(sel) { return sel === 'rt' ? rt : null; },
+  };
+  const rb = {
+    closest(sel) {
+      if (sel === 'a') return null;
+      if (sel === 'ruby') return ruby;
+      return null;
+    },
+  };
+  const calls = { getCharacterAtPoint: 0, selectFromPosition: 0, clearSelection: 0, onTapEmpty: 0 };
+  const documentObj = {
+    elementFromPoint() { return rb; },
+  };
+  const windowObj = {
+    flutter_inappwebview: { callHandler(name) { if (name === 'onTapEmpty') calls.onTapEmpty++; } },
+  };
+  const sandbox = {
+    document: documentObj,
+    window: windowObj,
+    getComputedStyle(el) {
+      assert.strictEqual(el, rt, 'must read the computed style of the ruby\'s <rt>');
+      return { display: sc.rtDisplay || 'ruby-text', visibility: sc.rtVisibility || 'visible' };
+    },
+  };
+  vm.createContext(sandbox);
+  const prepared =
+    '(function(){ var o = {\n' +
+    hiddenRubyAt + ',\n' +
+    selectText + ',\n' +
+    '  selection: null,\n' +
+    '  getCharacterAtPoint: function() { calls.getCharacterAtPoint++; return { node: {}, offset: 0 }; },\n' +
+    '  clearSelection: function() { calls.clearSelection++; },\n' +
+    '  selectFromPosition: function() { calls.selectFromPosition++; return "looked-up"; }\n' +
+    '}; return o; })()';
+  sandbox.calls = calls;
+  const obj = vm.runInContext(prepared, sandbox, { filename: 'furigana-toggle-reveal.js' });
+  return { obj, ruby, calls };
+}
+
+// 1. toggle 态未揭示（rt visibility:hidden）：点击 = 揭示，不查词、不算点空白。
+(function () {
+  const h = makeHarness({ rtVisibility: 'hidden' });
+  const r = h.obj.selectText(10, 20, 50, false);
+  assert.strictEqual(r, null, 'reveal tap returns null (no selection payload)');
+  assert.strictEqual(h.ruby.classList.contains('furigana-revealed'), true, 'ruby must be revealed');
+  assert.strictEqual(h.calls.getCharacterAtPoint, 0, 'reveal tap must NOT look up a word');
+  assert.strictEqual(h.calls.selectFromPosition, 0, 'reveal tap must NOT build a selection');
+  assert.strictEqual(h.calls.onTapEmpty, 0, 'reveal tap is not an empty tap');
+  assert.strictEqual(h.calls.clearSelection, 1, 'reveal tap clears any prior selection');
+})();
+
+// 2. 已揭示的 ruby：照常查词。
+(function () {
+  const h = makeHarness({ rtVisibility: 'hidden', revealed: true });
+  const r = h.obj.selectText(10, 20, 50, false);
+  assert.strictEqual(r, 'looked-up', 'revealed ruby taps look up normally');
+  assert.strictEqual(h.calls.getCharacterAtPoint, 1);
+})();
+
+// 3. hidden 态（rt display:none）：不是「可揭示」，照常查词。
+(function () {
+  const h = makeHarness({ rtDisplay: 'none', rtVisibility: 'hidden' });
+  const r = h.obj.selectText(10, 20, 50, false);
+  assert.strictEqual(r, 'looked-up', 'display:none furigana (hidden mode) is not revealable');
+  assert.strictEqual(h.ruby.classList.contains('furigana-revealed'), false);
+})();
+
+// 4. off 态 / 快捷键整页揭示后（rt 可见）：照常查词。
+(function () {
+  const h = makeHarness({ rtVisibility: 'visible' });
+  const r = h.obj.selectText(10, 20, 50, false);
+  assert.strictEqual(r, 'looked-up', 'visible furigana taps look up normally');
+  assert.strictEqual(h.ruby.classList.contains('furigana-revealed'), false);
+})();
+
+// 5. 悬停查词（fromHover）不揭示：鼠标滑过不能把注音一路翻开。
+(function () {
+  const h = makeHarness({ rtVisibility: 'hidden' });
+  const r = h.obj.selectText(10, 20, 50, true);
+  assert.strictEqual(r, 'looked-up', 'hover lookup ignores hidden furigana');
+  assert.strictEqual(h.ruby.classList.contains('furigana-revealed'), false, 'hover must not reveal');
+})();
+
+// 6. ruby 里没有 rt（只有 rp 之类）：没什么可揭示，照常查词。
+(function () {
+  const h = makeHarness({ hasRt: false, rtVisibility: 'hidden' });
+  const r = h.obj.selectText(10, 20, 50, false);
+  assert.strictEqual(r, 'looked-up', 'ruby without <rt> is not revealable');
+})();
+
+console.log('reader_furigana_toggle_reveal_behavior_test.js: all assertions passed');

--- a/fushi/test/reader/vertical_ruby_display_context_guard_test.dart
+++ b/fushi/test/reader/vertical_ruby_display_context_guard_test.dart
@@ -56,7 +56,7 @@ void main() {
     test('ruby 容器与 rp 在所有布局都强制 display(!important)', () async {
       for (final ({String wm, String vm}) c in layouts) {
         final String css = await _readerCss(
-            writingMode: c.wm, viewMode: c.vm, furiganaMode: 'show');
+            writingMode: c.wm, viewMode: c.vm, furiganaMode: 'off');
         expect(
             css.contains(
                 'ruby { display: ruby !important; ruby-position: over !important; }'),
@@ -81,7 +81,7 @@ void main() {
       // center=基字列)错位到振假名列。over 横排=基字上方、竖排=基字右侧，两写向都对。
       for (final ({String wm, String vm}) c in layouts) {
         final String css = await _readerCss(
-            writingMode: c.wm, viewMode: c.vm, furiganaMode: 'show');
+            writingMode: c.wm, viewMode: c.vm, furiganaMode: 'off');
         expect(css.contains('ruby-position: over !important'), isTrue,
             reason: '${c.wm}/${c.vm}: 必须强制 ruby-position:over!important，否则书本 '
                 '`ruby{ruby-position:under}` 竖排把振假名翻到基字左侧 + 高亮带错位');
@@ -100,7 +100,7 @@ void main() {
       final String css = await _readerCss(
           writingMode: 'vertical-rl',
           viewMode: 'continuous',
-          furiganaMode: 'show');
+          furiganaMode: 'off');
       expect(css.contains('ruby-position: over !important'), isTrue,
           reason: '竖排必须 ruby-position:over(振假名在右、留在基字高亮盒外)');
       expect(
@@ -112,9 +112,8 @@ void main() {
           reason: 'BUG-716：不再有 narrow-lane 窄条(避免 left 落点在宽盒/含注音轨时偏移)');
     });
 
-    test('振假名显示态(show/partial/toggle) rt 强制 display:ruby-text(!important)',
-        () async {
-      for (final String fm in <String>['show', 'partial', 'toggle']) {
+    test('振假名显示态(off/toggle) rt 强制 display:ruby-text(!important)', () async {
+      for (final String fm in <String>['off', 'toggle']) {
         final String css = await _readerCss(
             writingMode: 'vertical-rl',
             viewMode: 'continuous',
@@ -134,7 +133,7 @@ void main() {
       // 会把 rtc 里的每个 <rt> 包进匿名 ruby，落在正文流原位=注音以整字格内联进基字列
       // (用户截图：かん挤在貫/禄之间、ろく掉到词下方)。修复=显示态把 rtc 整个映射为
       // 单一注音级(display:ruby-text)、其 rt 子元素归位 inline(在注音里当普通文本跑)。
-      for (final String fm in <String>['show', 'partial', 'toggle']) {
+      for (final String fm in <String>['off', 'toggle']) {
         final String css = await _readerCss(
             writingMode: 'vertical-rl',
             viewMode: 'continuous',
@@ -153,11 +152,11 @@ void main() {
       }
     });
 
-    test('振假名 hide 模式 rt 仍是 display:none(强制显示不得覆盖隐藏)', () async {
+    test('振假名 hidden 模式 rt 仍是 display:none(强制显示不得覆盖隐藏)', () async {
       final String css = await _readerCss(
           writingMode: 'vertical-rl',
           viewMode: 'continuous',
-          furiganaMode: 'hide');
+          furiganaMode: 'hidden');
       expect(css.contains('rt, rtc { display: none !important; }'), isTrue,
           reason: 'hide 模式必须保留 rt,rtc{display:none!important}(振假名与 rtc 注音容器'
               '一起隐藏，防空 rtc 注音盒继续占注音道)');

--- a/fushi/test/reader/vertical_ruby_line_box_contain_guard_test.dart
+++ b/fushi/test/reader/vertical_ruby_line_box_contain_guard_test.dart
@@ -1,4 +1,6 @@
 import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/reader/reader_content_styles.dart';
@@ -56,6 +58,46 @@ void main() {
               '声明——它会抹掉竖排 ruby 交叉轴预留 → 振假名塌进基字(BUG-611)。'
               '删除后所有引擎回到默认 line-box 行为(为 ruby 预留空间)。',
         );
+      }
+    });
+
+    test(
+        'BUG-2472：只有 Apple 端（WebKit）发出 `block replaced`，且绝不带 glyphs；'
+        'Android / Windows / Linux 一律不发', () async {
+      for (final TargetPlatform p in <TargetPlatform>[
+        TargetPlatform.iOS,
+        TargetPlatform.macOS,
+      ]) {
+        debugDefaultTargetPlatformOverride = p;
+        try {
+          final String css = _stripCssComments(await _readerCss(
+              writingMode: 'vertical-rl', viewMode: 'paginated'));
+          expect(
+              css.contains(
+                  '-webkit-line-box-contain: block replaced !important;'),
+              isTrue,
+              reason: '$p：WebKit 必须只按块 line-height + 替换元素算行盒，'
+                  '否则首行含注音的段落被撑高 ≈0.215em（BUG-2472）');
+          expect(css.contains('glyphs'), isFalse,
+              reason: '$p：不得带回 BUG-611 的 glyphs（实测把行距撑大 6~9px）');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      }
+      for (final TargetPlatform p in <TargetPlatform>[
+        TargetPlatform.android,
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      ]) {
+        debugDefaultTargetPlatformOverride = p;
+        try {
+          final String css = _stripCssComments(await _readerCss(
+              writingMode: 'vertical-rl', viewMode: 'paginated'));
+          expect(css.contains('-webkit-line-box-contain'), isFalse,
+              reason: '$p：Blink / 旧 Android WebView 不得收到该属性（BUG-611）');
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
       }
     });
 

--- a/tool/run_mac_itest.ps1
+++ b/tool/run_mac_itest.ps1
@@ -11,8 +11,21 @@
 # Usage (from the repo root D:\APP\vs_claude_code\hibiki):
 #   .\tool\run_mac_itest.ps1
 #   .\tool\run_mac_itest.ps1 integration_test/desktop_reader_css_dom_test.dart
+#   .\tool\run_mac_itest.ps1 integration_test/<t>_test.dart -Ios [-IosDevice <udid>]
+#
+# `-Ios`: run the SAME test on an iOS simulator hosted by that Mac instead of
+# the macOS app (WebKit + the real 34pt safe area). The simulator is booted
+# first if it is shut down (`xcrun simctl boot` is a no-op when already
+# booted). `-IosDevice` is the simulator udid; when omitted the first
+# available iPhone simulator is picked on the Mac. The iOS build needs the
+# Rust aarch64-apple-ios-sim target and `~/.cargo/bin` on PATH. There is no
+# isolated data root to pass: a simulator container is a clean library
+# already. To look at the real screen use `xcrun simctl io <udid> screenshot`
+# (captureFlutterFrame cannot grab pixels on iOS; the WebView screenshot can).
 param(
-  [string]$Target = "integration_test/desktop_settings_smoke_test.dart"
+  [string]$Target = "integration_test/desktop_settings_smoke_test.dart",
+  [switch]$Ios,
+  [string]$IosDevice = ""
 )
 
 $mac = "shfaifsj@192.168.1.34"
@@ -28,12 +41,25 @@ Write-Host "[mac-itest] syncing committed history to Mac..." -ForegroundColor Cy
 # env, fast-forwards the checkout, and runs the test hidden on -d macos.
 $lines = @(
   'export LANG=en_US.UTF-8',
-  'export PATH=$HOME/flutter/bin:$HOME/.gem/ruby/2.6.0/bin:$PATH',
-  'cd ~/dev/hibiki && git fetch origin && git merge --ff-only origin/develop && cd fushi',
-  "FUSHI_TEST_HIDDEN=1 flutter test $Target -d macos --no-pub"
+  'export PATH=$HOME/flutter/bin:$HOME/.gem/ruby/2.6.0/bin:$HOME/.cargo/bin:$PATH',
+  'cd ~/dev/hibiki && git fetch origin && git merge --ff-only origin/develop && cd fushi'
 )
+if ($Ios) {
+  if ($IosDevice) {
+    $lines += "dev=$IosDevice"
+  } else {
+    # First available iPhone simulator udid (36-char UUID in the simctl listing).
+    $lines += 'dev=$(xcrun simctl list devices available | grep iPhone | grep -oE "[0-9A-F-]{36}" | head -1)'
+    $lines += 'test -n "$dev" || { echo "[mac-itest] no available iPhone simulator" >&2; exit 2; }'
+  }
+  $lines += 'xcrun simctl boot "$dev" 2>/dev/null || true'
+  $lines += "FUSHI_TEST_HIDDEN=1 flutter test $Target -d `"`$dev`" --no-pub"
+} else {
+  $lines += "FUSHI_TEST_HIDDEN=1 flutter test $Target -d macos --no-pub"
+}
 $b64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(($lines -join "`n")))
 
-Write-Host "[mac-itest] running $Target on macOS (hidden runner)..." -ForegroundColor Cyan
+$where = if ($Ios) { "iOS simulator" + $(if ($IosDevice) { " $IosDevice" } else { "" }) } else { "macOS (hidden runner)" }
+Write-Host "[mac-itest] running $Target on $where..." -ForegroundColor Cyan
 ssh $mac "echo $b64 | base64 --decode | bash"
 exit $LASTEXITCODE


### PR DESCRIPTION
## 内容

### 振假名开关改成三态 Off / Toggle / Hidden（对齐 Hoshi Reader iOS）
原布尔「隐藏振假名」改成三态：Off（正常显示）/ Toggle（默认隐藏，点击该词揭示注音、不查词）/ Hidden（一直隐藏）。设置 schema、阅读器 JS/CSS、i18n 一起改；旧布尔偏好值按原语义映射。

### BUG-2472 WebKit 上首行含振假名的段落被撑高
macOS / iOS 的 WebKit 对段落首行含 `<ruby>` 时把行盒撑高一截（Blink 不会），段首多出一条空带。真机量过横排 / 竖排 × 字号 22/43 四轮。修：平台门控注入 `-webkit-line-box-contain: block replaced`，Blink 侧零变化。

### 取证工具
- 振假名三态真 app 集成测试（toggle 揭示不查词 / hidden / off 热切换）。
- 振假名行盒高度跨引擎探针 itest（Blink 基线 vs WebKit；横竖排 × 两档字号；可经 dart-define 传真书 EPUB；含段落块轴多出量）。
- `tool/run_mac_itest.ps1 -Ios`：同一份集成测试跑在 Mac 上的 iOS 模拟器（WebKit + 真安全区）。

## 测试
Windows 离屏 runner 与 Mac 跨机各跑一遍振假名三态 itest；BUG-2472 在 Mac / iOS 模拟器上用探针量过修复前后的行盒高度。

## 备注
本地 develop 上 BUG-2472 的号是 BUG-2459，上游号池已占，PR 内改号。
