### PR TITLE
feat(shortcuts): 全 app 键盘滚动（↑/↓/PgUp/PgDn/Home/End）

### DIFF
--- a/docs/agent/shortcuts-inventory.md
+++ b/docs/agent/shortcuts-inventory.md
@@ -61,8 +61,23 @@
 | Action | 键盘默认 | 手柄默认 | 功能 |
 |---|---|---|---|
 | globalBack | Alt+← | —（手柄留空，避免被 reader B 遮蔽） | 返回上一级 |
-| globalScrollPageDown | （无键盘默认） | RB | 整页下滚 |
-| globalScrollPageUp | （无键盘默认） | LB | 整页上滚 |
+| globalScrollPageDown | PageDown | RB | 整页下滚（0.9 viewport） |
+| globalScrollPageUp | PageUp | LB | 整页上滚 |
+| globalScrollLineDown | ↓ | — | 单步下滚（0.15 viewport；焦点在真实控件上且下方有几何目标时让给焦点导航） |
+| globalScrollLineUp | ↑ | — | 单步上滚（同上） |
+| globalScrollToBottom | End | — | 滚到底 |
+| globalScrollToTop | Home | — | 滚到顶 |
+
+> 页面滚动六件套（2026-09-12）：键盘 / 手柄 / 鼠标三通道共用执行体
+> `shortcuts/page_scroll_shortcuts.dart`，目标解析唯一入口
+> `FushiFocusScroll.resolveActivePageScrollable`——焦点最近纵向 Scrollable →
+> `PageScrollRegistry` → 焦点的 `PrimaryScrollController` → **零登记兜底**：从
+> Navigator 当前路由子树里找第一个可见、可滚的纵向 Scrollable（剪掉非当前路由 /
+> Offstage / IndexedStack 非当前 child / 滑到屏幕外的 PageView 页）。三级都要求
+> 滚动视图属于**当前**路由，避免 Home/End 打到被阅读器或对话框盖住的书架上。
+> 文本框聚焦时六个键一律放行；解析到但当前页没有可滚的 Scrollable 时返回 ignored
+> （对话框里的 ↓ 仍由框架把焦点 bootstrap 到首个按钮）。reader / manga / video
+> 三页在自己的 scope 先消费 PageUp/PageDown/↑/↓，global 只兜它们没绑的键。
 
 ### audiobook scope（有声书激活时，在 reader scope 之后解析）
 
@@ -114,7 +129,8 @@
 |---|---|
 | Esc（在 Navigator 之上） | 退出全页路由层级。**已不再硬编码**：现按注册表解析 `globalBack`（`_handleGlobalBack`），Esc 落在弹层上仍让给框架的 barrierDismissible 契约 |
 | 方向键（单行文本框聚焦时按上/下，press 边） | 逃出文本框焦点（框架把方向键全吞成 caret intent 的补救） |
-| 方向键（无文本框聚焦，OS 自动重复 KeyRepeat） | 持续移动焦点（带面板几何 + 阅读顺序回退） |
+| 方向键（无文本框聚焦，OS 自动重复 KeyRepeat） | 持续移动焦点（带面板几何 + 阅读顺序回退）；受管控件到了尽头（该方向再无目标）时落到注册表的 globalScrollLine*（默认 ↑/↓ = 单步滚页） |
+| ↑/↓（焦点导航关闭，或焦点不在受管控件上） | 先问 `arrowKeyClaimedByFocus`（焦点在真实控件上且该方向有几何目标 → 移焦），否则按 global scope 解析成 globalScrollLineUp/Down 滚页。**不受**焦点导航开关门控 |
 | 裸 Space | 中和为 DoNothingIntent（不触发激活，焦点确认统一走 Enter / 手柄 A） |
 
 ### 2c. 有声书 Space 覆写（`reader_space_override.dart`）

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80512 (4736 per locale)
+/// Strings: 80580 (4740 per locale)
 ///
-/// Built on 2026-09-11 at 23:14 UTC
+/// Built on 2026-09-12 at 04:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6586,6 +6586,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_online_select_all => 'Select all';
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -17736,6 +17740,14 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -29112,6 +29124,14 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -40542,6 +40562,14 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -52005,6 +52033,14 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -63272,6 +63308,14 @@ class _StringsId extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -74630,6 +74674,14 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -85370,6 +85422,14 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -96120,6 +96180,14 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -107436,6 +107504,14 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -118805,6 +118881,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -130151,6 +130235,14 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -141298,6 +141390,14 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -152560,6 +152660,14 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -163792,6 +163900,14 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 // Path: <root>
@@ -174099,6 +174215,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '已加入 ${count} 章到下载队列';
+  @override
+  String get shortcut_action_global_scroll_line_down => '向下滚动一行';
+  @override
+  String get shortcut_action_global_scroll_line_up => '向上滚动一行';
+  @override
+  String get shortcut_action_global_scroll_to_top => '滚动到顶部';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => '滚动到底部';
 }
 
 // Path: <root>
@@ -184523,6 +184647,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_series_download_all_queued({required Object count}) =>
       '${count} chapters queued';
+  @override
+  String get shortcut_action_global_scroll_line_down => 'Scroll down one step';
+  @override
+  String get shortcut_action_global_scroll_line_up => 'Scroll up one step';
+  @override
+  String get shortcut_action_global_scroll_to_top => 'Scroll to top';
+  @override
+  String get shortcut_action_global_scroll_to_bottom => 'Scroll to bottom';
 }
 
 /// Flat map(s) containing all translations.
@@ -194279,6 +194411,14 @@ extension on _StringsEn {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -204030,6 +204170,14 @@ extension on _StringsAr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -213826,6 +213974,14 @@ extension on _StringsDe {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -223613,6 +223769,14 @@ extension on _StringsEs {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -233409,6 +233573,14 @@ extension on _StringsFr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -243176,6 +243348,14 @@ extension on _StringsId {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -252965,6 +253145,14 @@ extension on _StringsIt {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -262681,6 +262869,14 @@ extension on _StringsJa {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -272401,6 +272597,14 @@ extension on _StringsKo {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -282183,6 +282387,14 @@ extension on _StringsNl {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -291960,6 +292172,14 @@ extension on _StringsPtBr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -301744,6 +301964,14 @@ extension on _StringsRu {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -311500,6 +311728,14 @@ extension on _StringsTh {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -321271,6 +321507,14 @@ extension on _StringsTr {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -331036,6 +331280,14 @@ extension on _StringsVi {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }
@@ -340714,6 +340966,14 @@ extension on _StringsZhCn {
         return '全选';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '已加入 ${count} 章到下载队列';
+      case 'shortcut_action_global_scroll_line_down':
+        return '向下滚动一行';
+      case 'shortcut_action_global_scroll_line_up':
+        return '向上滚动一行';
+      case 'shortcut_action_global_scroll_to_top':
+        return '滚动到顶部';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return '滚动到底部';
       default:
         return null;
     }
@@ -350408,6 +350668,14 @@ extension on _StringsZhHk {
         return 'Select all';
       case 'manga_series_download_all_queued':
         return ({required Object count}) => '${count} chapters queued';
+      case 'shortcut_action_global_scroll_line_down':
+        return 'Scroll down one step';
+      case 'shortcut_action_global_scroll_line_up':
+        return 'Scroll up one step';
+      case 'shortcut_action_global_scroll_to_top':
+        return 'Scroll to top';
+      case 'shortcut_action_global_scroll_to_bottom':
+        return 'Scroll to bottom';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "新章自动下载",
   "manga_online_download_all": "下载全部",
   "manga_online_select_all": "全选",
-  "manga_series_download_all_queued": "已加入 $count 章到下载队列"
+  "manga_series_download_all_queued": "已加入 $count 章到下载队列",
+  "shortcut_action_global_scroll_line_down": "向下滚动一行",
+  "shortcut_action_global_scroll_line_up": "向上滚动一行",
+  "shortcut_action_global_scroll_to_top": "滚动到顶部",
+  "shortcut_action_global_scroll_to_bottom": "滚动到底部"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4734,5 +4734,9 @@
   "manga_series_auto_download": "Auto-download new chapters",
   "manga_online_download_all": "Download all",
   "manga_online_select_all": "Select all",
-  "manga_series_download_all_queued": "$count chapters queued"
+  "manga_series_download_all_queued": "$count chapters queued",
+  "shortcut_action_global_scroll_line_down": "Scroll down one step",
+  "shortcut_action_global_scroll_line_up": "Scroll up one step",
+  "shortcut_action_global_scroll_to_top": "Scroll to top",
+  "shortcut_action_global_scroll_to_bottom": "Scroll to bottom"
 }

--- a/fushi/lib/src/focus/fushi_focus_controller.dart
+++ b/fushi/lib/src/focus/fushi_focus_controller.dart
@@ -165,9 +165,11 @@ class FushiFocusController extends ChangeNotifier {
 
   /// 当前路由上是否登记了**至少一个**可聚焦的受管目标。
   ///
-  /// [move] 在零目标时会把焦点收回兜底节点并返回 true（「焦点已归位」），键盘
-  /// 方向键的「先移焦、无目标才滚动」仲裁不能拿那个 true 当「焦点引擎接管了」——
-  /// 纯展示页（统计 / 日志）上 ↑/↓ 必须落到滚动，这个 getter 就是那道门。
+  /// [move] 在零目标时走 [ensureFocus]：把焦点从页面自己的键事件 sink 踢到 app 级
+  /// [fallbackNode]（兜底节点已持焦时才返回 true）。键盘方向键的「先移焦、无目标才
+  /// 滚动」仲裁在零目标时根本不该调 [move]——纯展示页（统计 / 日志）上 ↑/↓ 必须
+  /// 落到滚动，且不能顺手把持焦的页面 sink 废掉（页面快捷键从此收不到键），这个
+  /// getter 就是那道门。
   bool get hasFocusableTargets => _focusableEntries().isNotEmpty;
 
   bool get activeIsOnlyFocusableInNearestScrollable {

--- a/fushi/lib/src/focus/fushi_focus_controller.dart
+++ b/fushi/lib/src/focus/fushi_focus_controller.dart
@@ -163,6 +163,13 @@ class FushiFocusController extends ChangeNotifier {
     return false;
   }
 
+  /// 当前路由上是否登记了**至少一个**可聚焦的受管目标。
+  ///
+  /// [move] 在零目标时会把焦点收回兜底节点并返回 true（「焦点已归位」），键盘
+  /// 方向键的「先移焦、无目标才滚动」仲裁不能拿那个 true 当「焦点引擎接管了」——
+  /// 纯展示页（统计 / 日志）上 ↑/↓ 必须落到滚动，这个 getter 就是那道门。
+  bool get hasFocusableTargets => _focusableEntries().isNotEmpty;
+
   bool get activeIsOnlyFocusableInNearestScrollable {
     final FushiFocusTargetEntry? active = _currentEntry();
     if (active == null || !active.context.mounted) return false;

--- a/fushi/lib/src/focus/fushi_focus_scroll.dart
+++ b/fushi/lib/src/focus/fushi_focus_scroll.dart
@@ -148,22 +148,44 @@ class FushiFocusScroll {
         : position.pixels > position.minScrollExtent + 0.5;
   }
 
-  /// [position] 所在的滚动视图是否属于**当前**路由。
+  /// [position] 所在的滚动视图此刻是否真的呈现给用户：属于**当前**路由，且祖先
+  /// 里没有藏起它的 `Offstage(offstage: true)` / 不可见的 [Visibility]。
   ///
   /// [PageScrollRegistry] 是一个栈：书架页登记的控制器在阅读器 / 对话框压上来之后
   /// 仍是栈顶且仍有 position（页面被 maintainState 保活）。不查路由就会把 Home/End
-  /// 打到被盖住的页面上——用户看不见任何变化，却把书架偷偷滚走了。无路由（widget
-  /// 测试直接 pump 的宿主）视为当前。
-  static bool _positionInCurrentRoute(ScrollPosition position) {
+  /// 打到被盖住的页面上——用户看不见任何变化，却把书架偷偷滚走了。同理，
+  /// `MediaLibraryShell` 对各视图「惰性构建 + Offstage 保活」：漫画库进过一次
+  /// 「发现」再切回「书架」，栈顶仍是发现页（FushiPageScaffold）的控制器，不查
+  /// Offstage 就会把可见书架晾着、去滚看不见的发现页。无路由（widget 测试直接
+  /// pump 的宿主）视为当前。
+  static bool _positionIsPresented(ScrollPosition position) {
     final BuildContext? context = position.context.notificationContext;
     if (context == null || !context.mounted) return false;
-    return ModalRoute.of(context)?.isCurrent ?? true;
+    if (!(ModalRoute.of(context)?.isCurrent ?? true)) return false;
+    bool hidden = false;
+    context.visitAncestorElements((Element ancestor) {
+      if (_hidesSubtree(ancestor.widget)) {
+        hidden = true;
+        return false;
+      }
+      return true;
+    });
+    return !hidden;
   }
 
-  /// [canScrollToward] 且属于当前路由——阶梯前三级的统一准入。
+  /// [widget] 是否把整棵子树藏起来了：`Offstage(offstage: true)`，或不可见的
+  /// [Visibility]（它的 maintainSize 形态仍有几何，光看 Offstage 抓不到；而
+  /// [IndexedStack] 的非当前 child 正是用它包的——SDK 里 IndexedStack 只是把每个
+  /// child 裹一层 `Visibility(visible: i == index, maintainState/Size: true)`，
+  /// 所以不需要也不能对 IndexedStack 自己做「按 index 挑子元素」的特例）。
+  static bool _hidesSubtree(Widget widget) =>
+      (widget is Offstage && widget.offstage) ||
+      (widget is Visibility && !widget.visible);
+
+  /// [canScrollToward] 且真的呈现在用户面前——阶梯前三级的统一准入。
   static bool _eligible(ScrollPosition position, {required bool towardEnd}) =>
       canScrollToward(position, towardEnd: towardEnd) &&
-      _positionInCurrentRoute(position);
+      _positionIsPresented(position);
 
   /// 解析「当前页面该被键盘 / 手柄 / 鼠标滚动动作滚的那个 ScrollPosition」。
   ///
@@ -176,9 +198,10 @@ class FushiFocusScroll {
   ///   3. [focusContext] 的 [PrimaryScrollController] —— `primary: true` 的滚动视图；
   ///   4. **零登记兜底**：从 [navigator] 当前可见路由的子树里按 element 树顺序找
   ///      第一个纵向 Scrollable。跳过非当前路由（被整页 / 对话框盖住的页面不能被
-  ///      滚）、`Offstage`（首页各 tab 靠它隐藏未选中者）、[IndexedStack] 的非当前
-  ///      child，并要求 viewport 真的与 Navigator 可见区域相交（排除 [PageView] /
-  ///      [TabBarView] 里已布局但滑到屏幕外的相邻页）。
+  ///      滚）、`Offstage`（首页各 tab 靠它隐藏未选中者）、不可见的 `Visibility`
+  ///      （[IndexedStack] 用它包非当前 child），并要求 viewport 真的与 Navigator
+  ///      可见区域相交（排除 [PageView] / [TabBarView] 里已布局但滑到屏幕外的
+  ///      相邻页）。
   ///
   /// 前三级是 2026-05 手柄 LB/RB 翻屏就有的路径；第 4 级是本次新增的兜底——
   /// 全仓只有 9 个页面登记 [PageScrollRegistry]，而桌面端的 ListView 默认**不**挂
@@ -232,7 +255,7 @@ class FushiFocusScroll {
     void visit(Element element) {
       if (found != null) return;
       final Widget widget = element.widget;
-      if (widget is Offstage && widget.offstage) return;
+      if (_hidesSubtree(widget)) return;
       if (widget is FocusScope) {
         // 每个 ModalRoute 的子树根部都是它自己的 FocusScope；非当前路由（被整页
         // 或对话框盖住）整棵剪掉——盖在下面的页面不能被滚。页面内部自己包的
@@ -250,15 +273,6 @@ class FushiFocusScroll {
           return;
         }
         // 外层滚不动（NestedScrollView 头已收起 / 空壳容器）就继续往里找。
-      }
-      if (widget is IndexedStack) {
-        final int? index = widget.index;
-        if (index == null) return;
-        int i = 0;
-        element.visitChildren((Element child) {
-          if (i++ == index) visit(child);
-        });
-        return;
       }
       element.visitChildren(visit);
     }

--- a/fushi/lib/src/focus/fushi_focus_scroll.dart
+++ b/fushi/lib/src/focus/fushi_focus_scroll.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fushi/src/focus/focus_geometry.dart';
+import 'package:fushi/src/focus/page_scroll_registry.dart';
 
 class FushiFocusScroll {
   const FushiFocusScroll._();
@@ -71,16 +72,7 @@ class FushiFocusScroll {
     if (wantAxis != null && axisDirectionToAxis(wantAxis) != position.axis) {
       return false;
     }
-    final double target =
-        (position.pixels + position.viewportDimension * signedFraction)
-            .clamp(position.minScrollExtent, position.maxScrollExtent);
-    if ((target - position.pixels).abs() < 0.5) return false;
-    position.animateTo(
-      target,
-      duration: const Duration(milliseconds: 120),
-      curve: Curves.easeOutCubic,
-    );
-    return true;
+    return scrollPositionByViewportFraction(position, signedFraction);
   }
 
   /// 把 [context] 最近的 [PrimaryScrollController] 滚动 viewport 的
@@ -104,17 +96,183 @@ class FushiFocusScroll {
     double signedFraction,
   ) {
     if (controller.positions.length != 1) return false;
-    final ScrollPosition position = controller.position;
+    return scrollPositionByViewportFraction(
+        controller.position, signedFraction);
+  }
+
+  /// 把一个已附着的 [position] 按 viewport 的 [signedFraction] 比例滚动一段。
+  ///
+  /// [scrollByViewportFraction] / [scrollController] / 页面级滚动动作最终都落到
+  /// 这里：一份 clamp + 「已到边界返回 false」判据，三条入口不再各抄一遍。
+  static bool scrollPositionByViewportFraction(
+    ScrollPosition position,
+    double signedFraction,
+  ) {
+    if (!position.hasPixels || !position.hasContentDimensions) return false;
     final double target =
         (position.pixels + position.viewportDimension * signedFraction)
             .clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((target - position.pixels).abs() < 0.5) return false;
-    controller.animateTo(
+    position.animateTo(
       target,
       duration: const Duration(milliseconds: 120),
       curve: Curves.easeOutCubic,
     );
     return true;
+  }
+
+  /// 把 [position] 滚到顶（[toEnd] 为 false）或滚到底（true）。已在该端返回 false。
+  ///
+  /// 懒构建列表的 `maxScrollExtent` 只是估计值，一次 End 未必真到最底——那是列表
+  /// 自身的性质，用户再按一次即可，这里不做「循环追到底」的花活。
+  static bool scrollPositionToEdge(ScrollPosition position,
+      {required bool toEnd}) {
+    if (!position.hasPixels || !position.hasContentDimensions) return false;
+    final double target =
+        toEnd ? position.maxScrollExtent : position.minScrollExtent;
+    if ((target - position.pixels).abs() < 0.5) return false;
+    position.animateTo(
+      target,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOutCubic,
+    );
+    return true;
+  }
+
+  /// [position] 还能不能朝 [towardEnd] 指定的方向再滚动一点。
+  static bool canScrollToward(ScrollPosition position,
+      {required bool towardEnd}) {
+    if (!position.hasPixels || !position.hasContentDimensions) return false;
+    return towardEnd
+        ? position.pixels < position.maxScrollExtent - 0.5
+        : position.pixels > position.minScrollExtent + 0.5;
+  }
+
+  /// [position] 所在的滚动视图是否属于**当前**路由。
+  ///
+  /// [PageScrollRegistry] 是一个栈：书架页登记的控制器在阅读器 / 对话框压上来之后
+  /// 仍是栈顶且仍有 position（页面被 maintainState 保活）。不查路由就会把 Home/End
+  /// 打到被盖住的页面上——用户看不见任何变化，却把书架偷偷滚走了。无路由（widget
+  /// 测试直接 pump 的宿主）视为当前。
+  static bool _positionInCurrentRoute(ScrollPosition position) {
+    final BuildContext? context = position.context.notificationContext;
+    if (context == null || !context.mounted) return false;
+    return ModalRoute.of(context)?.isCurrent ?? true;
+  }
+
+  /// [canScrollToward] 且属于当前路由——阶梯前三级的统一准入。
+  static bool _eligible(ScrollPosition position, {required bool towardEnd}) =>
+      canScrollToward(position, towardEnd: towardEnd) &&
+      _positionInCurrentRoute(position);
+
+  /// 解析「当前页面该被键盘 / 手柄 / 鼠标滚动动作滚的那个 ScrollPosition」。
+  ///
+  /// 这是全 app 页面级滚动动作（global scope 六件套：整屏 / 单步 / 到顶到底）的
+  /// **唯一**目标解析器，四级阶梯，取第一个**仍能朝 [towardEnd] 方向滚**的：
+  ///
+  ///   1. [focusContext] 最近的**纵向** Scrollable —— 焦点在某个列表里时先滚它
+  ///      （列表已到边缘时自然落到下一级，这就是「列表边缘接管」）；
+  ///   2. [PageScrollRegistry.current] —— 页面主动登记过的主滚动区；
+  ///   3. [focusContext] 的 [PrimaryScrollController] —— `primary: true` 的滚动视图；
+  ///   4. **零登记兜底**：从 [navigator] 当前可见路由的子树里按 element 树顺序找
+  ///      第一个纵向 Scrollable。跳过非当前路由（被整页 / 对话框盖住的页面不能被
+  ///      滚）、`Offstage`（首页各 tab 靠它隐藏未选中者）、[IndexedStack] 的非当前
+  ///      child，并要求 viewport 真的与 Navigator 可见区域相交（排除 [PageView] /
+  ///      [TabBarView] 里已布局但滑到屏幕外的相邻页）。
+  ///
+  /// 前三级是 2026-05 手柄 LB/RB 翻屏就有的路径；第 4 级是本次新增的兜底——
+  /// 全仓只有 9 个页面登记 [PageScrollRegistry]，而桌面端的 ListView 默认**不**挂
+  /// PrimaryScrollController（`PrimaryScrollController.shouldInherit` 只在移动端为
+  /// 真），于是绝大多数页面此前对键盘滚动完全不可达。宁可每次按键做一遍 element
+  /// 树遍历（一次按键、几千个 element、亚毫秒级），也不逐页手加登记。
+  ///
+  /// 找不到任何能滚的返回 null，调用方应放行按键（ignored）让更外层 / 框架接手。
+  static ScrollPosition? resolveActivePageScrollable({
+    required bool towardEnd,
+    BuildContext? focusContext,
+    NavigatorState? navigator,
+  }) {
+    if (focusContext != null && focusContext.mounted) {
+      final ScrollableState? nearest =
+          Scrollable.maybeOf(focusContext, axis: Axis.vertical);
+      if (nearest != null &&
+          _eligible(nearest.position, towardEnd: towardEnd)) {
+        return nearest.position;
+      }
+    }
+    final ScrollController? registered = PageScrollRegistry.current;
+    if (registered != null &&
+        _eligible(registered.position, towardEnd: towardEnd)) {
+      return registered.position;
+    }
+    if (focusContext != null && focusContext.mounted) {
+      final ScrollController? primary =
+          PrimaryScrollController.maybeOf(focusContext);
+      if (primary != null &&
+          primary.positions.length == 1 &&
+          _eligible(primary.position, towardEnd: towardEnd)) {
+        return primary.position;
+      }
+    }
+    if (navigator != null && navigator.mounted) {
+      return _firstScrollableInCurrentRoute(navigator, towardEnd: towardEnd);
+    }
+    return null;
+  }
+
+  /// 第 4 级兜底的 element 树遍历，见 [resolveActivePageScrollable]。
+  static ScrollPosition? _firstScrollableInCurrentRoute(
+    NavigatorState navigator, {
+    required bool towardEnd,
+  }) {
+    final Rect? stage = globalRectOfContext(navigator.context);
+    if (stage == null) return null;
+    ScrollPosition? found;
+
+    void visit(Element element) {
+      if (found != null) return;
+      final Widget widget = element.widget;
+      if (widget is Offstage && widget.offstage) return;
+      if (widget is FocusScope) {
+        // 每个 ModalRoute 的子树根部都是它自己的 FocusScope；非当前路由（被整页
+        // 或对话框盖住）整棵剪掉——盖在下面的页面不能被滚。页面内部自己包的
+        // FocusScope 解析到的仍是当前路由，照常下钻。
+        final ModalRoute<dynamic>? route = ModalRoute.of(element);
+        if (route != null && !route.isCurrent) return;
+      }
+      if (element is StatefulElement && element.state is ScrollableState) {
+        final ScrollableState scrollable = element.state as ScrollableState;
+        final ScrollPosition position = scrollable.position;
+        if (position.axis == Axis.vertical &&
+            canScrollToward(position, towardEnd: towardEnd) &&
+            _viewportIsOnStage(scrollable.context, stage)) {
+          found = position;
+          return;
+        }
+        // 外层滚不动（NestedScrollView 头已收起 / 空壳容器）就继续往里找。
+      }
+      if (widget is IndexedStack) {
+        final int? index = widget.index;
+        if (index == null) return;
+        int i = 0;
+        element.visitChildren((Element child) {
+          if (i++ == index) visit(child);
+        });
+        return;
+      }
+      element.visitChildren(visit);
+    }
+
+    navigator.context.visitChildElements(visit);
+    return found;
+  }
+
+  /// 滚动视图的 viewport 与 [stage]（Navigator 可见区域）有实际相交面积。
+  static bool _viewportIsOnStage(BuildContext context, Rect stage) {
+    final Rect? rect = globalRectOfContext(context);
+    if (rect == null) return false;
+    final Rect overlap = rect.intersect(stage);
+    return overlap.width > 1 && overlap.height > 1;
   }
 
   /// 方向 → viewport 比例正负号：down/right 为正（向后/下滚），up/left 为负。

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -81,6 +81,7 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show
         GamepadButtonIntent,
         arrowFocusMoveDirection,
+        arrowKeyClaimedByFocus,
         arrowTraversalDirection,
         dispatchNativeGamepadButtonIntent,
         focusedEditableText,
@@ -799,12 +800,18 @@ class _HomePageState extends BasePageState<HomePage>
     // focus — re-resolving a bound shortcut on every repeat would fire it
     // repeatedly. Skipped while a text field is focused so the field's own caret
     // keeps the arrows (same guard as the KeyDown arrow branch below).
+    //
+    // 仲裁走 [arrowKeyClaimedByFocus]：有焦点目标才移焦并认领；没有（列表边缘 /
+    // 焦点还停在本页键事件 sink 上）就放行冒泡，让 app 根的页面滚动兜底接住
+    // ——按下沿的 ↑/↓ 早已按注册表解析成 globalScrollLine* 走了同一条路，重复
+    // 沿若还自己 bootstrap 焦点，就成了「按一下滚页、按住却把焦点甩到首个卡片」。
     final TraversalDirection? repeatDir =
         event is KeyRepeatEvent ? arrowFocusMoveDirection(event) : null;
     if (repeatDir != null) {
       if (focusedEditableText() != null) return KeyEventResult.ignored;
-      gamepadMoveFocusInDirection(context, repeatDir);
-      return KeyEventResult.handled;
+      return arrowKeyClaimedByFocus(context, repeatDir)
+          ? KeyEventResult.handled
+          : KeyEventResult.ignored;
     }
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
 

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -84,8 +84,7 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
         arrowKeyClaimedByFocus,
         arrowTraversalDirection,
         dispatchNativeGamepadButtonIntent,
-        focusedEditableText,
-        gamepadMoveFocusInDirection;
+        focusedEditableText;
 import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart'
     show dispatchClaimedMouseAction, resolveMouseBindingAction;
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
@@ -891,10 +890,15 @@ class _HomePageState extends BasePageState<HomePage>
     // private `is EditableText` check missed every field (the primary focus is
     // EditableText's inner Focus, not the EditableText), so it never actually
     // guarded the search field's caret.
+    // 按下沿与上面的重复沿走**同一条**判据 [arrowKeyClaimedByFocus]：有焦点目标才
+    // 移焦并认领，没有就放行冒泡给 app 根（↑/↓ 在那里落到页面滚动；←/→ 没有
+    // global 绑定则交给框架）。此前按下沿单独走 gamepadMoveFocusInDirection 的
+    // 阅读顺序回退，焦点导航关闭时同一个 ← 按一下会跳焦点、按住却不动。
     final TraversalDirection? dir = arrowTraversalDirection(event.logicalKey);
     if (dir != null && focusedEditableText() == null) {
-      gamepadMoveFocusInDirection(context, dir);
-      return KeyEventResult.handled;
+      return arrowKeyClaimedByFocus(context, dir)
+          ? KeyEventResult.handled
+          : KeyEventResult.ignored;
     }
     return KeyEventResult.ignored;
   }

--- a/fushi/lib/src/pages/implementations/home_page.dart
+++ b/fushi/lib/src/pages/implementations/home_page.dart
@@ -87,6 +87,8 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
         focusedEditableText;
 import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart'
     show dispatchClaimedMouseAction, resolveMouseBindingAction;
+import 'package:fushi/src/shortcuts/page_scroll_shortcuts.dart'
+    show pageScrollRequestFor;
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi_core/fushi_core.dart'
     show
@@ -802,8 +804,8 @@ class _HomePageState extends BasePageState<HomePage>
     //
     // 仲裁走 [arrowKeyClaimedByFocus]：有焦点目标才移焦并认领；没有（列表边缘 /
     // 焦点还停在本页键事件 sink 上）就放行冒泡，让 app 根的页面滚动兜底接住
-    // ——按下沿的 ↑/↓ 早已按注册表解析成 globalScrollLine* 走了同一条路，重复
-    // 沿若还自己 bootstrap 焦点，就成了「按一下滚页、按住却把焦点甩到首个卡片」。
+    // ——按下沿的四个方向键在下面走的是**同一个**仲裁（六件套不在本页 return），
+    // 重复沿若还自己 bootstrap 焦点，就成了「按一下滚页、按住却把焦点甩到首个卡片」。
     final TraversalDirection? repeatDir =
         event is KeyRepeatEvent ? arrowFocusMoveDirection(event) : null;
     if (repeatDir != null) {
@@ -878,9 +880,17 @@ class _HomePageState extends BasePageState<HomePage>
       }
     }
 
-    if (action != null) return _executeShortcutAction(action);
+    // 页面滚动六件套（global scope，默认 ↑/↓ 单步）不由本页执行——执行体在 app 根
+    // [wrapWithGlobalNavigation]，而且它对方向键的规则是「先问焦点、无目标才滚」。
+    // 解析到六件套时**不能**在这里 return：`_executeShortcutAction` 对它们落 default
+    // → ignored 冒泡到根固然也能滚，但下面那段方向键仲裁就对 ↑/↓ 永远不可达，按下沿
+    // （根用 primaryFocus.context 仲裁）与重复沿（本页 context 仲裁）走成两条路。
+    // 让六件套穿过来、与重复沿同走一条仲裁；用户改绑到其它动作的键仍照常先执行。
+    if (action != null && pageScrollRequestFor(action) == null) {
+      return _executeShortcutAction(action);
+    }
 
-    // Arrow keys are unbound on home, so drive robust directional focus
+    // Arrow keys carry no home-scope binding, so drive robust directional focus
     // navigation through the SAME helper the gamepad D-pad/stick uses — keyboard
     // and gamepad therefore behave identically. Skipped while a text field is
     // focused so the field's own cursor movement keeps working (up/down then
@@ -891,8 +901,8 @@ class _HomePageState extends BasePageState<HomePage>
     // EditableText's inner Focus, not the EditableText), so it never actually
     // guarded the search field's caret.
     // 按下沿与上面的重复沿走**同一条**判据 [arrowKeyClaimedByFocus]：有焦点目标才
-    // 移焦并认领，没有就放行冒泡给 app 根（↑/↓ 在那里落到页面滚动；←/→ 没有
-    // global 绑定则交给框架）。此前按下沿单独走 gamepadMoveFocusInDirection 的
+    // 移焦并认领，没有就放行冒泡给 app 根（↑/↓ 在那里按六件套落到页面滚动；←/→
+    // 没有 global 绑定则交给框架）。此前按下沿单独走 gamepadMoveFocusInDirection 的
     // 阅读顺序回退，焦点导航关闭时同一个 ← 按一下会跳焦点、按住却不动。
     final TraversalDirection? dir = arrowTraversalDirection(event.logicalKey);
     if (dir != null && focusedEditableText() == null) {

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -898,10 +898,11 @@ bool gamepadMoveFocusInDirection(
 ///
 ///   · 焦点导航开启（有 [FushiFocusRoot] 控制器）且本页登记了受管目标：走与 D-pad
 ///     完全相同的 [gamepadMoveFocusInDirection]（几何目标 → 阅读顺序 → 「列表内
-///     只有自己可聚焦」时的边缘接管）。零目标的纯展示页直接让位——`move()` 在
-///     零目标时返回的 true 是「焦点已收回兜底节点」，不是接管，见
-///     [FushiFocusController.hasFocusableTargets]。
-///   · 焦点导航关闭（默认安装）：没有引擎做 bootstrap，也**不该**有——用户裁定
+///     只有自己可聚焦」时的边缘接管）。零受管目标时**不能**直接判「无目标」：
+///     `move()` 在零目标时返回的 true 是「焦点已收回兜底节点」（见
+///     [FushiFocusController.hasFocusableTargets]），而焦点仍可能停在一个未登记的
+///     原生控件上（可滚对话框里的 RadioListTile），那要落到下面的原生判据去移焦。
+///   · 焦点导航关闭（默认安装）或本页零受管目标：没有引擎做 bootstrap，也**不该**有——用户裁定
 ///     关闭时 Tab 不遍历焦点，方向键同理不该从空焦点凭空跳到首个控件（那会把
 ///     「按 ↓ 想滚页」变成「焦点跳走 + 页面被 ensureVisible 甩到别处」）。只有焦点
 ///     已经停在一个真实控件上（非 scope / 非 skipTraversal / 可聚焦）且该方向真有
@@ -912,18 +913,17 @@ bool arrowKeyClaimedByFocus(
     BuildContext context, TraversalDirection direction) {
   final FushiFocusController? controller =
       FushiFocusRoot.maybeControllerOf(context, listen: false);
-  if (controller != null) {
-    if (!controller.hasFocusableTargets) return false;
+  if (controller != null && controller.hasFocusableTargets) {
     return gamepadMoveFocusInDirection(context, direction);
   }
-  final FocusNode? origin = _directionalFocusOrigin();
+  final FocusNode? origin = directionalFocusOrigin();
   return origin != null && origin.focusInDirection(direction);
 }
 
 /// 当前主焦点若是一个能作为方向移焦起点的真实控件就返回它；null、scope、不可
 /// 聚焦、skip-traversal 的整页键事件 sink（从它的全屏矩形出发「往某个方向」没有
 /// 意义）都返回 null。[_movePrimaryFocusInDirection] 的 bootstrap 判据与此同一份。
-FocusNode? _directionalFocusOrigin() {
+FocusNode? directionalFocusOrigin() {
   final FocusNode? primary = FocusManager.instance.primaryFocus;
   if (primary == null ||
       primary is FocusScopeNode ||
@@ -943,7 +943,7 @@ bool _movePrimaryFocusInDirection(
   // node, or a skip-traversal wrapper (e.g. a full-page key-event sink — moving
   // "in a direction" from its whole-screen rect is meaningless, so jump to the
   // first real control instead).
-  final FocusNode? primary = _directionalFocusOrigin();
+  final FocusNode? primary = directionalFocusOrigin();
   if (primary == null) {
     return allowReadingOrderFallback && FocusScope.of(context).nextFocus();
   }

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -898,8 +898,8 @@ bool gamepadMoveFocusInDirection(
 ///
 ///   · 焦点导航开启（有 [FushiFocusRoot] 控制器）且本页登记了受管目标：走与 D-pad
 ///     完全相同的 [gamepadMoveFocusInDirection]（几何目标 → 阅读顺序 → 「列表内
-///     只有自己可聚焦」时的边缘接管）。零受管目标时**不能**直接判「无目标」：
-///     `move()` 在零目标时返回的 true 是「焦点已收回兜底节点」（见
+///     只有自己可聚焦」时的边缘接管）。零受管目标时**不能**调 `move()`：它会经
+///     ensureFocus 把持焦的页面 sink 踢到 app 级兜底节点（见
 ///     [FushiFocusController.hasFocusableTargets]），而焦点仍可能停在一个未登记的
 ///     原生控件上（可滚对话框里的 RadioListTile），那要落到下面的原生判据去移焦。
 ///   · 焦点导航关闭（默认安装）或本页零受管目标：没有引擎做 bootstrap，也**不该**有——用户裁定

--- a/fushi/lib/src/shortcuts/gamepad_service.dart
+++ b/fushi/lib/src/shortcuts/gamepad_service.dart
@@ -11,10 +11,10 @@ import 'package:gamepads/gamepads.dart' as gp;
 
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/fushi_focus_scroll.dart';
-import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/shortcuts/dictionary_popup_gamepad.dart';
 import 'package:fushi/src/shortcuts/global_external_lookup_route.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/page_scroll_shortcuts.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 
@@ -587,31 +587,25 @@ class GamepadService {
     unawaited(hooks.scrollBy(dyNorm * _kRightStickScrollPxPerTick));
   }
 
-  /// LB/RB page-scroll fallback: if [button] is bound to a global scroll-page
-  /// action, page the nearest [PrimaryScrollController] by ~0.9 viewport.
-  /// Returns whether it scrolled (so the dispatcher can stop).
+  /// 手柄的页面滚动兜底：[button] 绑到 global scope 的任一页面滚动动作（默认
+  /// LB/RB = 整屏；单步 / 到顶到底可由用户自绑）时，经三通道共用的
+  /// [executePageScroll] 滚当前页。返回是否真的滚了（滚了就不再往下派发）。
+  ///
+  /// 目标解析在 [FushiFocusScroll.resolveActivePageScrollable]：纯展示页
+  /// （统计 / 日志）的焦点停在顶层兜底节点、位于页面 scaffold 的
+  /// PrimaryScrollController **之上**，只按 context 找必然找不到——所以除了已登记
+  /// 的 PageScrollRegistry，还从 Navigator 当前路由子树里兜底找第一个纵向
+  /// Scrollable；键盘 PageUp/PageDown 与鼠标绑定走的是同一份。
   bool _tryScrollPage(BuildContext context, GamepadButton button) {
-    final ShortcutAction? action =
-        registry?.resolveGamepad(button, scope: ShortcutScope.global);
-    final double fraction;
-    if (action == ShortcutAction.globalScrollPageDown) {
-      fraction = 0.9;
-    } else if (action == ShortcutAction.globalScrollPageUp) {
-      fraction = -0.9;
-    } else {
-      return false;
-    }
-    // Prefer the registered active-page controller. On a pure-display page
-    // (statistics/logs) focus is the top-level fallback node, which sits ABOVE
-    // the page scaffold's PrimaryScrollController, so a context lookup from
-    // focus can never reach it. Fall back to a context lookup for pages not
-    // built on FushiPageScaffold (e.g. home tab content, focus inside list).
-    final ScrollController? pageController = PageScrollRegistry.current;
-    if (pageController != null &&
-        FushiFocusScroll.scrollController(pageController, fraction)) {
-      return true;
-    }
-    return FushiFocusScroll.scrollPrimary(context, fraction);
+    final PageScrollRequest? request = pageScrollRequestFor(
+      registry?.resolveGamepad(button, scope: ShortcutScope.global),
+    );
+    if (request == null) return false;
+    return executePageScroll(
+      request,
+      focusContext: context,
+      navigator: navigatorKey.currentState,
+    );
   }
 
   /// Routes a long-press (A held past the threshold) to the focused widget as a
@@ -898,20 +892,59 @@ bool gamepadMoveFocusInDirection(
   );
 }
 
+/// 键盘 ↑/↓ 的「先移焦、无目标才让给滚动」仲裁——与 D-pad 边缘接管同一套判据，
+/// 返回 true = 焦点引擎接管了这次按键（焦点已移动 / 已 bootstrap 到首个目标），
+/// 调用方不得再滚动；false = 该方向没有焦点目标，按键归页面滚动。
+///
+///   · 焦点导航开启（有 [FushiFocusRoot] 控制器）且本页登记了受管目标：走与 D-pad
+///     完全相同的 [gamepadMoveFocusInDirection]（几何目标 → 阅读顺序 → 「列表内
+///     只有自己可聚焦」时的边缘接管）。零目标的纯展示页直接让位——`move()` 在
+///     零目标时返回的 true 是「焦点已收回兜底节点」，不是接管，见
+///     [FushiFocusController.hasFocusableTargets]。
+///   · 焦点导航关闭（默认安装）：没有引擎做 bootstrap，也**不该**有——用户裁定
+///     关闭时 Tab 不遍历焦点，方向键同理不该从空焦点凭空跳到首个控件（那会把
+///     「按 ↓ 想滚页」变成「焦点跳走 + 页面被 ensureVisible 甩到别处」）。只有焦点
+///     已经停在一个真实控件上（非 scope / 非 skipTraversal / 可聚焦）且该方向真有
+///     几何目标时，才由框架同款的 [FocusNode.focusInDirection] 移焦。
+///
+/// 文本框聚焦的情形由调用方先用 [focusedEditableText] 排除，这里不重复判。
+bool arrowKeyClaimedByFocus(
+    BuildContext context, TraversalDirection direction) {
+  final FushiFocusController? controller =
+      FushiFocusRoot.maybeControllerOf(context, listen: false);
+  if (controller != null) {
+    if (!controller.hasFocusableTargets) return false;
+    return gamepadMoveFocusInDirection(context, direction);
+  }
+  final FocusNode? origin = _directionalFocusOrigin();
+  return origin != null && origin.focusInDirection(direction);
+}
+
+/// 当前主焦点若是一个能作为方向移焦起点的真实控件就返回它；null、scope、不可
+/// 聚焦、skip-traversal 的整页键事件 sink（从它的全屏矩形出发「往某个方向」没有
+/// 意义）都返回 null。[_movePrimaryFocusInDirection] 的 bootstrap 判据与此同一份。
+FocusNode? _directionalFocusOrigin() {
+  final FocusNode? primary = FocusManager.instance.primaryFocus;
+  if (primary == null ||
+      primary is FocusScopeNode ||
+      !primary.canRequestFocus ||
+      primary.skipTraversal) {
+    return null;
+  }
+  return primary;
+}
+
 bool _movePrimaryFocusInDirection(
   BuildContext context,
   TraversalDirection direction, {
   required bool allowReadingOrderFallback,
 }) {
-  final FocusNode? primary = FocusManager.instance.primaryFocus;
   // Bootstrap when nothing is usefully focused: null, a scope, a non-focusable
   // node, or a skip-traversal wrapper (e.g. a full-page key-event sink — moving
   // "in a direction" from its whole-screen rect is meaningless, so jump to the
   // first real control instead).
-  if (primary == null ||
-      primary is FocusScopeNode ||
-      !primary.canRequestFocus ||
-      primary.skipTraversal) {
+  final FocusNode? primary = _directionalFocusOrigin();
+  if (primary == null) {
     return allowReadingOrderFallback && FocusScope.of(context).nextFocus();
   }
   if (primary.focusInDirection(direction)) return true;

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -6,13 +6,12 @@ import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:macos_ui/macos_ui.dart' show WindowManipulator;
 import 'package:window_manager/window_manager.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
-import 'package:fushi/src/focus/fushi_focus_scroll.dart';
-import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/utils/window_caption_channel.dart';
 
 import 'package:fushi/src/shortcuts/context_menu_trigger.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
 import 'package:fushi/src/shortcuts/mouse_binding_dispatch.dart';
+import 'package:fushi/src/shortcuts/page_scroll_shortcuts.dart';
 import 'package:fushi/src/shortcuts/shortcut_action.dart';
 import 'package:fushi/src/shortcuts/shortcut_registry.dart';
 import 'package:fushi/src/shortcuts/window_fullscreen_hosts.dart';
@@ -20,6 +19,8 @@ import 'package:fushi/src/utils/components/fushi_desktop_title_bar.dart';
 import 'package:fushi/src/shortcuts/gamepad_service.dart'
     show
         arrowFocusMoveDirection,
+        arrowKeyClaimedByFocus,
+        arrowTraversalDirection,
         dispatchNativeGamepadButtonIntent,
         focusedEditableText,
         gamepadMoveFocusInDirection,
@@ -105,6 +106,7 @@ bool _topRouteIsPopup(GlobalKey<NavigatorState> navigatorKey) {
 ///    门控之外常驻生效。
 KeyEventResult _handleGlobalArrowFocus(
   GlobalKey<NavigatorState> navigatorKey,
+  FushiShortcutRegistry? registry,
   KeyEvent event,
 ) {
   final TraversalDirection? dir = arrowFocusMoveDirection(event);
@@ -133,22 +135,31 @@ KeyEventResult _handleGlobalArrowFocus(
     if (controller == null || !controller.primaryFocusIsManagedTarget) {
       return KeyEventResult.ignored;
     }
-    return _moveFocusForArrow(navigatorKey, dir);
+    return _moveFocusForArrow(navigatorKey, registry, event, dir);
   }
 
   // Part 1: single-line field escape, press edge only.
   if (event is! KeyDownEvent || _caretKeepsArrow(editable, dir)) {
     return KeyEventResult.ignored;
   }
-  return _moveFocusForArrow(navigatorKey, dir);
+  return _moveFocusForArrow(navigatorKey, registry, event, dir);
 }
 
 /// Moves directional focus one step in [dir] from whichever route is on top,
 /// then ALWAYS consumes the arrow: at a scroll/list edge the move is a no-op but
 /// the arrow has still been "spent" (so it never falls back to the caret or to
 /// the framework's fallback that lacks Hibiki's reading-order step).
+///
+/// 到了焦点目标的尽头（该方向再无受管控件、也没触发手柄式边缘接管）时，把这次
+/// 按键交给页面滚动：按注册表解析 [event]（默认 ↑/↓ = 单步滚动），命中就经
+/// [executePageScroll] 滚当前页。这样受管控件列表的末尾之后还有非聚焦内容
+/// （长说明文字 / 纯展示区）时，↓ 仍能把它们滚出来，而不是死在最后一个控件上。
+/// 无论滚没滚成都保持 handled（见上）。单行文本框逃逸那条路（Part 1）到这里时
+/// 文本框仍持焦，此时不滚：文本框聚焦下六个滚动键一律不接管。
 KeyEventResult _moveFocusForArrow(
   GlobalKey<NavigatorState> navigatorKey,
+  FushiShortcutRegistry? registry,
+  KeyEvent event,
   TraversalDirection dir,
 ) {
   // Mirror the gamepad service's dispatch context: the focused widget's context
@@ -157,7 +168,19 @@ KeyEventResult _moveFocusForArrow(
   final BuildContext? context = FocusManager.instance.primaryFocus?.context ??
       navigatorKey.currentContext;
   if (context == null) return KeyEventResult.ignored;
-  gamepadMoveFocusInDirection(context, dir);
+  if (!gamepadMoveFocusInDirection(context, dir) &&
+      registry != null &&
+      focusedEditableText() == null) {
+    final PageScrollRequest? request =
+        pageScrollRequestFor(_resolveGlobalKeyboardAction(registry, event));
+    if (request != null) {
+      executePageScroll(
+        request,
+        focusContext: FocusManager.instance.primaryFocus?.context,
+        navigator: navigatorKey.currentState,
+      );
+    }
+  }
   return KeyEventResult.handled;
 }
 
@@ -198,18 +221,40 @@ bool _caretKeepsArrow(EditableText editable, TraversalDirection dir) {
 ///   · 其余触发键（Alt+← / 手柄 B / 用户自绑键）⇒ 一律 [Navigator.maybePop]，弹层
 ///     上也照 pop —— 旧 `_handleGlobalBack` 行为（手柄用户靠它关对话框）。
 /// [Navigator.maybePop] 保证页面自己的 [PopScope] 闸门仍然先跑。
-KeyEventResult _handleGlobalBack(
-  GlobalKey<NavigatorState> navigatorKey,
-  FushiShortcutRegistry registry,
-  KeyEvent event,
-) {
-  if (event is! KeyDownEvent) return KeyEventResult.ignored;
+/// 此刻按住的修饰键集合（Ctrl / Shift / Alt / Meta），供本文件各注册表解析共用。
+Set<ModifierKey> _pressedModifiers() {
   final Set<ModifierKey> modifiers = <ModifierKey>{};
   final HardwareKeyboard hw = HardwareKeyboard.instance;
   if (hw.isControlPressed) modifiers.add(ModifierKey.ctrl);
   if (hw.isShiftPressed) modifiers.add(ModifierKey.shift);
   if (hw.isAltPressed) modifiers.add(ModifierKey.alt);
   if (hw.isMetaPressed) modifiers.add(ModifierKey.meta);
+  return modifiers;
+}
+
+/// 按 [ShortcutScope.global] 解析一次键盘事件。
+///
+/// TODO-847: IME 激活时 logicalKey 被改写成 process，传 physicalKey 让 registry
+/// 走物理键回退；文本框 composing 时传 null 关闭回退。
+ShortcutAction? _resolveGlobalKeyboardAction(
+  FushiShortcutRegistry registry,
+  KeyEvent event,
+) {
+  return registry.resolveKeyboard(
+    event.logicalKey,
+    modifiers: _pressedModifiers(),
+    scope: ShortcutScope.global,
+    physicalKey: focusedEditableText() == null ? event.physicalKey : null,
+  );
+}
+
+KeyEventResult _handleGlobalBack(
+  GlobalKey<NavigatorState> navigatorKey,
+  FushiShortcutRegistry registry,
+  KeyEvent event,
+) {
+  if (event is! KeyDownEvent) return KeyEventResult.ignored;
+  final Set<ModifierKey> modifiers = _pressedModifiers();
   // TODO-847: IME 激活时 logicalKey 被改写成 process，传 physicalKey 让 registry
   // 走物理键回退还原 globalBack（默认 Esc）；文本框 composing 时传 null 关闭回退。
   final PhysicalKeyboardKey? imeFallbackPhysicalKey =
@@ -302,20 +347,7 @@ KeyEventResult _handleGlobalToggleFullscreen(
   KeyEvent event,
 ) {
   if (event is! KeyDownEvent) return KeyEventResult.ignored;
-  final Set<ModifierKey> modifiers = <ModifierKey>{};
-  final HardwareKeyboard hw = HardwareKeyboard.instance;
-  if (hw.isControlPressed) modifiers.add(ModifierKey.ctrl);
-  if (hw.isShiftPressed) modifiers.add(ModifierKey.shift);
-  if (hw.isAltPressed) modifiers.add(ModifierKey.alt);
-  if (hw.isMetaPressed) modifiers.add(ModifierKey.meta);
-  final PhysicalKeyboardKey? imeFallbackPhysicalKey =
-      focusedEditableText() == null ? event.physicalKey : null;
-  ShortcutAction? action = registry.resolveKeyboard(
-    event.logicalKey,
-    modifiers: modifiers,
-    scope: ShortcutScope.global,
-    physicalKey: imeFallbackPhysicalKey,
-  );
+  ShortcutAction? action = _resolveGlobalKeyboardAction(registry, event);
   if (action == null) {
     final GamepadButton? gamepad = GamepadButton.fromKeyEvent(event);
     if (gamepad != null) {
@@ -337,6 +369,53 @@ KeyEventResult _handleGlobalToggleFullscreen(
 /// be toggled via [WindowManager] (mirrors [DesktopWindowPlacement] desktop gate).
 bool get desktopWindowFullscreenSupported =>
     Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+
+/// 键盘的页面滚动兜底（global scope 六件套：默认 PageUp/PageDown 整屏、↑/↓ 单步、
+/// Home/End 到顶到底）。服务所有自己没有键盘滚动语义的表面——库页 / 设置 / 统计 /
+/// 详情 / 对话框……阅读器 / 漫画 / 视频三页在更近的处理器里先消费了自己绑定的键
+/// （翻页 / 音量 / 章节），到不了这里；它们没绑的键（如视频页的 Home/End）落到这里
+/// 也只会滚它们路由里真实可见的纵向列表，没有就放行。
+///
+/// 按下沿与 OS 自动重复都接：按住 ↓ 要连续滚，与「按住方向键连续移焦」同款
+/// （[arrowFocusMoveDirection] 的理由）。
+///
+/// 三条**让位**规则，缺一条就是回归：
+///   1. 文本框聚焦 → 一律放行（↑/↓ 归光标 / 逃出单行框，Home/End 归行首行尾）；
+///   2. 触发键是方向键 → 先问焦点引擎（[arrowKeyClaimedByFocus]）：焦点在真实控件
+///      上且该方向有目标就移焦不滚；只有没目标（列表边缘 / 纯展示页 / 焦点停在
+///      兜底节点）才滚。实验性焦点导航开启且焦点已在受管控件上的情形根本到不了
+///      这里——[_handleGlobalArrowFocus] 在前面已经 handled（它的尽头同样落到滚动）；
+///   3. 解析到了但当前页没有任何能朝该方向滚的 Scrollable → 返回 ignored 而不是
+///      handled：对话框里的 ↓ 仍能让框架把焦点 bootstrap 到第一个按钮上，纯展示页
+///      到底之后方向键也不变成黑洞。
+KeyEventResult _handleGlobalScroll(
+  GlobalKey<NavigatorState> navigatorKey,
+  FushiShortcutRegistry registry,
+  KeyEvent event,
+) {
+  if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+    return KeyEventResult.ignored;
+  }
+  if (focusedEditableText() != null) return KeyEventResult.ignored;
+  final PageScrollRequest? request =
+      pageScrollRequestFor(_resolveGlobalKeyboardAction(registry, event));
+  if (request == null) return KeyEventResult.ignored;
+  final BuildContext? focusContext =
+      FocusManager.instance.primaryFocus?.context;
+  final TraversalDirection? arrow = arrowTraversalDirection(event.logicalKey);
+  if (arrow != null) {
+    final BuildContext? arbiter = focusContext ?? navigatorKey.currentContext;
+    if (arbiter != null && arrowKeyClaimedByFocus(arbiter, arrow)) {
+      return KeyEventResult.handled;
+    }
+  }
+  final bool scrolled = executePageScroll(
+    request,
+    focusContext: focusContext,
+    navigator: navigatorKey.currentState,
+  );
+  return scrolled ? KeyEventResult.handled : KeyEventResult.ignored;
+}
 
 /// app 根的**鼠标绑定兜底派发**：服务那些自己没有鼠标派发入口的表面（设置页 / 书架 /
 /// 统计页 / 对话框……）。
@@ -376,9 +455,9 @@ void _handleGlobalPointerDown(
 ///   · [ShortcutAction.globalBack] → [Navigator.maybePop]（与 [_handleGlobalBack] 同）；
 ///   · [ShortcutAction.globalToggleFullscreen] → [_toggleWindowFullscreen]（与
 ///     [_handleGlobalToggleFullscreen] 同，移动端无窗口时有意 no-op）；
-///   · [ShortcutAction.globalScrollPageUp] / [ShortcutAction.globalScrollPageDown] →
-///     与手柄 LB/RB 完全同一条 [PageScrollRegistry] → [FushiFocusScroll] 路径
-///     （`gamepad_service._tryScrollPage`）。
+///   · 页面滚动六件套（[ShortcutAction.globalScrollPageUp] 等）→ 与键盘 / 手柄
+///     LB/RB 完全同一个执行体 [executePageScroll]（目标解析在
+///     `FushiFocusScroll.resolveActivePageScrollable`）。
 ///
 /// global scope 里只有 [ShortcutAction.globalContextMenu] 有意落在 `default` 上并返回
 /// **false**：它是「哪个鼠标键唤出右键菜单」的按钮归属声明，执行体分散在各表面自己的
@@ -410,25 +489,22 @@ bool _executeGlobalMouseAction(
       }
       return true;
     case ShortcutAction.globalScrollPageUp:
-      return _scrollActivePage(context, -0.9);
     case ShortcutAction.globalScrollPageDown:
-      return _scrollActivePage(context, 0.9);
+    case ShortcutAction.globalScrollLineUp:
+    case ShortcutAction.globalScrollLineDown:
+    case ShortcutAction.globalScrollToTop:
+    case ShortcutAction.globalScrollToBottom:
+      // 鼠标没有「焦点在哪」的语义，前三级按 [context]（app 根，Navigator 之上，
+      // 查不到任何 Scrollable / PrimaryScrollController）自然落空，实际靠已登记的
+      // PageScrollRegistry 与当前路由子树兜底——与改造前的可达面只增不减。
+      return executePageScroll(
+        pageScrollRequestFor(action)!,
+        focusContext: FocusManager.instance.primaryFocus?.context ?? context,
+        navigator: navigatorKey.currentState,
+      );
     default:
       return false;
   }
-}
-
-/// 整页滚动：优先已登记的当前页 [ScrollController]，退回按 context 找
-/// [PrimaryScrollController]。与手柄 LB/RB 同一实现，理由见
-/// `gamepad_service._tryScrollPage` 的注释（纯展示页的焦点节点在页面 scaffold 的
-/// PrimaryScrollController **之上**，只按 context 找必然找不到）。
-bool _scrollActivePage(BuildContext context, double signedFraction) {
-  final ScrollController? pageController = PageScrollRegistry.current;
-  if (pageController != null &&
-      FushiFocusScroll.scrollController(pageController, signedFraction)) {
-    return true;
-  }
-  return FushiFocusScroll.scrollPrimary(context, signedFraction);
 }
 
 /// 裸空格中和：焦点确认永不走空格（确认键统一 Enter / 手柄 A，由框架默认提供），故在
@@ -680,7 +756,7 @@ Widget wrapWithGlobalNavigation({
       }
       if (focusNavigationEnabled) {
         final KeyEventResult arrowResult =
-            _handleGlobalArrowFocus(navigatorKey, event);
+            _handleGlobalArrowFocus(navigatorKey, registry, event);
         if (arrowResult == KeyEventResult.handled) return arrowResult;
       }
       // TODO-700 T1：注册表驱动的全局返回回退（Esc / Alt+← / B，或用户改键后的
@@ -700,6 +776,12 @@ Widget wrapWithGlobalNavigation({
         if (fullscreenResult == KeyEventResult.handled) {
           return fullscreenResult;
         }
+        // 页面滚动六件套（默认 PageUp/PageDown、↑/↓、Home/End）。同样**不受**
+        // [focusNavigationEnabled] 门控——「用键盘滚页面」与实验性焦点导航无关，
+        // 默认安装就得能用；方向键与焦点导航的让位规则见 [_handleGlobalScroll]。
+        final KeyEventResult scrollResult =
+            _handleGlobalScroll(navigatorKey, registry, event);
+        if (scrollResult == KeyEventResult.handled) return scrollResult;
       }
       // BUG-1266：走到这里说明**没有任何**处理器认领这次手柄按键。对手柄 B 必须
       // 就地消费，绝不能放行——见 [gamepadBackMustBeSwallowed] 的完整理由。

--- a/fushi/lib/src/shortcuts/global_navigation.dart
+++ b/fushi/lib/src/shortcuts/global_navigation.dart
@@ -21,6 +21,7 @@ import 'package:fushi/src/shortcuts/gamepad_service.dart'
         arrowFocusMoveDirection,
         arrowKeyClaimedByFocus,
         arrowTraversalDirection,
+        directionalFocusOrigin,
         dispatchNativeGamepadButtonIntent,
         focusedEditableText,
         gamepadMoveFocusInDirection,
@@ -385,9 +386,13 @@ bool get desktopWindowFullscreenSupported =>
 ///      上且该方向有目标就移焦不滚；只有没目标（列表边缘 / 纯展示页 / 焦点停在
 ///      兜底节点）才滚。实验性焦点导航开启且焦点已在受管控件上的情形根本到不了
 ///      这里——[_handleGlobalArrowFocus] 在前面已经 handled（它的尽头同样落到滚动）；
-///   3. 解析到了但当前页没有任何能朝该方向滚的 Scrollable → 返回 ignored 而不是
-///      handled：对话框里的 ↓ 仍能让框架把焦点 bootstrap 到第一个按钮上，纯展示页
-///      到底之后方向键也不变成黑洞。
+///   3. 弹层（对话框 / bottom sheet）里焦点还停在路由 FocusScope 上时，方向键
+///      **先让框架 bootstrap 焦点**（ignored → WidgetsApp 的 DirectionalFocusAction
+///      把焦点送进第一个按钮），而不是先滚内容：否则同一个对话框内容溢出时 ↓ 永远
+///      在滚、焦点进不了按钮，不溢出时才 bootstrap——语义随窗口高度漂移。焦点一旦
+///      落到按钮上，再按 ↓ 走规则 2，无目标时照常滚对话框内容；
+///   4. 解析到了但当前页没有任何能朝该方向滚的 Scrollable → 返回 ignored 而不是
+///      handled：纯展示页到底之后方向键也不变成黑洞。
 KeyEventResult _handleGlobalScroll(
   GlobalKey<NavigatorState> navigatorKey,
   FushiShortcutRegistry registry,
@@ -407,6 +412,9 @@ KeyEventResult _handleGlobalScroll(
     final BuildContext? arbiter = focusContext ?? navigatorKey.currentContext;
     if (arbiter != null && arrowKeyClaimedByFocus(arbiter, arrow)) {
       return KeyEventResult.handled;
+    }
+    if (directionalFocusOrigin() == null && _topRouteIsPopup(navigatorKey)) {
+      return KeyEventResult.ignored;
     }
   }
   final bool scrolled = executePageScroll(

--- a/fushi/lib/src/shortcuts/page_scroll_shortcuts.dart
+++ b/fushi/lib/src/shortcuts/page_scroll_shortcuts.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:fushi/src/focus/fushi_focus_scroll.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+
+/// global scope 的页面滚动动作（六件套）在键盘 / 手柄 / 鼠标三条通道上**共用的**
+/// 执行体。三条通道各自只做「按钮 → ShortcutAction」的解析，落地一律走这里，滚动
+/// 目标一律经 [FushiFocusScroll.resolveActivePageScrollable]——绝不允许某条通道
+/// 私藏一份「只认 PageScrollRegistry」的旧路径，那正是键盘滚不动大半页面的根因。
+enum PageScrollRequest {
+  lineUp,
+  lineDown,
+  pageUp,
+  pageDown,
+  toTop,
+  toBottom;
+
+  /// 朝内容末尾（向下）还是朝开头（向上）。
+  bool get towardEnd => switch (this) {
+        lineDown || pageDown || toBottom => true,
+        lineUp || pageUp || toTop => false,
+      };
+}
+
+/// 单步滚动的 viewport 比例（↑/↓ 一次）。与手柄「列表边缘接管」的 0.8 / 整屏的
+/// 0.9 同一量纲，取 0.15 ≈ 一行多一点：高分屏上不会一按就跳走半屏，也不至于
+/// 按十下才动一行。
+const double kPageScrollLineFraction = 0.15;
+
+/// 整屏滚动的 viewport 比例（PageUp / PageDown、手柄 LB / RB）。留 0.1 重叠让
+/// 用户能接上上一屏的末行。
+const double kPageScrollPageFraction = 0.9;
+
+/// [action] 是不是页面滚动动作；是则给出请求，否则 null。
+PageScrollRequest? pageScrollRequestFor(ShortcutAction? action) {
+  switch (action) {
+    case ShortcutAction.globalScrollLineUp:
+      return PageScrollRequest.lineUp;
+    case ShortcutAction.globalScrollLineDown:
+      return PageScrollRequest.lineDown;
+    case ShortcutAction.globalScrollPageUp:
+      return PageScrollRequest.pageUp;
+    case ShortcutAction.globalScrollPageDown:
+      return PageScrollRequest.pageDown;
+    case ShortcutAction.globalScrollToTop:
+      return PageScrollRequest.toTop;
+    case ShortcutAction.globalScrollToBottom:
+      return PageScrollRequest.toBottom;
+    default:
+      return null;
+  }
+}
+
+/// 执行一次页面滚动。返回**是否真的滚了**：false 时调用方不得认领这次输入
+/// （键盘返回 ignored / 鼠标不 claim），让更外层或框架接手——「解析到但没滚」
+/// 若也吞键，纯展示页上到底之后方向键就成了黑洞。
+///
+/// [focusContext] 是焦点所在的 context（决定阶梯前三级），[navigator] 供第四级
+/// 零登记兜底从当前路由子树里找 Scrollable；两者都可空，空了就跳过对应层级。
+bool executePageScroll(
+  PageScrollRequest request, {
+  BuildContext? focusContext,
+  NavigatorState? navigator,
+}) {
+  final ScrollPosition? position = FushiFocusScroll.resolveActivePageScrollable(
+    towardEnd: request.towardEnd,
+    focusContext: focusContext,
+    navigator: navigator,
+  );
+  if (position == null) return false;
+  switch (request) {
+    case PageScrollRequest.lineUp:
+      return FushiFocusScroll.scrollPositionByViewportFraction(
+        position,
+        -kPageScrollLineFraction,
+      );
+    case PageScrollRequest.lineDown:
+      return FushiFocusScroll.scrollPositionByViewportFraction(
+        position,
+        kPageScrollLineFraction,
+      );
+    case PageScrollRequest.pageUp:
+      return FushiFocusScroll.scrollPositionByViewportFraction(
+        position,
+        -kPageScrollPageFraction,
+      );
+    case PageScrollRequest.pageDown:
+      return FushiFocusScroll.scrollPositionByViewportFraction(
+        position,
+        kPageScrollPageFraction,
+      );
+    case PageScrollRequest.toTop:
+      return FushiFocusScroll.scrollPositionToEdge(position, toEnd: false);
+    case PageScrollRequest.toBottom:
+      return FushiFocusScroll.scrollPositionToEdge(position, toEnd: true);
+  }
+}

--- a/fushi/lib/src/shortcuts/shortcut_action.dart
+++ b/fushi/lib/src/shortcuts/shortcut_action.dart
@@ -342,9 +342,21 @@ enum ShortcutAction {
   //   · 其它页：maybePop（PopupRoute 让框架自己的 Esc 语义优先，见 global_navigation）
   globalBack(ShortcutScope.universal, 'global_back'),
 
-  // Global
+  // Global —— 页面滚动六件套（整屏 / 单步 / 到顶到底）。
+  //
+  // 三通道共用一个执行体 `page_scroll_shortcuts.dart`（键盘在
+  // wrapWithGlobalNavigation、手柄在 gamepad_service、鼠标在 app 根兜底），滚动目标
+  // 一律经 `FushiFocusScroll.resolveActivePageScrollable` 解析——页面**不必**登记
+  // PageScrollRegistry 也能被滚到（从 Navigator 当前路由子树里找第一个纵向
+  // Scrollable 兜底）。单步上下（默认 ↑/↓）与焦点导航共存：焦点在真实控件上且该
+  // 方向有几何目标时仍归焦点导航，只有没目标（列表边缘 / 纯展示页 / 焦点停在
+  // 兜底节点）才滚动；文本框聚焦时一律放行给光标。
   globalScrollPageDown(ShortcutScope.global, 'global_scroll_page_down'),
   globalScrollPageUp(ShortcutScope.global, 'global_scroll_page_up'),
+  globalScrollLineDown(ShortcutScope.global, 'global_scroll_line_down'),
+  globalScrollLineUp(ShortcutScope.global, 'global_scroll_line_up'),
+  globalScrollToTop(ShortcutScope.global, 'global_scroll_to_top'),
+  globalScrollToBottom(ShortcutScope.global, 'global_scroll_to_bottom'),
   // TODO-1093：窗口级/app 级「全屏切换」（区别于视频播放器内的
   // videoToggleFullscreen——那个只切视频表面）。执行体在 wrapWithGlobalNavigation
   // 里读本 action 的键盘绑定，命中时调 toggleDesktopWindowFullscreen()（macOS 走

--- a/fushi/lib/src/shortcuts/shortcut_defaults.dart
+++ b/fushi/lib/src/shortcuts/shortcut_defaults.dart
@@ -176,11 +176,34 @@ class ShortcutDefaults {
       _gB
     ]),
 
-    // LB/RB = 整页翻屏（gamepad-only；键盘留空，避免与 reader PageDown 在不同
-    // scope 的重复语义）。global scope，对所有非阅读器页通用；reader 页只解析
-    // reader+audiobook，不会被遮蔽。执行体见 wrapWithGlobalNavigation。
-    ShortcutAction.globalScrollPageDown: _kb([], [_gRB]),
-    ShortcutAction.globalScrollPageUp: _kb([], [_gLB]),
+    // 页面滚动六件套（global scope，对所有非媒体页通用）：
+    //   整屏 PageDown / PageUp（+ 手柄 RB / LB）、单步 ↓ / ↑、到底 End / 到顶 Home。
+    // 以前键盘位留空是怕与 reader 的 PageDown 撞语义——但 reader / manga / video 三页
+    // 都在自己的 scope 先解析并消费这些键，global 只兜它们没绑的键，撞不上。
+    // home+global 是同一 co-active 组，home 没绑任何裸方向 / 翻页键，不冲突。
+    // 执行体见 page_scroll_shortcuts.dart（键盘 / 手柄 / 鼠标三通道共用）。
+    ShortcutAction.globalScrollPageDown: _kb([
+      _key(LogicalKeyboardKey.pageDown),
+    ], [
+      _gRB
+    ]),
+    ShortcutAction.globalScrollPageUp: _kb([
+      _key(LogicalKeyboardKey.pageUp),
+    ], [
+      _gLB
+    ]),
+    ShortcutAction.globalScrollLineDown: _kb([
+      _key(LogicalKeyboardKey.arrowDown),
+    ]),
+    ShortcutAction.globalScrollLineUp: _kb([
+      _key(LogicalKeyboardKey.arrowUp),
+    ]),
+    ShortcutAction.globalScrollToTop: _kb([
+      _key(LogicalKeyboardKey.home),
+    ]),
+    ShortcutAction.globalScrollToBottom: _kb([
+      _key(LogicalKeyboardKey.end),
+    ]),
     // TODO-1093：窗口级全屏切换默认 F11（桌面惯例）。global scope、home+global
     // co-active 组内 F11 未被占用；手柄留空（gamepad 键在 home/global 组已被翻页/
     // 返回占用，用户可自绑）。移动端无窗口全屏语义，执行体在移动端 no-op。

--- a/fushi/lib/src/shortcuts/shortcut_labels.dart
+++ b/fushi/lib/src/shortcuts/shortcut_labels.dart
@@ -79,6 +79,14 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_global_scroll_page_down;
       case ShortcutAction.globalScrollPageUp:
         return t.shortcut_action_global_scroll_page_up;
+      case ShortcutAction.globalScrollLineDown:
+        return t.shortcut_action_global_scroll_line_down;
+      case ShortcutAction.globalScrollLineUp:
+        return t.shortcut_action_global_scroll_line_up;
+      case ShortcutAction.globalScrollToTop:
+        return t.shortcut_action_global_scroll_to_top;
+      case ShortcutAction.globalScrollToBottom:
+        return t.shortcut_action_global_scroll_to_bottom;
       case ShortcutAction.globalToggleFullscreen:
         return t.shortcut_action_global_toggle_fullscreen;
       case ShortcutAction.globalContextMenu:

--- a/fushi/test/shortcuts/global_keyboard_scroll_test.dart
+++ b/fushi/test/shortcuts/global_keyboard_scroll_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/fushi_focus_controller.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/shortcuts/global_navigation.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
@@ -279,6 +280,200 @@ void main() {
       await tester.pumpAndSettle();
       expect(controller.offset, visibleScrolled,
           reason: '登记栈顶仍是被盖住页面的控制器，但它不在当前路由，不得被滚');
+    });
+  });
+
+  group('审查返工：可见性判据', () {
+    testWidgets('IndexedStack 停在 index≥1 的子区：滚可见子区，不滚隐藏子区',
+        (WidgetTester tester) async {
+      final ScrollController hidden = ScrollController();
+      final ScrollController shown = ScrollController();
+      addTearDown(hidden.dispose);
+      addTearDown(shown.dispose);
+      Widget list(ScrollController c, String tag) => ListView.builder(
+            controller: c,
+            primary: false,
+            itemCount: 200,
+            itemExtent: 40,
+            itemBuilder: (BuildContext context, int i) => Text('$tag $i'),
+          );
+      await pumpApp(
+        tester,
+        page: Scaffold(
+          body: IndexedStack(
+            index: 1,
+            children: <Widget>[list(hidden, 'hidden'), list(shown, 'shown')],
+          ),
+        ),
+        registry: desktopRegistry(),
+      );
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.pageDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(shown.offset, greaterThan(0), reason: '可见子区（index 1）被滚');
+      expect(hidden.offset, 0, reason: 'Visibility 藏起来的子区不得被滚');
+      await tester.sendKeyEvent(LogicalKeyboardKey.end);
+      await tester.pumpAndSettle();
+      expect(shown.offset, shown.position.maxScrollExtent);
+      expect(hidden.offset, 0);
+    });
+
+    testWidgets('已登记但被 Offstage 藏起的控制器不占栈顶语义：滚可见列表',
+        (WidgetTester tester) async {
+      final ScrollController offstage = ScrollController();
+      final ScrollController visible = ScrollController();
+      addTearDown(offstage.dispose);
+      addTearDown(visible.dispose);
+      // 模拟 MediaLibraryShell「惰性构建 + Offstage 保活」下 FushiPageScaffold
+      // 已 push 的发现页控制器：栈顶是它，但它整棵在 Offstage 里。
+      PageScrollRegistry.push(offstage);
+      addTearDown(() => PageScrollRegistry.pop(offstage));
+      await pumpApp(
+        tester,
+        page: Scaffold(
+          body: Stack(
+            children: <Widget>[
+              Offstage(
+                offstage: true,
+                child: ListView.builder(
+                  controller: offstage,
+                  primary: false,
+                  itemCount: 200,
+                  itemExtent: 40,
+                  itemBuilder: (BuildContext context, int i) => Text('off $i'),
+                ),
+              ),
+              ListView.builder(
+                controller: visible,
+                primary: false,
+                itemCount: 200,
+                itemExtent: 40,
+                itemBuilder: (BuildContext context, int i) => Text('on $i'),
+              ),
+            ],
+          ),
+        ),
+        registry: desktopRegistry(),
+      );
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.pageDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(visible.offset, greaterThan(0), reason: '可见列表经兜底被滚');
+      expect(offstage.offset, 0, reason: '登记栈顶但 Offstage 的控制器不得被滚');
+    });
+
+    testWidgets('焦点导航开启、本页零受管目标、焦点在原生控件上：↓ 移焦不滚', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final FocusNode first = FocusNode(debugLabel: 'first');
+      final FocusNode second = FocusNode(debugLabel: 'second');
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navKey,
+        home: Scaffold(
+          body: ListView(
+            controller: controller,
+            primary: false,
+            children: <Widget>[
+              SizedBox(
+                height: 60,
+                child: TextButton(
+                  focusNode: first,
+                  onPressed: () {},
+                  child: const Text('first'),
+                ),
+              ),
+              SizedBox(
+                height: 60,
+                child: TextButton(
+                  focusNode: second,
+                  onPressed: () {},
+                  child: const Text('second'),
+                ),
+              ),
+              const SizedBox(height: 2000),
+            ],
+          ),
+        ),
+        builder: (BuildContext context, Widget? child) =>
+            wrapWithGlobalNavigation(
+          navigatorKey: navKey,
+          registry: desktopRegistry(),
+          focusNavigationEnabled: true,
+          // 生产结构：FushiFocusRoot 在全局导航层之内、Navigator 之上。
+          child: FushiFocusRoot(enabled: true, child: child!),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      first.requestFocus();
+      await tester.pump();
+      expect(first.hasPrimaryFocus, isTrue);
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(second.hasPrimaryFocus, isTrue,
+          reason: '零受管目标不等于零焦点目标：原生控件之间照常移焦');
+      expect(controller.offset, 0, reason: '目标在视口内，不该滚');
+    });
+
+    testWidgets('内容溢出的对话框：焦点停在路由 scope 时 ↓ 先进第一个按钮，再按才滚',
+        (WidgetTester tester) async {
+      final ScrollController page = ScrollController();
+      final ScrollController dialogScroll = ScrollController();
+      addTearDown(page.dispose);
+      addTearDown(dialogScroll.dispose);
+      final FocusNode ok = FocusNode(debugLabel: 'ok');
+      addTearDown(ok.dispose);
+      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navKey,
+        home: displayOnlyList(page),
+        builder: (BuildContext context, Widget? child) =>
+            wrapWithGlobalNavigation(
+          navigatorKey: navKey,
+          registry: desktopRegistry(),
+          focusNavigationEnabled: false,
+          child: child!,
+        ),
+      ));
+      await tester.pumpAndSettle();
+      showDialog<void>(
+        context: tester.element(find.byType(Scaffold)),
+        builder: (BuildContext context) => AlertDialog(
+          content: SizedBox(
+            width: 300,
+            height: 300,
+            child: ListView.builder(
+              controller: dialogScroll,
+              primary: false,
+              itemCount: 100,
+              itemExtent: 30,
+              itemBuilder: (BuildContext context, int i) => Text('line $i'),
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              focusNode: ok,
+              onPressed: () {},
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(ok.hasPrimaryFocus, isFalse, reason: '前置：焦点还停在对话框 scope');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(ok.hasPrimaryFocus, isTrue,
+          reason: '弹层里焦点未落到控件时，↓ 先由框架 bootstrap 进第一个按钮');
+      expect(dialogScroll.offset, 0, reason: '第一下不滚');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(ok.hasPrimaryFocus, isTrue, reason: '按钮下方无目标，焦点不动');
+      expect(dialogScroll.offset, greaterThan(0),
+          reason: '焦点已在控件上、无目标 → 滚对话框内容');
+      expect(page.offset, 0, reason: '被盖住的页面不动');
     });
   });
 

--- a/fushi/test/shortcuts/global_keyboard_scroll_test.dart
+++ b/fushi/test/shortcuts/global_keyboard_scroll_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/focus/fushi_focus_controller.dart';
+import 'package:fushi/src/focus/fushi_focus_target.dart';
 import 'package:fushi/src/focus/page_scroll_registry.dart';
 import 'package:fushi/src/shortcuts/global_navigation.dart';
 import 'package:fushi/src/shortcuts/input_binding.dart';
@@ -34,32 +35,43 @@ void main() {
     required Widget page,
     required FushiShortcutRegistry registry,
     bool focusNavigationEnabled = false,
+    Map<ShortcutActivator, Intent>? appShortcuts,
+    Map<Type, Action<Intent>>? appActions,
   }) async {
     final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
     await tester.pumpWidget(MaterialApp(
       navigatorKey: navKey,
       home: page,
+      shortcuts: appShortcuts,
+      actions: appActions,
       builder: (BuildContext context, Widget? child) =>
           wrapWithGlobalNavigation(
         navigatorKey: navKey,
         registry: registry,
         focusNavigationEnabled: focusNavigationEnabled,
-        child: child!,
+        // 生产结构：焦点导航开启时 FushiFocusRoot 在全局导航层之内、Navigator 之上
+        // （main.dart）。关闭时不挂——`FushiFocusRoot.maybeControllerOf` 为 null
+        // 就是「焦点导航关闭」的判据本身。
+        child: focusNavigationEnabled
+            ? FushiFocusRoot(enabled: true, child: child!)
+            : child!,
       ),
     ));
     await tester.pumpAndSettle();
   }
 
-  /// 纯展示长列表：零可聚焦子件、零登记、`primary: false`（桌面端默认也是如此）。
-  Widget displayOnlyList(ScrollController controller) => Scaffold(
-        body: ListView.builder(
-          controller: controller,
-          primary: false,
-          itemCount: 200,
-          itemExtent: 40,
-          itemBuilder: (BuildContext context, int i) => Text('row $i'),
-        ),
+  /// 纯展示长列表本体：零可聚焦子件、`primary: false`（桌面端默认也是如此）。
+  Widget bareDisplayList(ScrollController controller) => ListView.builder(
+        controller: controller,
+        primary: false,
+        itemCount: 200,
+        itemExtent: 40,
+        itemBuilder: (BuildContext context, int i) => Text('row $i'),
       );
+
+  /// 纯展示长列表页：零可聚焦子件、零登记。
+  Widget displayOnlyList(ScrollController controller) =>
+      Scaffold(body: bareDisplayList(controller));
 
   group('默认绑定表', () {
     test('global scope 六件套：桌面键盘位 PageUp/PageDown、↑/↓、Home/End', () {
@@ -202,18 +214,37 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
     });
 
-    testWidgets('实验性焦点导航开启时同样能滚（不受开关门控）', (WidgetTester tester) async {
+    testWidgets('实验性焦点导航开启时同样能滚（不受开关门控），且不把焦点踢出页面 sink',
+        (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
       addTearDown(controller.dispose);
+      // 页面级键事件 sink（首页 `_keyboardFocusNode` / 阅读器同款）：skipTraversal、
+      // 持焦。它是 `arrowKeyClaimedByFocus` 里 `hasFocusableTargets` 门的真实场景——
+      // 树里有 FushiFocusRoot、本页零受管目标、焦点停在一个「不可用」节点上：没门时
+      // `controller.move()` 走 ensureFocus 把焦点踢到 app 级兜底节点，页面照样滚，
+      // 但挂在 sink 上的页面快捷键从此收不到键。变异实测：删门即红。
+      final FocusNode sink =
+          FocusNode(debugLabel: 'page-sink', skipTraversal: true);
+      addTearDown(sink.dispose);
       await pumpApp(
         tester,
-        page: displayOnlyList(controller),
+        page: Scaffold(
+            body: Focus(focusNode: sink, child: bareDisplayList(controller))),
         registry: desktopRegistry(),
         focusNavigationEnabled: true,
       );
+      sink.requestFocus();
+      await tester.pump();
+      expect(sink.hasPrimaryFocus, isTrue);
+      final FushiFocusController focus = FushiFocusRoot.maybeControllerOf(
+        tester.element(find.byType(Scaffold)),
+        listen: false,
+      )!;
+      expect(focus.hasFocusableTargets, isFalse, reason: '前置：零受管目标');
       expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
       await tester.pumpAndSettle();
       expect(controller.offset, greaterThan(0));
+      expect(sink.hasPrimaryFocus, isTrue, reason: '↓ 只滚页，不得把焦点踢到兜底节点');
       expect(await tester.sendKeyEvent(LogicalKeyboardKey.end), isTrue);
       await tester.pumpAndSettle();
       expect(controller.offset, controller.position.maxScrollExtent);
@@ -249,26 +280,31 @@ void main() {
     testWidgets('已登记 PageScrollRegistry 的页面：可见时经登记滚，被对话框盖住时不滚',
         (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
+      final ScrollController decoy = ScrollController();
       addTearDown(controller.dispose);
+      addTearDown(decoy.dispose);
       PageScrollRegistry.push(controller);
       addTearDown(() => PageScrollRegistry.pop(controller));
-      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
-      await tester.pumpWidget(MaterialApp(
-        navigatorKey: navKey,
-        home: displayOnlyList(controller),
-        builder: (BuildContext context, Widget? child) =>
-            wrapWithGlobalNavigation(
-          navigatorKey: navKey,
-          registry: desktopRegistry(),
-          focusNavigationEnabled: false,
-          child: child!,
+      await pumpApp(
+        tester,
+        // 诱饵列表在树序上**先于**登记列表：第 4 级兜底按 element 树序取第一个
+        // 纵向 Scrollable 会命中诱饵；只有第 2 级（登记）真在工作，滚的才是登记的
+        // 那个。变异实测：删掉第 2 级即红（诱饵被滚、登记列表不动）。
+        page: Scaffold(
+          body: Column(
+            children: <Widget>[
+              Expanded(child: bareDisplayList(decoy)),
+              Expanded(child: bareDisplayList(controller)),
+            ],
+          ),
         ),
-      ));
-      await tester.pumpAndSettle();
+        registry: desktopRegistry(),
+      );
       await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
       await tester.pumpAndSettle();
       final double visibleScrolled = controller.offset;
-      expect(visibleScrolled, greaterThan(0));
+      expect(visibleScrolled, greaterThan(0), reason: '登记的列表被滚');
+      expect(decoy.offset, 0, reason: '树序更前的未登记诱饵不得被滚');
 
       showDialog<void>(
         context: tester.element(find.byType(Scaffold)),
@@ -525,25 +561,36 @@ void main() {
 
     testWidgets('焦点在列表末尾的可聚焦项上：↓ 无目标 → 接管滚动', (WidgetTester tester) async {
       final ScrollController controller = ScrollController();
+      final ScrollController decoy = ScrollController();
       addTearDown(controller.dispose);
+      addTearDown(decoy.dispose);
       final FocusNode last = FocusNode(debugLabel: 'last');
       addTearDown(last.dispose);
       await pumpApp(
         tester,
+        // 诱饵列表在树序上先于焦点所在列表：钉住阶梯第 1 级「焦点最近的纵向
+        // Scrollable 优先」——没有它，第 4 级会去滚树序第一的诱饵。
         page: Scaffold(
-          body: ListView(
-            controller: controller,
-            primary: false,
+          body: Column(
             children: <Widget>[
-              SizedBox(
-                height: 60,
-                child: TextButton(
-                  focusNode: last,
-                  onPressed: () {},
-                  child: const Text('only'),
+              Expanded(child: bareDisplayList(decoy)),
+              Expanded(
+                child: ListView(
+                  controller: controller,
+                  primary: false,
+                  children: <Widget>[
+                    SizedBox(
+                      height: 60,
+                      child: TextButton(
+                        focusNode: last,
+                        onPressed: () {},
+                        child: const Text('only'),
+                      ),
+                    ),
+                    const SizedBox(height: 2000),
+                  ],
                 ),
               ),
-              const SizedBox(height: 2000),
             ],
           ),
         ),
@@ -555,6 +602,89 @@ void main() {
       await tester.pumpAndSettle();
       expect(last.hasPrimaryFocus, isTrue, reason: '没别的目标，焦点不动');
       expect(controller.offset, greaterThan(0), reason: '列表边缘接管滚动');
+      expect(decoy.offset, 0, reason: '焦点所在列表优先于树序更前的诱饵');
+    });
+
+    testWidgets('焦点导航开启、焦点在最后一个受管控件上：↓ 无目标 → 滚动', (WidgetTester tester) async {
+      // 走的是 [_handleGlobalArrowFocus]（受管目标门）→ `_moveFocusForArrow` 的
+      // 尽头：受管控件用完之后还有非聚焦内容（长说明文字）时 ↓ 要把它们滚出来，
+      // 而不是死在最后一个控件上。变异实测：拿掉那段滚动回退即红。
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final FocusNode last = FocusNode(debugLabel: 'last-managed');
+      addTearDown(last.dispose);
+      await pumpApp(
+        tester,
+        page: Scaffold(
+          body: ListView(
+            controller: controller,
+            primary: false,
+            children: <Widget>[
+              SizedBox(
+                height: 60,
+                child: FushiFocusTarget(
+                  id: const FushiFocusId('first'),
+                  child: TextButton(onPressed: () {}, child: const Text('a')),
+                ),
+              ),
+              SizedBox(
+                height: 60,
+                child: FushiFocusTarget(
+                  id: const FushiFocusId('last'),
+                  focusNode: last,
+                  child: TextButton(onPressed: () {}, child: const Text('b')),
+                ),
+              ),
+              const SizedBox(height: 2000),
+            ],
+          ),
+        ),
+        registry: desktopRegistry(),
+        focusNavigationEnabled: true,
+      );
+      last.requestFocus();
+      await tester.pump();
+      expect(last.hasPrimaryFocus, isTrue);
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(last.hasPrimaryFocus, isTrue, reason: '下方无受管目标，焦点不动');
+      expect(controller.offset, greaterThan(0), reason: '受管控件尽头落到滚动');
+    });
+
+    testWidgets('解析到了但当前页滚不动：返回 ignored，按键继续冒泡给框架',
+        (WidgetTester tester) async {
+      // 规则 4 的观测点：把 ↑ / ↓ 在 WidgetsApp 层绑到探针 intent——它在 app 根的
+      // Focus.onKeyEvent **之后**才有机会跑。页面已在顶端时 ↑ 滚不动，根层必须放行
+      // （探针触发）；↓ 能滚则根层认领（探针不触发）。变异实测：无条件 handled 即红。
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final List<LogicalKeyboardKey> probed = <LogicalKeyboardKey>[];
+      await pumpApp(
+        tester,
+        page: displayOnlyList(controller),
+        registry: desktopRegistry(),
+        appShortcuts: <ShortcutActivator, Intent>{
+          const SingleActivator(LogicalKeyboardKey.arrowUp):
+              const _ProbeIntent(LogicalKeyboardKey.arrowUp),
+          const SingleActivator(LogicalKeyboardKey.arrowDown):
+              const _ProbeIntent(LogicalKeyboardKey.arrowDown),
+        },
+        appActions: <Type, Action<Intent>>{
+          _ProbeIntent: CallbackAction<_ProbeIntent>(
+            onInvoke: (_ProbeIntent intent) => probed.add(intent.key),
+          ),
+        },
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0);
+      expect(probed, <LogicalKeyboardKey>[LogicalKeyboardKey.arrowUp],
+          reason: '顶端 ↑ 滚不动 → 根层放行，框架层收到');
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(controller.offset, greaterThan(0));
+      expect(probed, <LogicalKeyboardKey>[LogicalKeyboardKey.arrowUp],
+          reason: '↓ 滚成了 → 根层认领，框架层收不到');
     });
 
     for (final bool focusNav in <bool>[false, true]) {
@@ -594,4 +724,9 @@ void main() {
       });
     }
   });
+}
+
+class _ProbeIntent extends Intent {
+  const _ProbeIntent(this.key);
+  final LogicalKeyboardKey key;
 }

--- a/fushi/test/shortcuts/global_keyboard_scroll_test.dart
+++ b/fushi/test/shortcuts/global_keyboard_scroll_test.dart
@@ -1,0 +1,402 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/focus/page_scroll_registry.dart';
+import 'package:fushi/src/shortcuts/global_navigation.dart';
+import 'package:fushi/src/shortcuts/input_binding.dart';
+import 'package:fushi/src/shortcuts/shortcut_action.dart';
+import 'package:fushi/src/shortcuts/shortcut_defaults.dart';
+import 'package:fushi/src/shortcuts/shortcut_registry.dart';
+
+/// 全 app 键盘滚动（用户：「我一般用键盘滚动，fushi 里全部页面都不行」）。
+///
+/// 三件事各钉一条：
+///   1. 默认绑定表：global scope 六件套的键盘位（PageUp/PageDown、↑/↓、Home/End），
+///      手柄 LB/RB 原样保留；
+///   2. 零登记页面也能被滚：一个没有任何可聚焦子件、没登记 PageScrollRegistry、
+///      也没挂 PrimaryScrollController 的 ListView 页面（桌面端 ListView 默认不挂），
+///      按键后 `controller.offset` 真变化——这是改造前完全不可达的那类页面；
+///   3. 让位规则：焦点在列表中间的可聚焦项上时 ↓ 走焦点导航（焦点变、页面不被
+///      单步滚动）；TextField 聚焦时 ↓/Home/End 一律不接管。
+///
+/// 宿主结构照生产：[wrapWithGlobalNavigation] 挂在 [MaterialApp.builder]（Navigator
+/// 之上），页面经 `home:` 作为路由挂进 Navigator——这样兜底解析器走的是真实的
+/// 「从 Navigator 当前路由子树里找 Scrollable」那条路，而不是被测试结构侥幸绕过。
+void main() {
+  FushiShortcutRegistry desktopRegistry() =>
+      FushiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
+
+  setUp(PageScrollRegistry.debugClear);
+
+  Future<void> pumpApp(
+    WidgetTester tester, {
+    required Widget page,
+    required FushiShortcutRegistry registry,
+    bool focusNavigationEnabled = false,
+  }) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navKey,
+      home: page,
+      builder: (BuildContext context, Widget? child) =>
+          wrapWithGlobalNavigation(
+        navigatorKey: navKey,
+        registry: registry,
+        focusNavigationEnabled: focusNavigationEnabled,
+        child: child!,
+      ),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  /// 纯展示长列表：零可聚焦子件、零登记、`primary: false`（桌面端默认也是如此）。
+  Widget displayOnlyList(ScrollController controller) => Scaffold(
+        body: ListView.builder(
+          controller: controller,
+          primary: false,
+          itemCount: 200,
+          itemExtent: 40,
+          itemBuilder: (BuildContext context, int i) => Text('row $i'),
+        ),
+      );
+
+  group('默认绑定表', () {
+    test('global scope 六件套：桌面键盘位 PageUp/PageDown、↑/↓、Home/End', () {
+      final Map<ShortcutAction, ShortcutBindingSet> win =
+          ShortcutDefaults.forPlatform(TargetPlatform.windows);
+      LogicalKeyboardKey soleKey(ShortcutAction action) {
+        final List<InputBinding> keys = win[action]!.keyboardBindings;
+        expect(keys, hasLength(1), reason: '${action.key} 应恰有一个键盘默认位');
+        expect(keys.single.modifiers, isEmpty,
+            reason: '${action.key} 默认位不带修饰键');
+        return keys.single.key;
+      }
+
+      expect(soleKey(ShortcutAction.globalScrollPageDown),
+          LogicalKeyboardKey.pageDown);
+      expect(soleKey(ShortcutAction.globalScrollPageUp),
+          LogicalKeyboardKey.pageUp);
+      expect(soleKey(ShortcutAction.globalScrollLineDown),
+          LogicalKeyboardKey.arrowDown);
+      expect(soleKey(ShortcutAction.globalScrollLineUp),
+          LogicalKeyboardKey.arrowUp);
+      expect(
+          soleKey(ShortcutAction.globalScrollToTop), LogicalKeyboardKey.home);
+      expect(
+          soleKey(ShortcutAction.globalScrollToBottom), LogicalKeyboardKey.end);
+    });
+
+    test('手柄 LB/RB 整屏翻页原样保留；新增四个动作不占手柄键', () {
+      final Map<ShortcutAction, ShortcutBindingSet> win =
+          ShortcutDefaults.forPlatform(TargetPlatform.windows);
+      expect(
+        win[ShortcutAction.globalScrollPageDown]!
+            .gamepadBindings
+            .map((GamepadBinding b) => b.button),
+        <GamepadButton>[GamepadButton.rb],
+      );
+      expect(
+        win[ShortcutAction.globalScrollPageUp]!
+            .gamepadBindings
+            .map((GamepadBinding b) => b.button),
+        <GamepadButton>[GamepadButton.lb],
+      );
+      for (final ShortcutAction action in <ShortcutAction>[
+        ShortcutAction.globalScrollLineDown,
+        ShortcutAction.globalScrollLineUp,
+        ShortcutAction.globalScrollToTop,
+        ShortcutAction.globalScrollToBottom,
+      ]) {
+        expect(action.scope, ShortcutScope.global);
+        expect(win[action]!.gamepadBindings, isEmpty);
+      }
+    });
+
+    test('六件套的键在 home+global co-active 组内互不撞键、也不撞 globalBack', () {
+      final FushiShortcutRegistry registry = desktopRegistry();
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.pageDown,
+        LogicalKeyboardKey.pageUp,
+        LogicalKeyboardKey.arrowDown,
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.home,
+        LogicalKeyboardKey.end,
+      ]) {
+        expect(
+            registry.resolveKeyboard(key,
+                modifiers: const <ModifierKey>{}, scope: ShortcutScope.home),
+            isNull,
+            reason: 'home scope 不得占用 ${key.keyLabel}');
+        expect(
+            registry.resolveKeyboard(key,
+                modifiers: const <ModifierKey>{},
+                scope: ShortcutScope.universal),
+            isNull,
+            reason: 'universal scope 不得占用 ${key.keyLabel}');
+        expect(
+            registry.resolveKeyboard(key,
+                modifiers: const <ModifierKey>{}, scope: ShortcutScope.global),
+            isNotNull,
+            reason: 'global scope 应把 ${key.keyLabel} 解析到滚动动作');
+      }
+    });
+  });
+
+  group('零登记纯展示页：键盘真的能滚', () {
+    testWidgets('PageDown / ArrowDown / End / Home 依次改变 controller.offset',
+        (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      await pumpApp(
+        tester,
+        page: displayOnlyList(controller),
+        registry: desktopRegistry(),
+      );
+      expect(PageScrollRegistry.debugDepth, 0, reason: '本页刻意不登记');
+      expect(controller.offset, 0);
+
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.pageDown), isTrue);
+      await tester.pumpAndSettle();
+      final double afterPageDown = controller.offset;
+      expect(afterPageDown, greaterThan(0), reason: 'PageDown 应整屏下滚');
+      expect(afterPageDown, lessThanOrEqualTo(600),
+          reason: '整屏 = 0.9 × viewport（测试 viewport 600）');
+
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      final double afterArrowDown = controller.offset;
+      expect(afterArrowDown, greaterThan(afterPageDown), reason: '↓ 应单步下滚');
+      expect(afterArrowDown - afterPageDown, lessThan(afterPageDown),
+          reason: '单步比整屏小');
+
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.end), isTrue);
+      await tester.pumpAndSettle();
+      expect(controller.offset, controller.position.maxScrollExtent,
+          reason: 'End 应滚到底');
+
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.home), isTrue);
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0, reason: 'Home 应滚回顶');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0, reason: '已在顶端时 ↑ 不动、不抛');
+    });
+
+    testWidgets('按住方向键（OS 自动重复）持续滚动', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      await pumpApp(
+        tester,
+        page: displayOnlyList(controller),
+        registry: desktopRegistry(),
+      );
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      final double afterDown = controller.offset;
+      expect(afterDown, greaterThan(0));
+      await tester.sendKeyRepeatEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(controller.offset, greaterThan(afterDown), reason: '重复沿也要滚');
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowDown);
+    });
+
+    testWidgets('实验性焦点导航开启时同样能滚（不受开关门控）', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      await pumpApp(
+        tester,
+        page: displayOnlyList(controller),
+        registry: desktopRegistry(),
+        focusNavigationEnabled: true,
+      );
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(controller.offset, greaterThan(0));
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.end), isTrue);
+      await tester.pumpAndSettle();
+      expect(controller.offset, controller.position.maxScrollExtent);
+    });
+
+    testWidgets('对话框压在页面上时，按键滚的不是被盖住的页面', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navKey,
+        home: displayOnlyList(controller),
+        builder: (BuildContext context, Widget? child) =>
+            wrapWithGlobalNavigation(
+          navigatorKey: navKey,
+          registry: desktopRegistry(),
+          focusNavigationEnabled: false,
+          child: child!,
+        ),
+      ));
+      await tester.pumpAndSettle();
+      showDialog<void>(
+        context: tester.element(find.text('row 0')),
+        builder: (BuildContext context) =>
+            const AlertDialog(content: Text('blocking')),
+      );
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
+      await tester.pumpAndSettle();
+      expect(controller.offset, 0, reason: '非当前路由的 Scrollable 不得被滚');
+    });
+
+    testWidgets('已登记 PageScrollRegistry 的页面：可见时经登记滚，被对话框盖住时不滚',
+        (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      PageScrollRegistry.push(controller);
+      addTearDown(() => PageScrollRegistry.pop(controller));
+      final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(MaterialApp(
+        navigatorKey: navKey,
+        home: displayOnlyList(controller),
+        builder: (BuildContext context, Widget? child) =>
+            wrapWithGlobalNavigation(
+          navigatorKey: navKey,
+          registry: desktopRegistry(),
+          focusNavigationEnabled: false,
+          child: child!,
+        ),
+      ));
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.pageDown);
+      await tester.pumpAndSettle();
+      final double visibleScrolled = controller.offset;
+      expect(visibleScrolled, greaterThan(0));
+
+      showDialog<void>(
+        context: tester.element(find.byType(Scaffold)),
+        builder: (BuildContext context) =>
+            const AlertDialog(content: Text('blocking')),
+      );
+      await tester.pumpAndSettle();
+      await tester.sendKeyEvent(LogicalKeyboardKey.end);
+      await tester.pumpAndSettle();
+      expect(controller.offset, visibleScrolled,
+          reason: '登记栈顶仍是被盖住页面的控制器，但它不在当前路由，不得被滚');
+    });
+  });
+
+  group('让位规则', () {
+    testWidgets('焦点在列表中间的可聚焦项上：↓ 移焦而不是单步滚动', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final List<FocusNode> nodes = List<FocusNode>.generate(
+        6,
+        (int i) => FocusNode(debugLabel: 'btn$i'),
+      );
+      addTearDown(() {
+        for (final FocusNode n in nodes) {
+          n.dispose();
+        }
+      });
+      await pumpApp(
+        tester,
+        page: Scaffold(
+          body: ListView(
+            controller: controller,
+            primary: false,
+            children: <Widget>[
+              for (int i = 0; i < nodes.length; i++)
+                SizedBox(
+                  height: 60,
+                  child: TextButton(
+                    focusNode: nodes[i],
+                    onPressed: () {},
+                    child: Text('btn $i'),
+                  ),
+                ),
+              const SizedBox(height: 2000),
+            ],
+          ),
+        ),
+        registry: desktopRegistry(),
+      );
+      nodes[2].requestFocus();
+      await tester.pump();
+      expect(nodes[2].hasPrimaryFocus, isTrue);
+
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(nodes[3].hasPrimaryFocus, isTrue, reason: '方向上有几何焦点目标时归焦点导航');
+      expect(controller.offset, 0,
+          reason: '目标已在视口内，不该触发单步滚动（ensureVisible 也无需动）');
+    });
+
+    testWidgets('焦点在列表末尾的可聚焦项上：↓ 无目标 → 接管滚动', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      addTearDown(controller.dispose);
+      final FocusNode last = FocusNode(debugLabel: 'last');
+      addTearDown(last.dispose);
+      await pumpApp(
+        tester,
+        page: Scaffold(
+          body: ListView(
+            controller: controller,
+            primary: false,
+            children: <Widget>[
+              SizedBox(
+                height: 60,
+                child: TextButton(
+                  focusNode: last,
+                  onPressed: () {},
+                  child: const Text('only'),
+                ),
+              ),
+              const SizedBox(height: 2000),
+            ],
+          ),
+        ),
+        registry: desktopRegistry(),
+      );
+      last.requestFocus();
+      await tester.pump();
+      expect(await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown), isTrue);
+      await tester.pumpAndSettle();
+      expect(last.hasPrimaryFocus, isTrue, reason: '没别的目标，焦点不动');
+      expect(controller.offset, greaterThan(0), reason: '列表边缘接管滚动');
+    });
+
+    for (final bool focusNav in <bool>[false, true]) {
+      testWidgets('TextField 聚焦时 ↓ / Home / End 一律不接管（焦点导航开关=$focusNav）',
+          (WidgetTester tester) async {
+        final ScrollController controller = ScrollController();
+        addTearDown(controller.dispose);
+        final FocusNode field = FocusNode(debugLabel: 'field');
+        addTearDown(field.dispose);
+        await pumpApp(
+          tester,
+          page: Scaffold(
+            body: ListView(
+              controller: controller,
+              primary: false,
+              children: <Widget>[
+                TextField(focusNode: field),
+                const SizedBox(height: 2000),
+              ],
+            ),
+          ),
+          registry: desktopRegistry(),
+          focusNavigationEnabled: focusNav,
+        );
+        field.requestFocus();
+        await tester.pump();
+        expect(field.hasPrimaryFocus, isTrue);
+        for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+          LogicalKeyboardKey.arrowDown,
+          LogicalKeyboardKey.end,
+          LogicalKeyboardKey.home,
+        ]) {
+          await tester.sendKeyEvent(key);
+          await tester.pumpAndSettle();
+          expect(controller.offset, 0, reason: '${key.keyLabel} 应归文本框');
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
## 问题

用户：「我一般用键盘滚动，fushi 里全部页面都不行。」

根因：焦点常停在顶层 `FushiFocusRoot` fallback 节点，Flutter 默认 `ScrollAction` 从焦点向上找不到页面的 Scrollable；app 自己的翻屏动作 `globalScrollPageUp/Down` 键盘位留空（只有手柄 LB/RB），方向键被焦点导航层接管。`PageScrollRegistry` 需页面主动登记，全仓只有 9 处。

## 改动

- `globalScrollPageUp/Down` 补 PageUp/PageDown；新增 global 动作 `globalScrollLineUp/Down`（↑/↓）、`globalScrollToTop/Bottom`（Home/End）。键盘/手柄/鼠标三通道共用执行体 `executePageScroll`（`page_scroll_shortcuts.dart`）。
- `FushiFocusScroll.resolveActivePageScrollable` 四级解析：焦点最近纵向 Scrollable → `PageScrollRegistry` → `PrimaryScrollController` → 当前路由子树 element 遍历（剪非当前路由 / `Offstage` / 不可见 `Visibility`），零登记页面也能滚；前三级同样要求「属于当前路由且未被 Offstage/Visibility 藏起」。
- ↑/↓ 与焦点导航共存：先问焦点（有受管目标走引擎、否则 `focusInDirection`），焦点尽头 / 纯展示页才滚；文本框聚焦一律放行；弹层里焦点未 bootstrap 时先让框架 bootstrap 再滚。
- reader / manga / video 页键位未动（各自 scope 先消费）。
- `docs/agent/shortcuts-inventory.md` 更新。

## 行为变化（请知悉）

焦点导航关闭（默认）时，焦点不在真实控件上按 ↓ 直接滚页（以前会把焦点跳到页面第一个控件）。

## 审查返工

IndexedStack 特例按错误树结构写（index≥1 整棵跳过、index==0 滚隐藏子区）→ 改统一可见性判据；登记栈顶被 Offstage 藏起仍被滚 → 判 `_positionIsPresented`；零受管目标误判无目标 → fall through 到原生 `focusInDirection`；首页 ←/→ 按下沿与重复沿同一判据；弹层先 bootstrap。变异实测确认测试钉住实现。

## 验证

- `flutter analyze` 零问题（rebase 到 origin/develop 后重跑）。
- `flutter test test/shortcuts test/focus test/i18n --no-pub`：776 条全绿（含新 `global_keyboard_scroll_test.dart` 16 条）；`test/pages --plain-name home` 47 条绿。
- **未做真机 / 离屏 itest 验证**：静态审查库页 ×3 / 设置 / 统计 / 词典 / 下载中心均为 ListView / CustomScrollView / SingleChildScrollView / FushiPageScaffold，按构造应全部可达，需在真 app 上按一遍六个键复核。

https://claude.ai/code/session_0167ukTuqAjGM7Xkm8XwefoZ
