### PR TITLE
feat(reader): 振假名第四态 dimmed（淡显）

### DIFF
--- a/fushi/integration_test/reader_furigana_three_state_itest.dart
+++ b/fushi/integration_test/reader_furigana_three_state_itest.dart
@@ -20,8 +20,10 @@ import 'support/itest_startup_guard.dart';
 import 'support/test_app_launcher.dart';
 import 'test_helpers.dart';
 
-/// 振假名三态（`src:reader_fushi:furigana_mode` = `off` / `toggle` / `hidden`）
-/// 真 app 证据（Windows 离屏 runner，真 WebView2 + 真分页 JS + 真 CSS 注入）。
+/// 振假名四态（`src:reader_fushi:furigana_mode` =
+/// `off` / `toggle` / `hidden` / `dimmed`）真 app 证据（Windows 离屏 runner，
+/// 真 WebView2 + 真分页 JS + 真 CSS 注入）。文件名保留 `three_state`（docs 里
+/// 有引用），覆盖面已是四态。
 ///
 /// 被测契约（`ReaderContentStyles._furiganaCss` + `fushiSelection.selectText`）：
 ///  1. `toggle`：未揭示 `<ruby>` 的 `rt` 是 `visibility:hidden`、ruby 带灰色虚线下划线
@@ -36,7 +38,10 @@ import 'test_helpers.dart';
 ///  4. 热切到 `hidden`（`setReaderFuriganaMode` → `onSettingsChangedLive`，与设置页
 ///     `notifyReaderSettingsChanged` 同一条路）：rt `display:none`；再热切到 `off`：
 ///     rt `visibility:visible` 且 ruby 无虚线下划线；
-///  5. 偏好在 `finally` 还原。
+///  5. 热切到 `dimmed`：rt 仍 `display:ruby-text`（结构与 `off` 一致，不是隐藏），
+///     但 `opacity` 被淡到 0.45；`body.show-all-rt`（readerToggleFurigana 快捷键
+///     在此态的语义 = 临时恢复全亮）把 opacity 拉回 1；切回 `off` opacity 回到 1；
+///  6. 偏好在 `finally` 还原。
 ///
 /// 素材是本文件现生成的一本**横排分页**单章 EPUB，正文前几段混有 `<ruby>…<rt>…</rt>
 /// </ruby>`（首屏即可命中，不依赖任何章节导航）。全程不点控件：开书走
@@ -240,6 +245,7 @@ String _probeJs(int index) => '''
     revealed: ruby.classList.contains('furigana-revealed'),
     rtVisibility: rtCs.visibility,
     rtDisplay: rtCs.display,
+    rtOpacity: rtCs.opacity,
     rubyDecorationLine: rubyCs.textDecorationLine,
     rubyDecorationStyle: rubyCs.textDecorationStyle,
     baseCx: (br.left + br.right) / 2,
@@ -278,6 +284,8 @@ class _RubyProbe {
   bool get revealed => raw['revealed'] == true;
   String get rtVisibility => raw['rtVisibility']?.toString() ?? '';
   String get rtDisplay => raw['rtDisplay']?.toString() ?? '';
+  double get rtOpacity =>
+      double.tryParse(raw['rtOpacity']?.toString() ?? '') ?? -1;
   String get rubyDecorationLine => raw['rubyDecorationLine']?.toString() ?? '';
   String get rubyDecorationStyle =>
       raw['rubyDecorationStyle']?.toString() ?? '';
@@ -295,6 +303,7 @@ class _RubyProbe {
   @override
   String toString() => 'base="$baseText" rt="$rtText" revealed=$revealed '
       'rtVisibility=$rtVisibility rtDisplay=$rtDisplay '
+      'rtOpacity=$rtOpacity '
       'rubyDecoration=$rubyDecorationLine/$rubyDecorationStyle '
       'baseCenter=(${_f(baseCx)},${_f(baseCy)}) inViewport=$inViewport '
       'baseRect=${raw['baseRect']} rubyRect=${raw['rubyRect']} '
@@ -364,8 +373,8 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'furigana_mode three-state: toggle hides rt + dotted underline, first tap '
-    'reveals without lookup, second tap looks up; hidden/off hot-switch',
+    'furigana_mode four-state: toggle hides rt + dotted underline, first tap '
+    'reveals without lookup, second tap looks up; hidden/off/dimmed hot-switch',
     timeout: const Timeout(Duration(minutes: 12)),
     (WidgetTester tester) async {
       await runFushiItest(
@@ -521,11 +530,67 @@ void main() {
             expect(s4b1.revealed, isFalse, reason: 'ruby #1 was never tapped');
             expect(s4b0.rtVisibility, 'visible');
             expect(s4b0.rtDisplay, 'ruby-text');
+            expect(s4b1.rtOpacity, closeTo(1.0, 0.001),
+                reason: '4b. off: rt 不淡显（opacity 1）');
             await _captureWeb('observe-a5-off-webview');
+
+            // ── 4c. 热切 dimmed：结构同 off，但 opacity 淡到 0.45 ──────
+            await source.setReaderFuriganaMode('dimmed');
+            await _pumpForPref(tester);
+            expect(ReaderFushiSource.readerSettings?.furiganaMode, 'dimmed');
+            final _RubyProbe s4c1 = await _probeUntil(
+                tester,
+                runJs,
+                1,
+                (p) => p.rtDisplay == 'ruby-text' && p.rtOpacity < 0.9,
+                '4c dimmed #1');
+            expect(s4c1.rtDisplay, 'ruby-text',
+                reason: '4c. dimmed 是「显示但淡」，注音结构必须与 off 一致，'
+                    '不得退化成 display:none / visibility:hidden');
+            expect(s4c1.rtVisibility, 'visible',
+                reason: '4c. dimmed: rt 仍 visible');
+            expect(s4c1.rtOpacity, closeTo(0.45, 0.01),
+                reason: '4c. dimmed: rt 淡显到 opacity 0.45（实测 '
+                    '${s4c1.rtOpacity}）');
+            expect(s4c1.rubyDecorationLine, isNot(contains('underline')),
+                reason: '4c. dimmed 不画 toggle 的虚线下划线');
+            await _captureWeb('observe-a6-dimmed-webview');
+            await _captureFrame(tester, 'observe-a6-dimmed');
+
+            // ── 4d. dimmed 下 show-all-rt（readerToggleFurigana 快捷键的
+            //        CSS 落点）= 临时恢复全亮 ─────────────────────────
+            await runJs("document.body.classList.add('show-all-rt');");
+            final _RubyProbe s4d = await _probeUntil(tester, runJs, 1,
+                (p) => p.rtOpacity > 0.9, '4d dimmed + show-all-rt');
+            expect(s4d.rtOpacity, closeTo(1.0, 0.001),
+                reason: '4d. dimmed + show-all-rt 必须把 opacity 拉回 1（'
+                    'readerToggleFurigana 在此态 = 临时恢复全亮），实测 '
+                    '${s4d.rtOpacity}');
+            expect(s4d.rtDisplay, 'ruby-text');
+            await _captureWeb('observe-a7-dimmed-show-all-webview');
+            await runJs("document.body.classList.remove('show-all-rt');");
+
+            // ── 4e. 切回 off：opacity 回到 1 ─────────────────────────
+            await source.setReaderFuriganaMode('off');
+            await _pumpForPref(tester);
+            expect(ReaderFushiSource.readerSettings?.furiganaMode, 'off');
+            final _RubyProbe s4e = await _probeUntil(
+                tester,
+                runJs,
+                1,
+                (p) => p.rtDisplay == 'ruby-text' && p.rtOpacity > 0.9,
+                '4e back to off');
+            expect(s4e.rtOpacity, closeTo(1.0, 0.001),
+                reason: '4e. 切回 off 后淡显必须完全撤掉（opacity 1），实测 '
+                    '${s4e.rtOpacity}');
+            expect(s4e.rtDisplay, 'ruby-text');
+            expect(s4e.rtVisibility, 'visible');
+            await _captureWeb('observe-a8-off-again-webview');
 
             debugPrint('[furigana3] PASS: toggle(hidden rt, dotted) → tap '
                 'reveals w/o lookup → tap looks up → hidden(display:none) → '
-                'off(visible, no underline)');
+                'off(visible, no underline) → dimmed(opacity 0.45) → '
+                'show-all-rt(opacity 1) → off(opacity 1)');
           } finally {
             await _closeReader(tester);
             await source.setReaderFuriganaMode(originalMode);

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80614 (4742 per locale)
+/// Strings: 80631 (4743 per locale)
 ///
-/// Built on 2026-09-12 at 04:45 UTC
+/// Built on 2026-09-12 at 05:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6594,6 +6594,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Skipped ${count} locked chapters';
   String get mihon_sources_search_hint => 'Search sources';
   String get mihon_source_login_forward => 'Forward';
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -17758,6 +17759,8 @@ class _StringsAr extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -29148,6 +29151,8 @@ class _StringsDe extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -40592,6 +40597,8 @@ class _StringsEs extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -52069,6 +52076,8 @@ class _StringsFr extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -63350,6 +63359,8 @@ class _StringsId extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -74722,6 +74733,8 @@ class _StringsIt extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -85476,6 +85489,8 @@ class _StringsJa extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -96240,6 +96255,8 @@ class _StringsKo extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -107570,6 +107587,8 @@ class _StringsNl extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -118953,6 +118972,8 @@ class _StringsPtBr extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -130313,6 +130334,8 @@ class _StringsRu extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -141474,6 +141497,8 @@ class _StringsTh extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -152750,6 +152775,8 @@ class _StringsTr extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -163996,6 +164023,8 @@ class _StringsVi extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 // Path: <root>
@@ -174316,6 +174345,8 @@ class _StringsZhCn extends _StringsEn {
   String get mihon_sources_search_hint => '搜索漫画源';
   @override
   String get mihon_source_login_forward => '前进';
+  @override
+  String get reader_furigana_dimmed => '淡显';
 }
 
 // Path: <root>
@@ -184754,6 +184785,8 @@ class _StringsZhHk extends _StringsEn {
   String get mihon_sources_search_hint => 'Search sources';
   @override
   String get mihon_source_login_forward => 'Forward';
+  @override
+  String get reader_furigana_dimmed => 'Dimmed';
 }
 
 /// Flat map(s) containing all translations.
@@ -194522,6 +194555,8 @@ extension on _StringsEn {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -204285,6 +204320,8 @@ extension on _StringsAr {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -214093,6 +214130,8 @@ extension on _StringsDe {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -223892,6 +223931,8 @@ extension on _StringsEs {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -233700,6 +233741,8 @@ extension on _StringsFr {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -243479,6 +243522,8 @@ extension on _StringsId {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -253280,6 +253325,8 @@ extension on _StringsIt {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -263008,6 +263055,8 @@ extension on _StringsJa {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -272740,6 +272789,8 @@ extension on _StringsKo {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -282534,6 +282585,8 @@ extension on _StringsNl {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -292323,6 +292376,8 @@ extension on _StringsPtBr {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -302119,6 +302174,8 @@ extension on _StringsRu {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -311887,6 +311944,8 @@ extension on _StringsTh {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -321670,6 +321729,8 @@ extension on _StringsTr {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -331447,6 +331508,8 @@ extension on _StringsVi {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }
@@ -341137,6 +341200,8 @@ extension on _StringsZhCn {
         return '搜索漫画源';
       case 'mihon_source_login_forward':
         return '前进';
+      case 'reader_furigana_dimmed':
+        return '淡显';
       default:
         return null;
     }
@@ -350843,6 +350908,8 @@ extension on _StringsZhHk {
         return 'Search sources';
       case 'mihon_source_login_forward':
         return 'Forward';
+      case 'reader_furigana_dimmed':
+        return 'Dimmed';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "仍然下载",
   "manga_series_download_all_locked_skipped": "已跳过 $count 个锁定章节",
   "mihon_sources_search_hint": "搜索漫画源",
-  "mihon_source_login_forward": "前进"
+  "mihon_source_login_forward": "前进",
+  "reader_furigana_dimmed": "淡显"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4740,5 +4740,6 @@
   "manga_chapter_locked_download_anyway": "Download anyway",
   "manga_series_download_all_locked_skipped": "Skipped $count locked chapters",
   "mihon_sources_search_hint": "Search sources",
-  "mihon_source_login_forward": "Forward"
+  "mihon_source_login_forward": "Forward",
+  "reader_furigana_dimmed": "Dimmed"
 }

--- a/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/caret.part.dart
@@ -688,8 +688,9 @@ extension _ReaderCaret on _ReaderFushiPageState {
         return KeyEventResult.handled;
       case ShortcutAction.readerToggleFurigana:
         // 振假名 toggle 态的整页揭示 / 收回（CSS `body.show-all-rt`）：键盘 / 手柄
-        // (R3) 没有「点一个揭示一个」的指针，这颗键一次揭示全页；off / hidden 态
-        // 没有对应 CSS，按下是 no-op。
+        // (R3) 没有「点一个揭示一个」的指针，这颗键一次揭示全页；dimmed 态同一颗键
+        // 是「临时恢复全亮」（opacity 拉回 1）；off / hidden 态没有对应 CSS，按下是
+        // no-op。
         _controller?.evaluateJavascript(
           source: "document.body.classList.toggle('show-all-rt');",
         );

--- a/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/webview.part.dart
@@ -589,9 +589,10 @@ extension _ReaderWebView on _ReaderFushiPageState {
 
   static bool _isValidFontData(Uint8List data) => isValidFontData(data);
 
-  // 振假名三态（off / toggle / hidden）不再装任何 JS 监听器：隐藏由 CSS 承担，
-  // toggle 态的「点一个揭示一个」收进 fushiSelection.selectText（查词入口，
-  // 命中隐藏注音的 ruby 只揭示、不查词），整页揭示走 readerToggleFurigana 快捷键。
+  // 振假名四态（off / toggle / hidden / dimmed）不再装任何 JS 监听器：隐藏 / 淡显
+  // 都由 CSS 承担，toggle 态的「点一个揭示一个」收进 fushiSelection.selectText
+  // （查词入口，命中隐藏注音的 ruby 只揭示、不查词），整页揭示 / dimmed 的临时全亮
+  // 走 readerToggleFurigana 快捷键。
   // 旧 `_buildFuriganaJs`（partial 的 click 切换 / toggle 的 dblclick 整页切换）已删。
 
   // ── Single IIFE setup script (mirrors Hoshi Android's readerSetupScript) ──

--- a/fushi/lib/src/reader/reader_content_styles.dart
+++ b/fushi/lib/src/reader/reader_content_styles.dart
@@ -1209,12 +1209,20 @@ body::after {
     // still wins for hidden furigana. The shown modes also own <rtc> (see
     // _rtcAnnotationCss); `hide` hides rtc together with rt so a hidden
     // annotation container cannot keep reserving lane space.
-    // 三态对齐 Hoshi Reader iOS `FuriganaMode { off, toggle, hidden }`（值域见
-    // ReaderSettings.furiganaMode）。`toggle` 的隐藏纯由 CSS 承担，不再靠装载时 JS
-    // 给 ruby 打 class：正文动态换章 / 设置热更新都只重发 CSS，JS 标记会漏掉新
-    // 内容或在热切换后残留。揭示 = 点击那个 ruby 加 `furigana-revealed`
+    // 四态（值域见 ReaderSettings.furiganaMode）：前三态 off / toggle / hidden
+    // 对齐 Hoshi Reader iOS `FuriganaMode`，`dimmed` 是 2026-09-12 用户追加的
+    // 「显示但淡」。`toggle` 的隐藏纯由 CSS 承担，不再靠装载时 JS 给 ruby 打
+    // class：正文动态换章 / 设置热更新都只重发 CSS，JS 标记会漏掉新内容或在热
+    // 切换后残留。揭示 = 点击那个 ruby 加 `furigana-revealed`
     // （fushiSelection.selectText 入口，命中隐藏注音的 ruby 只揭示、不查词）；
     // `body.show-all-rt` 是 readerToggleFurigana 快捷键（手柄 R3）的整页揭示。
+    //
+    // `dimmed` 的淡显只用 `opacity`，**不改 color**：注音色如果写死成某个灰，在
+    // 深浅主题 / 自定义正文色之间总有一边对比失衡（浅底上的浅灰几乎不可读、深底
+    // 上的深灰直接消失）；opacity 是对当前正文色的相对衰减，两边都成立，也不和
+    // 主题色变量、有声书高亮的背景填充打架。同一颗 `readerToggleFurigana` 快捷键
+    // 在 `dimmed` 下的语义是「临时恢复全亮」——`body.show-all-rt` 把 opacity 拉回
+    // 1，与 `toggle` 下「整页揭示」同构（都是一次性看清全页注音）。
     switch (mode) {
       case 'hidden':
         return 'rt, rtc { display: none !important; }';
@@ -1236,6 +1244,18 @@ ruby:not(.furigana-revealed):has(rt) {
 body.show-all-rt ruby > rt,
 body.show-all-rt ruby > rtc {
   visibility: visible !important;
+}''';
+      case 'dimmed':
+        return '''
+rt { display: ruby-text !important; font-size: 0.45em; }
+$_rtcAnnotationCss
+ruby > rt,
+ruby > rtc {
+  opacity: 0.45 !important;
+}
+body.show-all-rt ruby > rt,
+body.show-all-rt ruby > rtc {
+  opacity: 1 !important;
 }''';
       default:
         return '''

--- a/fushi/lib/src/reader/reader_engine_config.dart
+++ b/fushi/lib/src/reader/reader_engine_config.dart
@@ -77,8 +77,9 @@ class ReaderEngineConfig {
   final int swipeFastDistThreshold;
   final int wheelGestureQuietMs;
 
-  /// `off` / `toggle` / `hidden`（`ReaderSettings.furiganaMode` 的值域）。JS 侧
-  /// 现已不按它分支（隐藏由 CSS 承担），仍随 config 下发供探针 / 日志读。
+  /// `off` / `toggle` / `hidden` / `dimmed`（`ReaderSettings.furiganaMode` 的
+  /// 值域）。JS 侧现已不按它分支（隐藏 / 淡显都由 CSS 承担），仍随 config 下发
+  /// 供探针 / 日志读。
   final String furiganaMode;
 
   // ── caret ─────────────────────────────────────────────────────────

--- a/fushi/lib/src/reader/reader_settings.dart
+++ b/fushi/lib/src/reader/reader_settings.dart
@@ -305,13 +305,16 @@ class ReaderSettings {
   String get theme => _get<String>('theme', 'light-theme');
   Future<void> setTheme(String v) => _set<String>('theme', v);
 
-  /// 振假名显示形态，三态对齐 Hoshi Reader iOS `FuriganaMode`（2026-09-11 用户拍板）：
+  /// 振假名显示形态，四态（前三态对齐 Hoshi Reader iOS `FuriganaMode`，
+  /// 2026-09-11 用户拍板；`dimmed` 是 2026-09-12 用户追加的第四态）：
   ///  * `off`    —— 原样显示（历史值 `show`）；
   ///  * `toggle` —— 默认隐藏（`visibility:hidden`，注音轨占位保留、行高不抖），
   ///                点一个 `<ruby>` 揭示一个，且那一下不查词（历史值 `partial`；
   ///                历史 `toggle` 是「双击整页切换」，并入此态，整页揭示改由
   ///                `readerToggleFurigana` 快捷键承担）；
-  ///  * `hidden` —— `display:none`（历史值 `hide`）。
+  ///  * `hidden` —— `display:none`（历史值 `hide`）；
+  ///  * `dimmed` —— 照常显示但淡显（`opacity`，不改颜色，深浅主题都成立），
+  ///                `readerToggleFurigana` 快捷键在此态是「临时恢复全亮」。
   /// 持久化键 `furigana_mode` 不变，旧值经 [normalizeFuriganaMode] 归一化。
   String get furiganaMode {
     final dynamic raw = _cache['hide_furigana'];
@@ -867,14 +870,15 @@ class ReaderSettings {
   ({String fontFamily, String fontFaces}) buildCustomFontCss() =>
       customFontCssForEntries(customFonts);
 
-  /// 三态 `off` / `toggle` / `hidden`（见 [furiganaMode]）。历史四态映射：
-  /// `show`→`off`、`partial`→`toggle`、`toggle`→`toggle`、`hide`→`hidden`；
+  /// 四态 `off` / `toggle` / `hidden` / `dimmed`（见 [furiganaMode]）。历史值
+  /// 映射：`show`→`off`、`partial`→`toggle`、`toggle`→`toggle`、`hide`→`hidden`；
   /// 其余一律 `off`。
   static String normalizeFuriganaMode(String mode) =>
       switch (mode.toLowerCase().trim()) {
         'off' || 'show' => 'off',
         'toggle' || 'partial' => 'toggle',
         'hidden' || 'hide' => 'hidden',
+        'dimmed' => 'dimmed',
         _ => 'off',
       };
 
@@ -882,6 +886,7 @@ class ReaderSettings {
       switch (normalizeFuriganaMode(mode)) {
         'hidden' => 'Hide',
         'toggle' => 'Toggle',
+        'dimmed' => 'Dimmed',
         _ => 'Show',
       };
 

--- a/fushi/lib/src/settings/settings_schema_reading.dart
+++ b/fushi/lib/src/settings/settings_schema_reading.dart
@@ -185,7 +185,8 @@ SettingsDestination buildReadingDestination() {
             icon: Icons.translate_outlined,
             controlBelow: true,
             reader: const ReaderPlacement(group: ReaderGroup.layout, order: 13),
-            // 三态对齐 Hoshi Reader iOS：Off / Toggle / Hidden。
+            // 四态：Off / Toggle / Hidden（对齐 Hoshi Reader iOS）+ Dimmed
+            // （2026-09-12 用户追加的「显示但淡」）。
             options: <SettingsSegmentOption<String>>[
               SettingsSegmentOption<String>(
                 value: 'off',
@@ -201,6 +202,11 @@ SettingsDestination buildReadingDestination() {
                 value: 'hidden',
                 label: t.reader_furigana_hidden,
                 tooltip: t.reader_furigana_hidden,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'dimmed',
+                label: t.reader_furigana_dimmed,
+                tooltip: t.reader_furigana_dimmed,
               ),
             ],
             selected: (SettingsContext c) => c.readerSource.readerFuriganaMode,

--- a/fushi/test/i18n/strings_test.dart
+++ b/fushi/test/i18n/strings_test.dart
@@ -9,6 +9,7 @@ void main() {
       expect(strings.reader_furigana_off, '关闭');
       expect(strings.reader_furigana_toggle, '点击显示');
       expect(strings.reader_furigana_hidden, '隐藏');
+      expect(strings.reader_furigana_dimmed, '淡显');
       expect(
         strings.reader_furigana_mode_hint,
         '',

--- a/fushi/test/reader/furigana_mode_dedup_test.dart
+++ b/fushi/test/reader/furigana_mode_dedup_test.dart
@@ -25,6 +25,9 @@ void main() {
     'unknown',
     'HIDE ',
     'Show',
+    'dimmed',
+    'Dimmed',
+    ' DIMMED ',
   ];
 
   group('furigana 模式映射单一真相 (ReaderSettings)', () {
@@ -48,10 +51,13 @@ void main() {
       }
     });
 
-    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
+    test('四态值域与历史值映射（Off/Toggle/Hidden 对齐 Hoshi Reader iOS + Dimmed）', () {
       expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
       expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
       expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
+      // 第四态 dimmed（显示但淡）：2026-09-12 用户追加，大小写/空白同样归一。
+      expect(ReaderSettings.normalizeFuriganaMode('dimmed'), 'dimmed');
+      expect(ReaderSettings.normalizeFuriganaMode(' DIMMED '), 'dimmed');
       // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
       expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
       expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
@@ -59,56 +65,22 @@ void main() {
       expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
       expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
       expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
-      // 只剩三个规范值。
+      // 只剩四个规范值。
       for (final m in inputs) {
         expect(
-          <String>['off', 'toggle', 'hidden'],
+          <String>['off', 'toggle', 'hidden', 'dimmed'],
           contains(ReaderSettings.normalizeFuriganaMode(m)),
           reason: 'input="$m"',
         );
       }
     });
 
-    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
-      expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
-      expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
-      // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
-      expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
-      expect(ReaderSettings.normalizeFuriganaMode('hide'), 'hidden');
-      expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
-      expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
-      // 只剩三个规范值。
-      for (final m in inputs) {
-        expect(
-          <String>['off', 'toggle', 'hidden'],
-          contains(ReaderSettings.normalizeFuriganaMode(m)),
-          reason: 'input="$m"',
-        );
-      }
-    });
-
-    test('三态值域与历史四态映射（对齐 Hoshi Reader iOS Off/Toggle/Hidden）', () {
-      expect(ReaderSettings.normalizeFuriganaMode('off'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode('toggle'), 'toggle');
-      expect(ReaderSettings.normalizeFuriganaMode('hidden'), 'hidden');
-      // 历史值：show→off、partial→toggle（点一个揭示一个）、hide→hidden。
-      expect(ReaderSettings.normalizeFuriganaMode('show'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode('partial'), 'toggle');
-      expect(ReaderSettings.normalizeFuriganaMode('hide'), 'hidden');
-      expect(ReaderSettings.normalizeFuriganaMode('HIDE '), 'hidden');
-      expect(ReaderSettings.normalizeFuriganaMode('garbage'), 'off');
-      expect(ReaderSettings.normalizeFuriganaMode(''), 'off');
-      // 只剩三个规范值。
-      for (final m in inputs) {
-        expect(
-          <String>['off', 'toggle', 'hidden'],
-          contains(ReaderSettings.normalizeFuriganaMode(m)),
-          reason: 'input="$m"',
-        );
-      }
+    test('furiganaModeToStyle 四态各自有别（dimmed 不得降级成 Show）', () {
+      expect(ReaderSettings.furiganaModeToStyle('off'), 'Show');
+      expect(ReaderSettings.furiganaModeToStyle('toggle'), 'Toggle');
+      expect(ReaderSettings.furiganaModeToStyle('hidden'), 'Hide');
+      expect(ReaderSettings.furiganaModeToStyle('dimmed'), 'Dimmed');
+      expect(ReaderSettings.furiganaModeToStyle('garbage'), 'Show');
     });
 
     test('source 端转调 ReaderSettings 且不再保留重复 switch', () {

--- a/fushi/test/reader/reader_content_styles_test.dart
+++ b/fushi/test/reader/reader_content_styles_test.dart
@@ -358,6 +358,47 @@ void main() {
       await settings.setFuriganaMode('partial');
       expect(settings.furiganaMode, 'toggle');
     });
+
+    test('dimmed mode: rt stays ruby-text but is faded via opacity; '
+        'show-all-rt restores full opacity', () async {
+      final FushiDatabase db =
+          FushiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final ReaderSettings settings = ReaderSettings(db);
+      await settings.refreshFromDb();
+      await settings.setFuriganaMode('dimmed');
+      expect(settings.furiganaMode, 'dimmed');
+      final String css = ReaderContentStyles.css(settings: settings);
+      // 显示态：rt 仍强制 ruby-text（TODO-1308），rtc 接管照旧 —— dimmed 只是淡，
+      // 不是隐藏，注音结构与 off 完全一致。
+      expect(css,
+          contains('rt { display: ruby-text !important; font-size: 0.45em; }'));
+      expect(
+          css,
+          contains('rtc {\n'
+              '  display: ruby-text !important;\n'
+              '  font-size: 0.45em;\n}'));
+      expect(css, isNot(contains('rt, rtc { display: none !important; }')));
+      expect(css, isNot(contains('furigana-revealed')),
+          reason: 'dimmed 不走 toggle 的逐个揭示机制');
+      // 淡显只用 opacity（不改 color）：深浅主题 / 自定义正文色都成立。
+      expect(
+          css,
+          contains('ruby > rt,\n'
+              'ruby > rtc {\n'
+              '  opacity: 0.45 !important;\n}'));
+      // readerToggleFurigana 快捷键在 dimmed 下 = 临时恢复全亮。
+      expect(
+          css,
+          contains('body.show-all-rt ruby > rt,\n'
+              'body.show-all-rt ruby > rtc {\n'
+              '  opacity: 1 !important;\n}'));
+      // off 态不得漏出淡显规则（否则四态互相污染）。
+      await settings.setFuriganaMode('off');
+      final String offCss = ReaderContentStyles.css(settings: settings);
+      expect(offCss, isNot(contains('opacity: 0.45 !important')));
+      expect(offCss, isNot(contains('body.show-all-rt ruby > rt')));
+    });
   });
 
   group('ReaderContentStyles audiobook/selection highlight fill', () {

--- a/fushi/test/reader/vertical_ruby_display_context_guard_test.dart
+++ b/fushi/test/reader/vertical_ruby_display_context_guard_test.dart
@@ -112,8 +112,9 @@ void main() {
           reason: 'BUG-716：不再有 narrow-lane 窄条(避免 left 落点在宽盒/含注音轨时偏移)');
     });
 
-    test('振假名显示态(off/toggle) rt 强制 display:ruby-text(!important)', () async {
-      for (final String fm in <String>['off', 'toggle']) {
+    test('振假名显示态(off/toggle/dimmed) rt 强制 display:ruby-text(!important)',
+        () async {
+      for (final String fm in <String>['off', 'toggle', 'dimmed']) {
         final String css = await _readerCss(
             writingMode: 'vertical-rl',
             viewMode: 'continuous',
@@ -133,7 +134,7 @@ void main() {
       // 会把 rtc 里的每个 <rt> 包进匿名 ruby，落在正文流原位=注音以整字格内联进基字列
       // (用户截图：かん挤在貫/禄之间、ろく掉到词下方)。修复=显示态把 rtc 整个映射为
       // 单一注音级(display:ruby-text)、其 rt 子元素归位 inline(在注音里当普通文本跑)。
-      for (final String fm in <String>['off', 'toggle']) {
+      for (final String fm in <String>['off', 'toggle', 'dimmed']) {
         final String css = await _readerCss(
             writingMode: 'vertical-rl',
             viewMode: 'continuous',


### PR DESCRIPTION
## 内容

### 振假名第四态 `dimmed`（淡显）
三态 Off / Toggle / Hidden（#1434）扩成四态，新增 **Dimmed**：振假名照常显示但淡显。

- `normalizeFuriganaMode` 加 `dimmed`，`furiganaModeToStyle` 加 `Dimmed`；持久化键 `furigana_mode` 不变，历史值映射不动。
- `_furiganaCss` 新增 `dimmed` 分支：显示态 CSS 再加 `ruby > rt, ruby > rtc { opacity: 0.45 !important }`。淡显只用 opacity、不改 color——写死灰色在深浅主题总有一边对比失衡，opacity 是对当前正文色的相对衰减。`body.show-all-rt` 把 opacity 拉回 1，即 `readerToggleFurigana` 快捷键在此态的语义「临时恢复全亮」。
- 设置项加第四个 option，新 i18n key `reader_furigana_dimmed`（Dimmed / 淡显，经 `i18n_sync --add` + `dart run slang`）。
- 测试：值域/映射四态、CSS 生成器 dimmed（含 off 不漏出淡显规则）、vertical ruby 守卫显示态列表加 dimmed、zh 标签断言；集成测试 `reader_furigana_three_state_itest` 扩到四态（文件名保留）。
- 顺手去掉 `furigana_mode_dedup_test` 里三份同名重复用例。

## 测试
- `flutter analyze` 零问题；定向单测 130 条绿。
- Windows 离屏 runner 真 WebView2：`dimmed` 下 `getComputedStyle(rt).opacity=0.45 / display=ruby-text`，`show-all-rt` 后 1.0，切回 `off` 后 1.0（`[furigana3] PASS` 行）。
- Mac 跨机结果另评论补充。

https://claude.ai/code/session_01PJPGPUJAuSHd5s6wdP4AP5
