### PR TITLE
feat(backup): games 成为可选备份类别；修 BUG-2475/2476

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2282 条。点号进各自文件。
+> 共 2284 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2476](bugs/BUG-2476-backup-import-progress-statistics-switches-hidden.md) | ✅ | ✅ | 备份导入对话框永不显示「进度」「统计」开关 |
+| [BUG-2475](bugs/BUG-2475-backup-statistics-category-leaks-study-segments.md) | ✅ | ✅ | 备份取消勾选「统计」仍外泄 study_segments |
 | [BUG-2473](bugs/BUG-2473-manga-download-all-subscription-download-center.md) | ✅ | ✅ | 作品页下载全部/自动识别/订阅自动下载，mokuro 队列并入持久任务表，下载中心分区 |
 | [BUG-2472](bugs/BUG-2472-webkit-ruby-paragraph-first-line-growth.md) | ✅ | ✅ | WebKit 上首行含振假名的段落被撑高一截 |
 | [BUG-2471](bugs/BUG-2471-reader-settings-live-engine-config.md) | ✅ | ✅ | 阅读器边距等设置改完不实时生效 |

--- a/docs/bugs/BUG-2475-backup-statistics-category-leaks-study-segments.md
+++ b/docs/bugs/BUG-2475-backup-statistics-category-leaks-study-segments.md
@@ -1,0 +1,6 @@
+## BUG-2475 · 备份取消勾选「统计」仍外泄 study_segments
+- **报告**：2026-09-12（用户要求「所有数据类别都可选导出/导入」时审计发现）
+- **真实性**：✅ 真 bug。`fushi/lib/src/sync/backup_service.dart` 的 `_statisticsTables` 在 v92 加了唯一事实表 `study_segments` / `study_segment_tombstones` 之后没有跟进，导出时取消勾选「统计」只 DELETE 旧的 reading/video/mining 统计表，学习时长事实原样随包走；覆盖导入未勾「统计」同样裁不掉。
+- **[x] ① 已修复** — `_statisticsTables` 补上两张表（`backup_service.dart:618-629`），`statsCount` 改为含 `study_segments`（`_countStatisticsRows`）；提交 `07ab311561`。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/backup_games_category_test.dart`「统计类别裁 study_segments」用例。
+- **备注**：与 BUG-2476 同一提交（备份 games 类别 PR）。

--- a/docs/bugs/BUG-2476-backup-import-progress-statistics-switches-hidden.md
+++ b/docs/bugs/BUG-2476-backup-import-progress-statistics-switches-hidden.md
@@ -1,0 +1,6 @@
+## BUG-2476 · 备份导入对话框永不显示「进度」「统计」开关
+- **报告**：2026-09-12（用户要求「所有数据类别都可选导出/导入」时审计发现）
+- **真实性**：✅ 真 bug。`importSelectableCategories`（`fushi/lib/src/sync/sync_settings_schema/backup.part.dart`）含 progress / statistics，但对话框按 `summary.has(c)` 过滤显示，而 `summarizeBackupEntries`（`fushi/lib/src/sync/backup_service/restore.part.dart`）的 `present` 集合只由 6 个文件树类别填充，progress / statistics 永远不在 present 里 → 开关永不出现 → 被当作「未提供开关 = 总是导入」，用户无法在导入时跳过进度/统计。
+- **[x] ① 已修复** — `summarizeBackupEntries` 新增 `dbProgressCount` / `dbStatisticsCount`（老包 meta 缺计数时 `_peekContentRowCounts` 窥探 DB），present 补 progress / statistics（顺带 games）；`BackupMeta` 新增 `progressCount`；`summarizeLiveContent` 同步（`restore.part.dart:77-146`）；提交 `07ab311561`。
+- **[x] ② 已加自动化测试** — `fushi/test/sync/backup_games_category_test.dart`「导入摘要 meta / 窥探 / 纯函数」用例断言 present 含 progress / statistics。
+- **备注**：与 BUG-2475 同一提交。

--- a/docs/bugs/BUG-2476-backup-import-progress-statistics-switches-hidden.md
+++ b/docs/bugs/BUG-2476-backup-import-progress-statistics-switches-hidden.md
@@ -1,6 +1,6 @@
 ## BUG-2476 · 备份导入对话框永不显示「进度」「统计」开关
 - **报告**：2026-09-12（用户要求「所有数据类别都可选导出/导入」时审计发现）
-- **真实性**：✅ 真 bug。`importSelectableCategories`（`fushi/lib/src/sync/sync_settings_schema/backup.part.dart`）含 progress / statistics，但对话框按 `summary.has(c)` 过滤显示，而 `summarizeBackupEntries`（`fushi/lib/src/sync/backup_service/restore.part.dart`）的 `present` 集合只由 6 个文件树类别填充，progress / statistics 永远不在 present 里 → 开关永不出现 → 被当作「未提供开关 = 总是导入」，用户无法在导入时跳过进度/统计。
+- **真实性**：✅ 真 bug。`importSelectableCategories`（`fushi/lib/src/sync/sync_settings_schema/backup.part.dart`）含 progress / statistics，但对话框按 `summary.has(c)` 过滤显示，而 `summarizeBackupEntries`（`fushi/lib/src/sync/backup_service/restore.part.dart`）的 `present` 集合只由 6 个文件树类别填充，progress / statistics 永远不在 present 里 → 开关永不出现。而确认对话框把最终类别集算成「(非可选类别) ∪ (已勾选的可选类别)」——progress / statistics **是**可选类别却永不 present、永不可勾 → 一律被排除出集合 → 覆盖路径 `!wants(progress/statistics)` 为真、`_stripExcludedDataCategories` 把备份里的进度/统计**一律裁掉**（合并路径的 `_wants('progress'/'statistics')` 同理永假、从不合并）。即用户既看不到开关，进度/统计也从来没被导入过。
 - **[x] ① 已修复** — `summarizeBackupEntries` 新增 `dbProgressCount` / `dbStatisticsCount`（老包 meta 缺计数时 `_peekContentRowCounts` 窥探 DB），present 补 progress / statistics（顺带 games）；`BackupMeta` 新增 `progressCount`；`summarizeLiveContent` 同步（`restore.part.dart:77-146`）；提交 `07ab311561`。
 - **[x] ② 已加自动化测试** — `fushi/test/sync/backup_games_category_test.dart`「导入摘要 meta / 窥探 / 纯函数」用例断言 present 含 progress / statistics。
 - **备注**：与 BUG-2475 同一提交。

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80512 (4736 per locale)
+/// Strings: 80546 (4738 per locale)
 ///
-/// Built on 2026-09-11 at 23:14 UTC
+/// Built on 2026-09-12 at 04:35 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6586,6 +6586,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_online_select_all => 'Select all';
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  String get backup_category_games => 'Games';
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -17736,6 +17739,11 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -29112,6 +29120,11 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -40542,6 +40555,11 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -52005,6 +52023,11 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -63272,6 +63295,11 @@ class _StringsId extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -74630,6 +74658,11 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -85370,6 +85403,11 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -96120,6 +96158,11 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -107436,6 +107479,11 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -118805,6 +118853,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -130151,6 +130204,11 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -141298,6 +141356,11 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -152560,6 +152623,11 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -163792,6 +163860,11 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 // Path: <root>
@@ -174099,6 +174172,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '已加入 ${count} 章到下载队列';
+  @override
+  String get backup_category_games => '游戏';
+  @override
+  String get backup_category_games_desc => '游戏库、元数据来源与封面';
 }
 
 // Path: <root>
@@ -184523,6 +184600,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get backup_category_games => 'Games';
+  @override
+  String get backup_category_games_desc =>
+      'Game library, metadata sources and covers';
 }
 
 /// Flat map(s) containing all translations.
@@ -194279,6 +194361,10 @@ extension on _StringsEn {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -204030,6 +204116,10 @@ extension on _StringsAr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -213826,6 +213916,10 @@ extension on _StringsDe {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -223613,6 +223707,10 @@ extension on _StringsEs {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -233409,6 +233507,10 @@ extension on _StringsFr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -243176,6 +243278,10 @@ extension on _StringsId {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -252965,6 +253071,10 @@ extension on _StringsIt {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -262681,6 +262791,10 @@ extension on _StringsJa {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -272401,6 +272515,10 @@ extension on _StringsKo {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -282183,6 +282301,10 @@ extension on _StringsNl {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -291960,6 +292082,10 @@ extension on _StringsPtBr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -301744,6 +301870,10 @@ extension on _StringsRu {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -311500,6 +311630,10 @@ extension on _StringsTh {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -321271,6 +321405,10 @@ extension on _StringsTr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -331036,6 +331174,10 @@ extension on _StringsVi {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }
@@ -340714,6 +340856,10 @@ extension on _StringsZhCn {
         return '全选';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '已加入 ${count} 章到下载队列';
+      case 'backup_category_games':
+        return '游戏';
+      case 'backup_category_games_desc':
+        return '游戏库、元数据来源与封面';
       default:
         return null;
     }
@@ -350408,6 +350554,10 @@ extension on _StringsZhHk {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'backup_category_games':
+        return 'Games';
+      case 'backup_category_games_desc':
+        return 'Game library, metadata sources and covers';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "新章自动下载",
   "manga_online_download_all": "下载全部",
   "manga_online_select_all": "全选",
-  "manga_series_download_all_queued": "已加入 $count 章到下载队列"
+  "manga_series_download_all_queued": "已加入 $count 章到下载队列",
+  "backup_category_games": "游戏",
+  "backup_category_games_desc": "游戏库、元数据来源与封面"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4734,5 +4734,7 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "backup_category_games": "Games",
+  "backup_category_games_desc": "Game library, metadata sources and covers"
 }

--- a/fushi/lib/src/migration/migration_exporter.dart
+++ b/fushi/lib/src/migration/migration_exporter.dart
@@ -30,12 +30,15 @@ enum MigrationBatch {
 
 /// 每批的 [BackupService] 类别集合。
 ///
-/// 每批都带核心四类（progress/statistics/settings/profiles）：DB 始终整库随
+/// 每批都带核心五类（games/progress/statistics/settings/profiles）：DB 始终整库随
 /// 归档走，[BackupService] 的防幽灵语义会把「本批未带文件树」的内容行从 DB
 /// 复制件剥除（如 books 未勾 → epub_books 行不travel），因此各内容行恰好随
 /// **自己的批次**落地，合并引擎按业务键幂等 upsert，多批导入互不覆盖。
+/// games 归核心批：游戏库在 games 成为独立类别前一直随整库走，迁移语义不变
+/// （封面小，随核心批一起打包）。
 Set<BackupCategory> categoriesForBatch(MigrationBatch batch) {
   const Set<BackupCategory> core = <BackupCategory>{
+    BackupCategory.games,
     BackupCategory.progress,
     BackupCategory.statistics,
     BackupCategory.settings,

--- a/fushi/lib/src/pages/implementations/migration_import_page.dart
+++ b/fushi/lib/src/pages/implementations/migration_import_page.dart
@@ -179,6 +179,8 @@ class _MigrationImportPageState extends State<MigrationImportPage>
       final String fontsRoot =
           p.join(appModel.appDirectory.path, 'custom_fonts');
       final String videosRoot = p.join(appModel.appDirectory.path, 'videos');
+      final String gameCoversRoot =
+          p.join(appModel.appDirectory.path, 'game_covers');
       for (final MigrationImportBatch batch in scan.ready) {
         // **不能裸调 setState**：beginBackupImport() 上的是全屏遮罩，本页已被
         // 移出 widget 树（State 进入 defunct）。循环第一句就会抛
@@ -200,6 +202,7 @@ class _MigrationImportPageState extends State<MigrationImportPage>
           audiobooksRootDirectory: audiobooksRoot,
           fontsRootDirectory: fontsRoot,
           videosRootDirectory: videosRoot,
+          gameCoversRootDirectory: gameCoversRoot,
           onProgress: appModel.reportBackupImportProgress,
           // 同机换包名：用户期望「一切原样搬过来」，而 merge 默认只搬内容、
           // 不搬设置（那是给「另一台设备的备份」用的语义）。不开这个开关，

--- a/fushi/lib/src/pages/implementations/migration_page.dart
+++ b/fushi/lib/src/pages/implementations/migration_page.dart
@@ -105,6 +105,8 @@ class _MigrationPageState extends State<MigrationPage> {
         audiobooksRootDirectory:
             p.join(appModel.appDirectory.path, 'audiobooks'),
         fontsRootDirectory: p.join(appModel.appDirectory.path, 'custom_fonts'),
+        gameCoversRootDirectory:
+            p.join(appModel.appDirectory.path, 'game_covers'),
       );
       final MigrationExporter exporter = MigrationExporter(
         backupService: service,

--- a/fushi/lib/src/sync/backup_merge_engine.dart
+++ b/fushi/lib/src/sync/backup_merge_engine.dart
@@ -24,8 +24,11 @@ import 'package:fushi_core/fushi_core.dart';
 ///   per-bucket MAX-union, so re-importing the same backup is idempotent and
 ///   never double-counts.
 /// - favorites / mined sentences / activity events -> dedupe-UNION (both kept,
-///   duplicates dropped). galgame_sessions deliberately do NOT merge (their
-///   `galgames` hosts are machine-local and never travel; see merge()).
+///   duplicates dropped).
+/// - galgames -> push-only UNION keyed by a cross-device game identity (same
+///   id / same scrape identity / same exe path, see [_buildGameIdMap]); every
+///   game-keyed child row (sources, sessions, study segments, activity rows,
+///   tags) is remapped through that one map.
 /// - favorite SENTENCES (a `favorite_sentences` preference JSON blob, NOT a
 ///   table) -> content dedupe-UNION, delegated to [AggregateMergeService] (the
 ///   ATTACH SQL cannot merge a JSON blob, so this used to be dropped entirely).
@@ -152,6 +155,13 @@ class BackupMergeEngine {
             skipBookTombstones: true);
         await _insertAudioCues();
       }
+      // Game identity map (src game id → target game id) is built for EVERY
+      // merge: it is what every game-keyed child row (tags / study segments /
+      // activity rows / sessions) resolves through, whether or not the games
+      // category itself is ticked. Ticking games additionally inserts the
+      // unmatched src games (extending the map) + their scrape snapshots.
+      await _buildGameIdMap();
+      if (_wants('games')) await _insertMissingGalgames();
       // Media collections (unified-collections Phase 5) have no dialog toggle:
       // always merge the grouping itself; orphan members are kept and folded in
       // the UI. Self-guards against missing src tables (pre-migration backups).
@@ -173,12 +183,9 @@ class BackupMergeEngine {
         await _mergeActivityEvents();
         // v92：学习事实段按 uid LWW + 按身份墓碑（与 legacy 统计家族并行、互不触碰）。
         await _mergeStudySegments();
-        // galgame_sessions 刻意不合并（成文决策，不是遗漏）：游戏是本机局域
-        // 身份，galgames 行本身就不搬运（见 tables.dart 的 GalgameTagMappings
-        // 注释——整套游戏数据不进 live-sync 也不进备份合并导入，全量备份恢复
-        // 走整库文件拷贝原样还原），src 会话行的 game_id 在目标库没有宿主，
-        // 并进来只会造出悬空引用。唯一例外是游戏标签：它经刮削身份二跳落到
-        // 目标库自己的游戏行上（[_mergeTagsAndMappings] 的 v79 二跳）。
+        // 游玩会话事实随统计类别走：src 的 game_id 经 [_buildGameIdMap] 落到
+        // 目标库对应的游戏行上（2026-09 用户推翻旧的「游戏不参与合并」决策）。
+        await _mergeGalgameSessions();
       }
       await _mergeFavoriteSentencePrefs();
       await _mergeTagsAndMappings();
@@ -211,7 +218,138 @@ class BackupMergeEngine {
       // 迁移专用，放在全部点名 pref 合并之后：那几处是「按内容语义合并」（可能
       // 覆盖/取较新），这里只补它们没管的 key，不能反过来盖掉它们的结果。
       if (_adoptSourcePreferences) await _adoptMissingPreferences();
+      await _db.customStatement('DROP TABLE IF EXISTS $_gameMapTable');
     });
+  }
+
+  /// TEMP table `(src_id, dst_id)` mapping every src `galgames.id` that has a
+  /// counterpart on this device to that counterpart's id. Connection-local and
+  /// dropped at the end of [merge].
+  static const String _gameMapTable = 'temp.merge_game_map';
+
+  /// Builds [_gameMapTable] — the ONE cross-device game identity every
+  /// game-keyed row resolves through. A src game maps to a target game when,
+  /// in priority order:
+  ///  1. the same `id` exists on the target (same-device restore / re-merge of
+  ///     a backup that was itself merged before — ids are µs-timestamp strings
+  ///     minted once per game, so an id collision IS the same game);
+  ///  2. any scrape identity `(source, external_id)` in `galgame_sources`
+  ///     matches — a bgm/vndb subject id is the stable cross-device identity
+  ///     (two machines scraping the same game get the same id);
+  ///  3. the exact `exe_path` matches (same install path on both sides).
+  /// A src game with several target candidates (the user added the same game
+  /// twice) maps to the smallest id, deterministically. Unmatched src games
+  /// stay out of the map until [_insertMissingGalgames] inserts them; while
+  /// games are unticked their child rows therefore have no host and are
+  /// skipped instead of dangling.
+  Future<void> _buildGameIdMap() async {
+    await _db.customStatement('DROP TABLE IF EXISTS $_gameMapTable');
+    await _db.customStatement(
+      'CREATE TEMP TABLE merge_game_map '
+      '(src_id TEXT PRIMARY KEY, dst_id TEXT NOT NULL)',
+    );
+    await _db.customStatement(
+      'INSERT INTO $_gameMapTable (src_id, dst_id) '
+      'SELECT s.id, s.id FROM $_srcAlias.galgames AS s '
+      'WHERE EXISTS (SELECT 1 FROM galgames AS t WHERE t.id = s.id)',
+    );
+    await _db.customStatement(
+      'INSERT OR IGNORE INTO $_gameMapTable (src_id, dst_id) '
+      'SELECT ss.game_id, MIN(ts.game_id) '
+      'FROM $_srcAlias.galgame_sources AS ss '
+      'JOIN galgame_sources AS ts '
+      'ON ts.source = ss.source AND ts.external_id = ss.external_id '
+      "WHERE ss.external_id IS NOT NULL AND ss.external_id != '' "
+      'AND NOT EXISTS '
+      '(SELECT 1 FROM $_gameMapTable AS m WHERE m.src_id = ss.game_id) '
+      'GROUP BY ss.game_id',
+    );
+    await _db.customStatement(
+      'INSERT OR IGNORE INTO $_gameMapTable (src_id, dst_id) '
+      'SELECT s.id, MIN(t.id) FROM $_srcAlias.galgames AS s '
+      'JOIN galgames AS t ON t.exe_path = s.exe_path '
+      'WHERE NOT EXISTS '
+      '(SELECT 1 FROM $_gameMapTable AS m WHERE m.src_id = s.id) '
+      'GROUP BY s.id',
+    );
+  }
+
+  /// Galgames push-only UNION: inserts every src game that [_buildGameIdMap]
+  /// could not match (keeping its src id — the id is a stable string minted
+  /// once, not an autoincrement), extends the map with the identity mapping
+  /// for those rows, then unions `galgame_sources` under the remapped game id
+  /// (the target keeps its own snapshot for a `(game, source)` it already has).
+  /// `cover_path` is inserted verbatim (source-device path) and re-homed by the
+  /// caller's `_rebaseGameCoverPaths` after the covers are copied in.
+  Future<void> _insertMissingGalgames() async {
+    final List<String> cols = await _allColumns('galgames');
+    final String colList = cols.join(', ');
+    await _db.customStatement(
+      'INSERT INTO galgames ($colList) '
+      'SELECT $colList FROM $_srcAlias.galgames AS s '
+      'WHERE NOT EXISTS '
+      '(SELECT 1 FROM $_gameMapTable AS m WHERE m.src_id = s.id)',
+    );
+    await _db.customStatement(
+      'INSERT OR IGNORE INTO $_gameMapTable (src_id, dst_id) '
+      'SELECT s.id, s.id FROM $_srcAlias.galgames AS s',
+    );
+    // OR IGNORE: several src games can map to ONE target game (duplicate
+    // library entries on the source), yielding the same (game, source) twice
+    // within this single INSERT — the PK then keeps the first.
+    await _db.customStatement(
+      'INSERT OR IGNORE INTO galgame_sources '
+      '(game_id, source, external_id, data_json, score, rank, fetched_at) '
+      'SELECT m.dst_id, ss.source, ss.external_id, ss.data_json, ss.score, '
+      'ss.rank, ss.fetched_at '
+      'FROM $_srcAlias.galgame_sources AS ss '
+      'JOIN $_gameMapTable AS m ON m.src_id = ss.game_id '
+      'WHERE NOT EXISTS (SELECT 1 FROM galgame_sources AS t '
+      'WHERE t.game_id = m.dst_id AND t.source = ss.source)',
+    );
+  }
+
+  /// Play-session facts dedupe-UNION under the remapped game id. Natural key =
+  /// `(game, start_ms, end_ms)`: a session is one launch with an exact start
+  /// and end instant, so re-importing the same backup is idempotent. Src
+  /// sessions whose game has no host on this device are skipped (never a
+  /// dangling `game_id`).
+  Future<void> _mergeGalgameSessions() async {
+    await _db.customStatement(
+      'INSERT INTO galgame_sessions '
+      '(game_id, start_ms, end_ms, duration_seconds, date_key) '
+      'SELECT m.dst_id, s.start_ms, s.end_ms, s.duration_seconds, s.date_key '
+      'FROM $_srcAlias.galgame_sessions AS s '
+      'JOIN $_gameMapTable AS m ON m.src_id = s.game_id '
+      'WHERE NOT EXISTS (SELECT 1 FROM galgame_sessions AS t '
+      'WHERE t.game_id = m.dst_id AND t.start_ms = s.start_ms '
+      'AND t.end_ms = s.end_ms)',
+    );
+  }
+
+  /// SQL fragment (src alias [s]) resolving a `media_kind`/`media_key` pair to
+  /// this device's key: game keys go through [_gameMapTable] (LEFT JOIN alias
+  /// [m], see [_gameMapJoin]); every other kind is its own cross-device key.
+  static String _mappedMediaKey(String s, String m) =>
+      'COALESCE($m.dst_id, $s.media_key)';
+
+  /// LEFT JOIN of [_gameMapTable] as [m] for the game rows of src alias [s]
+  /// (`media_kind` column [kindColumn]). Non-game rows get a NULL [m] side.
+  String _gameMapJoin(String s, String m, {String kindColumn = 'media_kind'}) =>
+      'LEFT JOIN $_gameMapTable AS $m '
+      "ON $s.$kindColumn = '$kActivityMediaGame' AND $m.src_id = $s.media_key ";
+
+  /// WHERE fragment keeping every non-game row plus the game rows whose host
+  /// resolved through the map (an unmatched game row would dangle).
+  static String _hasHost(String s, String m,
+          {String kindColumn = 'media_kind'}) =>
+      "($s.$kindColumn <> '$kActivityMediaGame' OR $m.dst_id IS NOT NULL)";
+
+  /// Every column of [table] (quoted), for tables whose primary key is a
+  /// stable business string rather than an autoincrement `id`.
+  Future<List<String>> _allColumns(String table) async {
+    final rows = await _db.customSelect('PRAGMA table_info($table)').get();
+    return rows.map((r) => '"${r.data['name'] as String}"').toList();
   }
 
   /// 把源库里**本机还没有**的 `preferences` 行补进来（insert-if-absent）。
@@ -934,30 +1072,33 @@ class BackupMergeEngine {
   ///     （LWW，同值重放 no-op）；
   ///  ③ 删掉目标里被（合并后）墓碑压制的段（`start_at < deleted_at`，
   ///     BUG-2214 / BUG-2220：删除之前开始的段出局，之后开始的存活）。
-  /// 游戏段 / 碑（BUG-2221）不从备份搬入——与 galgame_sessions 同律，src 的
-  /// game_id 在目标库没有宿主。
+  /// 游戏段 / 碑的 media_key 是 src 的 galgames.id，经 [_gameMapTable] 落到本机
+  /// 对应游戏；没有宿主的游戏行跳过（不造悬空键）。
   /// 旧备份（v92 前）没有这两张表：ATTACH 前已迁到当前 schema，两侧必有表。
   Future<void> _mergeStudySegments() async {
+    final String key = _mappedMediaKey('s', 'm');
+    final String join = _gameMapJoin('s', 'm');
+    final String hasHost = _hasHost('s', 'm');
+    // 几个 src 游戏可能映射到同一个本机游戏 → 同 (kind, key) 多条碑，取 MAX。
     await _db.customStatement(
-      'INSERT INTO study_segment_tombstones (media_kind, media_key, deleted_at) '
-      'SELECT media_kind, media_key, deleted_at '
-      'FROM $_srcAlias.study_segment_tombstones AS s '
-      'WHERE s.media_kind <> ? '
-      'AND NOT EXISTS (SELECT 1 FROM study_segment_tombstones AS t '
-      'WHERE t.media_kind = s.media_kind AND t.media_key = s.media_key)',
-      <Object>[kActivityMediaGame],
+      'INSERT OR IGNORE INTO study_segment_tombstones '
+      '(media_kind, media_key, deleted_at) '
+      'SELECT s.media_kind, $key, MAX(s.deleted_at) '
+      'FROM $_srcAlias.study_segment_tombstones AS s $join'
+      'WHERE $hasHost '
+      'GROUP BY s.media_kind, $key',
     );
     await _db.customStatement(
       'UPDATE study_segment_tombstones SET deleted_at = ('
-      'SELECT s.deleted_at FROM $_srcAlias.study_segment_tombstones AS s '
+      'SELECT MAX(s.deleted_at) '
+      'FROM $_srcAlias.study_segment_tombstones AS s $join'
       'WHERE s.media_kind = study_segment_tombstones.media_kind '
-      'AND s.media_key = study_segment_tombstones.media_key) '
-      'WHERE study_segment_tombstones.media_kind <> ? '
-      'AND EXISTS (SELECT 1 FROM $_srcAlias.study_segment_tombstones AS s '
+      'AND $key = study_segment_tombstones.media_key) '
+      'WHERE EXISTS (SELECT 1 '
+      'FROM $_srcAlias.study_segment_tombstones AS s $join'
       'WHERE s.media_kind = study_segment_tombstones.media_kind '
-      'AND s.media_key = study_segment_tombstones.media_key '
+      'AND $key = study_segment_tombstones.media_key '
       'AND s.deleted_at > study_segment_tombstones.deleted_at)',
-      <Object>[kActivityMediaGame],
     );
     final List<String> cols = <String>[
       'uid',
@@ -975,27 +1116,27 @@ class BackupMergeEngine {
       'pages',
       'updated_at',
     ];
+    String srcCol(String c) => c == 'media_key' ? '$key AS media_key' : 's.$c';
     final String colList = cols.join(', ');
+    final String srcColList = cols.map(srcCol).join(', ');
     await _db.customStatement(
       'INSERT INTO study_segments ($colList) '
-      'SELECT $colList FROM $_srcAlias.study_segments AS s '
-      'WHERE s.media_kind <> ? '
+      'SELECT $srcColList FROM $_srcAlias.study_segments AS s $join'
+      'WHERE $hasHost '
       'AND NOT EXISTS (SELECT 1 FROM study_segments AS t WHERE t.uid = s.uid)',
-      <Object>[kActivityMediaGame],
     );
     final String setClause = cols
         .where((String c) => c != 'uid')
         .map((String c) =>
-            '$c = (SELECT s.$c FROM $_srcAlias.study_segments AS s '
+            '$c = (SELECT ${srcCol(c)} FROM $_srcAlias.study_segments AS s '
+            '${c == 'media_key' ? join : ''}'
             'WHERE s.uid = study_segments.uid)')
         .join(', ');
     await _db.customStatement(
       'UPDATE study_segments SET $setClause '
-      'WHERE study_segments.media_kind <> ? '
-      'AND EXISTS (SELECT 1 FROM $_srcAlias.study_segments AS s '
-      'WHERE s.uid = study_segments.uid '
+      'WHERE EXISTS (SELECT 1 FROM $_srcAlias.study_segments AS s $join'
+      'WHERE s.uid = study_segments.uid AND $hasHost '
       'AND s.updated_at > study_segments.updated_at)',
-      <Object>[kActivityMediaGame],
     );
     await _db.customStatement(
       'DELETE FROM study_segments WHERE EXISTS ('
@@ -1006,13 +1147,23 @@ class BackupMergeEngine {
     );
   }
 
+  /// ActivityEvents dedupe-UNION（语义见 [_mergeStudySegments] 上方的成段说明）。
+  /// game 行的 media_key 是 src 的 galgames.id：经 [_gameMapTable] 落到本机游戏；
+  /// 带 key 却无宿主的跳过，legacy 的无 key（只有 title）行原样并入。
   Future<void> _mergeActivityEvents() async {
     final List<String> cols = await _columnsExceptId('activity_events');
     final String colList = cols.join(', ');
+    final String key = _mappedMediaKey('s', 'm');
+    final String srcColList = cols
+        .map((String c) => c == '"media_key"' ? '$key AS media_key' : 's.$c')
+        .join(', ');
     await _db.customStatement(
       'INSERT INTO activity_events ($colList) '
-      'SELECT $colList FROM $_srcAlias.activity_events AS s '
-      'WHERE NOT EXISTS (SELECT 1 FROM activity_events AS t '
+      'SELECT $srcColList FROM $_srcAlias.activity_events AS s '
+      '${_gameMapJoin('s', 'm', kindColumn: 'media_type')}'
+      "WHERE (s.media_type <> '$kActivityMediaGame' OR s.media_key IS NULL "
+      'OR m.dst_id IS NOT NULL) '
+      'AND NOT EXISTS (SELECT 1 FROM activity_events AS t '
       'WHERE t.event_type = s.event_type AND t.media_type = s.media_type '
       'AND t.title = s.title AND t.timestamp_ms = s.timestamp_ms)',
     );
@@ -1088,15 +1239,12 @@ class BackupMergeEngine {
   ///
   /// v79（五表合一 + 用户令全 kind 合并）：src 在 ATTACH 前已迁到当前 schema，
   /// 五张旧映射表已并成 tag_assignments——这里按 kind 分三路：
-  ///  - epub/srt/video/**game 直键**：entry_key 本身跨库可比（bookKey / srt uid /
-  ///    bookUid / game id），宿主存在性逐 kind 校验后直插。game 的 id 是本机
-  ///    局域身份且 galgames 行不参与备份合并——直键只在 target 恰好有同 id 游戏
-  ///    （同机恢复 / 整库迁移后补合并）时命中；
-  ///  - **game 二跳**（用户令跨机也要并）：直键不命中的游戏标签行，经
-  ///    「src 该游戏的刮削身份 (source, external_id) → target 拥有同刮削身份的
-  ///    游戏」二跳落地——bgm/vndb 条目 id 是游戏唯一的跨机稳定身份（两机各自
-  ///    刮削同一部游戏得到同一个 subject id）。两侧任一没刮削/未命中 → 仍丢
-  ///    （按名/按路径猜会把标签打到别的游戏头上，宁缺毋错）；
+  ///  - epub/srt/video 直键：entry_key 本身跨库可比（bookKey / srt uid /
+  ///    bookUid），宿主存在性逐 kind 校验后直插；
+  ///  - game：entry_key 是 src 的 galgames.id，经 [_gameMapTable]（同 id /
+  ///    刮削身份 / exe 路径三级匹配 + games 勾选时新插入的游戏）落到本机游戏。
+  ///    旧版这里有「直键 + 刮削身份二跳」两条路，现在与游戏行合并共用一张映射
+  ///    表；无宿主的游戏标签行仍丢（按名猜会打到别的游戏头上，宁缺毋错）；
   ///  - collection：src 本地 id 无跨库意义，经 media_collections
   ///    (name, collection_type) 自然键映射到 target id（JOIN 不命中——被删除
   ///    墓碑跳过、target 无同名合集——天然不插入）。
@@ -1121,34 +1269,25 @@ class BackupMergeEngine {
       "OR (sm.media_kind = 'srt' AND EXISTS "
       '(SELECT 1 FROM srt_books AS sb WHERE sb.uid = sm.entry_key)) '
       "OR (sm.media_kind = 'video' AND EXISTS "
-      '(SELECT 1 FROM video_books AS v WHERE v.book_uid = sm.entry_key)) '
-      "OR (sm.media_kind = 'game' AND EXISTS "
-      '(SELECT 1 FROM galgames AS g WHERE g.id = sm.entry_key))'
+      '(SELECT 1 FROM video_books AS v WHERE v.book_uid = sm.entry_key))'
       ') '
       'AND NOT EXISTS (SELECT 1 FROM tag_assignments AS m '
       'WHERE m.media_kind = sm.media_kind AND m.entry_key = sm.entry_key '
       'AND m.tag_id = tt.id)',
     );
-    // game 二跳：直键不命中（target 无同 id 游戏 = 跨机场景）的游戏标签行，
-    // 按刮削身份重定位到 target 的对应游戏。DISTINCT 防同一 (game, tag) 经
-    // bgm+vndb 双源命中同一 target 游戏时重复；同一 externalId 在 target 命中
-    // 多个游戏（用户重复添加同一部）时每个都打上——标签是并集语义，多打不为错。
+    // game：经映射表落到本机游戏。几个 src 游戏可能映射到同一本机游戏 → 同
+    // (game, tag) 多行，INSERT OR IGNORE 吃掉重复（PK = kind+entry+tag）。
     await _db.customStatement(
-      'INSERT INTO tag_assignments (media_kind, entry_key, tag_id, added_at) '
-      "SELECT DISTINCT 'game', ts.game_id, tt.id, sm.added_at "
+      'INSERT OR IGNORE INTO tag_assignments '
+      '(media_kind, entry_key, tag_id, added_at) '
+      "SELECT '${TagHostKind.game.dbValue}', gm.dst_id, tt.id, "
+      'MIN(sm.added_at) '
       'FROM $_srcAlias.tag_assignments AS sm '
-      'JOIN $_srcAlias.galgame_sources AS ss '
-      'ON ss.game_id = sm.entry_key '
-      "AND ss.external_id IS NOT NULL AND ss.external_id != '' "
-      'JOIN galgame_sources AS ts '
-      'ON ts.source = ss.source AND ts.external_id = ss.external_id '
+      'JOIN $_gameMapTable AS gm ON gm.src_id = sm.entry_key '
       'JOIN $_srcAlias.book_tags AS st ON st.id = sm.tag_id '
       'JOIN book_tags AS tt ON tt.name = st.name '
-      "WHERE sm.media_kind = 'game' "
-      'AND NOT EXISTS (SELECT 1 FROM galgames AS g WHERE g.id = sm.entry_key) '
-      'AND NOT EXISTS (SELECT 1 FROM tag_assignments AS m '
-      "WHERE m.media_kind = 'game' AND m.entry_key = ts.game_id "
-      'AND m.tag_id = tt.id)',
+      "WHERE sm.media_kind = '${TagHostKind.game.dbValue}' "
+      'GROUP BY gm.dst_id, tt.id',
     );
   }
 

--- a/fushi/lib/src/sync/backup_merge_engine.dart
+++ b/fushi/lib/src/sync/backup_merge_engine.dart
@@ -714,12 +714,20 @@ class BackupMergeEngine {
           'FROM $_srcAlias.media_collection_items',
         )
         .get();
+    // game 成员的 entry_key 是 src 的 galgames.id：与标签 / 会话 / 学习段同律，经
+    // [_gameMapTable] 落到本机游戏 id；无宿主的成员跳过（否则落成永久孤儿）。
+    final Map<String, String> gameIdMap = await _readGameIdMap();
     for (final QueryRow it in srcItems) {
       final int srcCollectionId = it.read<int>('collection_id');
       final int? tgt = srcToTargetId[srcCollectionId];
       if (tgt == null) continue; // 合集被删除墓碑跳过或未映射：连带跳过成员。
       final String mediaType = it.read<String>('media_type');
-      final String entryKey = it.read<String>('entry_key');
+      String entryKey = it.read<String>('entry_key');
+      if (mediaType == MediaKind.game.dbValue) {
+        final String? mapped = gameIdMap[entryKey];
+        if (mapped == null) continue;
+        entryKey = mapped;
+      }
       final bool isEpub = mediaType == MediaKind.epub.dbValue;
       // 墓碑匹配在 bookKey 域：本地成员墓碑 entry_key 冻结在 bookKey 域（§4），
       // src epub 成员先归一再比；非 epub 键值自身即稳定键，直比。
@@ -745,6 +753,18 @@ class BackupMergeEngine {
         ],
       );
     }
+  }
+
+  /// [_gameMapTable] 读成 Dart 映射（src game id → 本机 game id），给逐行 Dart
+  /// 侧合并（合集成员）用；SQL 侧合并直接 JOIN 该表。
+  Future<Map<String, String>> _readGameIdMap() async {
+    final List<QueryRow> rows = await _db
+        .customSelect('SELECT src_id, dst_id FROM $_gameMapTable')
+        .get();
+    return <String, String>{
+      for (final QueryRow r in rows)
+        r.read<String>('src_id'): r.read<String>('dst_id'),
+    };
   }
 
   /// 目标（当前设备）DB 是否有名为 [table] 的表。与 [_srcTableExists] 对称，但查

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -833,8 +833,9 @@ Future<void> _retainAudiobooks(
 /// Games analogue of [_retainVideos]: DELETEs every `galgames` row whose `id`
 /// is NOT in [keep] (its `galgame_sources` / `galgame_sessions` follow via FK
 /// cascade) plus the game-kind rows of the logical-FK tables that never cascade
-/// (`tag_assignments`, `study_segments`, `study_segment_tombstones`,
-/// `activity_events`, keyed by `media_kind`/`media_type` = 'game'). [keep]
+/// (`tag_assignments`, `media_collection_items`, `study_segments`,
+/// `study_segment_tombstones`, `activity_events`, keyed by
+/// `media_kind`/`media_type` = 'game'). [keep]
 /// empty strips every game (the games category was unticked). Shared by the
 /// export strip and the overwrite-import strip so the two never diverge.
 Future<void> _retainGames(
@@ -853,6 +854,10 @@ Future<void> _retainGames(
         'DELETE FROM tag_assignments WHERE media_kind = ? AND entry_key '
         'NOT IN (SELECT id FROM galgames)',
         <Object>[TagHostKind.game.dbValue]);
+    await db.customStatement(
+        'DELETE FROM media_collection_items WHERE media_type = ? AND '
+        'entry_key NOT IN (SELECT id FROM galgames)',
+        <Object>[MediaKind.game.dbValue]);
     await db.customStatement(
         'DELETE FROM study_segments WHERE media_kind = ? AND media_key '
         'NOT IN (SELECT id FROM galgames)',

--- a/fushi/lib/src/sync/backup_service.dart
+++ b/fushi/lib/src/sync/backup_service.dart
@@ -77,6 +77,15 @@ enum BackupCategory {
   /// audio), so the UI leaves this opt-in by default like videos.
   localAudio,
 
+  /// Galgame library (`galgames` + its `galgame_sources` scrape snapshots) and
+  /// the game cover files (`<documents>/game_covers/<id>.<ext>`, packed under
+  /// the `game_covers/` archive prefix). Before this category existed the game
+  /// rows always rode the whole-DB blob (never excludable, never skippable on
+  /// import) while the covers never travelled at all. Play-session facts
+  /// (`galgame_sessions`, game-kind `study_segments` / `activity_events`) are
+  /// STATISTICS and follow that category, not this one. Included by default.
+  games,
+
   /// Reading progress: where you left off in every book. Covers the
   /// `reader_positions` + `bookmarks` tables and the `audiobook_pos_*`
   /// preference rows. When unticked these rows are stripped from the exported
@@ -300,10 +309,13 @@ class BackupMeta {
     this.audiobooksRoot,
     this.fontsRoot,
     this.localAudioRoot,
+    this.gameCoversRoot,
     this.videoFiles = const <String, String>{},
     this.excludedCategories = const <String>{},
     this.videoBookCount,
     this.audiobookCount,
+    this.gameCount,
+    this.progressCount,
   });
 
   final String appVersion;
@@ -328,6 +340,20 @@ class BackupMeta {
   /// back to a DB-blob peek (BUG-781).
   final int? audiobookCount;
 
+  /// Number of `galgames` rows carried in this backup's DB blob (0 when the
+  /// games category was unticked → every row stripped on export). Same role as
+  /// [videoBookCount]: lets the import dialog offer the games toggle even when
+  /// no cover FILES were packed. Null for older backups → import falls back to
+  /// a DB-blob peek.
+  final int? gameCount;
+
+  /// Number of progress rows (`reader_positions` + `bookmarks`) carried in this
+  /// backup's DB blob (0 when the progress category was unticked). Progress is
+  /// DB-only — it has no archive file tree to count — so without this the
+  /// import dialog could never tell whether the backup carries any progress and
+  /// never offered the toggle. Null for older backups → DB-blob peek.
+  final int? progressCount;
+
   /// Absolute root of the extracted-books tree on the SOURCE device
   /// (`<appDoc>/hoshi_books`), captured so import can rebase stored book paths
   /// to this device's root. Null for legacy (db-only) backups → import skips
@@ -350,6 +376,12 @@ class BackupMeta {
   /// `local_audio_dbs` preference paths onto this device's root. Null when the
   /// local-audio category was not packed (or a legacy backup).
   final String? localAudioRoot;
+
+  /// Absolute root of the game-cover tree on the SOURCE device
+  /// (`<documents>/game_covers`), captured so import can rebase the stored
+  /// `galgames.cover_path` values onto this device's root. Null when the games
+  /// category was not packed (or a legacy backup).
+  final String? gameCoversRoot;
 
   /// Exact source video path -> archive-relative path under `videos/`.
   ///
@@ -376,11 +408,14 @@ class BackupMeta {
         if (audiobooksRoot != null) 'audiobooksRoot': audiobooksRoot,
         if (fontsRoot != null) 'fontsRoot': fontsRoot,
         if (localAudioRoot != null) 'localAudioRoot': localAudioRoot,
+        if (gameCoversRoot != null) 'gameCoversRoot': gameCoversRoot,
         if (videoFiles.isNotEmpty) 'videoFiles': videoFiles,
         if (excludedCategories.isNotEmpty)
           'excludedCategories': excludedCategories.toList(),
         if (videoBookCount != null) 'videoBookCount': videoBookCount,
         if (audiobookCount != null) 'audiobookCount': audiobookCount,
+        if (gameCount != null) 'gameCount': gameCount,
+        if (progressCount != null) 'progressCount': progressCount,
       };
 
   factory BackupMeta.fromJson(Map<String, dynamic> json) => BackupMeta(
@@ -394,6 +429,7 @@ class BackupMeta {
         audiobooksRoot: json['audiobooksRoot'] as String?,
         fontsRoot: json['fontsRoot'] as String?,
         localAudioRoot: json['localAudioRoot'] as String?,
+        gameCoversRoot: json['gameCoversRoot'] as String?,
         videoFiles: (json['videoFiles'] as Map?)?.map(
                 (dynamic k, dynamic v) => MapEntry(k as String, v as String)) ??
             const <String, String>{},
@@ -403,6 +439,8 @@ class BackupMeta {
             const <String>{},
         videoBookCount: json['videoBookCount'] as int?,
         audiobookCount: json['audiobookCount'] as int?,
+        gameCount: json['gameCount'] as int?,
+        progressCount: json['progressCount'] as int?,
       );
 
   static BackupMeta? tryParse(String source) {
@@ -460,6 +498,10 @@ const String _audiobooksPrefix = 'audiobooks';
 const String _fontsPrefix = 'custom_fonts';
 const String _videosPrefix = 'videos';
 const String _localAudioPrefix = 'localAudio';
+
+/// Game cover files (`<documents>/game_covers/<galgames.id>.<ext>`) in the
+/// archive. Same name as the on-disk directory so the tree restores 1:1.
+const String _gameCoversPrefix = 'game_covers';
 
 /// Preference key (in the `preferences` table) whose JSON value is the
 /// local-audio library list `[{path, displayName, enabled, sources}]`. The
@@ -568,9 +610,13 @@ const List<String> _deviceLocalTablesParentFirst = <String>[
 /// `activity_events` / `galgame_sessions` are session-granularity FACT
 /// streams, not aggregates, but they are what the statistics pages render
 /// from — the untick promise ("my stats don't travel") must cover them too.
-/// The `galgames` library rows stay: games are content, their sessions are
-/// statistics (mirrors `clearAllGalgameStatistics`, which deletes only the
-/// session facts).
+/// The `galgames` library rows stay: games are content (the `games`
+/// category), their sessions are statistics (mirrors
+/// `clearAllGalgameStatistics`, which deletes only the session facts).
+///
+/// v92 added `study_segments` (the ONLY study-time fact table the statistics
+/// pages read from since then) and its identity tombstones; both were missing
+/// here, so an "exclude statistics" export still leaked every study segment.
 const List<String> _statisticsTables = <String>[
   'reading_statistics',
   'reading_hourly_logs',
@@ -582,6 +628,8 @@ const List<String> _statisticsTables = <String>[
   'favorite_words',
   'activity_events',
   'galgame_sessions',
+  'study_segments',
+  'study_segment_tombstones',
 ];
 
 /// The five profile-layer tables in CHILD-first order, so a DELETE sweep of
@@ -782,6 +830,48 @@ Future<void> _retainAudiobooks(
   }
 }
 
+/// Games analogue of [_retainVideos]: DELETEs every `galgames` row whose `id`
+/// is NOT in [keep] (its `galgame_sources` / `galgame_sessions` follow via FK
+/// cascade) plus the game-kind rows of the logical-FK tables that never cascade
+/// (`tag_assignments`, `study_segments`, `study_segment_tombstones`,
+/// `activity_events`, keyed by `media_kind`/`media_type` = 'game'). [keep]
+/// empty strips every game (the games category was unticked). Shared by the
+/// export strip and the overwrite-import strip so the two never diverge.
+Future<void> _retainGames(
+  String dbDirectory,
+  Set<String> keep,
+) async {
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    final String notKept = keep.isEmpty
+        ? ''
+        : ' WHERE id NOT IN '
+            '(${List<String>.filled(keep.length, '?').join(', ')})';
+    await db.customStatement('DELETE FROM galgames$notKept', keep.toList());
+    // Logical (non-FK) game references: orphaned once their host is gone.
+    await db.customStatement(
+        'DELETE FROM tag_assignments WHERE media_kind = ? AND entry_key '
+        'NOT IN (SELECT id FROM galgames)',
+        <Object>[TagHostKind.game.dbValue]);
+    await db.customStatement(
+        'DELETE FROM study_segments WHERE media_kind = ? AND media_key '
+        'NOT IN (SELECT id FROM galgames)',
+        <Object>[kActivityMediaGame]);
+    await db.customStatement(
+        'DELETE FROM study_segment_tombstones WHERE media_kind = ? AND '
+        'media_key NOT IN (SELECT id FROM galgames)',
+        <Object>[kActivityMediaGame]);
+    await db.customStatement(
+        'DELETE FROM activity_events WHERE media_type = ? AND '
+        '(media_key IS NULL OR media_key NOT IN (SELECT id FROM galgames))',
+        <Object>[kActivityMediaGame]);
+    await db.customStatement('VACUUM');
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
+}
+
 /// 一次导出里词典的**逐本**打包计划（BUG-2193）。
 ///
 /// 存在的理由：以前判据是一个 bool（`_hasCompleteDictionaryResources`），语义是
@@ -818,12 +908,14 @@ class BackupService {
     String? booksRootDirectory,
     String? audiobooksRootDirectory,
     String? fontsRootDirectory,
+    String? gameCoversRootDirectory,
   })  : _db = db,
         _dbDirectory = dbDirectory,
         _dictionaryResourceDirectory = dictionaryResourceDirectory,
         _booksRootDirectory = booksRootDirectory,
         _audiobooksRootDirectory = audiobooksRootDirectory,
         _fontsRootDirectory = fontsRootDirectory,
+        _gameCoversRootDirectory = gameCoversRootDirectory,
         _appVersion = appVersion;
 
   final FushiDatabase _db;
@@ -845,6 +937,11 @@ class BackupService {
   /// crossed over).
   final String? _fontsRootDirectory;
 
+  /// Root of the game-cover tree (`<documents>/game_covers`). When provided,
+  /// the cover files are packed into the backup alongside the `galgames` rows
+  /// whose `cover_path` points at them; null packs the rows without covers.
+  final String? _gameCoversRootDirectory;
+
   final String _appVersion;
 
   String get _dbPath => p.join(_dbDirectory, _dbName);
@@ -862,6 +959,21 @@ class BackupService {
         await _db.customSelect('SELECT COUNT(*) AS c FROM $table').getSingle();
     return row.data['c'] as int;
   }
+
+  /// Progress rows on the live DB (`reader_positions` + `bookmarks`), the
+  /// natural unit of the `progress` category for the export/import manifests.
+  Future<int> _countProgressRows() async =>
+      await _countRows('reader_positions') + await _countRows('bookmarks');
+
+  /// Statistics records on the live DB: the legacy day aggregates the old
+  /// `statsCount` already summed PLUS the v92 `study_segments` fact table —
+  /// since v92 new study time lands ONLY there, so a count that ignored it
+  /// reported "0 statistics" for every post-v92 library.
+  Future<int> _countStatisticsRows() async =>
+      await _countRows('reading_statistics') +
+      await _countRows('video_watch_statistics') +
+      await _countRows('mining_statistics') +
+      await _countRows('study_segments');
 
   /// Builds the export "what's inside" summary from the live DB + this device's
   /// content roots (TODO-1358). Counts are the natural unit per category; a root
@@ -887,6 +999,9 @@ class BackupService {
     // count, the packed content and the import readback all agree.
     final int fonts = (await _referencedFontFiles()).length;
     final int localAudio = await _countLocalAudioDbs();
+    final int games = await _countRows('galgames');
+    final int progress = await _countProgressRows();
+    final int statistics = await _countStatisticsRows();
     final Map<BackupCategory, int> counts = <BackupCategory, int>{
       BackupCategory.dictionary: dictionaries,
       BackupCategory.books: books,
@@ -894,6 +1009,9 @@ class BackupService {
       BackupCategory.fonts: fonts,
       BackupCategory.videos: videos,
       BackupCategory.localAudio: localAudio,
+      BackupCategory.games: games,
+      BackupCategory.progress: progress,
+      BackupCategory.statistics: statistics,
     };
     return BackupContentSummary(
       counts: counts,
@@ -1130,6 +1248,14 @@ class BackupService {
       if (!includeAudiobooks) {
         await _retainAudiobooks(tmpDir.path, const <String>{});
       }
+      // Games mirror videos/audiobooks: unticking strips every `galgames` row
+      // (+ FK cascade + the logical game-kind rows) from the DB COPY, so the
+      // game library never travels uninvited (before this category existed it
+      // ALWAYS rode the whole-DB blob).
+      final bool includeGames = wants(BackupCategory.games);
+      if (!includeGames) {
+        await _retainGames(tmpDir.path, const <String>{});
+      }
 
       // TODO-1193: the four data categories (progress / statistics / settings /
       // profiles) live only in the DB blob, so when the user unticks any of
@@ -1181,7 +1307,6 @@ class BackupService {
       );
 
       final books = await _db.getAllEpubBooks();
-      final stats = await _db.getAllReadingStatistics();
       // The count reported to the import confirm dialog must reflect what is
       // actually exported, not the live library — a book whose record was
       // stripped above must not be counted (TODO-1195 part C/A).
@@ -1239,13 +1364,16 @@ class BackupService {
       final int blobAudiobookCount =
           includeAudiobooks ? (await _db.getAllAudiobooks()).length : 0;
 
-      // "Statistics records" spans reading + video + mining buckets, not reading
-      // alone, so a video-watcher's backup no longer reports "0 statistics".
-      final int totalStatsCount = includeStatistics
-          ? stats.length +
-              await _countRows('video_watch_statistics') +
-              await _countRows('mining_statistics')
-          : 0;
+      // "Statistics records" spans reading + video + mining buckets + the v92
+      // study-segment facts, not reading alone, so a video-watcher's (or any
+      // post-v92) backup no longer reports "0 statistics".
+      final int totalStatsCount =
+          includeStatistics ? await _countStatisticsRows() : 0;
+      // Rows remaining in the exported DB blob for the DB-only categories, so
+      // the import dialog can offer their toggles without peeking the blob.
+      final int blobGameCount = includeGames ? await _countRows('galgames') : 0;
+      final int blobProgressCount =
+          includeProgress ? await _countProgressRows() : 0;
 
       // Record the SOURCE-device content roots so import can rebase the stored
       // absolute paths (epubPath/extractDir/coverPath/audioRoot/...) onto the
@@ -1267,9 +1395,12 @@ class BackupService {
             wants(BackupCategory.audiobooks) ? _audiobooksRootDirectory : null,
         fontsRoot: wants(BackupCategory.fonts) ? _fontsRootDirectory : null,
         localAudioRoot: wants(BackupCategory.localAudio) ? _dbDirectory : null,
+        gameCoversRoot: includeGames ? _gameCoversRootDirectory : null,
         videoFiles: videoFiles,
         videoBookCount: blobVideoBookCount,
         audiobookCount: blobAudiobookCount,
+        gameCount: blobGameCount,
+        progressCount: blobProgressCount,
         // Record every unticked category by enum name so import knows a layer is
         // empty BY CHOICE (vs a genuinely empty DB). Only settings/profiles are
         // acted on at import; the rest is diagnostic / future-proofing.
@@ -1304,6 +1435,10 @@ class BackupService {
       }
       if (_fontsRootDirectory != null && wants(BackupCategory.fonts)) {
         await _collectReferencedFontFiles(files);
+      }
+      if (_gameCoversRootDirectory != null && includeGames) {
+        await _collectTreeFiles(
+            Directory(_gameCoversRootDirectory), _gameCoversPrefix, files);
       }
 
       final String metaJson =

--- a/fushi/lib/src/sync/backup_service/path_rebase.part.dart
+++ b/fushi/lib/src/sync/backup_service/path_rebase.part.dart
@@ -19,6 +19,7 @@ Future<void> _rebaseAllPaths({
   required String? newFontsRoot,
   required String? newLocalAudioRoot,
   required String? newVideosRoot,
+  required String? newGameCoversRoot,
 }) async {
   await _rebaseContentPaths(
     dbDirectory: dbDirectory,
@@ -41,6 +42,39 @@ Future<void> _rebaseAllPaths({
     meta: meta,
     newVideosRoot: newVideosRoot,
   );
+  await _rebaseGameCoverPaths(
+    dbDirectory: dbDirectory,
+    meta: meta,
+    newGameCoversRoot: newGameCoversRoot,
+  );
+}
+
+/// Rebases every `galgames.cover_path` from the backup's
+/// [BackupMeta.gameCoversRoot] onto this device's [newGameCoversRoot]. No-op
+/// for a backup that packed no games / covers (meta root null) or an unticked
+/// games import (new root null). A cover not under the source root (a
+/// same-device merge, or the device's own rows) is left untouched by
+/// [rebasePath].
+Future<void> _rebaseGameCoverPaths({
+  required String dbDirectory,
+  required BackupMeta meta,
+  required String? newGameCoversRoot,
+}) async {
+  final String? oldRoot = meta.gameCoversRoot;
+  if (oldRoot == null || newGameCoversRoot == null) return;
+  final FushiDatabase db = FushiDatabase(dbDirectory);
+  try {
+    for (final GalgameRow g in await db.getAllGalgames()) {
+      final String? cover = g.coverPath;
+      if (cover == null) continue;
+      final String rebased = rebasePath(cover, oldRoot, newGameCoversRoot);
+      if (rebased == cover) continue;
+      await db.setGalgameCoverPath(g.id, rebased);
+    }
+    await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
+  } finally {
+    await db.close();
+  }
 }
 
 /// Rebases the imported DB's stored absolute content paths from the backup's

--- a/fushi/lib/src/sync/backup_service/restore.part.dart
+++ b/fushi/lib/src/sync/backup_service/restore.part.dart
@@ -68,6 +68,16 @@ class BackupRestoreService {
   /// files; videos = packed video files ([BackupMeta.videoFiles], else leaf
   /// files); localAudio = `local_audio_<n>.db` files (the `-wal`/`-shm` siblings
   /// are not separate databases).
+  ///
+  /// The DB-blob categories (videos / audiobooks / games / progress /
+  /// statistics) are decided by ROW counts: [meta] first, else the `db*Count`
+  /// peek. [peekFailed] = the caller needed the peek and it did not run — then
+  /// every such category whose count is still unknown is marked PRESENT
+  /// (offered as a ticked toggle) with no count. Fail-safe by construction:
+  /// an absent DB-blob category is not offered → not in the chosen set →
+  /// `!wants(c)` → the overwrite path STRIPS it (`_retainGames` & co.), so
+  /// "unknown" collapsing to "absent" would turn a failed temp-file extraction
+  /// into deleting the device's own games / progress / statistics.
   static BackupContentSummary summarizeBackupEntries(
     Iterable<String> archiveFileNames,
     BackupMeta? meta, {
@@ -76,6 +86,7 @@ class BackupRestoreService {
     int? dbGameCount,
     int? dbProgressCount,
     int? dbStatisticsCount,
+    bool peekFailed = false,
   }) {
     final Set<String> dictDirs = <String>{};
     final Set<String> bookDirs = <String>{};
@@ -159,7 +170,24 @@ class BackupRestoreService {
       if (progressCount > 0) BackupCategory.progress: progressCount,
       if (statisticsCount > 0) BackupCategory.statistics: statisticsCount,
     };
-    return BackupContentSummary(counts: counts, present: counts.keys.toSet());
+    // Peek needed but absent → the row counts meta lacks are UNKNOWN, and
+    // unknown must read as present (see doc). `statsCount` is always set on
+    // a parsed meta, so for statistics "meta lacks the count" means "meta
+    // predates progressCount" (the same generation that summed only the
+    // legacy aggregate tables).
+    final Set<BackupCategory> unknownPresent = <BackupCategory>{
+      if (peekFailed && meta?.videoBookCount == null) BackupCategory.videos,
+      if (peekFailed && meta?.audiobookCount == null)
+        BackupCategory.audiobooks,
+      if (peekFailed && meta?.gameCount == null) BackupCategory.games,
+      if (peekFailed && meta?.progressCount == null) BackupCategory.progress,
+      if (peekFailed && meta?.progressCount == null)
+        BackupCategory.statistics,
+    };
+    return BackupContentSummary(
+      counts: counts,
+      present: <BackupCategory>{...counts.keys, ...unknownPresent},
+    );
   }
 
   /// First path segment directly under `<prefix>/` in [posixName], or null when
@@ -209,7 +237,11 @@ class BackupRestoreService {
           dbAudiobookCount: peek?.audiobooks,
           dbGameCount: peek?.games,
           dbProgressCount: peek?.progress,
-          dbStatisticsCount: peek?.statistics);
+          dbStatisticsCount: peek?.statistics,
+          // A failed peek must never read as "the backup has none" — that
+          // would hide the toggles and the overwrite import would strip the
+          // device's own rows (see summarizeBackupEntries doc).
+          peekFailed: needPeek && peek == null);
     } catch (e, st) {
       debugPrint(
           'BackupRestoreService.summarizeBackupFile failed for $zipPath: $e\n$st');

--- a/fushi/lib/src/sync/backup_service/restore.part.dart
+++ b/fushi/lib/src/sync/backup_service/restore.part.dart
@@ -1,5 +1,15 @@
 part of '../backup_service.dart';
 
+/// Row counts peeked from a backup's DB blob for the import "what's inside"
+/// manifest when the meta predates the corresponding count field.
+typedef _ContentRowCounts = ({
+  int videos,
+  int audiobooks,
+  int games,
+  int progress,
+  int statistics,
+});
+
 /// 备份的恢复 / 合并 / 预览 / 崩溃恢复 / 读包摘要（B1 从 [BackupService] 分家）。
 ///
 /// 全部 static：恢复侧不需要导出侧的实例状态（库目录等都是参数）。共用的常量与
@@ -63,6 +73,9 @@ class BackupRestoreService {
     BackupMeta? meta, {
     int? dbVideoBookCount,
     int? dbAudiobookCount,
+    int? dbGameCount,
+    int? dbProgressCount,
+    int? dbStatisticsCount,
   }) {
     final Set<String> dictDirs = <String>{};
     final Set<String> bookDirs = <String>{};
@@ -70,6 +83,7 @@ class BackupRestoreService {
     int fontFiles = 0;
     int videoFiles = 0;
     int localAudioDbs = 0;
+    int gameCoverFiles = 0;
     for (final String raw in archiveFileNames) {
       final String name = raw.replaceAll(r'\', '/');
       final String? dictSeg =
@@ -100,6 +114,10 @@ class BackupRestoreService {
       if (name.startsWith('$_localAudioPrefix/')) {
         final String base = name.substring(_localAudioPrefix.length + 1);
         if (_localAudioDbOnly.hasMatch(base)) localAudioDbs++;
+        continue;
+      }
+      if (name.startsWith('$_gameCoversPrefix/')) {
+        if (name.length > _gameCoversPrefix.length + 1) gameCoverFiles++;
       }
     }
     // Video presence is decided by DB rows, NOT packed files: videos live in the
@@ -118,6 +136,18 @@ class BackupRestoreService {
     // a row-only / old backup and import ghost audiobooks un-skippably.
     final int audiobookCount =
         meta?.audiobookCount ?? dbAudiobookCount ?? audioDirs.length;
+    // Games decided by DB rows too: the `galgames` table rides the overwrite
+    // blob whether or not any cover file was packed. Same priority chain.
+    final int gameCount = meta?.gameCount ?? dbGameCount ?? gameCoverFiles;
+    // Progress / statistics are DB-ONLY categories (no archive tree at all),
+    // so without a row count the dialog could never show their toggles and
+    // they imported uninvited & un-skippable. meta first (new backups), else
+    // the DB-blob peek; a legacy backup with neither stays absent.
+    final int progressCount = meta?.progressCount ?? dbProgressCount ?? 0;
+    // The peek (old backups) counts the v92 `study_segments` too; an old
+    // meta's `statsCount` summed only the legacy day aggregates, so prefer the
+    // peek when it ran and fall back to meta (new backups, no peek needed).
+    final int statisticsCount = dbStatisticsCount ?? meta?.statsCount ?? 0;
     final Map<BackupCategory, int> counts = <BackupCategory, int>{
       if (dictDirs.isNotEmpty) BackupCategory.dictionary: dictDirs.length,
       if (bookDirs.isNotEmpty) BackupCategory.books: bookDirs.length,
@@ -125,6 +155,9 @@ class BackupRestoreService {
       if (fontFiles > 0) BackupCategory.fonts: fontFiles,
       if (videoCount > 0) BackupCategory.videos: videoCount,
       if (localAudioDbs > 0) BackupCategory.localAudio: localAudioDbs,
+      if (gameCount > 0) BackupCategory.games: gameCount,
+      if (progressCount > 0) BackupCategory.progress: progressCount,
+      if (statisticsCount > 0) BackupCategory.statistics: statisticsCount,
     };
     return BackupContentSummary(counts: counts, present: counts.keys.toSet());
   }
@@ -160,21 +193,23 @@ class BackupRestoreService {
       // (BUG-779 video / BUG-781 audiobooks). Peek the DB blob for the row counts
       // so the dialog can still offer the toggles. New backups carry the counts
       // in meta, so the (one-time) peek is skipped for them.
-      int? dbVideoBookCount;
-      int? dbAudiobookCount;
+      _ContentRowCounts? peek;
       final ArchiveFile? dbEntry = _findDbEntry(archive);
-      final bool needPeek =
-          (meta?.videoBookCount == null || meta?.audiobookCount == null) &&
-              dbEntry != null;
+      final bool needPeek = (meta == null ||
+              meta.videoBookCount == null ||
+              meta.audiobookCount == null ||
+              meta.gameCount == null ||
+              meta.progressCount == null) &&
+          dbEntry != null;
       if (needPeek) {
-        final ({int videos, int audiobooks})? peek =
-            await _peekContentRowCounts(zipPath, dbEntry.name);
-        dbVideoBookCount = peek?.videos;
-        dbAudiobookCount = peek?.audiobooks;
+        peek = await _peekContentRowCounts(zipPath, dbEntry.name);
       }
       return summarizeBackupEntries(names, meta,
-          dbVideoBookCount: dbVideoBookCount,
-          dbAudiobookCount: dbAudiobookCount);
+          dbVideoBookCount: peek?.videos,
+          dbAudiobookCount: peek?.audiobooks,
+          dbGameCount: peek?.games,
+          dbProgressCount: peek?.progress,
+          dbStatisticsCount: peek?.statistics);
     } catch (e, st) {
       debugPrint(
           'BackupRestoreService.summarizeBackupFile failed for $zipPath: $e\n$st');
@@ -192,7 +227,7 @@ class BackupRestoreService {
   /// [BackupMeta.audiobookCount] (BUG-779 / BUG-781). Reuses the isolate-backed
   /// [_extractEntriesStreaming] so a large metadata DB never materializes on
   /// the UI isolate.
-  static Future<({int videos, int audiobooks})?> _peekContentRowCounts(
+  static Future<_ContentRowCounts?> _peekContentRowCounts(
     String zipPath,
     String dbEntryName,
   ) async {
@@ -212,6 +247,13 @@ class BackupRestoreService {
         return (
           videos: _countTableIfPresent(db, 'video_books'),
           audiobooks: _countTableIfPresent(db, 'audiobooks'),
+          games: _countTableIfPresent(db, 'galgames'),
+          progress: _countTableIfPresent(db, 'reader_positions') +
+              _countTableIfPresent(db, 'bookmarks'),
+          statistics: _countTableIfPresent(db, 'reading_statistics') +
+              _countTableIfPresent(db, 'video_watch_statistics') +
+              _countTableIfPresent(db, 'mining_statistics') +
+              _countTableIfPresent(db, 'study_segments'),
         );
       } finally {
         db.dispose();
@@ -637,6 +679,7 @@ class BackupRestoreService {
     String? audiobooksRootDirectory,
     String? fontsRootDirectory,
     String? videosRootDirectory,
+    String? gameCoversRootDirectory,
     void Function(double progress)? onProgress,
   }) async {
     final dbPath = p.join(dbDirectory, _dbName);
@@ -723,6 +766,8 @@ class BackupRestoreService {
           wants(BackupCategory.videos) ? videosRootDirectory : null;
       final String? effLocalAudioRoot =
           wants(BackupCategory.localAudio) ? dbDirectory : null;
+      final String? effGameCoversRoot =
+          wants(BackupCategory.games) ? gameCoversRootDirectory : null;
 
       final sidecar = File(p.join(dbDirectory, _preserveSidecar));
       final String bakPath = '$dbPath.pre-restore.bak';
@@ -841,6 +886,12 @@ class BackupRestoreService {
                 onBytes: reportBytes)) {
           toCommit.add(effVideosRoot);
         }
+        if (effGameCoversRoot != null &&
+            await _prepareTreeReapply(
+                zipPath, archive, _gameCoversPrefix, effGameCoversRoot,
+                onBytes: reportBytes)) {
+          toCommit.add(effGameCoversRoot);
+        }
       } catch (_) {
         // A write failed: drop every staged temp dir; no tree was swapped.
         if (booksRootDirectory != null) {
@@ -854,6 +905,9 @@ class BackupRestoreService {
         }
         if (effVideosRoot != null) {
           await _abortPreparedTree(effVideosRoot);
+        }
+        if (effGameCoversRoot != null) {
+          await _abortPreparedTree(effGameCoversRoot);
         }
         rethrow;
       }
@@ -930,6 +984,7 @@ class BackupRestoreService {
           newFontsRoot: effFontsRoot,
           newLocalAudioRoot: effLocalAudioRoot,
           newVideosRoot: effVideosRoot,
+          newGameCoversRoot: effGameCoversRoot,
         );
       }
 
@@ -962,6 +1017,13 @@ class BackupRestoreService {
         // (effAudiobooksRoot=null) alone left ghost audiobooks (shelf + alignment
         // rows pointing at audio that never travelled).
         await _retainAudiobooks(dbDirectory, const <String>{});
+      }
+      if (!wants(BackupCategory.games)) {
+        // Games ride the overwrite DB blob like videos/audiobooks (galgames +
+        // FK cascade + logical game-kind rows); the cover tree restore was
+        // skipped above (effGameCoversRoot=null), so strip the rows too or the
+        // library would land as cover-less ghosts.
+        await _retainGames(dbDirectory, const <String>{});
       }
       if (!wants(BackupCategory.statistics) ||
           !wants(BackupCategory.progress)) {
@@ -1021,6 +1083,7 @@ class BackupRestoreService {
     String? audiobooksRootDirectory,
     String? fontsRootDirectory,
     String? videosRootDirectory,
+    String? gameCoversRootDirectory,
     void Function(double progress)? onProgress,
     bool adoptSourcePreferences = false,
   }) async {
@@ -1142,6 +1205,11 @@ class BackupRestoreService {
             zipPath, archive, _videosPrefix, videosRootDirectory,
             onBytes: reportBytes);
       }
+      if (gameCoversRootDirectory != null && wants(BackupCategory.games)) {
+        await _copyTreeIfAbsent(
+            zipPath, archive, _gameCoversPrefix, gameCoversRootDirectory,
+            onBytes: reportBytes);
+      }
       // Local-audio DBs are copy-if-absent into the support directory (never
       // overwrite the device's own local_audio_*.db files).
       if (wants(BackupCategory.localAudio)) {
@@ -1161,6 +1229,7 @@ class BackupRestoreService {
           newFontsRoot: fontsRootDirectory,
           newLocalAudioRoot: dbDirectory,
           newVideosRoot: videosRootDirectory,
+          newGameCoversRoot: gameCoversRootDirectory,
         );
       }
 

--- a/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
+++ b/fushi/lib/src/sync/sync_settings_schema/backup.part.dart
@@ -26,6 +26,8 @@ String backupCategoryLabel(BackupCategory category) {
       return t.backup_category_videos;
     case BackupCategory.localAudio:
       return t.backup_category_local_audio;
+    case BackupCategory.games:
+      return t.backup_category_games;
     case BackupCategory.progress:
       return t.backup_category_progress;
     case BackupCategory.statistics:
@@ -53,6 +55,8 @@ String backupCategoryDescription(BackupCategory category) {
       return t.backup_category_videos_desc;
     case BackupCategory.localAudio:
       return t.backup_category_local_audio_desc;
+    case BackupCategory.games:
+      return t.backup_category_games_desc;
     case BackupCategory.progress:
       return t.backup_category_progress_desc;
     case BackupCategory.statistics:
@@ -78,6 +82,7 @@ const Set<BackupCategory> importSelectableCategories = <BackupCategory>{
   BackupCategory.fonts,
   BackupCategory.videos,
   BackupCategory.localAudio,
+  BackupCategory.games,
   BackupCategory.progress,
   BackupCategory.statistics,
 };
@@ -160,6 +165,9 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
       // config; otherwise the restored config points at files that never
       // crossed over and the fonts silently never apply.
       fontsRootDirectory: p.join(appModel.appDirectory.path, 'custom_fonts'),
+      // Game covers travel with the `games` category (rows + cover files).
+      gameCoversRootDirectory:
+          p.join(appModel.appDirectory.path, 'game_covers'),
     );
     // TODO-1358: summarize what is on this device so the category picker shows
     // per-category counts (the database itself is always included).
@@ -200,30 +208,6 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
     // Per-video selection (the books analogue). Mutated by the nested video
     // picker; written back to [_selectedVideoKeys] only on confirm.
     Set<String>? chosenVideos = _selectedVideoKeys;
-    String labelFor(BackupCategory c) {
-      switch (c) {
-        case BackupCategory.dictionary:
-          return t.backup_category_dictionary;
-        case BackupCategory.books:
-          return t.backup_category_books;
-        case BackupCategory.audiobooks:
-          return t.backup_category_audiobooks;
-        case BackupCategory.fonts:
-          return t.backup_category_fonts;
-        case BackupCategory.videos:
-          return t.backup_category_videos;
-        case BackupCategory.localAudio:
-          return t.backup_category_local_audio;
-        case BackupCategory.progress:
-          return t.backup_category_progress;
-        case BackupCategory.statistics:
-          return t.backup_category_statistics;
-        case BackupCategory.settings:
-          return t.backup_category_settings;
-        case BackupCategory.profiles:
-          return t.backup_category_profiles;
-      }
-    }
 
     final bool? confirmed = await showAppDialog<bool>(
       context: context,
@@ -268,7 +252,7 @@ class _BackupExportWidgetState extends State<_BackupExportWidget> {
                   for (final BackupCategory c
                       in BackupCategory.values) ...<Widget>[
                     AdaptiveSettingsSwitchRow(
-                      title: labelFor(c),
+                      title: backupCategoryLabel(c),
                       subtitle: summary.counts.containsKey(c)
                           ? '${backupCategoryDescription(c)} '
                               '(${summary.countFor(c)})'
@@ -987,6 +971,8 @@ Future<void> runBackupImportFlowForFile({
       p.join(appModel.appDirectory.path, 'audiobooks');
   final String fontsRoot = p.join(appModel.appDirectory.path, 'custom_fonts');
   final String videosRoot = p.join(appModel.appDirectory.path, 'videos');
+  final String gameCoversRoot =
+      p.join(appModel.appDirectory.path, 'game_covers');
 
   try {
     // TODO-1151: 用户已确认 → 上屏全屏「正在导入备份，请勿关闭」遮罩（running 相位），
@@ -1016,6 +1002,7 @@ Future<void> runBackupImportFlowForFile({
         audiobooksRootDirectory: audiobooksRoot,
         fontsRootDirectory: fontsRoot,
         videosRootDirectory: videosRoot,
+        gameCoversRootDirectory: gameCoversRoot,
         // TODO-1183: 后台解压 isolate 经 SendPort 回报字节 → 确定进度条。
         onProgress: appModel.reportBackupImportProgress,
       );
@@ -1034,6 +1021,7 @@ Future<void> runBackupImportFlowForFile({
         // config paths onto this device's root.
         fontsRootDirectory: fontsRoot,
         videosRootDirectory: videosRoot,
+        gameCoversRootDirectory: gameCoversRoot,
         // TODO-1183: 后台解压 isolate 经 SendPort 回报字节 → 确定进度条。
         onProgress: appModel.reportBackupImportProgress,
       );

--- a/fushi/test/migration/migration_manifest_test.dart
+++ b/fushi/test/migration/migration_manifest_test.dart
@@ -156,6 +156,7 @@ void main() {
   group('MigrationExporter 纯逻辑', () {
     test('categoriesForBatch：每批都带核心四类，videos 永不出现', () {
       const Set<BackupCategory> core = <BackupCategory>{
+        BackupCategory.games,
         BackupCategory.progress,
         BackupCategory.statistics,
         BackupCategory.settings,

--- a/fushi/test/sync/aggregate_study_segments_sync_test.dart
+++ b/fushi/test/sync/aggregate_study_segments_sync_test.dart
@@ -614,12 +614,13 @@ void main() {
         'shared',
         'local',
         'backup',
-      }, reason: 'doomed 被备份里的墓碑压制；备份里的游戏段不搬入（BUG-2221）');
+      }, reason: 'doomed 被备份里的墓碑压制；备份里的游戏段无宿主游戏行 → 不搬入'
+          '（有宿主时经游戏身份映射落地，见 backup_games_category_test）');
       expect(byUid['shared']!.durationMs, 900, reason: 'LWW 取备份里更新的值');
       expect(
         (await merged.getStudySegmentTombstones()).single.mediaKey,
         'v3',
-        reason: '游戏碑不搬入',
+        reason: '无宿主的游戏碑不搬入',
       );
     });
 

--- a/fushi/test/sync/backup_categories_test.dart
+++ b/fushi/test/sync/backup_categories_test.dart
@@ -369,8 +369,8 @@ void main() {
         reason: 'audio tree absent from backup → existing tree untouched');
   });
   test(
-      'BackupCategory enumerates the six sidecar trees plus the four DB-only '
-      'data categories (db is never itself a category)', () {
+      'BackupCategory enumerates the seven content categories plus the four '
+      'DB-only data categories (db is never itself a category)', () {
     expect(BackupCategory.values.toSet(), <BackupCategory>{
       BackupCategory.dictionary,
       BackupCategory.books,
@@ -378,6 +378,7 @@ void main() {
       BackupCategory.fonts,
       BackupCategory.videos,
       BackupCategory.localAudio,
+      BackupCategory.games,
       BackupCategory.progress,
       BackupCategory.statistics,
       BackupCategory.settings,

--- a/fushi/test/sync/backup_games_category_test.dart
+++ b/fushi/test/sync/backup_games_category_test.dart
@@ -124,6 +124,8 @@ void main() {
     );
     final int tagId = await db.createTag('fav', 0xff0000);
     await db.addTagToGame(gameId, tagId);
+    final int collectionId = await db.createMediaCollection('gal-col');
+    await db.addToCollection(collectionId, MediaKind.game, gameId);
     await db.addActivityEvent(
       eventType: kActivityGame,
       mediaType: kActivityMediaGame,
@@ -209,6 +211,15 @@ void main() {
       expect(
         await countRows(db, 'tag_assignments', "WHERE media_kind = 'game'"),
         0,
+      );
+      expect(
+        await countRows(
+          db,
+          'media_collection_items',
+          "WHERE media_type = 'game'",
+        ),
+        0,
+        reason: '合集里的游戏成员随宿主一起裁掉，不留孤儿成员',
       );
       expect(
         await countRows(db, 'study_segments', "WHERE media_kind = 'game'"),
@@ -363,6 +374,74 @@ void main() {
       );
     },
   );
+
+  test('旧包窥探失败：未知按「存在」处理，games/progress/statistics 仍在 present', () async {
+    // 纯函数面：peekFailed 且 meta 缺计数 → present 含全部 DB-blob 类别（无计数）。
+    final BackupContentSummary pure =
+        BackupRestoreService.summarizeBackupEntries(
+      const <String>['fushi.db'],
+      BackupMeta(
+        appVersion: '1',
+        schemaVersion: 1,
+        createdAt: DateTime(2026),
+        bookCount: 0,
+        statsCount: 0,
+      ),
+      peekFailed: true,
+    );
+    expect(
+      pure.present,
+      containsAll(<BackupCategory>[
+        BackupCategory.games,
+        BackupCategory.progress,
+        BackupCategory.statistics,
+        BackupCategory.videos,
+        BackupCategory.audiobooks,
+      ]),
+      reason: '窥探失败若按 0 处理，开关不出现 → 类别集不含 games → 覆盖导入会把'
+          '本机游戏库删光；未知必须按存在处理',
+    );
+    expect(pure.countFor(BackupCategory.games), 0, reason: '无计数，只标存在');
+    // 新格式 meta（有计数）不受 peekFailed 影响：计数是权威。
+    final BackupContentSummary known =
+        BackupRestoreService.summarizeBackupEntries(
+      const <String>['fushi.db'],
+      BackupMeta(
+        appVersion: '1',
+        schemaVersion: 1,
+        createdAt: DateTime(2026),
+        bookCount: 0,
+        statsCount: 0,
+        videoBookCount: 0,
+        audiobookCount: 0,
+        gameCount: 0,
+        progressCount: 0,
+      ),
+      peekFailed: true,
+    );
+    expect(known.present, isEmpty);
+
+    // 真实文件面：旧 meta + 损坏的 fushi.db 条目 → _peekContentRowCounts 返回
+    // null → summarizeBackupFile 必须把 games 标成存在。
+    final String zip = p.join(dst.path, 'legacy_bad_db.zip');
+    final Archive out = Archive();
+    final List<int> metaBytes = utf8.encode(jsonEncode(<String, Object?>{
+      'appVersion': '1.0.0',
+      'schemaVersion': 1,
+      'createdAt': DateTime(2026).toIso8601String(),
+      'bookCount': 0,
+      'statsCount': 0,
+    }));
+    out.addFile(ArchiveFile('backup_meta.json', metaBytes.length, metaBytes));
+    final List<int> junk = utf8.encode('this is not a sqlite database at all');
+    out.addFile(ArchiveFile('fushi.db', junk.length, junk));
+    File(zip).writeAsBytesSync(ZipEncoder().encode(out)!);
+    final BackupContentSummary viaFile =
+        await BackupRestoreService.summarizeBackupFile(zip);
+    expect(viaFile.has(BackupCategory.games), isTrue);
+    expect(viaFile.has(BackupCategory.progress), isTrue);
+    expect(viaFile.has(BackupCategory.statistics), isTrue);
+  });
 
   test('覆盖导入 games 勾选：游戏行落地、封面树恢复、cover_path 重定位到本机', () async {
     final s = await seedSource(src);
@@ -598,6 +677,24 @@ void main() {
           "WHERE media_kind = 'game' AND entry_key = 'G1'",
         ),
         0,
+      );
+      expect(
+        await countRows(
+          cur,
+          'media_collection_items',
+          "WHERE media_type = 'game' AND entry_key = 'T1'",
+        ),
+        1,
+        reason: '合集成员与标签/会话同律：经身份映射落到 T1',
+      );
+      expect(
+        await countRows(
+          cur,
+          'media_collection_items',
+          "WHERE media_type = 'game' AND entry_key = 'G1'",
+        ),
+        0,
+        reason: '不得留下指向不存在游戏的孤儿成员',
       );
       // 全库不存在指向 G1 的任何引用。
       expect(

--- a/fushi/test/sync/backup_games_category_test.dart
+++ b/fushi/test/sync/backup_games_category_test.dart
@@ -1,0 +1,706 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/sync/backup_service.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'temp_dir_cleanup.dart';
+
+/// `BackupCategory.games`：游戏库（galgames + galgame_sources + 封面文件）成为
+/// 可选导出 / 导入类别。此前游戏行永远随整库 DB 走（导出不可剔、导入不可跳），
+/// 封面反而从不打包。顺带钉死两条一并修的旧承诺：`study_segments` 归统计类别，
+/// 导入摘要的 present 集合补上 progress / statistics / games。
+void main() {
+  late Directory src;
+  late Directory dst;
+
+  setUp(() async {
+    src = await Directory.systemTemp.createTemp('bk_games_src_');
+    dst = await Directory.systemTemp.createTemp('bk_games_dst_');
+  });
+  tearDown(() async {
+    for (final Directory d in <Directory>[src, dst]) {
+      if (d.existsSync()) await cleanupTempDir(d);
+    }
+  });
+
+  Future<int> countRows(
+    FushiDatabase db,
+    String table, [
+    String where = '',
+  ]) async {
+    final row = await db
+        .customSelect('SELECT COUNT(*) AS c FROM $table $where')
+        .getSingle();
+    return row.data['c'] as int;
+  }
+
+  Future<Archive> readZip(String zipPath) async {
+    final InputFileStream input = InputFileStream(zipPath);
+    try {
+      return ZipDecoder().decodeBuffer(input);
+    } finally {
+      await input.close();
+    }
+  }
+
+  Future<FushiDatabase> openBackupDb(String zipPath, Directory into) async {
+    final Archive archive = await readZip(zipPath);
+    final ArchiveFile dbFile = archive.findFile('fushi.db')!;
+    final Directory dir = Directory(p.join(into.path, 'exdb'))
+      ..createSync(recursive: true);
+    File(
+      p.join(dir.path, 'fushi.db'),
+    ).writeAsBytesSync(dbFile.content as List<int>);
+    return FushiDatabase(dir.path);
+  }
+
+  /// Seeds one game (`G1`, scrape identity bgm:100, cover on disk) with a
+  /// play session, a chars-only study segment, a tag and a legacy activity row,
+  /// plus one book with progress so the other categories have content too.
+  Future<({FushiDatabase db, String dbDir, String coversRoot})> seedSource(
+    Directory root, {
+    String gameId = 'G1',
+    String exePath = r'D:\games\g1\g1.exe',
+  }) async {
+    final String dbDir = p.join(root.path, 'support');
+    final String covers = p.join(root.path, 'documents', 'game_covers');
+    Directory(dbDir).createSync(recursive: true);
+    File(p.join(covers, '$gameId.png'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('PNG');
+    final FushiDatabase db = FushiDatabase(dbDir);
+    await db.upsertGalgame(
+      GalgamesCompanion.insert(
+        id: gameId,
+        name: 'Game One',
+        exePath: exePath,
+        workdir: p.dirname(exePath),
+        addedAt: 1,
+        coverPath: Value<String?>(p.join(covers, '$gameId.png')),
+      ),
+    );
+    await db.upsertGalgameSource(
+      GalgameSourcesCompanion.insert(
+        gameId: gameId,
+        source: 'bgm',
+        externalId: const Value<String?>('100'),
+        dataJson: '{}',
+        fetchedAt: 1,
+      ),
+    );
+    await db.insertGalgameSession(
+      GalgameSessionsCompanion.insert(
+        gameId: gameId,
+        startMs: 1000,
+        endMs: 61000,
+        durationSeconds: 60,
+        dateKey: '2026-01-01',
+      ),
+    );
+    await db.upsertStudySegment(
+      StudySegmentsCompanion.insert(
+        uid: 'seg-$gameId',
+        deviceId: 'dev-src',
+        mediaKind: kActivityMediaGame,
+        mediaKey: gameId,
+        title: 'Game One',
+        startAt: 2000,
+        endAt: 2000,
+        dateKey: '2026-01-01',
+        hour: 0,
+        chars: const Value<int>(42),
+        updatedAt: 2000,
+      ),
+    );
+    await db.upsertStudySegmentTombstone(
+      mediaKind: kActivityMediaGame,
+      mediaKey: gameId,
+      deletedAt: 500,
+    );
+    final int tagId = await db.createTag('fav', 0xff0000);
+    await db.addTagToGame(gameId, tagId);
+    await db.addActivityEvent(
+      eventType: kActivityGame,
+      mediaType: kActivityMediaGame,
+      title: 'Game One',
+      mediaKey: gameId,
+      dateKey: '2026-01-01',
+      timestampMs: 3000,
+      charsDelta: 5,
+    );
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: 'Bk',
+        title: 'Bk',
+        epubPath: 'x',
+        extractDir: 'y',
+        chapterCount: 1,
+        chaptersJson: '["c"]',
+        importedAt: 0,
+      ),
+    );
+    final String bkUid = (await db.resolveEpubBookUid('Bk'))!;
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookUid: bkUid,
+        sectionIndex: 0,
+        normCharOffset: 100,
+        updatedAt: 1,
+      ),
+    );
+    await db.upsertStudySegment(
+      StudySegmentsCompanion.insert(
+        uid: 'seg-book',
+        deviceId: 'dev-src',
+        mediaKind: 'read',
+        mediaKey: bkUid,
+        title: 'Bk',
+        startAt: 4000,
+        endAt: 5000,
+        dateKey: '2026-01-01',
+        hour: 0,
+        durationMs: const Value<int>(1000),
+        updatedAt: 5000,
+      ),
+    );
+    return (db: db, dbDir: dbDir, coversRoot: covers);
+  }
+
+  BackupService serviceFor(
+    ({FushiDatabase db, String dbDir, String coversRoot}) s,
+  ) =>
+      BackupService(
+        db: s.db,
+        dbDirectory: s.dbDir,
+        appVersion: '1.0.0',
+        gameCoversRootDirectory: s.coversRoot,
+      );
+
+  Set<BackupCategory> allExcept(BackupCategory c) =>
+      BackupCategory.values.toSet()..remove(c);
+
+  test('games 未勾：导出 DB 无任何游戏行、zip 无 game_covers、meta 记 0', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'no_games.zip');
+    final BackupMeta meta = await serviceFor(
+      s,
+    ).createBackup(zip, categories: allExcept(BackupCategory.games));
+    await s.db.close();
+
+    expect(meta.gameCount, 0);
+    expect(meta.gameCoversRoot, isNull);
+    expect(meta.excludedCategories, contains('games'));
+    final Archive archive = await readZip(zip);
+    expect(
+      archive.files.any((ArchiveFile f) => f.name.startsWith('game_covers/')),
+      isFalse,
+      reason: '未勾 games 不得打包封面',
+    );
+    final FushiDatabase db = await openBackupDb(zip, dst);
+    try {
+      expect(await countRows(db, 'galgames'), 0);
+      expect(await countRows(db, 'galgame_sources'), 0);
+      expect(await countRows(db, 'galgame_sessions'), 0);
+      expect(
+        await countRows(db, 'tag_assignments', "WHERE media_kind = 'game'"),
+        0,
+      );
+      expect(
+        await countRows(db, 'study_segments', "WHERE media_kind = 'game'"),
+        0,
+      );
+      expect(
+        await countRows(
+          db,
+          'study_segment_tombstones',
+          "WHERE media_kind = 'game'",
+        ),
+        0,
+      );
+      expect(
+        await countRows(db, 'activity_events', "WHERE media_type = 'game'"),
+        0,
+      );
+      // 其它类别不受牵连。
+      expect(await countRows(db, 'epub_books'), 1);
+      expect(
+        await countRows(db, 'study_segments', "WHERE media_kind = 'read'"),
+        1,
+      );
+      expect(await countRows(db, 'book_tags'), 0, reason: '只剩游戏引用的标签随宿主一起排干');
+    } finally {
+      await db.close();
+    }
+  });
+
+  test('games 勾选：导出 DB 有游戏行、zip 打包封面、meta 记根与计数', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'games.zip');
+    final BackupMeta meta = await serviceFor(s).createBackup(zip);
+    await s.db.close();
+
+    expect(meta.gameCount, 1);
+    expect(meta.gameCoversRoot, s.coversRoot);
+    expect(meta.progressCount, 1);
+    expect(meta.statsCount, 2, reason: 'study_segments 计入统计记录数');
+    final Archive archive = await readZip(zip);
+    expect(archive.findFile('game_covers/G1.png'), isNotNull);
+    final FushiDatabase db = await openBackupDb(zip, dst);
+    try {
+      expect(await countRows(db, 'galgames'), 1);
+      expect(await countRows(db, 'galgame_sources'), 1);
+      expect(await countRows(db, 'galgame_sessions'), 1);
+    } finally {
+      await db.close();
+    }
+    // 往返：meta JSON 带新字段。
+    final BackupMeta round = BackupMeta.fromJson(meta.toJson());
+    expect(round.gameCount, 1);
+    expect(round.progressCount, 1);
+    expect(round.gameCoversRoot, s.coversRoot);
+  });
+
+  test('statistics 未勾：study_segments 与其墓碑真的被裁掉', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'no_stats.zip');
+    await serviceFor(
+      s,
+    ).createBackup(zip, categories: allExcept(BackupCategory.statistics));
+    await s.db.close();
+    final FushiDatabase db = await openBackupDb(zip, dst);
+    try {
+      expect(await countRows(db, 'study_segments'), 0);
+      expect(await countRows(db, 'study_segment_tombstones'), 0);
+      expect(await countRows(db, 'galgame_sessions'), 0);
+      expect(await countRows(db, 'galgames'), 1, reason: '游戏行是内容');
+    } finally {
+      await db.close();
+    }
+  });
+
+  test('导出侧 summarizeLiveContent 报 games / progress / statistics 计数', () async {
+    final s = await seedSource(src);
+    final BackupContentSummary summary = await serviceFor(
+      s,
+    ).summarizeLiveContent();
+    await s.db.close();
+    expect(summary.countFor(BackupCategory.games), 1);
+    expect(summary.countFor(BackupCategory.progress), 1);
+    expect(summary.countFor(BackupCategory.statistics), 2);
+    expect(
+      summary.present,
+      containsAll(<BackupCategory>[
+        BackupCategory.games,
+        BackupCategory.progress,
+        BackupCategory.statistics,
+      ]),
+    );
+  });
+
+  test(
+    '导入摘要：新包经 meta、旧包经 DB 窥探，present 都含 games/progress/statistics',
+    () async {
+      final s = await seedSource(src);
+      final String zip = p.join(src.path, 'full.zip');
+      await serviceFor(s).createBackup(zip);
+      await s.db.close();
+
+      final BackupContentSummary viaMeta =
+          await BackupRestoreService.summarizeBackupFile(zip);
+      expect(viaMeta.countFor(BackupCategory.games), 1);
+      expect(viaMeta.countFor(BackupCategory.progress), 1);
+      expect(viaMeta.countFor(BackupCategory.statistics), 2);
+
+      // 旧包：meta 没有 gameCount / progressCount / gameCoversRoot（且
+      // excludedCategories 里没有 games）——重打一个只改 meta 的 zip。
+      final String legacyZip = await _rewriteMetaWithout(
+        zip,
+        dst,
+        const <String>[
+          'gameCount',
+          'progressCount',
+          'gameCoversRoot',
+          'statsCount',
+        ],
+      );
+      final BackupContentSummary viaPeek =
+          await BackupRestoreService.summarizeBackupFile(legacyZip);
+      expect(
+        viaPeek.countFor(BackupCategory.games),
+        1,
+        reason: '旧 meta 无计数 → 窥探 DB 行数',
+      );
+      expect(viaPeek.countFor(BackupCategory.progress), 1);
+      expect(viaPeek.countFor(BackupCategory.statistics), 2);
+      expect(viaPeek.has(BackupCategory.games), isTrue);
+
+      // 纯函数面：legacy meta + 窥探值 → present。
+      final BackupContentSummary pure =
+          BackupRestoreService.summarizeBackupEntries(
+        const <String>['fushi.db'],
+        BackupMeta(
+          appVersion: '1',
+          schemaVersion: 1,
+          createdAt: DateTime(2026),
+          bookCount: 0,
+          statsCount: 0,
+        ),
+        dbGameCount: 3,
+        dbProgressCount: 2,
+        dbStatisticsCount: 5,
+      );
+      expect(pure.countFor(BackupCategory.games), 3);
+      expect(pure.countFor(BackupCategory.progress), 2);
+      expect(
+        pure.countFor(BackupCategory.statistics),
+        5,
+        reason: '窥探值优先于旧 meta 只数 legacy 表的 statsCount',
+      );
+    },
+  );
+
+  test('覆盖导入 games 勾选：游戏行落地、封面树恢复、cover_path 重定位到本机', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'full.zip');
+    await serviceFor(s).createBackup(zip);
+    await s.db.close();
+
+    final String curDbDir = p.join(dst.path, 'support');
+    final String curCovers = p.join(dst.path, 'documents', 'game_covers');
+    Directory(curDbDir).createSync(recursive: true);
+    await BackupRestoreService.restoreBackup(
+      dbDirectory: curDbDir,
+      zipPath: zip,
+      gameCoversRootDirectory: curCovers,
+    );
+    final FushiDatabase cur = FushiDatabase(curDbDir);
+    try {
+      final List<GalgameRow> games = await cur.getAllGalgames();
+      expect(games, hasLength(1));
+      expect(games.single.coverPath, p.join(curCovers, 'G1.png'));
+      expect(File(p.join(curCovers, 'G1.png')).existsSync(), isTrue);
+      expect(await countRows(cur, 'galgame_sessions'), 1);
+    } finally {
+      await cur.close();
+    }
+  });
+
+  test('覆盖导入 games 未勾：备份里的游戏不落地（行与封面都不来）', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'full.zip');
+    await serviceFor(s).createBackup(zip);
+    await s.db.close();
+
+    final String curDbDir = p.join(dst.path, 'support');
+    final String curCovers = p.join(dst.path, 'documents', 'game_covers');
+    Directory(curDbDir).createSync(recursive: true);
+    await BackupRestoreService.restoreBackup(
+      dbDirectory: curDbDir,
+      zipPath: zip,
+      categories: allExcept(BackupCategory.games),
+      gameCoversRootDirectory: curCovers,
+    );
+    final FushiDatabase cur = FushiDatabase(curDbDir);
+    try {
+      expect(await countRows(cur, 'galgames'), 0);
+      expect(await countRows(cur, 'galgame_sessions'), 0);
+      expect(
+        await countRows(cur, 'study_segments', "WHERE media_kind = 'game'"),
+        0,
+      );
+      expect(await countRows(cur, 'epub_books'), 1, reason: '书照常恢复');
+      expect(File(p.join(curCovers, 'G1.png')).existsSync(), isFalse);
+    } finally {
+      await cur.close();
+    }
+  });
+
+  test(
+    '旧包（excludedCategories 无 games、meta 无 gameCount）导入等价于 games 已勾选',
+    () async {
+      final s = await seedSource(src);
+      final String zip = p.join(src.path, 'full.zip');
+      await serviceFor(s).createBackup(zip);
+      await s.db.close();
+      final String legacyZip = await _rewriteMetaWithout(
+        zip,
+        dst,
+        const <String>['gameCount', 'progressCount', 'gameCoversRoot'],
+      );
+      final BackupMeta legacyMeta = (await BackupRestoreService.validateBackup(
+        legacyZip,
+      ))!;
+      expect(legacyMeta.gameCount, isNull);
+      expect(legacyMeta.excludedCategories, isNot(contains('games')));
+
+      final String curDbDir = p.join(dst.path, 'support');
+      Directory(curDbDir).createSync(recursive: true);
+      await BackupRestoreService.restoreBackup(
+        dbDirectory: curDbDir,
+        zipPath: legacyZip,
+        gameCoversRootDirectory: p.join(dst.path, 'documents', 'game_covers'),
+      );
+      final FushiDatabase cur = FushiDatabase(curDbDir);
+      try {
+        expect(
+          await countRows(cur, 'galgames'),
+          1,
+          reason: '旧包的游戏行照旧随整库恢复（Never break userspace）',
+        );
+        expect(await countRows(cur, 'galgame_sessions'), 1);
+      } finally {
+        await cur.close();
+      }
+    },
+  );
+
+  test('合并导入：按刮削身份去重 + 子行重映射；新游戏插入并重定位封面', () async {
+    // src：G1（bgm:100，本机路径 D:\games\g1）+ G2（无刮削身份、独有）。
+    final s = await seedSource(src);
+    File(p.join(s.coversRoot, 'G2.png')).writeAsStringSync('PNG2');
+    await s.db.upsertGalgame(
+      GalgamesCompanion.insert(
+        id: 'G2',
+        name: 'Game Two',
+        exePath: r'D:\games\g2\g2.exe',
+        workdir: r'D:\games\g2',
+        addedAt: 2,
+        coverPath: Value<String?>(p.join(s.coversRoot, 'G2.png')),
+      ),
+    );
+    final String zip = p.join(src.path, 'merge.zip');
+    await serviceFor(s).createBackup(zip);
+    await s.db.close();
+
+    // target：同一部游戏 T1（bgm:100）装在别的路径、自己的封面 + 自己的会话。
+    final String curDbDir = p.join(dst.path, 'support');
+    final String curCovers = p.join(dst.path, 'documents', 'game_covers');
+    Directory(curDbDir).createSync(recursive: true);
+    File(p.join(curCovers, 'T1.jpg'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('JPG');
+    final FushiDatabase seed = FushiDatabase(curDbDir);
+    await seed.upsertGalgame(
+      GalgamesCompanion.insert(
+        id: 'T1',
+        name: 'Game One (local)',
+        exePath: r'E:\gal\one\one.exe',
+        workdir: r'E:\gal\one',
+        addedAt: 9,
+        coverPath: Value<String?>(p.join(curCovers, 'T1.jpg')),
+      ),
+    );
+    await seed.upsertGalgameSource(
+      GalgameSourcesCompanion.insert(
+        gameId: 'T1',
+        source: 'bgm',
+        externalId: const Value<String?>('100'),
+        dataJson: '{"local":true}',
+        fetchedAt: 9,
+      ),
+    );
+    await seed.insertGalgameSession(
+      GalgameSessionsCompanion.insert(
+        gameId: 'T1',
+        startMs: 9000,
+        endMs: 9900,
+        durationSeconds: 1,
+        dateKey: '2026-01-02',
+      ),
+    );
+    await seed.close();
+
+    await BackupRestoreService.mergeRestoreBackup(
+      dbDirectory: curDbDir,
+      zipPath: zip,
+      gameCoversRootDirectory: curCovers,
+    );
+
+    final FushiDatabase cur = FushiDatabase(curDbDir);
+    try {
+      final List<GalgameRow> games = await cur.getAllGalgames();
+      expect(
+        games.map((GalgameRow g) => g.id).toSet(),
+        <String>{'T1', 'G2'},
+        reason: 'G1 与 T1 同刮削身份 → 去重不插；G2 独有 → 插入',
+      );
+      final GalgameRow t1 = games.singleWhere((GalgameRow g) => g.id == 'T1');
+      expect(t1.coverPath, p.join(curCovers, 'T1.jpg'), reason: '目标自己的行原样保留');
+      expect(t1.exePath, r'E:\gal\one\one.exe');
+      final GalgameRow g2 = games.singleWhere((GalgameRow g) => g.id == 'G2');
+      expect(
+        g2.coverPath,
+        p.join(curCovers, 'G2.png'),
+        reason: '新插入行的 cover_path 重定位到本机 game_covers',
+      );
+      expect(
+        File(p.join(curCovers, 'G2.png')).existsSync(),
+        isTrue,
+        reason: '封面 copy-if-absent 落地',
+      );
+      // galgame_sources：T1 保留自己的 bgm 快照。
+      final List<GalgameSourceRow> t1Sources = await cur.getGalgameSources(
+        'T1',
+      );
+      expect(t1Sources.single.dataJson, '{"local":true}');
+      // 会话：src G1 的会话重映射到 T1；目标原有会话保留。
+      expect(
+        await countRows(cur, 'galgame_sessions', "WHERE game_id = 'T1'"),
+        2,
+      );
+      expect(
+        await countRows(cur, 'galgame_sessions', "WHERE game_id = 'G1'"),
+        0,
+        reason: '不得留下指向不存在宿主的会话',
+      );
+      // 学习段 / 墓碑 / 活动行 / 标签：media_key 全部落到 T1。
+      expect(
+        await countRows(
+          cur,
+          'study_segments',
+          "WHERE media_kind = 'game' AND media_key = 'T1'",
+        ),
+        1,
+      );
+      expect(
+        await countRows(
+          cur,
+          'study_segment_tombstones',
+          "WHERE media_kind = 'game' AND media_key = 'T1'",
+        ),
+        1,
+      );
+      expect(
+        await countRows(
+          cur,
+          'activity_events',
+          "WHERE media_type = 'game' AND media_key = 'T1'",
+        ),
+        1,
+      );
+      expect(
+        await countRows(
+          cur,
+          'tag_assignments',
+          "WHERE media_kind = 'game' AND entry_key = 'T1'",
+        ),
+        1,
+      );
+      expect(
+        await countRows(
+          cur,
+          'tag_assignments',
+          "WHERE media_kind = 'game' AND entry_key = 'G1'",
+        ),
+        0,
+      );
+      // 全库不存在指向 G1 的任何引用。
+      expect(
+        await countRows(cur, 'study_segments', "WHERE media_key = 'G1'"),
+        0,
+      );
+    } finally {
+      await cur.close();
+    }
+
+    // 幂等：再合并一次，行数不变。
+    await BackupRestoreService.mergeRestoreBackup(
+      dbDirectory: curDbDir,
+      zipPath: zip,
+      gameCoversRootDirectory: curCovers,
+    );
+    final FushiDatabase again = FushiDatabase(curDbDir);
+    try {
+      expect(await countRows(again, 'galgames'), 2);
+      expect(await countRows(again, 'galgame_sessions'), 2);
+      expect(
+        await countRows(again, 'study_segments', "WHERE media_kind = 'game'"),
+        1,
+      );
+      expect(
+        await countRows(again, 'tag_assignments', "WHERE media_kind = 'game'"),
+        1,
+      );
+    } finally {
+      await again.close();
+    }
+  });
+
+  test('合并导入 games 未勾：不插游戏；无宿主的游戏事实行跳过而非悬空', () async {
+    final s = await seedSource(src);
+    final String zip = p.join(src.path, 'merge.zip');
+    await serviceFor(s).createBackup(zip);
+    await s.db.close();
+
+    final String curDbDir = p.join(dst.path, 'support');
+    Directory(curDbDir).createSync(recursive: true);
+    await BackupRestoreService.mergeRestoreBackup(
+      dbDirectory: curDbDir,
+      zipPath: zip,
+      categories: allExcept(BackupCategory.games),
+      gameCoversRootDirectory: p.join(dst.path, 'documents', 'game_covers'),
+    );
+    final FushiDatabase cur = FushiDatabase(curDbDir);
+    try {
+      expect(await countRows(cur, 'galgames'), 0);
+      expect(await countRows(cur, 'galgame_sessions'), 0);
+      expect(
+        await countRows(cur, 'study_segments', "WHERE media_kind = 'game'"),
+        0,
+      );
+      expect(
+        await countRows(cur, 'tag_assignments', "WHERE media_kind = 'game'"),
+        0,
+      );
+      expect(
+        await countRows(cur, 'study_segments', "WHERE media_kind = 'read'"),
+        1,
+        reason: '非游戏统计照常合并',
+      );
+      expect(await countRows(cur, 'epub_books'), 1);
+    } finally {
+      await cur.close();
+    }
+  });
+}
+
+/// Repacks [zipPath] into [into] with the listed [keys] deleted from
+/// `backup_meta.json`, simulating a backup written before those fields existed.
+Future<String> _rewriteMetaWithout(
+  String zipPath,
+  Directory into,
+  List<String> keys,
+) async {
+  final InputFileStream input = InputFileStream(zipPath);
+  final Archive archive;
+  try {
+    archive = ZipDecoder().decodeBuffer(input);
+  } finally {
+    await input.close();
+  }
+  final Archive out = Archive();
+  for (final ArchiveFile f in archive.files) {
+    if (!f.isFile) continue;
+    if (f.name == 'backup_meta.json') {
+      final Map<String, dynamic> meta =
+          jsonDecode(utf8.decode(f.content as List<int>))
+              as Map<String, dynamic>;
+      for (final String k in keys) {
+        meta.remove(k);
+      }
+      final List<int> bytes = utf8.encode(jsonEncode(meta));
+      out.addFile(ArchiveFile(f.name, bytes.length, bytes));
+    } else {
+      final List<int> bytes = f.content as List<int>;
+      out.addFile(ArchiveFile(f.name, bytes.length, bytes));
+    }
+  }
+  final String outPath = p.join(into.path, 'legacy_${p.basename(zipPath)}');
+  File(outPath).writeAsBytesSync(ZipEncoder().encode(out)!);
+  return outPath;
+}

--- a/fushi/test/sync/backup_merge_import_test.dart
+++ b/fushi/test/sync/backup_merge_import_test.dart
@@ -432,8 +432,9 @@ void main() {
   });
 
   test(
-      'game tags cross-machine: scrape identity two-hop lands the tag on the '
-      "target's own game row (v79 二跳)", () async {
+      'game tags cross-machine: scrape identity lands the tag on the '
+      "target's own game row; an unmatched game is inserted with its tag",
+      () async {
     final curDir = await _tempDir('mg_cur_');
     addTearDown(() => cleanupTempDir(curDir));
     final cur = FushiDatabase(curDir.path);
@@ -466,7 +467,8 @@ void main() {
     addTearDown(() => cleanupTempDir(srcDir));
     final src = FushiDatabase(srcDir.path);
     // A 机：不同的本机 id + 同 bgm 条目 + 标签；另一部无刮削的游戏带标签
-    // （跨机无身份可匹配 → 如实丢弃）。
+    // （跨机无身份可匹配 → games 类别默认勾选，游戏行随备份插入，标签落在
+    // 它自己头上）。
     await src.upsertGalgame(GalgamesCompanion.insert(
       id: '111000000',
       name: 'GameA',
@@ -506,15 +508,17 @@ void main() {
     final after = FushiDatabase(curDir.path);
     addTearDown(after.close);
     final tagged = (await after.getTagAssignmentsForKind(TagHostKind.game));
-    expect(tagged, hasLength(1), reason: '二跳恰命中一行，重导不双计');
-    expect(tagged.single.entryKey, '222000000',
-        reason: '标签落在 B 机自己的游戏行上（经 bgm 12345 二跳），'
-            '不是 A 机的局域 id');
+    expect(tagged.map((TagAssignmentRow r) => r.entryKey).toSet(),
+        <String>{'222000000', '444000000'},
+        reason: '同 bgm 12345 的游戏落在 B 机自己的行上（不是 A 机的局域 id）；'
+            '无身份的游戏被插入后标签落在它自己头上；重导不双计');
     expect((await after.getTagsForGame('222000000')).single.name, '神作');
     expect(await after.getTagsForGame('333000000'), isEmpty,
         reason: '无刮削身份的旁观游戏不被误标');
-    expect(await after.getAllGalgames(), hasLength(2),
-        reason: 'galgames 行本身仍不搬运（A 机的游戏没被带过来）');
+    expect(
+        (await after.getAllGalgames()).map((GalgameRow g) => g.id).toSet(),
+        <String>{'222000000', '333000000', '444000000'},
+        reason: 'A 机与 B 机同身份的游戏去重，A 机独有的游戏插入（id 原样保留）');
   });
 
   test('favorite words dedupe-union keeps earlier createdAt', () async {
@@ -812,8 +816,8 @@ void main() {
   });
 
   test(
-      'galgame_sessions do NOT merge — machine-local game identity, by design '
-      '(P4 B3 成文决策)', () async {
+      'galgame_sessions merge under the game identity map: the src game is '
+      'inserted and its session follows; local rows untouched', () async {
     final curDir = await _tempDir('mg_cur_');
     addTearDown(() => cleanupTempDir(curDir));
     final cur = FushiDatabase(curDir.path);
@@ -862,14 +866,18 @@ void main() {
 
     final after = FushiDatabase(curDir.path);
     addTearDown(after.close);
-    expect((await after.getAllGalgames()).single.id, '222000000',
-        reason: '游戏行本机局域身份，不随备份合并搬运');
+    expect(
+        (await after.getAllGalgames()).map((GalgameRow g) => g.id).toSet(),
+        <String>{'222000000', '111000000'},
+        reason: '本机游戏原样保留；src 独有的游戏插入');
     final QueryRow sessions = await after
         .customSelect('SELECT COUNT(*) AS c FROM galgame_sessions')
         .getSingle();
-    expect(sessions.data['c'], 1,
-        reason: '成文决策：src 会话的 game_id 在目标库无宿主，不合并——'
-            '本机那条原样保留');
+    expect(sessions.data['c'], 2,
+        reason: '本机那条原样保留 + src 会话跟着它的宿主落地');
+    expect(
+        (await after.getGalgameSessions('111000000')).single.durationSeconds,
+        120);
   });
 
   test('reader position LWW: newer updatedAt wins, older does not clobber',

--- a/packages/fushi_core/lib/src/database/tables.dart
+++ b/packages/fushi_core/lib/src/database/tables.dart
@@ -2669,8 +2669,9 @@ class StudySegmentTombstones extends Table {
 // （v79：galgame_tag_mappings 已并入 [TagAssignments]。与游戏**元数据标签**
 // （bgm/vndb 刮削字符串，存 [GalgameSources].dataJson + [Galgames].customDataJson）
 // 仍是两条正交轴，刻意不合并：元数据标签是外部事实、动辄上百个且随刮削变动，
-// 塞进用户标签池会污染书/视频共享的那份手工标签。游戏标签依旧不进 live-sync /
-// 备份合并导入（合并层按 kind 过滤），全量备份恢复走整库文件拷贝原样还原。）
+// 塞进用户标签池会污染书/视频共享的那份手工标签。游戏标签依旧不进 live-sync；
+// 备份合并导入自 `BackupCategory.games` 起经游戏身份映射（同 id / 刮削身份 /
+// exe 路径）落到本机游戏行上，见 backup_merge_engine.dart 的 `_buildGameIdMap`。）
 
 // ── manga_extension_stores ──────────────────────────────────────────
 /// v65：用户自行添加的 Mihon 扩展仓库。Fushi 不预置第三方仓库。


### PR DESCRIPTION
## 目标

用户拍板：备份的**所有数据类别都可选导出/导入**。此前 `BackupCategory` 10 项里没有游戏：`galgames` / `galgame_sources` 永远随整库 DB 走，导出不可剔、导入不可跳，游戏封面反而从不打包——推荐包里混进用户游戏就是这么来的。

## 改动

- 新增 `BackupCategory.games`（导出默认勾选；导入可勾）：导出未勾 `_retainGames`（galgames → cascade sources/sessions，另清 game 类 `tag_assignments` / `study_segments` / 墓碑 / `activity_events` / `media_collection_items`）；勾选时打包 `game_covers/`，`BackupMeta.gameCoversRoot` 供导入端重定位 `cover_path`。
- 覆盖导入：未勾 games 按选择裁掉（与 books/videos/audiobooks 同语义）。
- 合并导入：**新增游戏合并**（推翻旧「游戏是本机局域身份不合并」决策）——TEMP 表 `merge_game_map` 三级身份匹配（同 id → `galgame_sources` (source, external_id) → exe_path），标签/会话/学习段/合集成员全部走同一张映射表，无宿主的行跳过；删除了旧的 `media_kind <> 'game'` 过滤与「直键 + 二跳」两条路。
- 顺手修两处已坏承诺：**BUG-2475** `_statisticsTables` 补 v92 的 `study_segments` / 墓碑（取消勾「统计」仍外泄）；**BUG-2476** 导入对话框 progress / statistics 开关永不显示（present 集合只统计文件类别）。
- 审查返工：旧备份窥探失败时未知按「存在」处理（否则 games 不出开关 → 覆盖导入把本机游戏库删光）——videos/audiobooks 同一 fail-open 面一并收。
- 旧包（`excludedCategories` 无 games）导入等价于 games 已勾选，向后兼容有测试钉死；格式无版本号变化。
- i18n `backup_category_games` / `_desc` 经 `i18n_sync --add`。

## 代价

PR 前的旧备份每次读包摘要会解压 `fushi.db` 一次窥探计数（秒级、一次性；新导出的包 meta 自带计数不再窥探）。

## 验证

- `flutter analyze` 零问题（rebase 到 origin/develop 后重跑）。
- `flutter test test/sync test/migration test/i18n --no-pub`：2698 条全绿；新测试 `test/sync/backup_games_category_test.dart`（11 条）。
- 存量文件手写短风格，未整文件 format。

https://claude.ai/code/session_0167ukTuqAjGM7Xkm8XwefoZ
