### PR TITLE
fix(reader): 歌词模式显示已匹配的 EPUB 原文

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2292 条。点号进各自文件。
+> 共 2293 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2490](bugs/BUG-2490-lyrics-original-text.md) | ✅ | ✅ | 歌词模式显示转录文本而非已匹配的原文 |
 | [BUG-2482](bugs/BUG-2482-webkit-line-box-contain-zero-height-lines.md) | ✅ | ✅ | WebKit 上 BUG-2472 的 line-box-contain 把嵌套 inline / 空行行盒压成零高：目录列叠印、空行消失 |
 | [BUG-2481](bugs/BUG-2481-manga-ocr-progress-boxes-update-all-sort.md) | ✅ | ✅ | 作品页 OCR 无进度显示；阅读器无识别范围显示；扩展无一键更新；源列表无按下载量排序 |
 | [BUG-2480](bugs/BUG-2480-manga-login-import-from-browser-extension.md) | ✅ | ✅ | 漫画源登录：从系统浏览器（经 Fushi 扩展）导入已登录会话，不必在 app 内重登 |

--- a/docs/bugs/BUG-2490-lyrics-original-text.md
+++ b/docs/bugs/BUG-2490-lyrics-original-text.md
@@ -1,0 +1,7 @@
+## BUG-2490 · 歌词模式显示转录文本而非已匹配的原文
+- **报告**：2026-09-13（用户截图：正常阅读显示「牛／痴れ者／馬鹿」，歌词显示「うし／知れもの／バカ」）
+- **真实性**：✅ 真 bug。`fushi/lib/src/media/audiobook/lyrics_mode_html.dart:33` 原来直接渲染 `AudioCue.text`，即语音转录结果；`reader_fushi/lyrics.part.dart:178` 未传 EPUB。匹配器仅将原文位置写入 `textFragmentId`，不会改写字幕文本。普通阅读展示 EPUB，因此没有同样的文字差异。`reader_fushi/audiobook.part.dart:1065` 的制卡 cue 句子同样直接读取转录文本。
+- **[x] ① 已修复** — `LyricsCueTextResolver` 复用 `EpubBook.chapterPlainText` 与 `AudioTextNormalizer.normalizeWithOffsets`，按已匹配的 UTF-16 范围提取原文字形（排除 ruby 注音），歌词 HTML 和歌词模式制卡 cue 句子共用。保留原 `AudioCue`、时间、索引、tokenTiming；没有匹配或非法范围时回退原字幕。支持合法跨章匹配、拒绝半代理对/整书越界；按需缓存最多三章。提交见本文件所属修复提交。
+- **[x] ② 已加自动化测试** — `fushi/test/media/audiobook/lyrics_cue_text_test.dart`：10 项，涵盖截图差异、ruby、内部标点、全角、跨章/空章、无匹配/越界、非 BMP、HTML 转义、cue 不变和生产接线。定向测试退出码 0；`flutter analyze --no-pub` 通过。
+- **备注**：范围边界沿用归一化匹配坐标，不扩大到范围外的开引号或句末标点。历史范围没有正文版本指纹，合法但陈旧的匹配仍需重新匹配。用户只提供截图，尚未拿到原 EPUB/字幕做真实设备上的原始失败路径复测；自动化文本/HTML 验证不等于设备验收。正常阅读、悬浮歌词和 ASR 算法不在本轮修改范围。
+- **扩展验证**：`tests_for_changes.dart --include-dart` 推导守卫加相邻歌词/坐标测试共 566 个文件，分 15 批执行（避免 Windows 命令行长度上限）：4,160 项通过、4 项失败，整批退出码 1。失败为 `video_double_tap_seek_guard_test.dart`、`video_popup_cue_actions_guard_test.dart`、`video_remote_resume_guard_test.dart`、`video_render_fixes_guard_test.dart` 各一项源码断言；已用 `git diff HEAD --` 核对测试及其读取的视频源文件与基线 `e61c243117` 相同，本轮未改，未计为通过。日志在 worktree 的 `fushi/.lyrics-tests-*.log`。BUG 号/索引检查通过。

--- a/fushi/lib/src/media/audiobook/lyrics_cue_text.dart
+++ b/fushi/lib/src/media/audiobook/lyrics_cue_text.dart
@@ -1,0 +1,83 @@
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_engine/epub/epub_book.dart';
+
+/// Resolves display text without changing transcript cues or their token timing.
+/// Uses the same ruby-free chapter text and UTF-16 normalization as the matcher.
+class LyricsCueTextResolver {
+  LyricsCueTextResolver(this.book);
+
+  final EpubBook book;
+  final Map<int, ({String text, NormalizedTextWithOffsets norm})> _chapters =
+      <int, ({String text, NormalizedTextWithOffsets norm})>{};
+
+  String textForCue(AudioCue cue) {
+    final SubtitleRematchFragment? fragment = SubtitleRematchCodec.tryDecode(
+      cue.textFragmentId,
+    );
+    if (fragment == null ||
+        fragment.sectionIndex < 0 ||
+        fragment.sectionIndex >= book.chapters.length ||
+        fragment.normCharStart < 0 ||
+        fragment.normCharEnd <= fragment.normCharStart) {
+      return cue.text;
+    }
+
+    int start = fragment.normCharStart;
+    int remaining = fragment.normCharEnd - start;
+    final StringBuffer result = StringBuffer();
+    for (
+      int section = fragment.sectionIndex;
+      section < book.chapters.length;
+      section++
+    ) {
+      final ({String text, NormalizedTextWithOffsets norm}) chapter = _chapter(
+        section,
+      );
+      final String normalized = chapter.norm.text;
+      final bool first = section == fragment.sectionIndex;
+      if (first &&
+          (start >= normalized.length || !_isBoundary(normalized, start))) {
+        return cue.text;
+      }
+      final int available = normalized.length - start;
+      if (remaining <= available) {
+        final int end = start + remaining;
+        if (!_isBoundary(normalized, end)) return cue.text;
+        result.write(
+          chapter.text.substring(
+            first ? chapter.norm.starts[start] : 0,
+            chapter.norm.ends[end - 1],
+          ),
+        );
+        return result.toString();
+      }
+      // The matcher concatenates chapters; a cue may span chapter boundaries.
+      // Keep intervening punctuation, but never clamp an invalid end to the book.
+      result.write(
+        chapter.text.substring(first ? chapter.norm.starts[start] : 0),
+      );
+      remaining -= available;
+      start = 0;
+    }
+    return cue.text;
+  }
+
+  ({String text, NormalizedTextWithOffsets norm}) _chapter(int section) {
+    final ({String text, NormalizedTextWithOffsets norm})? cached = _chapters
+        .remove(section);
+    final String text = cached?.text ?? book.chapterPlainText(section);
+    final ({String text, NormalizedTextWithOffsets norm}) value =
+        cached ??
+        (text: text, norm: AudioTextNormalizer.normalizeWithOffsets(text));
+    _chapters[section] = value;
+    while (_chapters.length > 3) {
+      _chapters.remove(_chapters.keys.first);
+    }
+    return value;
+  }
+
+  static bool _isBoundary(String text, int offset) =>
+      offset == text.length ||
+      text.codeUnitAt(offset) < 0xdc00 ||
+      text.codeUnitAt(offset) > 0xdfff;
+}

--- a/fushi/lib/src/media/audiobook/lyrics_mode_html.dart
+++ b/fushi/lib/src/media/audiobook/lyrics_mode_html.dart
@@ -1,4 +1,6 @@
 import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_engine/epub/epub_book.dart';
+import 'package:fushi/src/media/audiobook/lyrics_cue_text.dart';
 import 'package:fushi/src/reader/reader_selection_scripts.dart';
 
 class LyricsModeHtml {
@@ -7,6 +9,7 @@ class LyricsModeHtml {
   static String generate({
     required List<AudioCue> cues,
     required int currentIndex,
+    EpubBook? book,
     int loadGeneration = 0,
     required String backgroundColor,
     required String textColor,
@@ -22,15 +25,20 @@ class LyricsModeHtml {
     String fontFaceCss = '',
   }) {
     final StringBuffer cueHtml = StringBuffer();
+    final LyricsCueTextResolver? textResolver = book == null
+        ? null
+        : LyricsCueTextResolver(book);
     for (int i = 0; i < cues.length; i++) {
-      final String escaped = _escapeHtml(cues[i].text);
+      final String escaped = _escapeHtml(
+        textResolver?.textForCue(cues[i]) ?? cues[i].text,
+      );
       final String fragId = _escapeAttr(cues[i].textFragmentId);
       final int dist = (i - currentIndex).abs();
       final String cls = dist == 0
           ? 'cue current'
           : dist <= 3
-              ? 'cue near-$dist'
-              : 'cue';
+          ? 'cue near-$dist'
+          : 'cue';
       cueHtml.write(
         '<div class="$cls" data-cue-index="$i" '
         'data-text-fragment-id="$fragId">'
@@ -54,14 +62,16 @@ class LyricsModeHtml {
     // 由 writing-mode 决定读序，无需翻 padding 值。
     final double padTop = vertical ? marginTop : 45 + marginTop;
     final double padBottom = vertical ? marginBottom : 45 + marginBottom;
-    final double padLeft =
-        vertical ? 45 + marginLeft : (marginLeft > 0 ? marginLeft : 2.5);
-    final double padRight =
-        vertical ? 45 + marginRight : (marginRight > 0 ? marginRight : 2.5);
+    final double padLeft = vertical
+        ? 45 + marginLeft
+        : (marginLeft > 0 ? marginLeft : 2.5);
+    final double padRight = vertical
+        ? 45 + marginRight
+        : (marginRight > 0 ? marginRight : 2.5);
     final String containerPaddingCss = vertical
         ? 'padding: ${padTop}vh ${padRight}vw ${padBottom}vh ${padLeft}vw;'
         : 'padding: calc(45vh + ${marginTop}vh) ${marginLeft > 0 ? marginLeft : 2.5}vw '
-            'calc(45vh + ${marginBottom}vh) ${marginRight > 0 ? marginRight : 2.5}vw;';
+              'calc(45vh + ${marginBottom}vh) ${marginRight > 0 ? marginRight : 2.5}vw;';
     // JS 端轴标记：true=竖排横滚（用 scrollBy 增量绕开 vertical-rl 负向 scrollX）。
     final String verticalJs = vertical ? 'true' : 'false';
     // TODO-908 / BUG-852：听力沉浸模糊。blur=true 时给 body 挂 `lyrics-blur` class，CSS

--- a/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/audiobook.part.dart
@@ -1063,7 +1063,13 @@ extension _ReaderAudiobook on _ReaderFushiPageState {
   }
 
   void _syncCueSentence() {
-    final String cueText = _lookupCue?.text ?? '';
+    final AudioCue? cue = _lookupCue;
+    final EpubBook? book = _book;
+    final String cueText = cue == null
+        ? ''
+        : _lyricsMode && book != null
+            ? LyricsCueTextResolver(book).textForCue(cue)
+            : cue.text;
     if (cueText.isNotEmpty) {
       appModel.currentMediaSource?.setCurrentCueSentence(
         selection: FushiTextSelection(text: cueText),

--- a/fushi/lib/src/pages/implementations/reader_fushi/lyrics.part.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi/lyrics.part.dart
@@ -177,6 +177,7 @@ extension _ReaderLyrics on _ReaderFushiPageState {
 
     final String html = LyricsModeHtml.generate(
       cues: _lyricsCueList,
+      book: _book,
       currentIndex: cueWindow.currentIndex,
       loadGeneration: loadGeneration,
       backgroundColor: colorToCss(bg),

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -31,6 +31,7 @@ import 'package:fushi/src/media/audiobook/audiobook_bridge.dart';
 import 'package:fushi/src/media/audiobook/audiobook_session.dart';
 import 'package:fushi/src/media/audiobook/audiobook_session_launcher.dart';
 import 'package:fushi/src/media/audiobook/lyrics_mode_html.dart';
+import 'package:fushi/src/media/audiobook/lyrics_cue_text.dart';
 import 'package:fushi/src/media/audiobook/floating_lyric_lookup_routing.dart';
 import 'package:fushi_audio/fushi_audio.dart';
 import 'package:fushi/src/media/audiobook/highlight_bridge.dart';

--- a/fushi/pubspec.yaml
+++ b/fushi/pubspec.yaml
@@ -2,7 +2,7 @@ name: fushi
 resolution: workspace
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 2.6.0+1339
+version: 2.6.0+1340
 environment:
   sdk: ">=3.8.0 <4.0.0"
   flutter: "^3.41.6"

--- a/fushi/test/media/audiobook/lyrics_cue_text_test.dart
+++ b/fushi/test/media/audiobook/lyrics_cue_text_test.dart
@@ -1,0 +1,222 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fushi/src/media/audiobook/lyrics_cue_text.dart';
+import 'package:fushi/src/media/audiobook/lyrics_mode_html.dart';
+import 'package:fushi_audio/fushi_audio.dart';
+import 'package:fushi_engine/epub/epub_book.dart';
+import 'package:html/parser.dart' as html_parser;
+
+EpubBook _book(List<String> bodies) => EpubBook(
+  title: 'Lyrics regression',
+  chapters: <EpubChapter>[
+    for (int i = 0; i < bodies.length; i++)
+      EpubChapter(
+        id: '$i',
+        href: '$i.xhtml',
+        mediaType: 'application/xhtml+xml',
+        html: '<html><body>${bodies[i]}</body></html>',
+      ),
+  ],
+);
+
+AudioCue _cue(int start, int end, {int section = 0, String text = 'ASR'}) =>
+    AudioCue()
+      ..id = 42
+      ..bookKey = 'book'
+      ..chapterHref = '$section.xhtml'
+      ..sentenceIndex = 7
+      ..textFragmentId = SubtitleRematchCodec.encodeHit(
+        sectionIndex: section,
+        normCharStart: start,
+        normCharEnd: end,
+      )
+      ..text = text
+      ..startMs = 1234
+      ..endMs = 5678
+      ..audioFileIndex = 2;
+
+String _html(List<AudioCue> cues, {EpubBook? book}) => LyricsModeHtml.generate(
+  cues: cues,
+  book: book,
+  currentIndex: 0,
+  backgroundColor: '#fff',
+  textColor: '#000',
+  accentColor: '#f08',
+  fontSize: 24,
+);
+
+void main() {
+  test('matched lyrics preserve screenshot kanji instead of ASR spellings', () {
+    const List<(String, String)> pairs = <(String, String)>[
+      ('牛の餌', 'うしの餌'),
+      ('僕の痴れ者', '僕の知れもの'),
+      ('運命の出会いなんかに憧れた僕が馬鹿だった', '運命の出会いなんかに憧れた僕がバカだった'),
+      ('一攫千金ならぬ一攫美少女なんて夢のまた夢だった', '一獲千金ならぬ一カク美少女なんて夢のまた夢だった'),
+    ];
+    for (final (String original, String transcript) in pairs) {
+      final EpubBook book = _book(<String>[original]);
+      final AudioCue cue = _cue(
+        0,
+        AudioTextNormalizer.normalize(original).length,
+        text: transcript,
+      );
+      expect(LyricsCueTextResolver(book).textForCue(cue), original);
+      expect(
+        html_parser
+            .parse(_html(<AudioCue>[cue], book: book))
+            .querySelector('.cue')!
+            .text,
+        original,
+      );
+    }
+  });
+
+  test(
+    'ruby annotations are excluded and internal punctuation and glyphs retained',
+    () {
+      final EpubBook book = _book(<String>[
+        '「<ruby>馬鹿<rp>（</rp><rt>ばか</rt><rp>）</rp><rtc>BAKA</rtc></ruby>、ＡＢＣ！カナ。」',
+      ]);
+      expect(LyricsCueTextResolver(book).textForCue(_cue(0, 7)), '馬鹿、ＡＢＣ！カナ');
+    },
+  );
+
+  test(
+    'fragment addresses the specified chapter and span rather than searching ASR',
+    () {
+      final EpubBook book = _book(<String>['猫だ。', '前。犬だ。後']);
+      expect(
+        LyricsCueTextResolver(
+          book,
+        ).textForCue(_cue(1, 3, section: 1, text: '猫だ')),
+        '犬だ',
+      );
+    },
+  );
+
+  test(
+    'cross-chapter cue preserves intervening punctuation through empty chapters',
+    () {
+      final EpubBook book = _book(<String>['前。猫、', '', '！', '犬だ。後']);
+      expect(LyricsCueTextResolver(book).textForCue(_cue(1, 5)), '猫、！犬だ。後');
+      expect(LyricsCueTextResolver(book).textForCue(_cue(1, 4)), '猫、！犬だ');
+    },
+  );
+
+  test('unmatched and non-rematch fragments retain transcript', () {
+    final LyricsCueTextResolver resolver = LyricsCueTextResolver(
+      _book(<String>['猫だ']),
+    );
+    for (final String fragment in <String>[
+      '',
+      'srt://1',
+      '#line1',
+      'fushi-cue://s=0',
+    ]) {
+      final AudioCue cue = _cue(0, 2)..textFragmentId = fragment;
+      expect(resolver.textForCue(cue), 'ASR');
+    }
+  });
+
+  test('invalid ranges fall back without clamping or partial chapter text', () {
+    final LyricsCueTextResolver resolver = LyricsCueTextResolver(
+      _book(<String>['猫だ', '犬だ']),
+    );
+    for (final AudioCue cue in <AudioCue>[
+      _cue(-1, 1),
+      _cue(1, 1),
+      _cue(2, 1),
+      _cue(2, 3),
+      _cue(0, 5),
+      _cue(0, 1, section: -1),
+      _cue(0, 1, section: 2),
+    ]) {
+      expect(resolver.textForCue(cue), 'ASR', reason: cue.textFragmentId);
+    }
+    expect(
+      LyricsCueTextResolver(_book(<String>[''])).textForCue(_cue(0, 1)),
+      'ASR',
+    );
+  });
+
+  test('astral CJK uses UTF-16 ranges and rejects split surrogate pairs', () {
+    final LyricsCueTextResolver resolver = LyricsCueTextResolver(
+      _book(<String>['𠮷野。犬']),
+    );
+    expect(resolver.textForCue(_cue(0, 2)), '𠮷');
+    expect(resolver.textForCue(_cue(0, 3)), '𠮷野');
+    expect(resolver.textForCue(_cue(0, 1)), 'ASR');
+    expect(resolver.textForCue(_cue(1, 3)), 'ASR');
+    final LyricsCueTextResolver across = LyricsCueTextResolver(
+      _book(<String>['猫', '𠮷野']),
+    );
+    expect(across.textForCue(_cue(0, 2)), 'ASR');
+    expect(across.textForCue(_cue(0, 3)), '猫𠮷');
+  });
+
+  test(
+    'HTML displays escaped original text and preserves cue metadata and timing',
+    () {
+      final EpubBook book = _book(<String>['猫&lt;犬&amp;鳥&gt;牛']);
+      final AudioCue cue = _cue(0, 4, text: 'ねこいぬとりうし');
+      final String fragment = cue.textFragmentId;
+      final CueTokenTiming timing = CueTokenTiming(
+        tokens: <String>['ねこ'],
+        offsetsMs: <int>[100],
+      );
+      cue.tokenTiming = timing;
+      final List<AudioCue> cues = <AudioCue>[cue];
+      final String html = _html(cues, book: book);
+      final element = html_parser.parse(html).querySelector('.cue')!;
+      expect(element.text, '猫<犬&鳥>牛');
+      expect(element.children, isEmpty);
+      expect(element.attributes['data-text-fragment-id'], fragment);
+      expect(element.attributes['data-cue-index'], '0');
+      expect(cues.single, same(cue));
+      expect(cue.text, 'ねこいぬとりうし');
+      expect(cue.textFragmentId, fragment);
+      expect(cue.id, 42);
+      expect(cue.sentenceIndex, 7);
+      expect((cue.startMs, cue.endMs, cue.audioFileIndex), (1234, 5678, 2));
+      expect(cue.tokenTiming, same(timing));
+    },
+  );
+
+  test('HTML without EPUB context keeps existing transcript rendering', () {
+    expect(
+      html_parser
+          .parse(_html(<AudioCue>[_cue(0, 2, text: '犬＆猫')]))
+          .querySelector('.cue')!
+          .text,
+      '犬＆猫',
+    );
+  });
+
+  test(
+    'reader supplies EPUB to lyrics and resolves mining cue text only in lyrics mode',
+    () {
+      final String lyrics = File(
+        'lib/src/pages/implementations/reader_fushi/lyrics.part.dart',
+      ).readAsStringSync();
+      final int generateStart = lyrics.indexOf('LyricsModeHtml.generate(');
+      final String generate = lyrics.substring(
+        generateStart,
+        lyrics.indexOf('\n    );', generateStart),
+      );
+      expect(generate, contains('book: _book'));
+      final String audio = File(
+        'lib/src/pages/implementations/reader_fushi/audiobook.part.dart',
+      ).readAsStringSync();
+      final int syncStart = audio.indexOf('void _syncCueSentence()');
+      final String sync = audio.substring(
+        syncStart,
+        audio.indexOf('\n  ///', syncStart),
+      );
+      expect(sync, contains('_lyricsMode && book != null'));
+      expect(sync, contains('LyricsCueTextResolver(book).textForCue(cue)'));
+      expect(sync, contains('setCurrentCueSentence('));
+      expect(sync, contains('FushiTextSelection(text: cueText)'));
+    },
+  );
+}


### PR DESCRIPTION
歌词模式原先直接显示 ASR 转录文本，因此正文中的「牛／痴れ者／馬鹿」会显示为「うし／知れもの／バカ」。现在按已保存的 EPUB 匹配范围提取原文，歌词显示与歌词模式制卡句子使用同一来源。

保留原字幕时间轴、cue 身份与 tokenTiming；支持跨章节和 ruby 基底文本，无有效匹配时回退转录字幕。记录 BUG-2490。

验证：
- 新增 10 项回归测试通过；flutter analyze --no-pub 通过。
- 扩展检查 566 个测试文件：4,160 项通过、4 项既有视频源码守卫失败。失败位于 video_double_tap_seek_guard_test、video_popup_cue_actions_guard_test、video_remote_resume_guard_test、video_render_fixes_guard_test；相关测试及视频代码与基线 e61c243117 相同。
- 原 EPUB/字幕的真实设备切换、播放与查词复测待补；本地未跑全量测试套件。
