### PR TITLE
fix(manga): percent-decode only at the URL boundary (BUG-2484)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2288 条。点号进各自文件。
+> 共 2289 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2484](bugs/BUG-2484-manga-percent-filename.md) | ✅ | ✅ | 漫画页文件名含裸百分号时翻页/选字/制卡全抛 Illegal percent encoding |
 | [BUG-2482](bugs/BUG-2482-webkit-line-box-contain-zero-height-lines.md) | ✅ | ✅ | WebKit 上 BUG-2472 的 line-box-contain 把嵌套 inline / 空行行盒压成零高：目录列叠印、空行消失 |
 | [BUG-2481](bugs/BUG-2481-manga-ocr-progress-boxes-update-all-sort.md) | ✅ | ✅ | 作品页 OCR 无进度显示；阅读器无识别范围显示；扩展无一键更新；源列表无按下载量排序 |
 | [BUG-2480](bugs/BUG-2480-manga-login-import-from-browser-extension.md) | ✅ | ✅ | 漫画源登录：从系统浏览器（经 Fushi 扩展）导入已登录会话，不必在 app 内重登 |

--- a/docs/bugs/BUG-2484-manga-percent-filename.md
+++ b/docs/bugs/BUG-2484-manga-percent-filename.md
@@ -1,0 +1,6 @@
+## BUG-2484 · 漫画页文件名含裸百分号时翻页/选字/制卡全抛 Illegal percent encoding
+- **报告**：2026-09-12（用户：错误日志 `fushi_error_log (3).txt`，2.5.2-debug.14696，`MangaFushi.onTextSelected` 168 次 + `UncaughtZone` 131 次同一栈 `Invalid argument(s): Illegal percent encoding in URI`）
+- **真实性**：✅ 真 bug。根因 `packages/fushi_engine/lib/media/manga/manga_storage.dart:152`（修前）`resolvePageFilePath` 无条件 `Uri.decodeComponent(relative)`，但 5 个调用点里只有 WebView 拦截器 `_interceptRequest` 与 `resolveImageUrlToFile` 传的是 `manga.local/img/<已编码>`；`resolveMangaPageImage`、`_updateCurrentPageImagePath`、互联 host `mangaPageFile`（`local_library_host_service/manga.part.dart:46`）直接传 `manga.json` 的裸文件名。图名含 `%`（如 `100%.jpg`）即抛，翻页 `MangaTurnQueue` / 选字制卡 `_selectPageForMining` / 当前页图路径三条链全断；副作用：形如 `%41.jpg` 的合法名被静默解码成 `A.jpg` 后 404。
+- **[x] ① 已修复** — 解码收回 URL 边界：新增 `MangaFushiPage.decodeMangaImagePath`（非法编码 → null/404，不再抛），`resolvePageFilePath` 只吃裸相对路径，与 `mangaImageUrl` 逐段 `encodeComponent` 对称；拦截器 403/404 分支同步改用已解码路径。
+- **[x] ② 已加自动化测试** — `fushi/test/pages/manga_interceptor_test.dart`（裸 `%` 直解、`%41.jpg` 不误解码、`mangaImageUrl → resolveImageUrlToFile` 往返、非法编码回 null），`manga_path_case_preserved_test.dart` 的 percent 用例改到 URL 入口。
+- **备注**：无法从日志得知触发的具体文件名，但契约错位与文件名无关；同一日志里的 `UpdateChecker.httpGet` 是镜像站网络失败，与本 bug 无关。

--- a/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
+++ b/fushi/lib/src/media/manga/reader/manga_fushi_page.dart
@@ -552,12 +552,28 @@ class MangaFushiPage extends BaseSourcePage {
   static String? resolveMangaResource(String imagesRoot, String relative) =>
       MangaStorage.resolvePageFilePath(imagesRoot, relative);
 
+  /// `manga.local/img/` 之后的 percent-encoded 段 → 裸相对路径；非法编码 → null。
+  ///
+  /// 解码只在这里（URL 边界）做一次，与 [mangaImageUrl] 的逐段 `encodeComponent`
+  /// 对称；[resolveMangaResource] 只吃裸路径（BUG-2484）。外来 URL 编码非法是输入
+  /// 校验失败，按「解析不到」处理，不让 `ArgumentError` 掀翻拦截器。
+  static String? decodeMangaImagePath(String encodedRelative) {
+    try {
+      return Uri.decodeComponent(encodedRelative);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
   /// 纯函数：`manga.local` 图片 URL → 树内文件路径；host 不对/越界/缺文件 → null。
   static String? resolveImageUrlToFile(String imagesRoot, String imgUrl) {
     final Uri? uri = Uri.tryParse(imgUrl);
     if (uri == null || uri.host != kMangaHost) return null;
     if (!uri.path.startsWith('/img/')) return null;
-    final String relative = uri.path.substring('/img/'.length);
+    final String? relative = decodeMangaImagePath(
+      uri.path.substring('/img/'.length),
+    );
+    if (relative == null) return null;
     return resolveMangaResource(imagesRoot, relative);
   }
 
@@ -1701,8 +1717,10 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     if (url.host != MangaFushiPage.kMangaHost) return null;
     final String path = url.path;
     if (!path.startsWith('/img/')) return _notFound('unknown path: $path');
-    final String relative = path.substring('/img/'.length);
-    final String decodedRelative = Uri.decodeComponent(relative);
+    final String? decodedRelative = MangaFushiPage.decodeMangaImagePath(
+      path.substring('/img/'.length),
+    );
+    if (decodedRelative == null) return _notFound('bad encoding: $path');
     final MangaReaderSession? pageSession = _pageSession;
     final int? pageIndex = _localPageIndices[_localPageKey(decodedRelative)];
     if (pageSession != null && pageIndex != null) {
@@ -1734,18 +1752,18 @@ class _MangaFushiPageState extends BaseSourcePageState<MangaFushiPage>
     }
     final String? filePath = MangaFushiPage.resolveMangaResource(
       imagesDir,
-      relative,
+      decodedRelative,
     );
     if (filePath == null) {
       // 区分穿越（403）与缺文件（404）：规范化 join 后越界即穿越企图。
       final String canonicalRoot = p.canonicalize(imagesDir);
       final String candidate = p.canonicalize(
-        p.join(canonicalRoot, Uri.decodeComponent(relative)),
+        p.join(canonicalRoot, decodedRelative),
       );
       if (!p.isWithin(canonicalRoot, candidate)) {
-        return _forbidden('path traversal blocked: $relative');
+        return _forbidden('path traversal blocked: $decodedRelative');
       }
-      return _notFound('resource not found: $relative');
+      return _notFound('resource not found: $decodedRelative');
     }
     return WebResourceResponse(
       contentType: _mangaMimeForPath(filePath),

--- a/fushi/test/pages/manga_interceptor_test.dart
+++ b/fushi/test/pages/manga_interceptor_test.dart
@@ -18,33 +18,48 @@ void main() {
     tearDown(() => root.deleteSync(recursive: true));
 
     test('树内图片路径可解析（保留子目录结构）', () {
-      final String? resolved =
-          MangaFushiPage.resolveMangaResource(root.path, 'vol1/p001.jpg');
+      final String? resolved = MangaFushiPage.resolveMangaResource(
+        root.path,
+        'vol1/p001.jpg',
+      );
       expect(resolved, isNotNull);
       expect(File(resolved!).existsSync(), isTrue);
     });
 
-    test('percent-encoded 路径解码后解析（与 mangaImageUrl 编码对称）', () {
-      final String? resolved =
-          MangaFushiPage.resolveMangaResource(root.path, 'vol1/p001%2Ejpg');
+    test('BUG-2484：裸路径不解码——含 % 的图名原样解析、不抛', () {
+      File(p.join(root.path, 'vol1', '100%.jpg')).writeAsBytesSync(<int>[1]);
+      final String? resolved = MangaFushiPage.resolveMangaResource(
+        root.path,
+        'vol1/100%.jpg',
+      );
       expect(resolved, isNotNull);
+      expect(p.basename(resolved!), '100%.jpg');
+    });
+
+    test('BUG-2484：形如 %41.jpg 的合法图名不被误解码成 A.jpg', () {
+      File(p.join(root.path, 'vol1', '%41.jpg')).writeAsBytesSync(<int>[1]);
+      File(p.join(root.path, 'vol1', 'A.jpg')).writeAsBytesSync(<int>[2]);
+      final String? resolved = MangaFushiPage.resolveMangaResource(
+        root.path,
+        'vol1/%41.jpg',
+      );
+      expect(resolved, isNotNull);
+      expect(p.basename(resolved!), '%41.jpg');
     });
 
     test('路径穿越被拒（../../ 越出 images 根）', () {
-      final String? resolved =
-          MangaFushiPage.resolveMangaResource(root.path, '../../../etc/passwd');
-      expect(resolved, isNull);
-    });
-
-    test('encoded 穿越同样被拒（%2E%2E%2F）', () {
       final String? resolved = MangaFushiPage.resolveMangaResource(
-          root.path, '%2E%2E%2F%2E%2E%2Fsecret.txt');
+        root.path,
+        '../../../etc/passwd',
+      );
       expect(resolved, isNull);
     });
 
     test('树内缺文件回 null', () {
-      final String? resolved =
-          MangaFushiPage.resolveMangaResource(root.path, 'vol1/missing.jpg');
+      final String? resolved = MangaFushiPage.resolveMangaResource(
+        root.path,
+        'vol1/missing.jpg',
+      );
       expect(resolved, isNull);
     });
   });
@@ -63,7 +78,9 @@ void main() {
 
     test('manga.local 图片 URL 解析到树内文件', () {
       final String? resolved = MangaFushiPage.resolveImageUrlToFile(
-          root.path, 'https://manga.local/img/p001.jpg');
+        root.path,
+        'https://manga.local/img/p001.jpg',
+      );
       expect(resolved, isNotNull);
       final String? customSchemeResolved = MangaFushiPage.resolveImageUrlToFile(
         root.path,
@@ -72,15 +89,60 @@ void main() {
       expect(customSchemeResolved, isNotNull);
     });
 
+    test('percent-encoded 路径在 URL 边界解码（与 mangaImageUrl 编码对称）', () {
+      final String? resolved = MangaFushiPage.resolveImageUrlToFile(
+        root.path,
+        'https://manga.local/img/p001%2Ejpg',
+      );
+      expect(resolved, isNotNull);
+    });
+
+    test('encoded 穿越被拒（%2E%2E%2F）', () {
+      final String? resolved = MangaFushiPage.resolveImageUrlToFile(
+        root.path,
+        'https://manga.local/img/%2E%2E%2F%2E%2E%2Fsecret.txt',
+      );
+      expect(resolved, isNull);
+    });
+
+    test('BUG-2484：含 % 的图名经 mangaImageUrl 编码后能往返解析', () {
+      File(p.join(root.path, 'vol 1', '100%.jpg'))
+        ..createSync(recursive: true)
+        ..writeAsBytesSync(<int>[1]);
+      final String url = MangaFushiPage.mangaImageUrl('images/vol 1/100%.jpg');
+      expect(url, 'https://manga.local/img/vol%201/100%25.jpg');
+      final String? resolved = MangaFushiPage.resolveImageUrlToFile(
+        root.path,
+        url,
+      );
+      expect(resolved, isNotNull);
+      expect(p.basename(resolved!), '100%.jpg');
+    });
+
+    test('BUG-2484：URL 编码非法回 null 而不是抛 ArgumentError', () {
+      expect(MangaFushiPage.decodeMangaImagePath('100%.jpg'), isNull);
+      expect(
+        MangaFushiPage.resolveImageUrlToFile(
+          root.path,
+          'https://manga.local/img/100%.jpg',
+        ),
+        isNull,
+      );
+    });
+
     test('错误 host / 非 img 路径回 null', () {
       expect(
         MangaFushiPage.resolveImageUrlToFile(
-            root.path, 'https://fushi.local/img/p001.jpg'),
+          root.path,
+          'https://fushi.local/img/p001.jpg',
+        ),
         isNull,
       );
       expect(
         MangaFushiPage.resolveImageUrlToFile(
-            root.path, 'https://manga.local/other/p001.jpg'),
+          root.path,
+          'https://manga.local/other/p001.jpg',
+        ),
         isNull,
       );
     });

--- a/fushi/test/pages/manga_path_case_preserved_test.dart
+++ b/fushi/test/pages/manga_path_case_preserved_test.dart
@@ -27,10 +27,9 @@ void main() {
 
   /// 磁盘上真实存在的、相对 [root] 的正斜杠路径集合（大小写原样）。
   Set<String> onDiskEntries() => <String>{
-        for (final FileSystemEntity e in root.listSync(recursive: true))
-          if (e is File)
-            p.relative(e.path, from: root.path).replaceAll('\\', '/'),
-      };
+    for (final FileSystemEntity e in root.listSync(recursive: true))
+      if (e is File) p.relative(e.path, from: root.path).replaceAll('\\', '/'),
+  };
 
   void writeImage(String relative) {
     final File f = File(p.join(root.path, p.joinAll(relative.split('/'))));
@@ -50,14 +49,20 @@ void main() {
   ]) {
     test('解析「$entry」保留真实大小写，与磁盘条目逐字节一致', () {
       writeImage(entry);
-      final String? resolved =
-          MangaFushiPage.resolveMangaResource(root.path, entry);
+      final String? resolved = MangaFushiPage.resolveMangaResource(
+        root.path,
+        entry,
+      );
 
       expect(resolved, isNotNull, reason: '文件真实存在，解析不该返回 null');
-      expect(onDiskEntries(), contains(relOf(resolved!)),
-          reason: '解析出的「${relOf(resolved)}」与磁盘大小写不符 —— 大小写敏感的 '
-              'Android/Linux 上 existsSync 会失败（页图 404、制卡无封面），'
-              '在 Windows 上则让 Anki 封面媒体名被小写化');
+      expect(
+        onDiskEntries(),
+        contains(relOf(resolved!)),
+        reason:
+            '解析出的「${relOf(resolved)}」与磁盘大小写不符 —— 大小写敏感的 '
+            'Android/Linux 上 existsSync 会失败（页图 404、制卡无封面），'
+            '在 Windows 上则让 Anki 封面媒体名被小写化',
+      );
       // 返回值契约：绝对路径（canonicalize 会绝对化，normalize 不会，故实现里
       // 显式补了 p.absolute；这条断言锁住那个补偿别被删掉）。
       expect(p.isAbsolute(resolved), isTrue);
@@ -74,11 +79,12 @@ void main() {
     expect(onDiskEntries(), contains(relOf(resolved!)));
   });
 
-  test('百分号编码的混合大小写条目解码后仍保留大小写', () {
+  test('百分号编码的混合大小写条目在 URL 入口解码后仍保留大小写', () {
     writeImage('Vol 1/P001.JPG');
-    final String? resolved = MangaFushiPage.resolveMangaResource(
+    // 解码只在 URL 边界做（BUG-2484），裸路径入口不认 percent-encoding。
+    final String? resolved = MangaFushiPage.resolveImageUrlToFile(
       root.path,
-      'Vol%201/P001.JPG',
+      'https://manga.local/img/Vol%201/P001.JPG',
     );
     expect(resolved, isNotNull);
     expect(onDiskEntries(), contains(relOf(resolved!)));
@@ -93,7 +99,9 @@ void main() {
       );
       expect(
         MangaFushiPage.resolveMangaResource(
-            root.path, 'Vol1/../../escaped.jpg'),
+          root.path,
+          'Vol1/../../escaped.jpg',
+        ),
         isNull,
       );
     });
@@ -101,15 +109,19 @@ void main() {
     test('大小写不同的 ../ 逃逸也被拒绝（校验侧仍走 canonicalize）', () {
       // 逃逸判定不能因为大小写差异被绕过：即便根目录名大小写写反，
       // 越界校验用的 canonicalize 仍把两侧折平，`../` 照样拦下。
-      final Directory outside =
-          Directory.systemTemp.createTempSync('manga_outside_');
+      final Directory outside = Directory.systemTemp.createTempSync(
+        'manga_outside_',
+      );
       addTearDown(() {
         if (outside.existsSync()) outside.deleteSync(recursive: true);
       });
-      File(p.join(outside.path, 'Secret.JPG'))
-          .writeAsBytesSync(<int>[0xFF, 0xD8]);
-      final String escape =
-          p.relative(p.join(outside.path, 'Secret.JPG'), from: root.path);
+      File(
+        p.join(outside.path, 'Secret.JPG'),
+      ).writeAsBytesSync(<int>[0xFF, 0xD8]);
+      final String escape = p.relative(
+        p.join(outside.path, 'Secret.JPG'),
+        from: root.path,
+      );
       expect(
         MangaFushiPage.resolveMangaResource(root.path, escape),
         isNull,

--- a/packages/fushi_engine/lib/media/manga/manga_storage.dart
+++ b/packages/fushi_engine/lib/media/manga/manga_storage.dart
@@ -101,7 +101,7 @@ class MangaStorage {
       kImagesDirName,
       ...segments.sublist(0, segments.length - 1),
     ];
-    for (int i = 2;; i++) {
+    for (int i = 2; ; i++) {
       candidate = <String>[...prefix, '$stem ($i)$ext'].join('/');
       key = candidate.toLowerCase();
       if (!used.contains(key)) {
@@ -141,6 +141,13 @@ class MangaStorage {
   /// 纯路径解析 + 穿越守卫：[relative] 在 [imagesRoot] 内解析到**存在的**文件时返回
   /// 规范绝对路径（保留磁盘真实大小写），越界或缺文件一律 null。
   ///
+  /// [relative] 是**裸**相对路径（`manga.json` 里 [pageRelativePath] 之后的原样文件
+  /// 名），本层不做任何 percent 解码：解码只属于造过 URL 的那一侧（阅读器 WebView
+  /// 拦截器 / `manga.local` URL 解析）。BUG-2484：此前在这里无条件
+  /// `Uri.decodeComponent`，而五个调用点里三个直接传 `manga.json` 的裸文件名——
+  /// 图名含 `%`（`100%.jpg`）时翻页/选字/制卡三条链全抛
+  /// `Illegal percent encoding`，形如 `%41.jpg` 的合法名还会被静默解码成 `A.jpg`。
+  ///
   /// BUG-1221 的两种路径形式必须并存：越界判定用 `p.canonicalize`（Windows 上整体
   /// 小写化，`../` 逃逸不会被大小写差异绕过），返回值用 `p.absolute` + `p.normalize`
   /// （同样绝对化并折叠 `.`/`..`，但保留大小写——返回值会流出本次读取，被制卡当作
@@ -149,8 +156,7 @@ class MangaStorage {
   /// 归位到本层（原先是阅读器 widget 的静态方法）是因为互联 host 供图必须用**同一条**
   /// 穿越守卫：安全边界靠复制粘贴维持，抄漏一处就是真漏洞。
   static String? resolvePageFilePath(String imagesRoot, String relative) {
-    final String decoded = Uri.decodeComponent(relative);
-    final String joined = p.join(imagesRoot, decoded);
+    final String joined = p.join(imagesRoot, relative);
     if (!p.isWithin(p.canonicalize(imagesRoot), p.canonicalize(joined))) {
       return null;
     }


### PR DESCRIPTION
## 问题

用户错误日志（2.5.2-debug.14696）里 299 次 `Invalid argument(s): Illegal percent encoding in URI`，栈顶 `MangaStorage.resolvePageFilePath` → `Uri.decodeComponent`，入口分别是 `MangaFushi.onTextSelected`（选字制卡，168 次）与 `UncaughtZone`（`MangaTurnQueue` 翻页 / `_updateCurrentPageImagePath`，131 次）。

## 根因（BUG-2484）

`resolvePageFilePath` 无条件 `Uri.decodeComponent(relative)`，但 5 个调用点里只有 WebView 拦截器 `_interceptRequest` 与 `resolveImageUrlToFile` 传的是 `manga.local/img/<已编码>`；`resolveMangaPageImage`、`_updateCurrentPageImagePath`、互联 host `mangaPageFile` 直接传 `manga.json` 的裸文件名。图名含 `%`（如 `100%.jpg`）就抛；形如 `%41.jpg` 的合法名还会被静默解码成 `A.jpg` 后 404。

## 修法

解码只在 URL 边界做一次（新增 `MangaFushiPage.decodeMangaImagePath`，非法编码 → null/404 而不是掀翻拦截器），`resolvePageFilePath` 只吃裸相对路径，与 `mangaImageUrl` 的逐段 `encodeComponent` 对称。拦截器 403/404 分支同步改用已解码路径。

## 验证

- `flutter analyze` 无问题
- `flutter test test/pages/manga_interceptor_test.dart test/pages/manga_path_case_preserved_test.dart test/pages/manga_mining_cover_test.dart`：24/24 绿（新增裸 `%` 直解、`%41.jpg` 不误解码、`mangaImageUrl → resolveImageUrlToFile` 往返、非法编码回 null 四条；两条按旧契约写的 percent 用例改到 URL 入口）
- `bugs_per_file_guard_test` 绿，`dart run tool/bug.dart check` 无撞号

https://claude.ai/code/session_01CLjqvReAsTCTS9BpYEzQJL
