### PR TITLE
feat(mining): sentence audio head/tail padding settings (asbplayer-style)

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 80971 (4763 per locale)
+/// Strings: 81056 (4768 per locale)
 ///
-/// Built on 2026-09-12 at 10:42 UTC
+/// Built on 2026-09-12 at 11:41 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6639,6 +6639,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get backup_category_games => 'Games';
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -17869,6 +17876,18 @@ class _StringsAr extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -29325,6 +29344,18 @@ class _StringsDe extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -40835,6 +40866,18 @@ class _StringsEs extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -52378,6 +52421,18 @@ class _StringsFr extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -63725,6 +63780,18 @@ class _StringsId extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -75163,6 +75230,18 @@ class _StringsIt extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -85983,6 +86062,18 @@ class _StringsJa extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -96813,6 +96904,18 @@ class _StringsKo extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -108209,6 +108312,18 @@ class _StringsNl extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -119658,6 +119773,18 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -131084,6 +131211,18 @@ class _StringsRu extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -142311,6 +142450,18 @@ class _StringsTh extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -153653,6 +153804,18 @@ class _StringsTr extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -164965,6 +165128,18 @@ class _StringsVi extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 // Path: <root>
@@ -175345,6 +175520,16 @@ class _StringsZhCn extends _StringsEn {
   String get backup_category_games => '游戏';
   @override
   String get backup_category_games_desc => '游戏库、元数据来源与封面';
+  @override
+  String get mining_audio_head_pad => '句子音频开头余量';
+  @override
+  String get mining_audio_head_pad_hint => '字幕开始前多保留这么多音频，避免首音被切掉；不会越过上一句。';
+  @override
+  String get mining_audio_tail_pad => '句子音频结尾余量';
+  @override
+  String get mining_audio_tail_pad_hint => '字幕结束后多保留这么多音频，避免句尾被切短；不会越过下一句。';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} 毫秒';
 }
 
 // Path: <root>
@@ -185849,6 +186034,18 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get backup_category_games_desc =>
       'Game library, metadata sources and covers';
+  @override
+  String get mining_audio_head_pad => 'Audio padding before sentence';
+  @override
+  String get mining_audio_head_pad_hint =>
+      'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+  @override
+  String get mining_audio_tail_pad => 'Audio padding after sentence';
+  @override
+  String get mining_audio_tail_pad_hint =>
+      'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+  @override
+  String mining_audio_pad_readout({required Object ms}) => '${ms} ms';
 }
 
 /// Flat map(s) containing all translations.
@@ -195674,6 +195871,16 @@ extension on _StringsEn {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -205494,6 +205701,16 @@ extension on _StringsAr {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -215359,6 +215576,16 @@ extension on _StringsDe {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -225215,6 +225442,16 @@ extension on _StringsEs {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -235080,6 +235317,16 @@ extension on _StringsFr {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -244916,6 +245163,16 @@ extension on _StringsId {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -254774,6 +255031,16 @@ extension on _StringsIt {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -264559,6 +264826,16 @@ extension on _StringsJa {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -274348,6 +274625,16 @@ extension on _StringsKo {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -284199,6 +284486,16 @@ extension on _StringsNl {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -294045,6 +294342,16 @@ extension on _StringsPtBr {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -303898,6 +304205,16 @@ extension on _StringsRu {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -313723,6 +314040,16 @@ extension on _StringsTh {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -323563,6 +323890,16 @@ extension on _StringsTr {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -333397,6 +333734,16 @@ extension on _StringsVi {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }
@@ -343142,6 +343489,16 @@ extension on _StringsZhCn {
         return '游戏';
       case 'backup_category_games_desc':
         return '游戏库、元数据来源与封面';
+      case 'mining_audio_head_pad':
+        return '句子音频开头余量';
+      case 'mining_audio_head_pad_hint':
+        return '字幕开始前多保留这么多音频，避免首音被切掉；不会越过上一句。';
+      case 'mining_audio_tail_pad':
+        return '句子音频结尾余量';
+      case 'mining_audio_tail_pad_hint':
+        return '字幕结束后多保留这么多音频，避免句尾被切短；不会越过下一句。';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} 毫秒';
       default:
         return null;
     }
@@ -352905,6 +353262,16 @@ extension on _StringsZhHk {
         return 'Games';
       case 'backup_category_games_desc':
         return 'Game library, metadata sources and covers';
+      case 'mining_audio_head_pad':
+        return 'Audio padding before sentence';
+      case 'mining_audio_head_pad_hint':
+        return 'Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.';
+      case 'mining_audio_tail_pad':
+        return 'Audio padding after sentence';
+      case 'mining_audio_tail_pad_hint':
+        return 'Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.';
+      case 'mining_audio_pad_readout':
+        return ({required Object ms}) => '${ms} ms';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "显示识别范围",
   "remote_manga_added_to_shelf": "已加入漫画书架，章节从对端下载",
   "backup_category_games": "游戏",
-  "backup_category_games_desc": "游戏库、元数据来源与封面"
+  "backup_category_games_desc": "游戏库、元数据来源与封面",
+  "mining_audio_head_pad": "句子音频开头余量",
+  "mining_audio_head_pad_hint": "字幕开始前多保留这么多音频，避免首音被切掉；不会越过上一句。",
+  "mining_audio_tail_pad": "句子音频结尾余量",
+  "mining_audio_tail_pad_hint": "字幕结束后多保留这么多音频，避免句尾被切短；不会越过下一句。",
+  "mining_audio_pad_readout": "${ms} 毫秒"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4761,5 +4761,10 @@
   "manga_ocr_boxes_toggle": "Show recognized text regions",
   "remote_manga_added_to_shelf": "Added to the manga shelf; chapters download from the peer",
   "backup_category_games": "Games",
-  "backup_category_games_desc": "Game library, metadata sources and covers"
+  "backup_category_games_desc": "Game library, metadata sources and covers",
+  "mining_audio_head_pad": "Audio padding before sentence",
+  "mining_audio_head_pad_hint": "Extra audio kept before the subtitle starts, so the first syllable is not clipped. Never runs into the previous line.",
+  "mining_audio_tail_pad": "Audio padding after sentence",
+  "mining_audio_tail_pad_hint": "Extra audio kept after the subtitle ends, so trailing sounds are not cut short. Never runs into the next line.",
+  "mining_audio_pad_readout": "${ms} ms"
 }

--- a/fushi/lib/src/media/audiobook/mining_audio_clip.dart
+++ b/fushi/lib/src/media/audiobook/mining_audio_clip.dart
@@ -7,8 +7,9 @@ import 'package:fushi_audio/fushi_audio.dart';
 /// Human speech onset (attack of the first mora) is short, so a small lead-in is
 /// enough to keep the very first sound from being clipped. Kept intentionally
 /// smaller than [kMiningTailPadMs] because a long head easily bleeds the previous
-/// sentence's tail into the clip. Phase 0: a constant (not yet a setting) so the
-/// intent and the value stay in one place.
+/// sentence's tail into the clip. This is the DEFAULT of the user preference
+/// `mining_audio_head_pad_ms` (PreferencesRepository.miningAudioHeadPadMs); the
+/// value lives here so the default and the padding logic stay in one place.
 const int kMiningHeadPadMs = 120;
 
 /// Default tail padding (ms) appended to a mining audio clip.
@@ -16,8 +17,15 @@ const int kMiningHeadPadMs = 120;
 /// Sentence endings decay slowly (trailing vowels, particles, breath), so the
 /// tail needs more room than the head to avoid a hard cut that swallows the final
 /// mora. Larger than [kMiningHeadPadMs] for that reason. Clamped against the next
-/// same-file cue so it never bleeds the following sentence's onset in.
+/// same-file cue so it never bleeds the following sentence's onset in. DEFAULT of
+/// the user preference `mining_audio_tail_pad_ms`.
 const int kMiningTailPadMs = 200;
+
+/// Upper bound (ms) for either padding edge, shared by the preference clamp and
+/// the settings slider so the two cannot drift apart. One second is already far
+/// past any realistic onset/decay; the neighbouring-cue clamp in
+/// [padSentenceRange] bounds it further in practice.
+const int kMiningPadMaxMs = 1000;
 
 /// Resolves the audio range used when exporting sentence audio for Anki.
 ///
@@ -25,7 +33,9 @@ const int kMiningTailPadMs = 200;
 /// the reader's full normalized sentence range; when that is unavailable, match
 /// Hoshi Android's behavior by expanding to adjacent cues whose text belongs to
 /// the selected sentence. [delayMs] is the user's global A/V sync offset and is
-/// applied to both edges, not as a sentence-tail padding.
+/// applied to both edges, not as a sentence-tail padding. [headPadMs] /
+/// [tailPadMs] are the user's clip padding preferences (defaults = the Phase 0
+/// constants); see [padSentenceRange] for how they are clamped.
 ///
 /// [cue] is the cue the looked-up word fell inside. It can be null: audiobook
 /// cue alignment leaves gaps (titles, captions, alignment misses, chapter
@@ -43,6 +53,8 @@ AudioPlaybackRange? miningSentenceAudioRange({
   int? sentenceNormCharOffset,
   int? sentenceNormCharLength,
   int delayMs = 0,
+  int headPadMs = kMiningHeadPadMs,
+  int tailPadMs = kMiningTailPadMs,
 }) {
   final AudioPlaybackRange? positionRange = _rangeFromSentencePosition(
     cues: cues,
@@ -89,8 +101,8 @@ AudioPlaybackRange? miningSentenceAudioRange({
   final AudioPlaybackRange paddedRange = padSentenceRange(
     positiveRange,
     cues: cues,
-    headPadMs: kMiningHeadPadMs,
-    tailPadMs: kMiningTailPadMs,
+    headPadMs: headPadMs,
+    tailPadMs: tailPadMs,
   );
   return _shiftRange(paddedRange, delayMs);
 }

--- a/fushi/lib/src/mining/immersion_mining_engine.dart
+++ b/fushi/lib/src/mining/immersion_mining_engine.dart
@@ -422,7 +422,8 @@ class ImmersionMiningEngine {
             _frame(
           inputPath: src,
           outputPath: '$tempDir/immersion_frame.${attempt.fileExtension}',
-          atSeconds: req.clipStartMs / 1000.0,
+          // 静态帧锚点与音频窗起点分离：窗起点含用户头 padding，封面不该跟着往前。
+          atSeconds: req.stillFrameAnchorMs / 1000.0,
           // 由收口原语决定这次尝试要不要报告（能力探测那次是 null）。
           onFailure: onFailure,
           tlsPinSha256: req.mediaSourceTlsPinSha256,

--- a/fushi/lib/src/models/app_model.dart
+++ b/fushi/lib/src/models/app_model.dart
@@ -7060,6 +7060,12 @@ class AppModel with ChangeNotifier {
   void setGalMiningStillFormat(MiningStillFormat format) =>
       prefsRepo.setGalMiningStillFormat(format);
 
+  /// 制卡句子音频头/尾 padding（毫秒），视频字幕与有声书两条制卡链共用。
+  int get miningAudioHeadPadMs => prefsRepo.miningAudioHeadPadMs;
+  void setMiningAudioHeadPadMs(int ms) => prefsRepo.setMiningAudioHeadPadMs(ms);
+  int get miningAudioTailPadMs => prefsRepo.miningAudioTailPadMs;
+  void setMiningAudioTailPadMs(int ms) => prefsRepo.setMiningAudioTailPadMs(ms);
+
   bool get deduplicatePitchAccents => prefsRepo.deduplicatePitchAccents;
   void toggleDeduplicatePitchAccents() =>
       prefsRepo.toggleDeduplicatePitchAccents();

--- a/fushi/lib/src/models/preferences_repository.dart
+++ b/fushi/lib/src/models/preferences_repository.dart
@@ -27,6 +27,8 @@ import 'package:fushi/src/media/video/video_custom_action_bindings.dart';
 import 'package:fushi/src/media/video/video_immersive_mode.dart';
 import 'package:fushi/src/media/video/video_lua_capability.dart';
 import 'package:fushi/src/media/video/video_subtitle_obscure_mode.dart';
+import 'package:fushi/src/media/audiobook/mining_audio_clip.dart'
+    show kMiningHeadPadMs, kMiningPadMaxMs, kMiningTailPadMs;
 import 'package:fushi/src/mining/galgame_library.dart';
 // 迁移判据要用「这个存量代理地址归一得出来吗」，与 applyAppProxy 同一份实现，
 // 不在这里重写一遍（重写就会漂移，而漂移的后果是存量用户升级即断网）。
@@ -1809,6 +1811,32 @@ class PreferencesRepository extends ChangeNotifier implements PrefStore {
 
   void setGalMiningAnimatedFormat(MiningAnimatedFormat format) async {
     await setPref('gal_mining_animated_format', format.wireName);
+    notifyListeners();
+  }
+
+  // 制卡句子音频的头/尾 padding（毫秒）。对齐 asbplayer 的 audio padding：字幕 cue 的
+  // 时间窗通常比实际发声短，尾音/助词/呼吸直接被硬切。视频字幕与有声书两条制卡链共用
+  // 这一对值（同一个人听同一种语言，句首/句尾余量的需求不随媒体种类变），裁剪时都走
+  // [padSentenceRange] 夹相邻 cue 边界，所以填大了也不会把下一句混进来。
+  // 默认值 = 原有声书硬编码常量（头 120 / 尾 200，[kMiningHeadPadMs]/[kMiningTailPadMs]），
+  // 有声书用户行为零变化；视频链此前完全没 padding，默认即获得余量。
+  int get miningAudioHeadPadMs =>
+      (getPref('mining_audio_head_pad_ms', defaultValue: kMiningHeadPadMs)
+              as int)
+          .clamp(0, kMiningPadMaxMs);
+
+  void setMiningAudioHeadPadMs(int ms) async {
+    await setPref('mining_audio_head_pad_ms', ms.clamp(0, kMiningPadMaxMs));
+    notifyListeners();
+  }
+
+  int get miningAudioTailPadMs =>
+      (getPref('mining_audio_tail_pad_ms', defaultValue: kMiningTailPadMs)
+              as int)
+          .clamp(0, kMiningPadMaxMs);
+
+  void setMiningAudioTailPadMs(int ms) async {
+    await setPref('mining_audio_tail_pad_ms', ms.clamp(0, kMiningPadMaxMs));
     notifyListeners();
   }
 

--- a/fushi/lib/src/pages/implementations/anki_settings_page.dart
+++ b/fushi/lib/src/pages/implementations/anki_settings_page.dart
@@ -17,6 +17,8 @@ import 'package:fushi/src/anki/anki_config_controls.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/anki/ankiconnect_port_repair.dart';
 import 'package:fushi/src/anki/lapis_template_service.dart';
+import 'package:fushi/src/media/audiobook/mining_audio_clip.dart'
+    show kMiningPadMaxMs;
 import 'package:fushi_engine/mining/immersion_mining_request.dart'
     show MiningAnimatedFormat, MiningStillFormat, VideoMiningImageMode;
 import 'package:fushi/src/platform/platform_providers.dart';
@@ -590,6 +592,26 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           child: _buildMiningAudioQualityRow(),
         ),
         SettingsSearchTarget(
+          id: 'card_creation.anki.mining_audio_head_pad',
+          child: _buildMiningAudioPadRow(
+            title: t.mining_audio_head_pad,
+            subtitle: t.mining_audio_head_pad_hint,
+            icon: Icons.first_page,
+            value: appModel.miningAudioHeadPadMs,
+            onChanged: appModel.setMiningAudioHeadPadMs,
+          ),
+        ),
+        SettingsSearchTarget(
+          id: 'card_creation.anki.mining_audio_tail_pad',
+          child: _buildMiningAudioPadRow(
+            title: t.mining_audio_tail_pad,
+            subtitle: t.mining_audio_tail_pad_hint,
+            icon: Icons.last_page,
+            value: appModel.miningAudioTailPadMs,
+            onChanged: appModel.setMiningAudioTailPadMs,
+          ),
+        ),
+        SettingsSearchTarget(
           id: 'card_creation.anki.video_mining_image_mode',
           child: _buildVideoMiningImageModePicker(),
         ),
@@ -675,6 +697,38 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       readout: labels[tier],
       onChanged: (double value) {
         appModel.setMiningAudioQuality(value.round());
+        setState(() {});
+      },
+    );
+  }
+
+  /// 制卡句子音频头/尾 padding 滑块（对齐 asbplayer 的 audio padding）。0..[kMiningPadMaxMs]
+  /// 毫秒、步进 50；透传 [AppModel.miningAudioHeadPadMs] / [miningAudioTailPadMs]，视频字幕与
+  /// 有声书两条制卡链共用。实际裁剪时还会夹在相邻 cue 边界内（[padSentenceRange]），所以填
+  /// 大了也不会把邻句混进来——hint 文案即由此而来。
+  Widget _buildMiningAudioPadRow({
+    required String title,
+    required String subtitle,
+    required IconData icon,
+    required int value,
+    required void Function(int ms) onChanged,
+  }) {
+    const int step = 50;
+    final int clamped = value.clamp(0, kMiningPadMaxMs);
+    final String readout = t.mining_audio_pad_readout(ms: clamped);
+    return AdaptiveSettingsSliderRow(
+      title: title,
+      subtitle: subtitle,
+      icon: icon,
+      value: clamped.toDouble(),
+      min: 0,
+      max: kMiningPadMaxMs.toDouble(),
+      divisions: kMiningPadMaxMs ~/ step,
+      step: step.toDouble(),
+      label: readout,
+      readout: readout,
+      onChanged: (double v) {
+        onChanged((v / step).round() * step);
         setState(() {});
       },
     );
@@ -1450,8 +1504,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           ? t.anki_reposition_auto_hint
           : t.anki_reposition_unsupported,
       value: supported && settings.autoRepositionEnabled,
-      onChanged:
-          supported ? (bool v) => vm.setAutoRepositionEnabled(v) : null,
+      onChanged: supported ? (bool v) => vm.setAutoRepositionEnabled(v) : null,
     );
   }
 

--- a/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
@@ -1126,6 +1126,8 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
       sentenceNormCharOffset: normOffset,
       sentenceNormCharLength: normLength,
       delayMs: audioController?.delayMs.value ?? 0,
+      headPadMs: appModel.miningAudioHeadPadMs,
+      tailPadMs: appModel.miningAudioTailPadMs,
     );
     if (clip == null ||
         clip.audioFileIndex < 0 ||

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -131,11 +131,25 @@ extension _VideoLookupMining on _VideoFushiPageState {
     // 按锚定 cue 所属流取轴（查副字幕词制卡时用副轨生效轴；无 cue 回落有效流轴）。
     final int clipDelayMs =
         cue == null ? controller.miningDelayMs : controller.delayMsForCue(cue);
+    // 头/尾 padding（用户偏好，对齐 asbplayer）：字幕 cue 的时间窗通常比实际发声短，
+    // 尾音直接被硬切。与有声书制卡共用 [padSentenceRange]：在字幕文件时基（未加
+    // delay）上加 padding，并夹在锚定 cue 所属流的相邻 cue 边界内，不把邻句混进来；
+    // 之后再整体逆变换回播放器轴（先 pad 再 shift，与有声书链同序）。非正区间（无
+    // cue → `0..0`）不 pad——那是下游「不抽媒体」的哨兵，pad 了会把哨兵变成真区间。
+    final AudioPlaybackRange? paddedRange =
+        (mergedRange == null || mergedRange.endMs <= mergedRange.startMs)
+            ? mergedRange
+            : padSentenceRange(
+                mergedRange,
+                cues: cue == null
+                    ? controller.miningCues
+                    : controller.cueStreamOwning(cue),
+                headPadMs: appModel.miningAudioHeadPadMs,
+                tailPadMs: appModel.miningAudioTailPadMs,
+              );
     return (
-      clipStartMs: miningClipTimeMs(
-          mergedRange?.startMs ?? cue?.startMs ?? 0, clipDelayMs),
-      clipEndMs:
-          miningClipTimeMs(mergedRange?.endMs ?? cue?.endMs ?? 0, clipDelayMs),
+      clipStartMs: miningClipTimeMs(paddedRange?.startMs ?? 0, clipDelayMs),
+      clipEndMs: miningClipTimeMs(paddedRange?.endMs ?? 0, clipDelayMs),
       // 多句时 cueSentence 用合并文本与 sentence 一致；草稿空时退回单 cue 文本作 fallback。
       cueSentence: _miningDraft.isEmpty ? cue?.text : mergedSentence,
       sentence: mergedSentence,

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -97,6 +97,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
   ({
     int clipStartMs,
     int clipEndMs,
+    int stillFrameAtMs,
     String sentence,
     String? cueSentence,
   }) _resolveVideoMiningRange(VideoPlayerController controller) {
@@ -150,6 +151,9 @@ extension _VideoLookupMining on _VideoFushiPageState {
     return (
       clipStartMs: miningClipTimeMs(paddedRange?.startMs ?? 0, clipDelayMs),
       clipEndMs: miningClipTimeMs(paddedRange?.endMs ?? 0, clipDelayMs),
+      // 「字幕起始帧」封面锚点用**未 pad** 的字幕起点（同一逆变换）：封面承诺的是字幕
+      // 开始那一刻的画面，不能跟着音频头 padding 往前退到上一个镜头。
+      stillFrameAtMs: miningClipTimeMs(mergedRange?.startMs ?? 0, clipDelayMs),
       // 多句时 cueSentence 用合并文本与 sentence 一致；草稿空时退回单 cue 文本作 fallback。
       cueSentence: _miningDraft.isEmpty ? cue?.text : mergedSentence,
       sentence: mergedSentence,
@@ -163,6 +167,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
     final ({
       int clipStartMs,
       int clipEndMs,
+      int stillFrameAtMs,
       String sentence,
       String? cueSentence,
     }) range = _resolveVideoMiningRange(controller);
@@ -185,6 +190,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
       // 音频/封面区间 = 合并后的首句起→末句止（单句即该 cue 时间窗，两端相等→不抽）。
       clipStartMs: range.clipStartMs,
       clipEndMs: range.clipEndMs,
+      stillFrameAtMs: range.stillFrameAtMs,
       sentence: range.sentence,
       cueSentence: range.cueSentence,
     );
@@ -213,6 +219,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
     final ({
       int clipStartMs,
       int clipEndMs,
+      int stillFrameAtMs,
       String sentence,
       String? cueSentence,
     }) range = _resolveVideoMiningRange(controller);
@@ -222,6 +229,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
       fields: fields,
       clipStartMs: range.clipStartMs,
       clipEndMs: range.clipEndMs,
+      stillFrameAtMs: range.stillFrameAtMs,
       sentence: range.sentence,
       cueSentence: range.cueSentence,
       updateNoteId: noteId,
@@ -253,6 +261,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
     required Map<String, String> fields,
     required int clipStartMs,
     required int clipEndMs,
+    required int stillFrameAtMs,
     required String sentence,
     String? cueSentence,
     int? updateNoteId,
@@ -380,6 +389,7 @@ extension _VideoLookupMining on _VideoFushiPageState {
         remoteAudioClipper: remoteAudioClipper,
         clipStartMs: clipStartMs,
         clipEndMs: clipEndMs,
+        stillFrameAtMs: stillFrameAtMs,
         sentence: sentence,
         cueSentence: cueSentence,
         // TODO-761（方案 B）：播放列表下拼「系列名 - 剧集名」，单视频/远端仍是剧集名，零变化。

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -25,6 +25,8 @@ import 'package:window_manager/window_manager.dart';
 import 'package:fushi/i18n/strings.g.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/storage/app_paths.dart';
+import 'package:fushi/src/media/audiobook/mining_audio_clip.dart'
+    show padSentenceRange;
 import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:fushi/src/media/sources/reader_fushi_source.dart';
 import 'package:fushi_engine/media/tracking/media_tracking_service.dart'

--- a/fushi/lib/src/settings/settings_schema_card_creation.dart
+++ b/fushi/lib/src/settings/settings_schema_card_creation.dart
@@ -345,6 +345,18 @@ SettingsDestination _buildAnkiPanel(AnkiSettingsPanel panel, String title) {
           subtitle: t.mining_audio_quality_hint,
         ),
         SettingsBodySearchEntry(
+          id: 'card_creation.anki.mining_audio_head_pad',
+          hasRevealTarget: true,
+          title: t.mining_audio_head_pad,
+          subtitle: t.mining_audio_head_pad_hint,
+        ),
+        SettingsBodySearchEntry(
+          id: 'card_creation.anki.mining_audio_tail_pad',
+          hasRevealTarget: true,
+          title: t.mining_audio_tail_pad,
+          subtitle: t.mining_audio_tail_pad_hint,
+        ),
+        SettingsBodySearchEntry(
           id: 'card_creation.anki.video_mining_image_mode',
           hasRevealTarget: true,
           title: t.video_mining_image_mode,

--- a/fushi/test/pages/video_controls_customization_guard_test.dart
+++ b/fushi/test/pages/video_controls_customization_guard_test.dart
@@ -392,12 +392,13 @@ void main() {
         contains(
             '}) _resolveVideoMiningRange(VideoPlayerController controller) {'));
     // TODO-680/BUG-392：两端点在裁音频/封面前都经 miningClipTimeMs(...clipDelayMs)
-    // 逆变换回播放器轴（dart format 会把 clipEndMs 的调用换行，故按实参锚定）。
+    // 逆变换回播放器轴；输入是已加头/尾 padding 的 paddedRange（先 pad 再 shift，
+    // 夹边界/偏好接线由 test/settings/mining_audio_padding_guard_test.dart 守）。
     expect(page, contains('miningClipTimeMs('));
     expect(page,
-        contains('mergedRange?.startMs ?? cue?.startMs ?? 0, clipDelayMs)'));
+        contains('miningClipTimeMs(paddedRange?.startMs ?? 0, clipDelayMs)'));
     expect(
-        page, contains('mergedRange?.endMs ?? cue?.endMs ?? 0, clipDelayMs)'));
+        page, contains('miningClipTimeMs(paddedRange?.endMs ?? 0, clipDelayMs)'));
     expect(page, contains('_lastLookupCue ??'));
     expect(page, contains('_mineVideoCard('));
     // TODO-270 D：清草稿以「制卡成功」信号 result.ankiConnect 为判据（两后端成功时都

--- a/fushi/test/pages/video_mining_context_guard_test.dart
+++ b/fushi/test/pages/video_mining_context_guard_test.dart
@@ -288,12 +288,14 @@ void main() {
     // miningClipTimeMs 逆变换回播放器轴的目标毫秒），降级帧必须用同一个 cue 时间从视频
     // 文件抽，才与例句对齐。
     // TODO-1000: 降级阶梯搬进沉浸引擎：GIF -> cue 时间抽单帧(_frame) -> stillFallback
-    // (shell 传 controller.screenshot) 最后兜底。cue 抽帧的取帧时间 = req.clipStartMs/1000。
+    // (shell 传 controller.screenshot) 最后兜底。cue 抽帧的取帧时间 = req.stillFrameAnchorMs
+    // /1000：视频链传**未 pad** 的字幕起点（音频窗起点含用户头 padding，封面不跟着往前退，
+    // 见 test/settings/mining_audio_padding_guard_test.dart）；不传时回落 clipStartMs。
     final String engineNorm = engine.replaceAll(RegExp(r'\s+'), ' ');
     expect(engine, contains('extractVideoFrameViaFfmpeg'),
         reason: 'GIF 不可用时须按 cue 时间从视频文件抽单帧（而非截当前解码帧）。');
-    expect(engineNorm, contains('atSeconds: req.clipStartMs / 1000.0'),
-        reason: '降级帧的取帧时间必须 = clipStartMs（与 GIF 主路径同一播放器轴坐标）。');
+    expect(engineNorm, contains('atSeconds: req.stillFrameAnchorMs / 1000.0'),
+        reason: '降级帧的取帧时间必须 = 字幕起点锚（与 GIF 主路径同一播放器轴坐标）。');
     // shell 在点击时立即启动当前帧截图，并把冻结的 Future 作为最后兜底喂进引擎；
     // 不能等任务真正出队后再读 controller，否则换集/销毁会截错或访问已释放播放器。
     final String mineCard = region(
@@ -305,7 +307,7 @@ void main() {
 
     // 引擎里：cue 抽帧(_frame) 必须排在 stillFallback（当前解码帧）之前——有区间时优先按
     // cue 取帧，截当前帧只能是 cue 抽帧也失败/无区间后的最后兜底。
-    final int frameIdx = engineNorm.indexOf('atSeconds: req.clipStartMs');
+    final int frameIdx = engineNorm.indexOf('atSeconds: req.stillFrameAnchorMs');
     final int stillIdx = engineNorm.indexOf('req.stillFallback!()');
     expect(frameIdx, greaterThanOrEqualTo(0));
     expect(stillIdx, greaterThan(frameIdx),

--- a/fushi/test/pages/video_mining_context_guard_test.dart
+++ b/fushi/test/pages/video_mining_context_guard_test.dart
@@ -90,11 +90,14 @@ void main() {
     expect(resolve, contains('controller.currentCue ??'));
     expect(resolve, contains('resolveMiningCueForPosition('),
         reason: 'currentCue 为空（gap/末句后）时须按位置解析，制卡才有句子音频。');
-    // 制卡区间 = 合并后的首句起→末句止（单句即该 cue 时间窗）；草稿空时退回单 cue 起止。
-    expect(resolve, contains('mergedRange?.startMs ?? cue?.startMs ?? 0'),
-        reason: '制卡音频/封面区间起点 = 合并区间起点（单句即该 cue 的 startMs）。');
-    expect(resolve, contains('mergedRange?.endMs ?? cue?.endMs ?? 0'),
-        reason: '制卡音频/封面区间终点 = 合并区间终点（单句即该 cue 的 endMs）。');
+    // 制卡区间 = 合并后的首句起→末句止（单句即该 cue 时间窗）再加用户头/尾 padding
+    // （padSentenceRange 夹相邻 cue 边界）；无 cue 且草稿空时 mergedRange 为 null → 0..0。
+    expect(resolve, contains('padSentenceRange('),
+        reason: '制卡区间必须经头/尾 padding（与有声书链同一函数）。');
+    expect(resolve, contains('miningClipTimeMs(paddedRange?.startMs ?? 0'),
+        reason: '制卡音频/封面区间起点 = 加 padding 后的合并区间起点。');
+    expect(resolve, contains('miningClipTimeMs(paddedRange?.endMs ?? 0'),
+        reason: '制卡音频/封面区间终点 = 加 padding 后的合并区间终点。');
 
     // onMineEntry 把解析结果喂给落卡链路 _mineVideoCard（单句/多句同一出口）。
     // TODO-590 batch14: onMineEntry 体搬进 part 的 `_onMineEntryImpl`；end marker

--- a/fushi/test/settings/mining_audio_padding_guard_test.dart
+++ b/fushi/test/settings/mining_audio_padding_guard_test.dart
@@ -5,6 +5,9 @@ import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/src/media/audiobook/mining_audio_clip.dart';
 import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi_anki/fushi_anki_core.dart' show AnkiMiningSource;
+import 'package:fushi_engine/mining/immersion_mining_request.dart'
+    show ImmersionMiningRequest;
 import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi_core/fushi_core.dart';
 
@@ -165,6 +168,54 @@ void main() {
         src,
         isNot(contains('mergedRange?.startMs ?? cue?.startMs')),
         reason: '旧的未 pad 区间不能再直接进 shift',
+      );
+    });
+
+    test('「字幕起始帧」封面锚点用未 pad 的字幕起点，不跟音频头 padding 往前退', () {
+      // 审查 M1：clipStartMs 同时是音频窗起点与 subtitleStart 静态帧取帧时刻；pad 后
+      // 封面会抽到字幕开始前那一帧（切镜处 = 上一个镜头）。锚点必须独立成字段。
+      final String src = File(
+        'lib/src/pages/implementations/video_fushi/lookup_mining.part.dart',
+      ).readAsStringSync();
+      expect(
+        src,
+        contains(
+          'stillFrameAtMs: miningClipTimeMs(mergedRange?.startMs ?? 0, clipDelayMs)',
+        ),
+        reason: '锚点 = 未 pad 的合并区间起点，经同一 A/V 逆变换',
+      );
+      expect(
+        src,
+        contains('stillFrameAtMs: stillFrameAtMs,'),
+        reason: '锚点必须真的进 ImmersionMiningRequest',
+      );
+
+      final String engine = File(
+        'lib/src/mining/immersion_mining_engine.dart',
+      ).readAsStringSync();
+      expect(engine, contains('atSeconds: req.stillFrameAnchorMs / 1000.0'));
+      expect(
+        engine,
+        isNot(contains('atSeconds: req.clipStartMs / 1000.0')),
+        reason: '静态帧不能再直接取音频窗起点',
+      );
+    });
+
+    test('ImmersionMiningRequest.stillFrameAnchorMs：不传回落窗起点、frozen 保留', () {
+      ImmersionMiningRequest req({int? still}) => ImmersionMiningRequest(
+        fields: const <String, String>{},
+        clipStartMs: 4880,
+        clipEndMs: 6400,
+        stillFrameAtMs: still,
+        sentence: 'は',
+        source: AnkiMiningSource.video,
+      );
+      expect(req().stillFrameAnchorMs, 4880, reason: '其它来源不传 = 原行为');
+      expect(req(still: 5000).stillFrameAnchorMs, 5000);
+      expect(
+        req(still: 5000).frozen().stillFrameAnchorMs,
+        5000,
+        reason: '入队冻结不能丢锚点',
       );
     });
 

--- a/fushi/test/settings/mining_audio_padding_guard_test.dart
+++ b/fushi/test/settings/mining_audio_padding_guard_test.dart
@@ -1,0 +1,213 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/audiobook/mining_audio_clip.dart';
+import 'package:fushi/src/models/preferences_repository.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_core/fushi_core.dart';
+
+/// 制卡句子音频头/尾 padding 设置（对齐 asbplayer 的 audio padding）守卫。
+///
+/// 锁住四层契约（不依赖真机 / ffmpeg）：
+/// 1. 偏好默认 = 原有声书硬编码常量（头 120 / 尾 200，Never break userspace）+ 写穿
+///    Drift + 越界夹到 `0..kMiningPadMaxMs`；
+/// 2. [miningSentenceAudioRange] 把偏好值透传给 [padSentenceRange]（默认参数 = 常量，
+///    既有调用方签名零变化）；
+/// 3. 视频字幕制卡路径用同一个 [padSentenceRange]、喂偏好值、夹锚定 cue 所属流、
+///    **先 pad 再 shift**（与有声书链同序）；有声书路径喂偏好值；
+/// 4. Anki 设置页有两个滑块行 + 搜索条目，wire 到 AppModel 的 getter/setter，滑块上限与
+///    偏好 clamp 共用 [kMiningPadMaxMs]。
+
+FushiDatabase _testDb() {
+  return FushiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+}
+
+AudioCue _cue({required int startMs, required int endMs, String text = 'x'}) {
+  return AudioCue()
+    ..bookKey = 'book'
+    ..chapterHref = 'chapter.xhtml'
+    ..sentenceIndex = 0
+    ..textFragmentId = '#s0'
+    ..text = text
+    ..startMs = startMs
+    ..endMs = endMs
+    ..audioFileIndex = 0;
+}
+
+void main() {
+  group('偏好层', () {
+    late FushiDatabase db;
+    late PreferencesRepository repo;
+
+    setUp(() async {
+      db = _testDb();
+      repo = PreferencesRepository(db);
+      await repo.loadFromDb();
+    });
+
+    tearDown(() async {
+      repo.dispose();
+      await db.close();
+    });
+
+    test('默认 = 原有声书硬编码常量（头 120 / 尾 200）', () {
+      expect(repo.miningAudioHeadPadMs, kMiningHeadPadMs);
+      expect(repo.miningAudioTailPadMs, kMiningTailPadMs);
+      expect(kMiningHeadPadMs, 120, reason: '默认值改了就是行为变更，必须有意');
+      expect(kMiningTailPadMs, 200, reason: '默认值改了就是行为变更，必须有意');
+    });
+
+    test('setMiningAudioHeadPadMs 写穿 Drift（往返 + DB key + 越界夹取）', () async {
+      repo.setMiningAudioHeadPadMs(300);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(repo.miningAudioHeadPadMs, 300);
+
+      final PreferencesRepository restored = PreferencesRepository(db);
+      await restored.loadFromDb();
+      expect(restored.miningAudioHeadPadMs, 300, reason: '设过必须落盘且跨实例可见');
+      final Map<String, String> prefs = await db.getAllPrefs();
+      expect(
+        prefs.containsKey('mining_audio_head_pad_ms'),
+        isTrue,
+        reason: 'DB key 必须是 mining_audio_head_pad_ms',
+      );
+      restored.dispose();
+
+      repo.setMiningAudioHeadPadMs(99999);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(repo.miningAudioHeadPadMs, kMiningPadMaxMs, reason: '越界夹到上限');
+      repo.setMiningAudioHeadPadMs(-5);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(repo.miningAudioHeadPadMs, 0, reason: '负值夹到 0');
+    });
+
+    test('setMiningAudioTailPadMs 写穿 Drift（往返 + DB key + 越界夹取）', () async {
+      repo.setMiningAudioTailPadMs(450);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(repo.miningAudioTailPadMs, 450);
+
+      final PreferencesRepository restored = PreferencesRepository(db);
+      await restored.loadFromDb();
+      expect(restored.miningAudioTailPadMs, 450, reason: '设过必须落盘且跨实例可见');
+      final Map<String, String> prefs = await db.getAllPrefs();
+      expect(
+        prefs.containsKey('mining_audio_tail_pad_ms'),
+        isTrue,
+        reason: 'DB key 必须是 mining_audio_tail_pad_ms',
+      );
+      restored.dispose();
+
+      repo.setMiningAudioTailPadMs(99999);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(repo.miningAudioTailPadMs, kMiningPadMaxMs, reason: '越界夹到上限');
+    });
+  });
+
+  group('miningSentenceAudioRange 透传 padding', () {
+    test('默认参数 = 常量（既有调用方零变化）', () {
+      final AudioCue cue = _cue(startMs: 5000, endMs: 6200, text: 'は');
+      final AudioPlaybackRange? clip = miningSentenceAudioRange(
+        cues: <AudioCue>[cue],
+        cue: cue,
+        sentence: 'は',
+      );
+      expect(clip!.startMs, 5000 - kMiningHeadPadMs);
+      expect(clip.endMs, 6200 + kMiningTailPadMs);
+    });
+
+    test('显式 head/tail 生效，且先 pad 再 shift', () {
+      final AudioCue cue = _cue(startMs: 5000, endMs: 6200, text: 'は');
+      final AudioPlaybackRange? clip = miningSentenceAudioRange(
+        cues: <AudioCue>[cue],
+        cue: cue,
+        sentence: 'は',
+        headPadMs: 0,
+        tailPadMs: 700,
+        delayMs: -250,
+      );
+      // pad: 5000/6900；shift -250: 4750/6650。
+      expect(clip!.startMs, 4750);
+      expect(clip.endMs, 6650);
+    });
+
+    test('用户把 tail 调大也不越过下一句（夹边界保留）', () {
+      final AudioCue cue = _cue(startMs: 5000, endMs: 6200, text: 'は');
+      final AudioCue next = _cue(startMs: 6500, endMs: 8000, text: '次');
+      final AudioPlaybackRange? clip = miningSentenceAudioRange(
+        cues: <AudioCue>[cue, next],
+        cue: cue,
+        sentence: 'は',
+        tailPadMs: 1000,
+      );
+      expect(clip!.endMs, 6500, reason: 'tail 被下一句起点夹住');
+    });
+  });
+
+  group('调用点源码守卫', () {
+    test('视频字幕制卡：同一 padSentenceRange、喂偏好、夹锚定 cue 所属流、先 pad 再 shift', () {
+      final String src = File(
+        'lib/src/pages/implementations/video_fushi/lookup_mining.part.dart',
+      ).readAsStringSync();
+      expect(src, contains('padSentenceRange('));
+      expect(src, contains('headPadMs: appModel.miningAudioHeadPadMs'));
+      expect(src, contains('tailPadMs: appModel.miningAudioTailPadMs'));
+      expect(
+        src,
+        contains('controller.cueStreamOwning(cue)'),
+        reason: '夹边界必须用锚定 cue 所属流（主/副字幕独立），不能硬认主流',
+      );
+      // 先 pad（字幕时基）再 miningClipTimeMs 逆变换：pad 结果必须是 shift 的输入。
+      expect(src, contains('miningClipTimeMs(paddedRange?.startMs ?? 0'));
+      expect(src, contains('miningClipTimeMs(paddedRange?.endMs ?? 0'));
+      expect(
+        src,
+        isNot(contains('mergedRange?.startMs ?? cue?.startMs')),
+        reason: '旧的未 pad 区间不能再直接进 shift',
+      );
+    });
+
+    test('有声书制卡：miningSentenceAudioRange 喂偏好值', () {
+      final String src = File(
+        'lib/src/pages/implementations/reader_fushi/audiobook.part.dart',
+      ).readAsStringSync();
+      expect(src, contains('headPadMs: appModel.miningAudioHeadPadMs'));
+      expect(src, contains('tailPadMs: appModel.miningAudioTailPadMs'));
+    });
+
+    test('Anki 设置页：两个滑块行 + 搜索条目，上限与偏好 clamp 共用 kMiningPadMaxMs', () {
+      final String page = File(
+        'lib/src/pages/implementations/anki_settings_page.dart',
+      ).readAsStringSync();
+      expect(page, contains("id: 'card_creation.anki.mining_audio_head_pad'"));
+      expect(page, contains("id: 'card_creation.anki.mining_audio_tail_pad'"));
+      expect(page, contains('value: appModel.miningAudioHeadPadMs'));
+      expect(page, contains('onChanged: appModel.setMiningAudioHeadPadMs'));
+      expect(page, contains('value: appModel.miningAudioTailPadMs'));
+      expect(page, contains('onChanged: appModel.setMiningAudioTailPadMs'));
+      expect(page, contains('max: kMiningPadMaxMs.toDouble()'));
+
+      final String schema = File(
+        'lib/src/settings/settings_schema_card_creation.dart',
+      ).readAsStringSync();
+      expect(
+        schema,
+        contains("id: 'card_creation.anki.mining_audio_head_pad'"),
+      );
+      expect(
+        schema,
+        contains("id: 'card_creation.anki.mining_audio_tail_pad'"),
+      );
+
+      final String prefs = File(
+        'lib/src/models/preferences_repository.dart',
+      ).readAsStringSync();
+      expect(
+        prefs,
+        contains('.clamp(0, kMiningPadMaxMs)'),
+        reason: '偏好 clamp 与滑块上限必须是同一个常量',
+      );
+    });
+  });
+}

--- a/fushi/test/settings/settings_flatten_anki_profile_test.dart
+++ b/fushi/test/settings/settings_flatten_anki_profile_test.dart
@@ -318,7 +318,8 @@ void main() {
       <SettingsDestination>[],
       panelId: 'card_creation.media.open',
     );
-    expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2));
+    // 图片质量 / 音频质量 + 句子音频头/尾 padding 两对滑块。
+    expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(4));
     expect(find.byType(AdaptiveSettingsSwitchRow), findsNothing);
   });
 

--- a/fushi/test/settings/settings_schema_coverage_test.dart
+++ b/fushi/test/settings/settings_schema_coverage_test.dart
@@ -399,6 +399,12 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'test/settings/mining_media_quality_guard_test.dart + test/utils/desktop_audio_clipper_test.dart',
   'cardCreation/Audio quality':
       'test/settings/mining_media_quality_guard_test.dart + test/utils/desktop_audio_clipper_test.dart',
+  // 句子音频头/尾 padding：效果在裁剪区间（padSentenceRange），纯函数 + 偏好写穿 +
+  // 两条制卡链调用点源码守卫都在专项测试里。
+  'cardCreation/Audio padding before sentence':
+      'test/settings/mining_audio_padding_guard_test.dart',
+  'cardCreation/Audio padding after sentence':
+      'test/settings/mining_audio_padding_guard_test.dart',
   // TODO-135: 默认标签区现无条件显示（hibiki/分类两开关移出 isConfigured 门控），
   // focus-driven 现能驱动到它们；但它们写的是 AnkiSettings（经 SharedPreferences，
   // 非本测试的内存 DB），故 changed=false。标签拼装行为本体由 hibiki_anki 真制卡

--- a/packages/fushi_engine/lib/mining/immersion_mining_request.dart
+++ b/packages/fushi_engine/lib/mining/immersion_mining_request.dart
@@ -286,6 +286,7 @@ class ImmersionMiningRequest {
     required this.fields,
     required this.clipStartMs,
     required this.clipEndMs,
+    this.stillFrameAtMs,
     required this.sentence,
     this.mediaSource,
     this.audioSource,
@@ -315,6 +316,18 @@ class ImmersionMiningRequest {
   final Map<String, String> fields;
   final int clipStartMs;
   final int clipEndMs;
+
+  /// 「字幕起始帧」静态封面的取帧时刻（播放器轴，毫秒）。null = 用 [clipStartMs]。
+  ///
+  /// 为什么单独一个字段：`[clipStartMs, clipEndMs]` 是**音频/动图窗**，会被用户的句子
+  /// 音频头 padding 往前扩；而「字幕起始帧」承诺的是字幕**开始那一刻**的画面——台词
+  /// 起点常与切镜重合，往前哪怕 120ms 抽到的就是上一个镜头。两层语义只共用一对数字
+  /// 时，padding 一旦可调就会把封面带偏；视频调用方传未 pad 的 cue 起点，其余来源
+  /// （无 padding 概念）不传即回落到窗起点，行为零变化。
+  final int? stillFrameAtMs;
+
+  /// 静态起始帧实际取帧时刻：[stillFrameAtMs] 优先，否则窗起点 [clipStartMs]。
+  int get stillFrameAnchorMs => stillFrameAtMs ?? clipStartMs;
   final String sentence;
   final String? mediaSource;
 
@@ -418,6 +431,7 @@ class ImmersionMiningRequest {
         ),
         clipStartMs: clipStartMs,
         clipEndMs: clipEndMs,
+        stillFrameAtMs: stillFrameAtMs,
         sentence: sentence,
         mediaSource: mediaSource,
         audioSource: audioSource,


### PR DESCRIPTION
## 做了什么

制卡句子音频的**头/尾 padding 可调**（对齐 asbplayer 的 audio padding），用户反馈「句尾经常被切短」。

- 现状：视频字幕制卡裁的就是 cue 原始时间窗（**零 padding**）；有声书制卡有 padding 但是硬编码常量（头 120 / 尾 200）。
- 现在：两条链共用一对偏好 `mining_audio_head_pad_ms` / `mining_audio_tail_pad_ms`（默认沿用原常量 → 有声书零变化，视频默认即获得尾部余量）。
- 裁剪仍走 `padSentenceRange` **夹相邻 cue 边界**（用户拍板保留），先 pad 再按 A/V 延迟 shift；视频链夹边界用锚定 cue 所属流（主/副字幕独立）。
- UI：设置 → 制卡 → Anki 媒体面板两个滑块（0..1000ms，步 50）+ 搜索条目；i18n 5 个 key 经 `i18n_sync`。
- 审查返工：`ImmersionMiningRequest.stillFrameAtMs` 把「字幕起始帧」封面锚点与音频窗起点分离，封面不跟头 padding 往前退到上一个镜头（其余来源不传 → 回落 `clipStartMs`，零变化）。

## 验证

- `flutter analyze`（含 test）绿；`dart analyze` fushi_engine 绿。
- `flutter test test/settings test/mining`：1855 绿；`test/media/audiobook` + 视频制卡相关 8 条守卫：全绿；`test/i18n` 30 绿。
- 新守卫 `fushi/test/settings/mining_audio_padding_guard_test.dart`（偏好写穿/clamp、纯函数透传、两条链调用点、UI 接线、帧锚点）。
- 未做真机试听（纯区间计算，由纯函数单测覆盖）。

https://claude.ai/code/session_015NaFtcCSwyUKsCRxHqrf1a
