### PR TITLE
feat(manga): reader top bar redesign (floating/pinned) + OCR settings entry from library (BUG-2483)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2287 条。点号进各自文件。
+> 共 2288 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2483](bugs/BUG-2483-manga-library-settings-tab-wrong-destination.md) | ✅ | ✅ | manga-library-settings-tab-wrong-destination |
 | [BUG-2481](bugs/BUG-2481-manga-ocr-progress-boxes-update-all-sort.md) | ✅ | ✅ | 作品页 OCR 无进度显示；阅读器无识别范围显示；扩展无一键更新；源列表无按下载量排序 |
 | [BUG-2480](bugs/BUG-2480-manga-login-import-from-browser-extension.md) | ✅ | ✅ | 漫画源登录：从系统浏览器（经 Fushi 扩展）导入已登录会话，不必在 app 内重登 |
 | [BUG-2479](bugs/BUG-2479-manga-locked-chapter-login-guidance.md) | ✅ | ✅ | 锁定章节无登录引导；Android 无登录入口；登录页无前进后退；源列表无搜索 |

--- a/docs/bugs/BUG-2483-manga-library-settings-tab-wrong-destination.md
+++ b/docs/bugs/BUG-2483-manga-library-settings-tab-wrong-destination.md
@@ -1,0 +1,6 @@
+## BUG-2483 · manga-library-settings-tab-wrong-destination
+- **报告**：2026-09-12（用户：「书架里面的漫画打开 OCR 的地方，缺少配置 OCR 的设置」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/media/manga/manga_library_page.dart:76` 漫画库页「设置」标签的 `ModuleSettingsView` 指向 `SettingsDestinationId.reading`（EPUB 字体/排版），而漫画 OCR（引擎偏好 / 模型下载 / Lens 语言 / 外部 mokuro 路径）在拆出「漫画」一级分类时已搬到 `SettingsDestinationId.manga`（`settings_schema_manga.dart`），库页设置标签里根本找不到 OCR。另外作品页（`manga_series_page.dart` 的「识别本章 / 识别全部已下载 / 开始 OCR」，BUG-2461 后是阅读器外唯一的 OCR 触发点）与 OCR 向导（`manga_ocr_wizard_dialog.dart`）解析不到引擎时只给一行红字，没有任何通向设置的入口。
+- **[x] ① 已修复** — `fe7131792c`：库页设置标签改指 `SettingsDestinationId.manga`；作品页动作行（本地卷 / 在线条目）与向导各加「OCR 设置」按钮直达 `MangaOcrSettingsPage`（同一个 `MangaOcrSettingsSection`）；向导返回后经新增的 `resolveEngines` 回调重新装配引擎（`MangaOcrWizardEngines.resolve()` 把 mokuro 路径 / 偏好快照进依赖集，只重探探不到刚配好的路径）。
+- **[x] ② 已加自动化测试** — `fushi/test/settings/settings_schema_coverage_test.dart`（`manga/Floating toolbar` 登记）、`fushi/test/pages/module_top_settings_tabs_guard_test.dart`（库页设置标签存在）；同轮顶栏重设计的守卫见 `fushi/test/pages/manga_toggle_chrome_test.dart` / `fushi/test/media/manga/manga_reader_chrome_test.dart`。
+- **备注**：同一轮把漫画阅读器顶栏重设计为 `MangaReaderTopBar`（悬浮/固定两态，偏好 `manga_chrome_floating`），见同一提交。

--- a/fushi/integration_test/manga_chrome_shot_itest.dart
+++ b/fushi/integration_test/manga_chrome_shot_itest.dart
@@ -1,0 +1,117 @@
+/// 漫画阅读器顶栏重设计的像素证据：固定态（栏常驻、正文让位）与悬浮态（默认收起）。
+///
+/// 造一本两页的本地漫画直接推 [MangaFushiPage]，抓根 RenderView 帧
+/// （`captureFlutterFrame`：顶栏是 Flutter 层，WebView 纹理抓不到、本就不是本跑的
+/// 证明对象）。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/models.dart';
+import 'package:fushi/src/media/manga/reader/manga_fushi_page.dart';
+import 'package:fushi/utils.dart';
+import 'package:fushi_core/fushi_core.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'helpers/generate_test_image.dart';
+import 'helpers/library_fixture.dart';
+import 'helpers/observe_capture.dart';
+import 'support/test_app_launcher.dart';
+import 'test_helpers.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('漫画顶栏：固定态常驻让位 / 悬浮态默认收起', (WidgetTester tester) async {
+    await launchFushiTestApp();
+    expect(await waitForHome(tester), isTrue, reason: '主页应在 90s 内出现');
+    await tester.pump(const Duration(seconds: 2));
+    final AppModel appModel = await readyAppModel(tester);
+
+    final Directory bookDir =
+        Directory.systemTemp.createTempSync('manga_chrome_shot_');
+    const TestImageGenerator gen = TestImageGenerator();
+    final Directory images = Directory(p.join(bookDir.path, 'images'))
+      ..createSync();
+    File(p.join(images.path, 'p001.png'))
+        .writeAsBytesSync(gen.pngBytes(width: 800, height: 1200, seed: 1));
+    File(p.join(images.path, 'p002.png'))
+        .writeAsBytesSync(gen.pngBytes(width: 800, height: 1200, seed: 2));
+    File(p.join(bookDir.path, 'manga.json')).writeAsStringSync(jsonEncode(
+      <String, Object?>{
+        'pages': <Map<String, Object?>>[
+          for (final String name in <String>['p001.png', 'p002.png'])
+            <String, Object?>{
+              'url': name,
+              'width': 800,
+              'height': 1200,
+              'blocks': <Object?>[],
+            },
+        ],
+      },
+    ));
+    const String bookKey = 'chrome-shot-manga';
+    await appModel.database.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: 'ゆるキャン△ 第1巻',
+      epubPath: 'manga.json',
+      extractDir: bookDir.path,
+      chapterCount: 2,
+      chaptersJson: '[]',
+      importedAt: DateTime.now().millisecondsSinceEpoch,
+      format: const Value<String>('manga'),
+    ));
+
+    final bool floatingBefore = appModel.mangaChromeFloating;
+    try {
+      for (final bool floating in <bool>[false, true]) {
+        await appModel.setMangaChromeFloating(floating);
+        final NavigatorState nav = appModel.navigatorKey.currentState!;
+        final BuildContext navContext = nav.context;
+        if (!navContext.mounted) fail('navigator context unmounted');
+        unawaited(nav.push(adaptivePageRoute<void>(
+          context: navContext,
+          builder: (BuildContext context) => const FushiAppUiScaleNeutralizer(
+            child: MangaFushiPage(item: null, bookKey: bookKey),
+          ),
+        )));
+        for (int i = 0; i < 40; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          if (find
+              .byKey(const ValueKey<String>('manga_content_ready'))
+              .evaluate()
+              .isNotEmpty) {
+            break;
+          }
+        }
+        await tester.pump(const Duration(seconds: 2));
+        final String tag = floating ? 'floating' : 'pinned';
+        final ObserveShot shot =
+            await captureFlutterFrame(tester, '01-manga-chrome-$tag');
+        expect(shot.saved, isTrue);
+        final bool barPainted = find
+            .byKey(const ValueKey<String>('manga_reader_top_bar'))
+            .evaluate()
+            .isNotEmpty;
+        final Rect body = tester.getRect(
+            find.byKey(const ValueKey<String>('manga_content_ready')));
+        debugPrint('[manga-chrome] floating=$floating barPainted=$barPainted '
+            'bodyTop=${body.top} shot=${shot.path}');
+        expect(barPainted, !floating,
+            reason: '固定态栏常驻；悬浮态默认收起');
+        expect(body.top > 0, !floating, reason: '固定态正文让位；悬浮态全出血');
+        nav.pop();
+        await tester.pump(const Duration(seconds: 1));
+      }
+    } finally {
+      await appModel.setMangaChromeFloating(floatingBefore);
+      if (bookDir.existsSync()) bookDir.deleteSync(recursive: true);
+    }
+  });
+}

--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80903 (4759 per locale)
+/// Strings: 80954 (4762 per locale)
 ///
-/// Built on 2026-09-12 at 06:44 UTC
+/// Built on 2026-09-12 at 07:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6633,6 +6633,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Recognizing ${done}/${total}';
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  String get manga_ocr_settings_open => 'OCR settings';
+  String get manga_chrome_floating => 'Floating toolbar';
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -17853,6 +17857,13 @@ class _StringsAr extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -29299,6 +29310,13 @@ class _StringsDe extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -40799,6 +40817,13 @@ class _StringsEs extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -52332,6 +52357,13 @@ class _StringsFr extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -63669,6 +63701,13 @@ class _StringsId extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -75097,6 +75136,13 @@ class _StringsIt extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -85907,6 +85953,13 @@ class _StringsJa extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -96727,6 +96780,13 @@ class _StringsKo extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -108113,6 +108173,13 @@ class _StringsNl extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -119552,6 +119619,13 @@ class _StringsPtBr extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -130968,6 +131042,13 @@ class _StringsRu extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -142185,6 +142266,13 @@ class _StringsTh extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -153517,6 +153605,13 @@ class _StringsTr extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -164819,6 +164914,13 @@ class _StringsVi extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 // Path: <root>
@@ -175191,6 +175293,13 @@ class _StringsZhCn extends _StringsEn {
   String get manga_chapter_ocr_status_queued => '等待识别';
   @override
   String get manga_ocr_boxes_toggle => '显示识别范围';
+  @override
+  String get manga_ocr_settings_open => 'OCR 设置';
+  @override
+  String get manga_chrome_floating => '悬浮工具栏';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      '工具栏收起不遮挡页面，点页面中央或鼠标移到顶边唤出；关闭则常驻在页面上方';
 }
 
 // Path: <root>
@@ -185685,6 +185794,13 @@ class _StringsZhHk extends _StringsEn {
   String get manga_chapter_ocr_status_queued => 'Waiting for recognition';
   @override
   String get manga_ocr_boxes_toggle => 'Show recognized text regions';
+  @override
+  String get manga_ocr_settings_open => 'OCR settings';
+  @override
+  String get manga_chrome_floating => 'Floating toolbar';
+  @override
+  String get manga_chrome_floating_subtitle =>
+      'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
 }
 
 /// Flat map(s) containing all translations.
@@ -195502,6 +195618,12 @@ extension on _StringsEn {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -205314,6 +205436,12 @@ extension on _StringsAr {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -215171,6 +215299,12 @@ extension on _StringsDe {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -225019,6 +225153,12 @@ extension on _StringsEs {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -234876,6 +235016,12 @@ extension on _StringsFr {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -244704,6 +244850,12 @@ extension on _StringsId {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -254554,6 +254706,12 @@ extension on _StringsIt {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -264331,6 +264489,12 @@ extension on _StringsJa {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -274112,6 +274276,12 @@ extension on _StringsKo {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -283955,6 +284125,12 @@ extension on _StringsNl {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -293793,6 +293969,12 @@ extension on _StringsPtBr {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -303638,6 +303820,12 @@ extension on _StringsRu {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -313455,6 +313643,12 @@ extension on _StringsTh {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -323287,6 +323481,12 @@ extension on _StringsTr {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -333113,6 +333313,12 @@ extension on _StringsVi {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }
@@ -342850,6 +343056,12 @@ extension on _StringsZhCn {
         return '等待识别';
       case 'manga_ocr_boxes_toggle':
         return '显示识别范围';
+      case 'manga_ocr_settings_open':
+        return 'OCR 设置';
+      case 'manga_chrome_floating':
+        return '悬浮工具栏';
+      case 'manga_chrome_floating_subtitle':
+        return '工具栏收起不遮挡页面，点页面中央或鼠标移到顶边唤出；关闭则常驻在页面上方';
       default:
         return null;
     }
@@ -352605,6 +352817,12 @@ extension on _StringsZhHk {
         return 'Waiting for recognition';
       case 'manga_ocr_boxes_toggle':
         return 'Show recognized text regions';
+      case 'manga_ocr_settings_open':
+        return 'OCR settings';
+      case 'manga_chrome_floating':
+        return 'Floating toolbar';
+      case 'manga_chrome_floating_subtitle':
+        return 'Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page.';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} 章排队中",
   "manga_chapter_ocr_status_running": "识别中 ${done}/${total}",
   "manga_chapter_ocr_status_queued": "等待识别",
-  "manga_ocr_boxes_toggle": "显示识别范围"
+  "manga_ocr_boxes_toggle": "显示识别范围",
+  "manga_ocr_settings_open": "OCR 设置",
+  "manga_chrome_floating": "悬浮工具栏",
+  "manga_chrome_floating_subtitle": "工具栏收起不遮挡页面，点页面中央或鼠标移到顶边唤出；关闭则常驻在页面上方"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4757,5 +4757,8 @@
   "manga_series_ocr_queued_count": "${count} chapters waiting",
   "manga_chapter_ocr_status_running": "Recognizing ${done}/${total}",
   "manga_chapter_ocr_status_queued": "Waiting for recognition",
-  "manga_ocr_boxes_toggle": "Show recognized text regions"
+  "manga_ocr_boxes_toggle": "Show recognized text regions",
+  "manga_ocr_settings_open": "OCR settings",
+  "manga_chrome_floating": "Floating toolbar",
+  "manga_chrome_floating_subtitle": "Hide the toolbar over the page; tap the middle of the page or hover at the top edge to reveal it. Off keeps the toolbar pinned above the page."
 }

--- a/fushi/lib/src/media/manga/library/manga_series_page.dart
+++ b/fushi/lib/src/media/manga/library/manga_series_page.dart
@@ -20,6 +20,7 @@ import 'package:fushi/src/media/manga/manga_ocr_background_job.dart';
 import 'package:fushi/src/media/manga/manga_ocr_engine_probe.dart';
 import 'package:fushi/src/media/manga/manga_ocr_job_stream.dart';
 import 'package:fushi/src/media/manga/manga_ocr_provider.dart';
+import 'package:fushi/src/media/manga/manga_ocr_settings_page.dart';
 import 'package:fushi/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:fushi/src/media/manga/ocr/google_lens_disclosure.dart';
 import 'package:fushi/src/media/manga/ocr/manga_ocr_engine.dart';
@@ -1554,6 +1555,7 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
             icon: const Icon(Icons.document_scanner_outlined),
             label: Text(t.manga_ocr_wizard_run),
           ),
+          _ocrSettingsButton(),
         ],
       );
     }
@@ -1609,9 +1611,28 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
             icon: const Icon(Icons.document_scanner_outlined),
             label: Text(t.manga_series_ocr_all_downloaded),
           ),
+          _ocrSettingsButton(),
         ],
       ],
     );
+  }
+
+  /// 「OCR 设置」：作品页是阅读器外触发 OCR 的入口（BUG-2461），引擎偏好 / 模型
+  /// 下载 / Lens 语言 / 外部 mokuro 路径必须就在触发点旁边可达——否则解析不到引擎
+  /// 时用户只看到一条红 toast，不知道该去哪配。返回后重建：偏好是 AppModel 上的
+  /// 状态，下一次「识别」按新偏好解析。
+  Widget _ocrSettingsButton() {
+    return OutlinedButton.icon(
+      key: const ValueKey<String>('manga_series_ocr_settings'),
+      onPressed: () => unawaited(_openOcrSettings()),
+      icon: const Icon(Icons.tune_outlined),
+      label: Text(t.manga_ocr_settings_open),
+    );
+  }
+
+  Future<void> _openOcrSettings() async {
+    await MangaOcrSettingsPage.push(context);
+    if (mounted) setState(() {});
   }
 
   /// 本地卷没有章节，章节区换成「这一卷有多少页、读到哪」。

--- a/fushi/lib/src/media/manga/manga_library_page.dart
+++ b/fushi/lib/src/media/manga/manga_library_page.dart
@@ -73,9 +73,11 @@ class MangaLibraryPage extends StatelessWidget {
           label: t.settings,
           builder: (BuildContext context, Widget navigation) =>
               ModuleSettingsView(
-            destinationId: SettingsDestinationId.reading,
-            navigation: navigation,
-          ),
+                // 漫画有独立的「漫画」设置分类（观看偏好 + OCR 引擎/模型 + 在线目录）；
+                // 此前误指 reading（EPUB 字体/排版），漫画库页的设置标签里根本找不到 OCR。
+                destinationId: SettingsDestinationId.manga,
+                navigation: navigation,
+              ),
         ),
       ],
     );

--- a/fushi/lib/src/media/manga/manga_module.dart
+++ b/fushi/lib/src/media/manga/manga_module.dart
@@ -135,7 +135,16 @@ abstract final class MangaModule {
     );
     return showAppDialog<String>(
       context: context,
-      builder: (_) => MangaOcrWizardDialog(engines: engines, db: db),
+      builder: (_) => MangaOcrWizardDialog(
+        engines: engines,
+        db: db,
+        resolveEngines: (BuildContext ctx) => MangaOcrWizardEngines.resolve(
+          context: ctx,
+          db: db,
+          remoteRunnerOverride: remoteRunnerOverride,
+          desktopOverride: desktopOverride,
+        ),
+      ),
     );
   }
 
@@ -168,6 +177,12 @@ abstract final class MangaModule {
         startPage: startPage,
         onlyMissing: true,
         launchInBackground: true,
+        resolveEngines: (BuildContext ctx) => MangaOcrWizardEngines.resolve(
+          context: ctx,
+          db: db,
+          remoteRunnerOverride: remoteRunnerOverride,
+          desktopOverride: desktopOverride,
+        ),
       ),
     );
   }

--- a/fushi/lib/src/media/manga/manga_ocr_settings_page.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_settings_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fushi/src/media/manga/manga_ocr_provider.dart';
+import 'package:fushi/src/media/manga/manga_ocr_settings_section.dart';
+import 'package:fushi/src/models/app_model.dart';
+import 'package:fushi/utils.dart';
+
+/// 「漫画 OCR」设置的独立页：引擎偏好 / 内置模型下载 / Lens 语言 / 外部 mokuro。
+///
+/// 正文与设置分类里的同名子页是**同一个** [MangaOcrSettingsSection]，只是外壳换成
+/// 可 push 的整页。作品页「识别本章 / 识别全部」与 OCR 向导都是在阅读器外触发 OCR
+/// 的入口（BUG-2461），它们此前解析不到引擎时只给一行红字，用户得自己去设置里翻
+/// 「漫画 → 漫画 OCR」；现在一颗按钮直达，返回后调用方按需重探引擎。
+class MangaOcrSettingsPage extends ConsumerWidget {
+  const MangaOcrSettingsPage({super.key});
+
+  /// push 本页并等待返回。返回后调用方通常要重探引擎可用性（模型可能刚下完）。
+  static Future<void> push(BuildContext context) {
+    return Navigator.of(context).push<void>(
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (BuildContext context) => const MangaOcrSettingsPage(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppModel appModel = ref.watch(appProvider);
+    return FushiPageScaffold(
+      title: t.manga_ocr_section,
+      subtitle: t.manga_ocr_section_summary,
+      body: SingleChildScrollView(
+        key: const ValueKey<String>('manga_ocr_settings_page'),
+        child: MangaOcrSettingsSection(
+          service: ref.read(mangaOcrServiceProvider),
+          enginePreferenceGetter: () => appModel.mangaOcrEnginePreference,
+          enginePreferenceSetter: appModel.setMangaOcrEnginePreference,
+          lensLanguageGetter: () => appModel.mangaOcrLensLanguage,
+          lensLanguageSetter: appModel.setMangaOcrLensLanguage,
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/fushi/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 
 import 'package:fushi_core/fushi_core.dart';
 import 'package:fushi/src/media/import/import_dialog_frame.dart';
+import 'package:fushi/src/media/manga/manga_ocr_settings_page.dart';
 import 'package:fushi/src/media/import/real_path_directory_picker.dart';
 import 'package:fushi/src/media/manga/external_mokuro_runner.dart';
 import 'package:fushi_engine/media/manga/manga_importer.dart';
@@ -45,6 +46,7 @@ class MangaOcrWizardDialog extends ConsumerStatefulWidget {
     this.startPage = 0,
     this.onlyMissing = true,
     this.launchInBackground = false,
+    this.resolveEngines,
     super.key,
   });
 
@@ -78,6 +80,11 @@ class MangaOcrWizardDialog extends ConsumerStatefulWidget {
   /// 已导入漫画由阅读器持有任务时，选好引擎后立即关闭向导并返回后台任务。
   final bool launchInBackground;
 
+  /// 从「OCR 设置」页返回后重新装配引擎依赖集。[engines] 是打开向导时的快照
+  /// （外部 mokuro 路径 / 引擎偏好都在 `resolve()` 里读了一次），用户在设置页里
+  /// 刚配好的路径不重新装配就探不到。null（测试直连 engines）= 只重探不重装。
+  final MangaOcrWizardEngines Function(BuildContext context)? resolveEngines;
+
   @override
   ConsumerState<MangaOcrWizardDialog> createState() =>
       _MangaOcrWizardDialogState();
@@ -98,9 +105,13 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
 
   _WizardStage _stage = _WizardStage.pick;
 
+  /// 当前引擎依赖集；初值是 [MangaOcrWizardDialog.engines]，从设置页返回后可被
+  /// [MangaOcrWizardDialog.resolveEngines] 换成新装配。
+  late MangaOcrWizardEngines _engines = widget.engines;
+
   /// Lens 识别语言（主子标签）。初值来自偏好；仅 Lens 引擎显示选择器。
   late String _lensLanguage =
-      normalizeLensLanguage(widget.engines.initialLensLanguage);
+      normalizeLensLanguage(_engines.initialLensLanguage);
   String? _imageDir;
   MangaOcrFolderStatus? _folderStatus;
 
@@ -203,7 +214,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     // 探测与能力表在 `manga_ocr_engine_probe.dart`：下载完成钩子的自动 OCR 读的是
     // 同一份判据，向导这里只剩「把结果摆进状态」。
     final MangaOcrEngineAvailability availability =
-        await probeMangaOcrEngines(widget.engines);
+        await probeMangaOcrEngines(_engines);
     if (!mounted) return;
     setState(() {
       _builtinAvailable = availability.builtinReady;
@@ -213,7 +224,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       _remoteTarget = availability.remoteTarget;
       _lensAvailable = availability.lensOffered;
       _checkingEngines = false;
-      final String preferenceKey = widget.engines.initialEnginePreference ??
+      final String preferenceKey = _engines.initialEnginePreference ??
           MangaOcrEnginePreference.auto.key;
       final MangaOcrEnginePreference preference =
           MangaOcrEnginePreferenceKey.fromKey(preferenceKey);
@@ -231,7 +242,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   /// 「选参数」，跑任务的能力不该被绑在一个 widget 的 State 上。
   MangaOcrJobSpec _jobSpec(String dir) => MangaOcrJobSpec(
         engine: _engine,
-        engines: widget.engines,
+        engines: _engines,
         imageDirPath: dir,
         lensLanguage: _lensLanguage,
         startPage: widget.startPage,
@@ -251,7 +262,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   /// `pumpAndSettle` 永远 settle 不了（既有的三条入口测试当场超时）。UI 上的
   /// 表现与「已配对主机」一致——先灰着，探测回来再亮。
   Future<void> _probeSystemOcr() async {
-    final SystemOcrMangaRunner? runner = widget.engines.systemOcrRunner;
+    final SystemOcrMangaRunner? runner = _engines.systemOcrRunner;
     if (runner == null) return;
     bool available = false;
     try {
@@ -388,7 +399,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runSystem(String dir) {
-    _runSub = widget.engines.systemOcrRunner!
+    _runSub = _engines.systemOcrRunner!
         .ocrFolder(
       imageDirPath: dir,
       volumeTitle: _title,
@@ -414,7 +425,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runLens(String dir) {
-    _runSub = widget.engines.lensRunner!
+    _runSub = _engines.lensRunner!
         .ocrFolder(
       imageDirPath: dir,
       volumeTitle: _title,
@@ -440,7 +451,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runBuiltin(String dir) {
-    _runSub = widget.engines.service
+    _runSub = _engines.service
         .ocrFolder(imageDirPath: dir, volumeTitle: _title)
         .listen(
       (MangaOcrVolumeEvent event) {
@@ -460,7 +471,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runExternal(String dir) {
-    _runSub = widget.engines.externalRunner!.run(dir).listen(
+    _runSub = _engines.externalRunner!.run(dir).listen(
       (MokuroRunEvent event) {
         if (!mounted) return;
         if (event.finished) {
@@ -488,7 +499,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       _onOcrError(t.manga_remote_ocr_no_host);
       return;
     }
-    _runSub = widget.engines.remoteRunner!
+    _runSub = _engines.remoteRunner!
         .run(target: target, imageDirPath: dir, volumeTitle: _title)
         .listen(
       (MangaOcrRemoteEvent event) {
@@ -846,7 +857,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
           : (String? value) {
               if (value == null) return;
               setState(() => _lensLanguage = value);
-              widget.engines.lensLanguageSetter?.call(value);
+              _engines.lensLanguageSetter?.call(value);
             },
       decoration: InputDecoration(
         labelText: t.manga_ocr_lens_language_label,
@@ -866,6 +877,15 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     );
   }
 
+  Future<void> _openOcrSettings() async {
+    await MangaOcrSettingsPage.push(context);
+    if (!mounted) return;
+    final MangaOcrWizardEngines Function(BuildContext)? resolve =
+        widget.resolveEngines;
+    if (resolve != null) _engines = resolve(context);
+    await _refreshEngines();
+  }
+
   List<Widget> _buildActions(bool busy) {
     if (_stage == _WizardStage.running) {
       return <Widget>[
@@ -876,6 +896,14 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       ];
     }
     return <Widget>[
+      // 引擎不可用 / 想换引擎：直达「漫画 OCR」设置，返回后重探——刚下完的模型、
+      // 刚配好的 mokuro 路径立刻能选，不必关掉向导重开。
+      TextButton.icon(
+        key: const ValueKey<String>('manga_ocr_wizard_settings'),
+        onPressed: busy ? null : () => unawaited(_openOcrSettings()),
+        icon: const Icon(Icons.tune_outlined, size: 18),
+        label: Text(t.manga_ocr_settings_open),
+      ),
       TextButton(
         onPressed: busy ? null : () => Navigator.pop(context),
         child: Text(t.dialog_cancel),

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -35,6 +35,9 @@ import 'package:fushi/src/media/manga/library/online_manga_library_entry.dart';
 import 'package:fushi/src/media/manga/library/online_manga_library_service.dart';
 import 'package:fushi_engine/media/manga/mokuro_payload.dart';
 import 'package:fushi/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
+import 'package:fushi/src/media/manga/library/online_manga_chapter_updates.dart'
+    show mangaChapterDisplayName;
+import 'package:fushi/src/media/manga/reader/manga_reader_chrome.dart';
 import 'package:fushi/src/media/manga/reader/manga_volume_key_paging_controller.dart';
 import 'package:fushi/src/media/manga/reader/manga_zoom_preference_debouncer.dart';
 import 'package:fushi/src/focus/page_focus_ownership.dart';
@@ -66,6 +69,9 @@ import 'package:fushi/src/focus/webview_key_bridge.dart';
 import 'package:fushi/src/media/manga/reader/manga_window_load_gate.dart';
 import 'package:fushi/src/pages/base_source_page.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_webview.dart';
+import 'package:fushi/src/reader/reader_chrome_controller.dart';
+import 'package:fushi/src/reader/reader_desktop_chrome.dart'
+    show kReaderHoverRevealStripHeight;
 import 'package:fushi/src/reader/reader_selection_data.dart';
 import 'package:fushi/src/reader/reader_selection_scripts.dart';
 import 'package:fushi/src/startup/exit_flush_registry.dart';
@@ -80,12 +86,15 @@ import 'package:fushi/src/media/video/video_exit_flush.dart';
 /// code does not own manga rendering, interaction, or OCR overlay behavior.
 /// 选区 payload → 弹窗锚点视口矩形。
 ///
-/// 漫画 WebView 以 scale 1.0、零 inset 渲染（[FushiAppUiScaleNeutralizer] 中和层），
-/// JS `getClientRects` 的视口坐标可直接当屏幕坐标用（恒等映射）。payload 不带 `rect`
-/// 时（块级兜底命中）锚到屏幕中心 1x1 矩形，镜像阅读器的回退。
+/// 漫画 WebView 以 scale 1.0 渲染（[FushiAppUiScaleNeutralizer] 中和层），JS
+/// `getClientRects` 的视口坐标加上 WebView 左上角在屏幕上的位置 [viewportOrigin]
+/// 就是屏幕坐标。顶栏固定态让位时 WebView 顶部下移 [mangaChromeTopInset]，这里
+/// 是**唯一**把 JS 坐标换成屏幕坐标的地方（右键菜单锚点走同一个偏移）。payload
+/// 不带 `rect` 时（块级兜底命中）锚到 WebView 中心 1x1 矩形，镜像阅读器的回退。
 Rect mangaSelectionRectFromPayload(
   ReaderSelectionData data, {
   required Size fallbackScreen,
+  Offset viewportOrigin = Offset.zero,
 }) {
   final Map<String, double>? rect = data.rect;
   if (rect != null) {
@@ -94,13 +103,13 @@ Rect mangaSelectionRectFromPayload(
       rect['y'] ?? 0,
       rect['width'] ?? 0,
       rect['height'] ?? 0,
-    );
+    ).shift(viewportOrigin);
   }
   return Rect.fromCenter(
     center: Offset(fallbackScreen.width / 2, fallbackScreen.height / 2),
     width: 1,
     height: 1,
-  );
+  ).shift(viewportOrigin);
 }
 
 enum MangaReaderInputAction {
@@ -249,6 +258,7 @@ class MangaWindowGeneration {
 Future<void> dispatchMangaSelection(
   ReaderSelectionData data, {
   required Size fallbackScreen,
+  Offset viewportOrigin = Offset.zero,
   required Future<void> Function(int? pageIndex) selectPageForMining,
   required void Function(String sentence) setSentence,
   required Future<void> Function(
@@ -266,6 +276,7 @@ Future<void> dispatchMangaSelection(
   final Rect rect = mangaSelectionRectFromPayload(
     data,
     fallbackScreen: fallbackScreen,
+    viewportOrigin: viewportOrigin,
   );
   await search(data.text, rect, data.verticalWriting);
 }
@@ -775,6 +786,15 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
   /// 已被翻页占用，没有这个按钮的话触屏设备再没有第二条通道能把界面唤回来。
   bool _chromeVisible = true;
 
+  /// 顶栏形态偏好快照（打开书时读一次，见 [AppModel.mangaChromeFloating]）：
+  /// true = 悬浮（不占布局、默认收起、点页面中央 / 顶边悬停唤出、自动收起）；
+  /// false = 固定（常驻、占 [kMangaChromeBarHeight]，正文 WebView 让位）。
+  bool _chromeFloating = true;
+
+  /// 悬浮态的唤出 / 自动收起状态机（与 EPUB 阅读器共用同一台控制器）。固定态下
+  /// 它的 `transientVisible` 无意义，顶栏只看 [_chromeVisible]。
+  final ReaderChromeController _chrome = ReaderChromeController();
+
   bool _isWindowFullscreen = false;
   bool _ownsWindowFullscreen = false;
   bool _fullscreenTransitioning = false;
@@ -985,6 +1005,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
         source: _MangaReaderInputSource.volumeKey,
       ),
     );
+    _chrome.addListener(_onChromeChanged);
     WidgetsBinding.instance.addObserver(this);
     if (Platform.isWindows || Platform.isLinux) {
       windowManager.addListener(this);
@@ -1068,8 +1089,45 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     _studyClock?.detach();
     ExitFlushRegistry.instance.defer(_flushPosition);
     _pageNotifier.dispose();
+    _chrome
+      ..removeListener(_onChromeChanged)
+      ..dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _onChromeChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// 固定态下正文 WebView 顶部让出的高度（0 = 全出血）。所有 JS→Flutter 的
+  /// 视口坐标（查词选区 / 右键菜单锚点）都加这个偏移；顶栏自己按同一个
+  /// `MediaQuery.padding.top` 画，两边同源。
+  double get _chromeTopInset => mangaChromeTopInset(
+    floating: _chromeFloating,
+    chromeVisible: _chromeVisible,
+    statusBarInset: MediaQuery.paddingOf(context).top,
+  );
+
+  /// 悬浮态：正文中央空白点击在「唤出」与「收起」间切换（EPUB 阅读器「点空白
+  /// 隐藏控制栏」同款）。固定态 / 界面已隐藏（M 键）时空白点击仍是 no-op。
+  void _toggleFloatingChrome() {
+    if (!_chromeFloating || !_chromeVisible) return;
+    if (_chrome.transientVisible) {
+      _chrome.hideTransient();
+    } else {
+      _chrome.reveal(kMangaChromeAutoHide);
+    }
+  }
+
+  /// 鼠标停在顶栏上不自动收起；离开后重新计时。
+  void _onChromeHover(bool hovering) {
+    if (!_chromeFloating) return;
+    if (hovering) {
+      _chrome.cancelAutoHide();
+    } else if (_chrome.transientVisible) {
+      _chrome.armAutoHide(kMangaChromeAutoHide);
+    }
   }
 
   Future<void> _readInitialFullscreenState() async {
@@ -1311,6 +1369,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     );
     _pageAnimation = MangaPageAnimationKey.fromKey(appModel.mangaPageAnimation);
     _tapZonePaging = appModel.mangaTapZonePaging;
+    _chromeFloating = appModel.mangaChromeFloating;
     _applyVolumeKeyPaging(appModel.mangaVolumeKeyPaging);
 
     // 阅读模式：用户覆盖优先，null 走自动判定（页图长宽比中位数）。
@@ -2815,7 +2874,8 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     final Size screen = MediaQuery.of(context).size;
     await dispatchMangaSelection(
       data,
-      fallbackScreen: screen,
+      fallbackScreen: Size(screen.width, screen.height - _chromeTopInset),
+      viewportOrigin: Offset(0, _chromeTopInset),
       selectPageForMining: _selectPageForMining,
       setSentence: (String sentence) {
         // TODO-956 下限兜底：句子派生不出时退回词本身，绝不让收藏/制卡拿到空句。
@@ -3253,7 +3313,9 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     }
     if (decoded is! Map || !mounted) return;
     final double x = (decoded['x'] as num?)?.toDouble() ?? 0;
-    final double y = (decoded['y'] as num?)?.toDouble() ?? 0;
+    // JS clientY 是 WebView 视口坐标；固定态顶栏让位时 WebView 顶部不在屏幕 0。
+    final double y =
+        ((decoded['y'] as num?)?.toDouble() ?? 0) + _chromeTopInset;
     // BUG-1438（与 BUG-129/261/381/781 同族）：JS 报的 clientX/clientY 是 **真实屏幕
     // 坐标**——漫画页整棵子树被 FushiAppUiScaleNeutralizer 中和回净缩放=1（见
     // manga_fushi_source.dart），WebView 全出血铺满真实视口。但 showMenu 的
@@ -3410,13 +3472,17 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
               child: Stack(
                 fit: StackFit.expand,
                 children: <Widget>[
-                  Positioned.fill(child: _buildBody()),
+                  // 固定态顶栏让位：WebView 顶部下移，JS 视口坐标经
+                  // [_chromeTopInset] 换算回屏幕坐标（选区 / 右键菜单两处）。
+                  Positioned.fill(top: _chromeTopInset, child: _buildBody()),
                   // 查词弹窗层：必须在同一个键盘 Focus 子树里，否则原生词典
                   // WebView 持焦后会吞掉翻页键。
                   Positioned.fill(
                     key: const ValueKey<String>('manga_dictionary_host'),
                     child: buildDictionary(),
                   ),
+                  // 顶栏 = 返回键 + 标题/页码 + 动作组。
+                  //
                   // 返回键是本页**唯一**的出口，它的可见性只能由用户意图
                   // （[_chromeVisible]）决定，绝不能再挂内容状态门控。
                   //
@@ -3426,34 +3492,39 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
                   // 翻页占用，页内没有第二条退出通道；iOS 又没有系统返回键，
                   // `PopScope(canPop: false)` 还顺手关掉了侧滑返回——三者叠加的结果
                   // 是用户只能杀进程。出口不是内容的一部分，不随内容存亡。
-                  if (_chromeVisible)
+                  //
+                  // 所以栏本体只受 [_chromeVisible]（固定态）/ 加悬浮唤出态门控；
+                  // 内容门控只落在栏里的**动作组**上（[_buildTopChrome]）：没有正文
+                  // 时页码 / 布局 / 缩放全无意义，栏只剩返回键。
+                  if (mangaChromeBarPainted(
+                    floating: _chromeFloating,
+                    chromeVisible: _chromeVisible,
+                    transientVisible: _chrome.transientVisible,
+                    contentReady: _chromeActionsEnabled,
+                  ))
                     Positioned(
                       top: 0,
                       left: 0,
-                      child: SafeArea(
-                        child: IconButton(
-                          key: const ValueKey<String>(
-                            'manga_reader_back_button',
-                          ),
-                          tooltip: MaterialLocalizations.of(
-                            context,
-                          ).backButtonTooltip,
-                          color: Colors.white,
-                          icon: const Icon(Icons.arrow_back_ios_new),
-                          onPressed: () => Navigator.of(context).maybePop(),
-                        ),
-                      ),
+                      right: 0,
+                      child: _buildTopChrome(),
                     ),
-                  // 顶部 chrome：页码指示 + 阅读模式切换。「本章未下载」态没有正文，
-                  // 页码 / 布局 / 缩放全无意义，一并不显示。
-                  if (_bookRow != null &&
-                      !_loadFailed &&
-                      !_chapterNotDownloaded &&
-                      _chromeVisible)
+                  // 悬浮态桌面顶边热区：栏收起时鼠标移到窗口顶部几像素即唤出
+                  // （EPUB 阅读器 `_buildHoverRevealLayer` 同款）。
+                  if (_chromeFloating &&
+                      _chromeActionsEnabled &&
+                      isDesktopPlatform &&
+                      !_chrome.transientVisible)
                     Positioned(
                       top: 0,
+                      left: 0,
                       right: 0,
-                      child: SafeArea(child: _buildTopChrome()),
+                      height: kReaderHoverRevealStripHeight,
+                      child: MouseRegion(
+                        key: const ValueKey<String>('manga_hover_reveal_strip'),
+                        opaque: true,
+                        onEnter: (_) => _chrome.reveal(kMangaChromeAutoHide),
+                        child: const SizedBox.expand(),
+                      ),
                     ),
                   // BUG-1888：隐藏态唯一的唤回入口（理由见 [_chromeVisible]）。
                   // 与返回键同理不挂内容门控——否则「隐藏界面后内容加载失败」会把
@@ -3511,191 +3582,210 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     );
   }
 
+  /// 顶栏动作是否有意义：没有正文（加载失败 / 本章未下载）时只剩返回键。
+  bool get _chromeActionsEnabled =>
+      _bookRow != null &&
+      !_loadFailed &&
+      !_chapterNotDownloaded &&
+      _chromeVisible;
+
+  /// 栏标题：书架在线条目 = `作品 · 章`；本地卷 = 书名。
+  String get _chromeTitle {
+    final OnlineMangaLibraryEntry? entry = _shelfEntry;
+    if (entry != null &&
+        _shelfChapterIndex >= 0 &&
+        _shelfChapterIndex < entry.chapters.length) {
+      return '${entry.series.title} · '
+          '${mangaChapterDisplayName(entry.chapters[_shelfChapterIndex])}';
+    }
+    return _bookRow?.title ?? '';
+  }
+
   Widget _buildTopChrome() {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        ValueListenableBuilder<int>(
-          valueListenable: _pageNotifier,
-          builder: (BuildContext context, int page, Widget? child) {
-            final int pageCount = _payload?.images.length ?? 0;
-            if (pageCount <= 0) return const SizedBox.shrink();
-            // 双页 spread 显示页码区间（如 3-4 / 40）；单页保持原样。
-            final int spreadIndex = MangaFushiPage.spreadIndexForPage(
-              _spreads,
-              page,
-            );
-            final MangaSpreadEntry? entry =
-                (spreadIndex >= 0 && spreadIndex < _spreads.length)
-                ? _spreads[spreadIndex]
-                : null;
-            final String label = (entry != null && entry.isSpread)
-                ? '${entry.pageIndices.first + 1}-'
-                      '${entry.pageIndices.last + 1} / $pageCount'
-                : '${page + 1} / $pageCount';
-            return TextButton(
-              key: const ValueKey<String>('manga_page_jump_button'),
-              onPressed: () => unawaited(_showPageJumpDialog()),
-              child: Text(
-                label,
-                style: Theme.of(
-                  context,
-                ).textTheme.labelLarge?.copyWith(color: Colors.white70),
-              ),
-            );
-          },
+    final bool ready = _chromeActionsEnabled;
+    return MangaReaderTopBar(
+      key: const ValueKey<String>('manga_reader_top_bar'),
+      title: ready ? _chromeTitle : '',
+      floating: _chromeFloating,
+      backTooltip: MaterialLocalizations.of(context).backButtonTooltip,
+      onBack: () => Navigator.of(context).maybePop(),
+      onHoverChanged: _onChromeHover,
+      pageLabel: ready ? _pageLabel : null,
+      pageListenable: _pageNotifier,
+      onPageTap: () => unawaited(_showPageJumpDialog()),
+      status: ready ? _buildChromeStatus() : null,
+      groups: ready ? _chromeActionGroups() : const <List<MangaChromeAction>>[],
+    );
+  }
+
+  /// 页码胶囊文案：双页 spread 显示区间（如 `3-4 / 40`），单页原样。
+  String? _pageLabel() {
+    final int pageCount = _payload?.images.length ?? 0;
+    if (pageCount <= 0) return null;
+    final int page = _pageNotifier.value;
+    final int spreadIndex = MangaFushiPage.spreadIndexForPage(_spreads, page);
+    final MangaSpreadEntry? entry =
+        (spreadIndex >= 0 && spreadIndex < _spreads.length)
+        ? _spreads[spreadIndex]
+        : null;
+    return (entry != null && entry.isSpread)
+        ? '${entry.pageIndices.first + 1}-'
+              '${entry.pageIndices.last + 1} / $pageCount'
+        : '${page + 1} / $pageCount';
+  }
+
+  /// 页码右侧的状态胶囊：整卷 OCR 进度 `12/40 · DirectML`（BUG-1163：当前真正
+  /// 生效的推理后端常驻显示，降级时琥珀色）；debug 下再挂一颗命中信息胶囊。
+  Widget? _buildChromeStatus() {
+    final List<Widget> chips = <Widget>[];
+    if (_wholeVolumeOcrRunning) {
+      final MangaOcrAcceleration? accel = _wholeVolumeOcrAcceleration;
+      final String progress = _wholeVolumeOcrTotal > 0
+          ? '$_wholeVolumeOcrDone/$_wholeVolumeOcrTotal'
+          : t.manga_ocr_wizard_running;
+      chips.add(
+        MangaChromeStatusChip(
+          key: const ValueKey<String>('manga_ocr_acceleration_label'),
+          text: accel == null ? progress : '$progress · ${accel.label}',
+          warning: accel?.degraded ?? false,
         ),
-        // 整卷 OCR 在阅读器外触发；这里只在任务运行时给一个取消入口。
-        if (_wholeVolumeOcrRunning)
-          Tooltip(
-            message: t.dialog_cancel,
-            child: IconButton(
-              key: const ValueKey<String>('manga_ocr_cancel_button'),
-              icon: const Icon(Icons.stop_circle_outlined, color: Colors.white),
-              onPressed: _cancelWholeVolumeOcr,
-            ),
-          ),
-        if (_wholeVolumeOcrRunning && _wholeVolumeOcrTotal > 0)
-          Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Text(
-              '$_wholeVolumeOcrDone/$_wholeVolumeOcrTotal',
-              style: Theme.of(
-                context,
-              ).textTheme.labelSmall?.copyWith(color: Colors.white70),
-            ),
-          ),
-        // BUG-1163：当前真正生效的执行后端常驻显示，降级时标红。
-        if (_wholeVolumeOcrRunning && _wholeVolumeOcrAcceleration != null)
-          Padding(
-            padding: const EdgeInsets.only(right: 4),
-            child: Text(
-              _wholeVolumeOcrAcceleration!.label,
-              key: const ValueKey<String>('manga_ocr_acceleration_label'),
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: _wholeVolumeOcrAcceleration!.degraded
-                    ? Colors.amberAccent
-                    : Colors.white70,
-              ),
-            ),
-          ),
-        if (kDebugMode && _debugOcrHitOrientation != null)
-          Container(
-            key: const ValueKey<String>('manga_ocr_hit_debug'),
-            margin: const EdgeInsets.only(right: 6),
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-            decoration: BoxDecoration(
-              color: Colors.black87,
-              border: Border.all(color: Colors.lightGreenAccent),
-              borderRadius: FushiBorderRadius.chip,
-            ),
-            child: Text(
+      );
+    }
+    if (kDebugMode && _debugOcrHitOrientation != null) {
+      chips.add(
+        MangaChromeStatusChip(
+          key: const ValueKey<String>('manga_ocr_hit_debug'),
+          text:
               '${_debugOcrHitOrientation == 'vertical' ? '竖排' : '横排'}'
               ' · ${_debugOcrHitCharacter ?? ''}'
               ' · ${_debugOcrSelectedText ?? ''}'
               ' · $_zoomPercent%',
-              style: Theme.of(
-                context,
-              ).textTheme.labelSmall?.copyWith(color: Colors.lightGreenAccent),
-            ),
-          ),
+        ),
+      );
+    }
+    if (chips.isEmpty) return null;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        for (int i = 0; i < chips.length; i++) ...<Widget>[
+          if (i > 0) const SizedBox(width: 6),
+          chips[i],
+        ],
+      ],
+    );
+  }
+
+  /// 顶栏动作，三组从左到右：导航（章节）│ 视图（单双页 / 阅读模式 / 识别范围 /
+  /// OCR 取消）│ 界面（隐藏 / 全屏）。pinned 的在窄窗仍是图标，其余折进 ⋮。
+  List<List<MangaChromeAction>> _chromeActionGroups() {
+    return <List<MangaChromeAction>>[
+      <MangaChromeAction>[
         // 章节列表：只有书架里的在线条目才有「章」。本地卷（一卷一条目、无章节）
         // 和源浏览预览（没有书架身份）都不显示，免得给出一个点开必然是空的入口。
         if (_shelfEntry != null)
-          Tooltip(
-            message: t.manga_series_chapters_action,
-            child: IconButton(
-              key: const ValueKey<String>('manga_reader_chapters'),
-              icon: const Icon(Icons.list_alt_outlined, color: Colors.white),
-              onPressed: _switchingChapter
-                  ? null
-                  : () => unawaited(_showChapterPicker()),
-            ),
-          ),
-        // 布局偏好菜单（自动/单页/双页）：只对 spread 模式有意义，webtoon 恒单页。
-        if (_mode == MangaReadingMode.spread)
-          PopupMenuButton<MangaSpreadPreference>(
-            tooltip: t.spread_mode,
-            icon: const Icon(Icons.menu_book_outlined, color: Colors.white),
-            initialValue: _spreadPreference,
-            onSelected: (MangaSpreadPreference preference) =>
-                unawaited(_setSpreadPreference(preference)),
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<MangaSpreadPreference>>[
-                  CheckedPopupMenuItem<MangaSpreadPreference>(
-                    value: MangaSpreadPreference.auto,
-                    checked: _spreadPreference == MangaSpreadPreference.auto,
-                    child: Text(t.spread_auto),
-                  ),
-                  CheckedPopupMenuItem<MangaSpreadPreference>(
-                    value: MangaSpreadPreference.single,
-                    checked: _spreadPreference == MangaSpreadPreference.single,
-                    child: Text(t.spread_off),
-                  ),
-                  CheckedPopupMenuItem<MangaSpreadPreference>(
-                    value: MangaSpreadPreference.double,
-                    checked: _spreadPreference == MangaSpreadPreference.double,
-                    child: Text(t.spread_on),
-                  ),
-                ],
-          ),
-        Tooltip(
-          message: t.manga_mode_toggle,
-          child: IconButton(
-            icon: Icon(
-              _mode == MangaReadingMode.webtoon
-                  ? Icons.view_day_outlined
-                  : Icons.auto_stories_outlined,
-              color: Colors.white,
-            ),
-            onPressed: () => unawaited(_toggleReadingMode()),
-          ),
-        ),
-        Tooltip(
-          message: t.manga_ocr_boxes_toggle,
-          child: IconButton(
-            key: const ValueKey<String>('manga_ocr_boxes_toggle'),
-            icon: Icon(
-              _showOcrBoxes
-                  ? Icons.highlight_alt
-                  : Icons.highlight_alt_outlined,
-              color: _showOcrBoxes ? Colors.amberAccent : Colors.white,
-            ),
-            onPressed: () => unawaited(_toggleOcrBoxes()),
-          ),
-        ),
-        // BUG-1888：隐藏界面。与快捷键（默认 M / 手柄 Y）同一个执行体。
-        Tooltip(
-          message: t.manga_interface_hide,
-          child: IconButton(
-            key: const ValueKey<String>('manga_chrome_hide_button'),
-            icon: const Icon(
-              Icons.visibility_off_outlined,
-              color: Colors.white,
-            ),
-            onPressed: _toggleMangaChrome,
-          ),
-        ),
-        if (desktopWindowFullscreenSupported)
-          Tooltip(
-            message: t.shortcut_action_global_toggle_fullscreen,
-            child: IconButton(
-              key: const ValueKey<String>('manga_fullscreen_button'),
-              icon: Icon(
-                _isWindowFullscreen
-                    ? Icons.fullscreen_exit_rounded
-                    : Icons.fullscreen_rounded,
-                color: Colors.white,
-              ),
-              // The method itself serializes native transitions. Keeping the
-              // button enabled avoids rebuilding it as permanently disabled
-              // when the final state update occurs before the transition's
-              // finally block clears its guard.
-              onPressed: () => unawaited(_toggleMangaFullscreen()),
-            ),
+          MangaChromeAction(
+            key: const ValueKey<String>('manga_reader_chapters'),
+            icon: Icons.list_alt_outlined,
+            label: t.manga_series_chapters_action,
+            pinned: true,
+            onPressed: _switchingChapter
+                ? null
+                : () => unawaited(_showChapterPicker()),
           ),
       ],
-    );
+      <MangaChromeAction>[
+        // 布局偏好（自动/单页/双页）循环切换：只对 spread 模式有意义，webtoon 恒单页。
+        if (_mode == MangaReadingMode.spread)
+          MangaChromeAction(
+            key: const ValueKey<String>('manga_spread_preference_button'),
+            icon: _spreadPreferenceIcon,
+            label: '${t.spread_mode}: $_spreadPreferenceLabel',
+            onPressed: () => unawaited(_cycleSpreadPreference()),
+          ),
+        MangaChromeAction(
+          key: const ValueKey<String>('manga_mode_toggle_button'),
+          icon: _mode == MangaReadingMode.webtoon
+              ? Icons.view_day_outlined
+              : Icons.auto_stories_outlined,
+          label: t.manga_mode_toggle,
+          onPressed: () => unawaited(_toggleReadingMode()),
+        ),
+        MangaChromeAction(
+          key: const ValueKey<String>('manga_ocr_boxes_toggle'),
+          icon: _showOcrBoxes
+              ? Icons.highlight_alt
+              : Icons.highlight_alt_outlined,
+          label: t.manga_ocr_boxes_toggle,
+          active: _showOcrBoxes,
+          onPressed: () => unawaited(_toggleOcrBoxes()),
+        ),
+        // 整卷 OCR 在阅读器外触发；这里只在任务运行时给一个取消入口。
+        if (_wholeVolumeOcrRunning)
+          MangaChromeAction(
+            key: const ValueKey<String>('manga_ocr_cancel_button'),
+            icon: Icons.stop_circle_outlined,
+            label: t.dialog_cancel,
+            pinned: true,
+            onPressed: _cancelWholeVolumeOcr,
+          ),
+      ],
+      <MangaChromeAction>[
+        // BUG-1888：隐藏界面。与快捷键（默认 M / 手柄 Y）同一个执行体。
+        MangaChromeAction(
+          key: const ValueKey<String>('manga_chrome_hide_button'),
+          icon: Icons.visibility_off_outlined,
+          label: t.manga_interface_hide,
+          pinned: true,
+          onPressed: _toggleMangaChrome,
+        ),
+        if (desktopWindowFullscreenSupported)
+          MangaChromeAction(
+            key: const ValueKey<String>('manga_fullscreen_button'),
+            icon: _isWindowFullscreen
+                ? Icons.fullscreen_exit_rounded
+                : Icons.fullscreen_rounded,
+            label: t.shortcut_action_global_toggle_fullscreen,
+            // The method itself serializes native transitions. Keeping the
+            // button enabled avoids rebuilding it as permanently disabled
+            // when the final state update occurs before the transition's
+            // finally block clears its guard.
+            onPressed: () => unawaited(_toggleMangaFullscreen()),
+          ),
+      ],
+    ];
+  }
+
+  IconData get _spreadPreferenceIcon {
+    switch (_spreadPreference) {
+      case MangaSpreadPreference.auto:
+        return Icons.auto_awesome_motion_outlined;
+      case MangaSpreadPreference.single:
+        return Icons.crop_portrait_outlined;
+      case MangaSpreadPreference.double:
+        return Icons.menu_book_outlined;
+    }
+  }
+
+  String get _spreadPreferenceLabel {
+    switch (_spreadPreference) {
+      case MangaSpreadPreference.auto:
+        return t.spread_auto;
+      case MangaSpreadPreference.single:
+        return t.spread_off;
+      case MangaSpreadPreference.double:
+        return t.spread_on;
+    }
+  }
+
+  /// 自动 → 单页 → 双页 → 自动。三态用一颗按钮循环，比弹菜单少一次点击，
+  /// 且能折进溢出菜单（菜单里没法再套菜单）。
+  Future<void> _cycleSpreadPreference() {
+    final MangaSpreadPreference next = switch (_spreadPreference) {
+      MangaSpreadPreference.auto => MangaSpreadPreference.single,
+      MangaSpreadPreference.single => MangaSpreadPreference.double,
+      MangaSpreadPreference.double => MangaSpreadPreference.auto,
+    };
+    return _setSpreadPreference(next);
   }
 
   Widget _buildBody() {
@@ -3834,6 +3924,7 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
           handlerName: 'onTapEmpty',
           callback: (List<dynamic> _) {
             _focusOwnership.reclaim(FocusReclaimCause.gesture);
+            _toggleFloatingChrome();
           },
         );
         controller.addJavaScriptHandler(

--- a/fushi/lib/src/media/manga/reader/manga_reader_chrome.dart
+++ b/fushi/lib/src/media/manga/reader/manga_reader_chrome.dart
@@ -1,0 +1,352 @@
+/// 漫画阅读器顶栏（chrome）。
+///
+/// 与 EPUB 阅读器的 [ReaderDesktopHeader] 同一套视觉语言（48px、左返回 / 中标题 /
+/// 右动作、窄窗折叠进 ⋮ 溢出菜单），但布局自己画：漫画页永远是黑底，动作要按
+/// 「导航 / 视图 / 界面」分组并夹分隔线，还要塞 OCR 进度胶囊，[ReaderDesktopHeader]
+/// 的 `title + leading + trailing` 三槽装不下。折叠阈值复用 [readerHeaderCompact]，
+/// 折叠规则（只留 pinned、其余进 ⋮）与 EPUB 同一句。
+///
+/// 两种形态由页面决定、本组件只管画：
+///  * 固定（`floating == false`）：实底、占布局，页面把正文 WebView 往下让
+///    [mangaChromeTopInset]；
+///  * 悬浮（`floating == true`）：半透明、盖在正文上，默认收起、唤出后自动收起。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:fushi/utils.dart' show FushiBorderRadius;
+import 'package:fushi/src/reader/reader_desktop_chrome.dart'
+    show kReaderDesktopHeaderHeight, readerHeaderCompact;
+
+/// 顶栏内容行高（不含系统状态栏）。与 EPUB 顶栏同值，两个阅读器视觉对齐。
+const double kMangaChromeBarHeight = kReaderDesktopHeaderHeight;
+
+/// 悬浮态唤出后自动收起的时长。漫画不另设滑杆：EPUB 那边是 1–10s 可调、默认 3s，
+/// 漫画先跟默认，等真有人要调再开旗。
+const Duration kMangaChromeAutoHide = Duration(seconds: 3);
+
+/// 固定态下正文 WebView 顶部让出的高度（纯函数，单测钉住）。
+///
+///  * 悬浮 / 界面被隐藏（M 键）→ 0：正文全出血；
+///  * 固定且界面可见 → 状态栏 + 顶栏行高。正文让位的高度**必须**等于顶栏画出的
+///    高度（同一个常量），否则页图第一行会压在栏下（EPUB 顶栏 BUG-2387 同款铁律）。
+double mangaChromeTopInset({
+  required bool floating,
+  required bool chromeVisible,
+  required double statusBarInset,
+}) {
+  if (floating || !chromeVisible) return 0;
+  return statusBarInset + kMangaChromeBarHeight;
+}
+
+/// 当前是否该画顶栏（纯函数）。
+///
+///  * 界面被用户隐藏（M 键，[chromeVisible] == false）→ 不画；
+///  * 固定态 → 画；
+///  * 悬浮态 → 唤出中（[transientVisible]）才画——**但没有正文时无条件画**
+///    （[contentReady] == false：加载失败 / 本章未下载）。悬浮态的唤出手势是正文
+///    WebView 的中央点击，没有正文就没有那条通道；桌面还有顶边热区，触屏没有，
+///    返回键一收就再也叫不回来（iOS 没有系统返回键 + `PopScope(canPop: false)`
+///    关掉了侧滑，只能杀进程）。出口不随内容存亡，也不随形态收起。
+bool mangaChromeBarPainted({
+  required bool floating,
+  required bool chromeVisible,
+  required bool transientVisible,
+  required bool contentReady,
+}) {
+  if (!chromeVisible) return false;
+  return !floating || transientVisible || !contentReady;
+}
+
+/// 顶栏里的一颗动作。[active] 是「开关型」动作的当前态（高亮 + 溢出菜单打勾）。
+class MangaChromeAction {
+  const MangaChromeAction({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.key,
+    this.pinned = false,
+    this.active = false,
+    this.busy = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+  final Key? key;
+
+  /// 窄窗紧凑形态仍保留为图标按钮；其余收进 ⋮。
+  final bool pinned;
+
+  /// 开关型动作当前处于开启态：图标用强调色，溢出菜单里带勾。
+  final bool active;
+
+  /// 忙碌中：图标位画转圈（例如整卷 OCR 进行中）。
+  final bool busy;
+}
+
+/// 顶栏。`[← 返回] [标题 · 页码胶囊] ……… [组1] │ [组2] │ [组3] [⋮]`。
+class MangaReaderTopBar extends StatelessWidget {
+  const MangaReaderTopBar({
+    super.key,
+    required this.title,
+    required this.onBack,
+    required this.backTooltip,
+    required this.groups,
+    required this.floating,
+    this.pageLabel,
+    this.pageListenable,
+    this.onPageTap,
+    this.status,
+    this.onHoverChanged,
+  });
+
+  /// 书名 / 章节名；空串时只画页码。
+  final String title;
+  final VoidCallback onBack;
+  final String backTooltip;
+
+  /// 动作分组（按顺序从左到右），组与组之间画分隔线。空组自动跳过。
+  final List<List<MangaChromeAction>> groups;
+
+  /// 悬浮态：半透明底；固定态：实底。
+  final bool floating;
+
+  /// 页码胶囊文案（如 `3-4 / 40`），每次 [pageListenable] 触发时重新取；返回
+  /// null 不画。只重建胶囊、不重建整页——翻页是高频事件，页面本体带着原生
+  /// WebView，不该跟着 setState。
+  final String? Function()? pageLabel;
+  final Listenable? pageListenable;
+  final VoidCallback? onPageTap;
+
+  /// 页码胶囊右侧的状态件（OCR 进度胶囊 / debug 命中信息）。
+  final Widget? status;
+
+  /// 鼠标进出顶栏（悬浮态：悬停期间不自动收起）。
+  final ValueChanged<bool>? onHoverChanged;
+
+  static const Color _fg = Colors.white;
+  static const Color _fgDim = Colors.white70;
+  static const Color _accent = Colors.amberAccent;
+
+  Color get _background =>
+      floating ? const Color(0xB3000000) : const Color(0xF2141414);
+
+  @override
+  Widget build(BuildContext context) {
+    final double statusBar = MediaQuery.paddingOf(context).top;
+    final List<List<MangaChromeAction>> visibleGroups =
+        <List<MangaChromeAction>>[
+          for (final List<MangaChromeAction> g in groups)
+            if (g.isNotEmpty) g,
+        ];
+    return MouseRegion(
+      onEnter: (_) => onHoverChanged?.call(true),
+      onExit: (_) => onHoverChanged?.call(false),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: _background,
+          border: floating
+              ? null
+              : const Border(bottom: BorderSide(color: Colors.white12)),
+        ),
+        child: Padding(
+          padding: EdgeInsets.only(top: statusBar),
+          child: SizedBox(
+            height: kMangaChromeBarHeight,
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                final bool compact = readerHeaderCompact(constraints.maxWidth);
+                // 折叠规则与 EPUB 顶栏 `readerHeaderOverflow` 同一句：紧凑态只留
+                // pinned，其余按组序收进 ⋮。
+                final List<MangaChromeAction> overflow = <MangaChromeAction>[
+                  for (final List<MangaChromeAction> g in visibleGroups)
+                    for (final MangaChromeAction a in g)
+                      if (compact && !a.pinned) a,
+                ];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    children: <Widget>[
+                      IconButton(
+                        key: const ValueKey<String>('manga_reader_back_button'),
+                        tooltip: backTooltip,
+                        color: _fg,
+                        iconSize: 22,
+                        icon: const Icon(Icons.arrow_back),
+                        onPressed: onBack,
+                      ),
+                      Expanded(child: _buildTitleArea(context, compact)),
+                      for (
+                        int i = 0;
+                        i < visibleGroups.length;
+                        i++
+                      ) ...<Widget>[
+                        if (i > 0 && !compact) _divider(),
+                        for (final MangaChromeAction a in visibleGroups[i])
+                          if (!compact || a.pinned) _button(a),
+                      ],
+                      if (overflow.isNotEmpty) _overflowMenu(context, overflow),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitleArea(BuildContext context, bool compact) {
+    final TextTheme text = Theme.of(context).textTheme;
+    return Row(
+      children: <Widget>[
+        if (title.isNotEmpty && !compact)
+          Flexible(
+            child: Padding(
+              padding: const EdgeInsets.only(left: 4, right: 8),
+              child: Text(
+                title,
+                key: const ValueKey<String>('manga_reader_title'),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: text.titleSmall?.copyWith(
+                  color: _fg.withValues(alpha: 0.9),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        if (pageLabel != null)
+          ListenableBuilder(
+            listenable:
+                pageListenable ?? Listenable.merge(const <Listenable>[]),
+            builder: (BuildContext context, Widget? _) {
+              final String? label = pageLabel!();
+              if (label == null) return const SizedBox.shrink();
+              return Material(
+                color: Colors.white12,
+                borderRadius: FushiBorderRadius.chip,
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  key: const ValueKey<String>('manga_page_jump_button'),
+                  onTap: onPageTap,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 5,
+                    ),
+                    child: Text(
+                      label,
+                      style: text.labelLarge?.copyWith(
+                        color: _fg,
+                        fontFeatures: const <FontFeature>[
+                          FontFeature.tabularFigures(),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        if (status != null) ...<Widget>[
+          const SizedBox(width: 8),
+          Flexible(child: status!),
+        ],
+      ],
+    );
+  }
+
+  Widget _divider() => const Padding(
+    padding: EdgeInsets.symmetric(horizontal: 2),
+    child: SizedBox(
+      width: 1,
+      height: 20,
+      child: ColoredBox(color: Colors.white24),
+    ),
+  );
+
+  Widget _button(MangaChromeAction a) {
+    final Widget icon = a.busy
+        ? const SizedBox.square(
+            dimension: 20,
+            child: CircularProgressIndicator(strokeWidth: 2, color: _fg),
+          )
+        : Icon(a.icon, color: a.active ? _accent : _fg);
+    return IconButton(
+      key: a.key,
+      tooltip: a.label,
+      iconSize: 22,
+      icon: icon,
+      onPressed: a.onPressed,
+    );
+  }
+
+  Widget _overflowMenu(BuildContext context, List<MangaChromeAction> overflow) {
+    return PopupMenuButton<MangaChromeAction>(
+      key: const ValueKey<String>('manga_chrome_overflow'),
+      tooltip: MaterialLocalizations.of(context).moreButtonTooltip,
+      icon: const Icon(Icons.more_vert, color: _fg),
+      iconSize: 22,
+      onSelected: (MangaChromeAction a) => a.onPressed?.call(),
+      itemBuilder: (BuildContext context) =>
+          <PopupMenuEntry<MangaChromeAction>>[
+            for (final MangaChromeAction a in overflow)
+              PopupMenuItem<MangaChromeAction>(
+                value: a,
+                enabled: a.onPressed != null,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Icon(a.icon, size: 20),
+                    const SizedBox(width: 12),
+                    Flexible(child: Text(a.label)),
+                    if (a.active) ...<Widget>[
+                      const SizedBox(width: 12),
+                      const Icon(Icons.check, size: 18),
+                    ],
+                  ],
+                ),
+              ),
+          ],
+    );
+  }
+}
+
+/// 顶栏右侧的小胶囊（OCR 进度 `12/40 · DirectML`）。[warning] 时琥珀色（BUG-1163：
+/// 推理后端降级必须看得见）。
+class MangaChromeStatusChip extends StatelessWidget {
+  const MangaChromeStatusChip({
+    super.key,
+    required this.text,
+    this.warning = false,
+  });
+
+  final String text;
+  final bool warning;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color fg = warning
+        ? MangaReaderTopBar._accent
+        : MangaReaderTopBar._fgDim;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.white10,
+        borderRadius: FushiBorderRadius.chip,
+        border: warning ? Border.all(color: fg.withValues(alpha: 0.6)) : null,
+      ),
+      child: Text(
+        text,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: fg,
+          fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
+        ),
+      ),
+    );
+  }
+}

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -8122,6 +8122,10 @@ class AppModel with ChangeNotifier {
   Future<void> setMangaVolumeKeyPaging(bool value) =>
       prefsRepo.setMangaVolumeKeyPaging(value);
 
+  bool get mangaChromeFloating => prefsRepo.mangaChromeFloating;
+  Future<void> setMangaChromeFloating(bool value) =>
+      prefsRepo.setMangaChromeFloating(value);
+
   bool get mangaTapZonePaging => prefsRepo.mangaTapZonePaging;
   Future<void> setMangaTapZonePaging(bool value) =>
       prefsRepo.setMangaTapZonePaging(value);

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -2764,6 +2764,17 @@ class PreferencesRepository extends ChangeNotifier implements PrefStore {
     notifyListeners();
   }
 
+  /// 漫画阅读器顶栏是否悬浮（默认开，与 EPUB 阅读器「点空白隐藏控制栏」同默认）。
+  /// 悬浮 = 顶栏不占布局、默认收起、点页面中央 / 顶边悬停唤出并自动收起；
+  /// 关 = 顶栏常驻并占 48px 布局高，页图在它下方排布。
+  bool get mangaChromeFloating =>
+      getPref('manga_chrome_floating', defaultValue: true) as bool;
+
+  Future<void> setMangaChromeFloating(bool value) async {
+    await setPref('manga_chrome_floating', value);
+    notifyListeners();
+  }
+
   /// 点击页面左右边缘翻页。默认开：触屏此前完全没有点击翻页手段。
   bool get mangaTapZonePaging =>
       getPref('manga_tap_zone_paging', defaultValue: true) as bool;

--- a/fushi/lib/src/settings/settings_schema_manga.dart
+++ b/fushi/lib/src/settings/settings_schema_manga.dart
@@ -127,6 +127,17 @@ SettingsDestination buildMangaDestination() {
             onChanged: (SettingsContext c, bool value) =>
                 c.appModel.setMangaTapZonePaging(value),
           ),
+          // 顶栏悬浮/常驻：与 EPUB 阅读器「点空白隐藏控制栏」同一模型（悬浮 = 不占
+          // 布局、默认收起、点页面中央或顶边悬停唤出后自动收起；关 = 常驻并让位）。
+          SettingsSwitchItem(
+            id: 'manga.chrome_floating',
+            title: t.manga_chrome_floating,
+            subtitle: t.manga_chrome_floating_subtitle,
+            icon: Icons.vertical_align_top_outlined,
+            value: (SettingsContext c) => c.appModel.mangaChromeFloating,
+            onChanged: (SettingsContext c, bool value) =>
+                c.appModel.setMangaChromeFloating(value),
+          ),
           // 音量键只有 Android 侧 `MainActivity.dispatchKeyEvent` 会拦截并转发
           // （见 VolumeKeyChannel），iOS 与桌面端均没有实现，故只在 Android 显示。
           SettingsSwitchItem(

--- a/fushi/test/media/manga/manga_reader_chrome_test.dart
+++ b/fushi/test/media/manga/manga_reader_chrome_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/manga/reader/manga_fushi_page.dart'
+    show mangaSelectionRectFromPayload;
+import 'package:fushi/src/media/manga/reader/manga_reader_chrome.dart';
+import 'package:fushi/src/reader/reader_desktop_chrome.dart'
+    show kReaderDesktopHeaderCompactWidth;
+import 'package:fushi/src/reader/reader_selection_data.dart';
+
+void main() {
+  group('mangaChromeTopInset', () {
+    test('悬浮 / 界面隐藏 → 0；固定且可见 → 状态栏 + 栏高', () {
+      expect(
+        mangaChromeTopInset(
+          floating: true,
+          chromeVisible: true,
+          statusBarInset: 24,
+        ),
+        0,
+      );
+      expect(
+        mangaChromeTopInset(
+          floating: false,
+          chromeVisible: false,
+          statusBarInset: 24,
+        ),
+        0,
+      );
+      expect(
+        mangaChromeTopInset(
+          floating: false,
+          chromeVisible: true,
+          statusBarInset: 24,
+        ),
+        24 + kMangaChromeBarHeight,
+      );
+    });
+  });
+
+  group('mangaChromeBarPainted', () {
+    test('固定态只看 chromeVisible；悬浮态还要 transientVisible', () {
+      expect(
+        mangaChromeBarPainted(
+          floating: false,
+          chromeVisible: true,
+          transientVisible: false,
+          contentReady: true,
+        ),
+        isTrue,
+      );
+      expect(
+        mangaChromeBarPainted(
+          floating: true,
+          chromeVisible: true,
+          transientVisible: false,
+          contentReady: true,
+        ),
+        isFalse,
+      );
+      expect(
+        mangaChromeBarPainted(
+          floating: true,
+          chromeVisible: true,
+          transientVisible: true,
+          contentReady: true,
+        ),
+        isTrue,
+      );
+      // 没有正文（加载失败 / 未下载）：悬浮态也无条件画——没有 WebView 就没有
+      // 中央点击这条唤出通道，返回键收起就是 iOS 死锁。
+      expect(
+        mangaChromeBarPainted(
+          floating: true,
+          chromeVisible: true,
+          transientVisible: false,
+          contentReady: false,
+        ),
+        isTrue,
+      );
+      // M 键隐藏界面：两种形态都不画（悬浮唤出态也压不过用户意图）。
+      expect(
+        mangaChromeBarPainted(
+          floating: true,
+          chromeVisible: false,
+          transientVisible: true,
+          contentReady: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('mangaSelectionRectFromPayload', () {
+    test('固定态 WebView 让位后选区矩形整体下移 viewportOrigin', () {
+      final ReaderSelectionData data = ReaderSelectionData.fromJson(
+        <String, dynamic>{
+          'text': 'x',
+          'sentence': 'x',
+          'rect': <String, dynamic>{
+            'x': 10.0,
+            'y': 20.0,
+            'width': 30.0,
+            'height': 40.0,
+          },
+        },
+      );
+      expect(
+        mangaSelectionRectFromPayload(
+          data,
+          fallbackScreen: const Size(800, 600),
+          viewportOrigin: const Offset(0, 72),
+        ),
+        const Rect.fromLTWH(10, 92, 30, 40),
+      );
+      // 无 rect 的兜底：WebView 中心再加偏移。
+      final ReaderSelectionData noRect = ReaderSelectionData.fromJson(
+        <String, dynamic>{'text': 'x', 'sentence': 'x'},
+      );
+      expect(
+        mangaSelectionRectFromPayload(
+          noRect,
+          fallbackScreen: const Size(800, 528),
+          viewportOrigin: const Offset(0, 72),
+        ).center,
+        const Offset(400, 264 + 72),
+      );
+    });
+  });
+
+  group('MangaReaderTopBar', () {
+    Widget host({required double width, required bool floating}) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(padding: EdgeInsets.only(top: 20)),
+          child: Scaffold(
+            body: Align(
+              alignment: Alignment.topCenter,
+              child: SizedBox(
+                width: width,
+                child: MangaReaderTopBar(
+                  title: 'Title',
+                  floating: floating,
+                  backTooltip: 'back',
+                  onBack: () {},
+                  pageLabel: () => '3-4 / 40',
+                  onPageTap: () {},
+                  status: const MangaChromeStatusChip(
+                    key: ValueKey<String>('chip'),
+                    text: '12/40 · DirectML',
+                    warning: true,
+                  ),
+                  groups: <List<MangaChromeAction>>[
+                    <MangaChromeAction>[
+                      MangaChromeAction(
+                        key: const ValueKey<String>('a_pinned'),
+                        icon: Icons.list,
+                        label: 'A',
+                        pinned: true,
+                        onPressed: () {},
+                      ),
+                    ],
+                    const <MangaChromeAction>[],
+                    <MangaChromeAction>[
+                      MangaChromeAction(
+                        key: const ValueKey<String>('b_overflow'),
+                        icon: Icons.tune,
+                        label: 'B',
+                        active: true,
+                        onPressed: () {},
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('宽窗：全部按钮直接画，返回键 / 页码 / 状态胶囊都在', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(width: kReaderDesktopHeaderCompactWidth + 40, floating: false),
+      );
+      expect(
+        find.byKey(const ValueKey<String>('manga_reader_back_button')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('manga_page_jump_button')),
+        findsOneWidget,
+      );
+      expect(find.text('3-4 / 40'), findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('chip')), findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('a_pinned')), findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('b_overflow')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey<String>('manga_chrome_overflow')),
+        findsNothing,
+      );
+      // 栏总高 = 状态栏 + 栏行高（固定态让位量与画出高度同源）。
+      final Size size = tester.getSize(find.byType(MangaReaderTopBar));
+      expect(size.height, 20 + kMangaChromeBarHeight);
+    });
+
+    testWidgets('窄窗：非 pinned 动作折进 ⋮，菜单项带勾', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(width: kReaderDesktopHeaderCompactWidth - 40, floating: true),
+      );
+      expect(find.byKey(const ValueKey<String>('a_pinned')), findsOneWidget);
+      expect(find.byKey(const ValueKey<String>('b_overflow')), findsNothing);
+      final Finder overflow = find.byKey(
+        const ValueKey<String>('manga_chrome_overflow'),
+      );
+      expect(overflow, findsOneWidget);
+      await tester.tap(overflow);
+      await tester.pumpAndSettle();
+      expect(find.text('B'), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+  });
+}

--- a/fushi/test/pages/manga_fushi_page_online_chapter_test.dart
+++ b/fushi/test/pages/manga_fushi_page_online_chapter_test.dart
@@ -98,6 +98,10 @@ class _MangaTestAppModel extends AppModel {
   String get mangaPageAnimation => MangaPageAnimation.slide.key;
   @override
   bool get mangaTapZonePaging => true;
+
+  // 固定顶栏：测试默认要看得见栏里的按钮（悬浮态默认收起）。
+  @override
+  bool get mangaChromeFloating => false;
   @override
   bool get mangaVolumeKeyPaging => false;
 }

--- a/fushi/test/pages/manga_fushi_page_test.dart
+++ b/fushi/test/pages/manga_fushi_page_test.dart
@@ -17,6 +17,8 @@ import 'package:fushi/src/media/manga/ocr/manga_ocr_job_registry.dart';
 import 'package:fushi/src/media/manga/manga_overlay_html.dart';
 import 'package:fushi/src/media/manga/manga_reading_mode.dart';
 import 'package:fushi/src/media/manga/manga_view_prefs.dart';
+import 'package:fushi/src/media/manga/reader/manga_reader_chrome.dart'
+    show kMangaChromeBarHeight;
 import 'package:fushi_engine/media/manga/mokuro_payload.dart';
 import 'package:fushi/src/media/media_item.dart';
 import 'package:fushi_engine/ocr/manga_ocr_service.dart';
@@ -73,8 +75,20 @@ class _MangaTestAppModel extends AppModel {
   @override
   bool get mangaTapZonePaging => true;
 
+  // 固定顶栏：测试默认要看得见栏里的按钮（悬浮态默认收起）。
+  @override
+  bool get mangaChromeFloating => false;
+
   @override
   bool get mangaVolumeKeyPaging => false;
+}
+
+/// 悬浮顶栏偏好开的 fake。
+class _FloatingChromeAppModel extends _MangaTestAppModel {
+  _FloatingChromeAppModel(super.db);
+
+  @override
+  bool get mangaChromeFloating => true;
 }
 
 /// 整卷 OCR 入口测试用 fake 服务（只有 modelStatus 有意义）。
@@ -329,6 +343,77 @@ void main() {
     expect(find.byKey(const ValueKey<String>('manga_ocr_cancel_button')),
         findsNothing,
         reason: '没有外部任务在跑时不显示取消按钮');
+  });
+
+  testWidgets('悬浮顶栏：偏好开 → 书就绪后栏默认收起、正文全出血；固定 → 栏常驻且正文让位',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(600, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    final FushiDatabase db = FushiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final Directory bookDir =
+        Directory.systemTemp.createTempSync('manga_floating_chrome_');
+    addTearDown(() {
+      if (bookDir.existsSync()) bookDir.deleteSync(recursive: true);
+    });
+    File(p.join(bookDir.path, 'manga.json')).writeAsStringSync(_mangaJson());
+    Directory(p.join(bookDir.path, 'images')).createSync();
+    File(p.join(bookDir.path, 'images', 'p001.jpg')).writeAsBytesSync(<int>[1]);
+    File(p.join(bookDir.path, 'images', 'p002.jpg')).writeAsBytesSync(<int>[2]);
+    const String bookKey = '悬浮顶栏テスト';
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: bookKey,
+      title: bookKey,
+      epubPath: 'manga.json',
+      extractDir: bookDir.path,
+      chapterCount: 2,
+      chaptersJson: '[]',
+      importedAt: DateTime.now().millisecondsSinceEpoch,
+      format: const Value<String>('manga'),
+    ));
+
+    Future<void> pumpReady(AppModel appModel) async {
+      await tester.runAsync(() async {
+        await tester.pumpWidget(_harness(appModel, _item(bookKey), bookKey));
+        for (int i = 0; i < 50; i++) {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await tester.pump();
+          if (find
+              .byKey(const ValueKey<String>('manga_content_ready'))
+              .evaluate()
+              .isNotEmpty) {
+            break;
+          }
+        }
+      });
+      await tester.pump();
+      expect(find.byKey(const ValueKey<String>('manga_content_ready')),
+          findsOneWidget);
+    }
+
+    // 固定：栏常驻，正文顶部让出栏高（无状态栏 → 恰好 kMangaChromeBarHeight）。
+    await pumpReady(_MangaTestAppModel(db));
+    final Finder bar = find.byKey(const ValueKey<String>('manga_reader_top_bar'));
+    expect(bar, findsOneWidget, reason: '固定态顶栏常驻');
+    expect(
+      tester.getTopLeft(
+          find.byKey(const ValueKey<String>('manga_content_ready'))),
+      const Offset(0, kMangaChromeBarHeight),
+      reason: '固定态正文必须让出与栏同高的空间（BUG-2387 同款铁律）',
+    );
+
+    // 悬浮：栏默认收起（没有唤出手势前不画），正文全出血。
+    await tester.pumpWidget(const SizedBox.shrink());
+    await pumpReady(_FloatingChromeAppModel(db));
+    expect(bar, findsNothing, reason: '悬浮态默认收起');
+    expect(
+      tester.getTopLeft(
+          find.byKey(const ValueKey<String>('manga_content_ready'))),
+      Offset.zero,
+      reason: '悬浮态正文全出血',
+    );
   });
 
   testWidgets('加载失败（无书行）时 chrome 不构建 → 无 OCR 相关按钮，但返回按钮仍在',

--- a/fushi/test/pages/manga_spread_double_page_test.dart
+++ b/fushi/test/pages/manga_spread_double_page_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/models.dart';
-import 'package:fushi/src/media/manga/manga_spread_model.dart';
 import 'package:fushi/src/media/manga/manga_view_prefs.dart';
 import 'package:fushi/src/media/media_item.dart';
 import 'package:fushi/src/pages/implementations/manga_fushi_page.dart';
@@ -67,6 +66,10 @@ class _MangaTestAppModel extends AppModel {
 
   @override
   bool get mangaTapZonePaging => true;
+
+  // 固定顶栏：测试默认要看得见栏里的按钮（悬浮态默认收起）。
+  @override
+  bool get mangaChromeFloating => false;
 
   @override
   bool get mangaVolumeKeyPaging => false;
@@ -197,8 +200,11 @@ void main() {
         findsOneWidget);
     expect(find.text('2-3 / 4'), findsOneWidget,
         reason: '横屏 auto 双页 + 封面独占：恢复到含第 3 页的跨页，指示区间 2-3');
-    // 布局偏好菜单在 spread 模式下可见。
-    expect(find.byType(PopupMenuButton<MangaSpreadPreference>), findsOneWidget);
+    // 布局偏好（自动/单页/双页循环）按钮在 spread 模式下可见。
+    expect(
+      find.byKey(const ValueKey<String>('manga_spread_preference_button')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('竖屏视口自动单页：页码保持单页显示', (WidgetTester tester) async {

--- a/fushi/test/pages/manga_toggle_chrome_test.dart
+++ b/fushi/test/pages/manga_toggle_chrome_test.dart
@@ -79,13 +79,12 @@ void main() {
       required bool dictionaryShown,
       required MangaReadingMode mode,
       bool crossPageStep = false,
-    }) =>
-        MangaFushiPage.inputActionForShortcut(
-          action: ShortcutAction.mangaToggleChrome,
-          crossPageStep: crossPageStep,
-          dictionaryShown: dictionaryShown,
-          mode: mode,
-        );
+    }) => MangaFushiPage.inputActionForShortcut(
+      action: ShortcutAction.mangaToggleChrome,
+      crossPageStep: crossPageStep,
+      dictionaryShown: dictionaryShown,
+      mode: mode,
+    );
 
     test('spread 模式、无弹窗：解析成 toggleChrome', () {
       expect(
@@ -160,17 +159,25 @@ void main() {
         isTrue,
         reason: '可见性必须是页面自己的状态字段',
       );
-      // 顶栏画的是页码 / 框选 OCR / 单双页，没有内容时它们无意义——继续挂内容门控
-      // （「本章未下载」态同样没有正文，2026-09-12 起一并门掉）。
+      // 顶栏里的动作组（页码 / 单双页 / OCR 取消）没有内容时无意义——继续挂内容
+      // 门控（「本章未下载」态同样没有正文，2026-09-12 起一并门掉）。顶栏重设计后
+      // 门控收进 `_chromeActionsEnabled` 一个 getter：栏本体（含返回键）只看
+      // `_chromeVisible`（固定态）/ 悬浮唤出态，动作组才问它。
       expect(
         pageSrc.contains(
-          '_bookRow != null &&\n'
-          '                      !_loadFailed &&\n'
-          '                      !_chapterNotDownloaded &&\n'
-          '                      _chromeVisible',
+          'bool get _chromeActionsEnabled =>\n'
+          '      _bookRow != null &&\n'
+          '      !_loadFailed &&\n'
+          '      !_chapterNotDownloaded &&\n'
+          '      _chromeVisible;',
         ),
         isTrue,
-        reason: '顶栏（页码/OCR/单双页）在没有内容时不该画',
+        reason: '顶栏动作组（页码/OCR/单双页）在没有内容时不该画',
+      );
+      expect(
+        pageSrc.contains('groups: ready ? _chromeActionGroups()'),
+        isTrue,
+        reason: '内容门控必须落在动作组上，而不是整条栏（返回键在栏里）',
       );
       // 出口不是内容的一部分。返回键与唤回键**不得**再出现内容门控：
       // 加载失败或迟迟未就绪时它们一起消失，iOS 上就是「只能杀进程」
@@ -199,7 +206,8 @@ void main() {
       expect(
         pageSrc.contains("'manga_chrome_show_button'"),
         isTrue,
-        reason: '漫画正文是原生 WebView、空白点击已被翻页占用，'
+        reason:
+            '漫画正文是原生 WebView、空白点击已被翻页占用，'
             '没有这个按钮触屏设备再无第二条通道唤回界面',
       );
       expect(pageSrc.contains("'manga_chrome_hide_button'"), isTrue);
@@ -218,10 +226,7 @@ void main() {
     });
 
     test('快捷键执行体走同一个 _toggleMangaChrome', () {
-      expect(
-        pageSrc.contains('MangaReaderInputAction.toggleChrome'),
-        isTrue,
-      );
+      expect(pageSrc.contains('MangaReaderInputAction.toggleChrome'), isTrue);
       expect(pageSrc.contains('_toggleMangaChrome();'), isTrue);
       expect(
         pageSrc.contains('onPressed: _toggleMangaChrome,'),

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -115,6 +115,13 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'manga/Page turn animation': 'test/media/manga/manga_overlay_html_test.dart',
   'manga/Tap edges to turn pages':
       'test/media/manga/manga_overlay_html_test.dart',
+  // 顶栏悬浮/固定：写 prefsRepo（changed=true），生效点是阅读器打开书时读一次
+  // appModel.mangaChromeFloating 决定栏形态与正文让位——harness 里没有阅读器。
+  // 由 manga_reader_chrome_test 咬住让位/绘制两条纯函数，manga_fushi_page_test
+  // 「悬浮顶栏」用例咬住偏好 → 页面形态的接线。
+  'manga/Floating toolbar':
+      'test/media/manga/manga_reader_chrome_test.dart + '
+          'test/pages/manga_fushi_page_test.dart（悬浮顶栏）',
   // BUG-2450：在线源封面磁盘缓存保留天数。写 prefsRepo（changed=true），生效点是
   // MihonCoverCache.maxAge（过期条目下次读取删掉重取），harness 里没有封面缓存
   // 目录可探。由专项测试咬住：过期封面重新联网、未过期命中磁盘、偏好改动即时


### PR DESCRIPTION
## 背景

用户反馈：① 书架里打开 OCR 的地方找不到 OCR 设置；② 漫画阅读器顶部按钮「烂完了」——没有底色、没有分组、顺序随手堆、窄窗挤爆。

## 改动

### A. 书架 OCR 设置入口（BUG-2483，真 bug）
- `manga_library_page.dart` 漫画库页「设置」标签此前指向 `SettingsDestinationId.reading`（EPUB 字体/排版），而漫画 OCR 早已搬到 `manga` 分类 → 改指 `manga`。
- 作品页动作行（本地卷 / 在线条目）与 OCR 向导各加「OCR 设置」按钮，直达新页 `MangaOcrSettingsPage`（复用 `MangaOcrSettingsSection`）。
- 向导返回后经新增 `resolveEngines` 回调**重新装配**引擎：`MangaOcrWizardEngines.resolve()` 把 mokuro 路径 / 偏好快照进依赖集，只重探探不到刚配好的路径。

### B. 阅读器顶栏重设计（新文件 `manga_reader_chrome.dart`）
- 48px 顶栏：`[← 返回][作品 · 章 · 页码胶囊] … [章节]│[单双页 / 阅读模式 / 识别范围 / OCR 取消]│[隐藏 / 全屏]`，三组夹分隔线；窄窗（<760，复用 `readerHeaderCompact`）非 pinned 动作折进 ⋮。
- OCR 进度改成 `12/40 · DirectML` 胶囊（降级琥珀，BUG-1163 可见性保留）。
- 单双页偏好从弹菜单改为一键循环（自动→单页→双页），能折进溢出菜单。
- **悬浮 / 固定两态**，新偏好 `manga_chrome_floating`（默认开，与 EPUB「点空白隐藏控制栏」同模型；设置 → 漫画 → 浏览与翻页）：
  - 悬浮：不占布局、默认收起、点页面中央 / 桌面顶边悬停唤出、3s 自动收起、悬停栏上不收；
  - 固定：常驻并让正文 WebView 下移 `statusBar + 48`，JS→Flutter 的两处视口坐标（查词选区 / 右键菜单锚点）经同一偏移换算。
- **没有正文时悬浮态也无条件画栏**：没有 WebView 就没有中央点击这条唤出通道，返回键一收就是 iOS 死锁（守卫 `manga_toggle_chrome_test` 的内容门控锚点跟着收进 `_chromeActionsEnabled`，不变式不变：内容门控只有一处、返回键不挂）。
- 所有测试钉死的 `ValueKey` 保留；M 键 / 手柄 Y 执行体不动。

## 验证
- `flutter analyze` 零问题。
- 定向：`test/pages/manga_*`（含新增「悬浮顶栏偏好 → 页面形态」用例）、`test/media/manga/manga_reader_chrome_test.dart`（新）、`test/settings` 整目录（含 `kCoveredElsewhere` 登记）、作品页 / 向导 / i18n 相邻测试——全绿（退出码 0）。
- 离屏 itest `integration_test/manga_chrome_shot_itest.dart`（固定 / 悬浮两帧真实像素）：跑完后追加到本 PR。

## 未做 / 注意
- 悬浮态自动收起固定 3s（EPUB 那边有 1–10s 滑杆），等真有人要调再开旗。
- `strings.g.dart` 用 `dart format --language-version=3.6` 保持入库的短风格（否则 1.7 万行噪音）。

https://claude.ai/code/session_01RxnDtxCQ7buCUo14ftWM49
