### PR TITLE
feat(mining): 选择句子上下文对话框支持逐句手改文本

### DIFF
--- a/fushi/lib/i18n/strings.g.dart
+++ b/fushi/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 81192 (4776 per locale)
+/// Strings: 81243 (4779 per locale)
 ///
-/// Built on 2026-09-12 at 15:46 UTC
+/// Built on 2026-09-13 at 04:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -6657,6 +6657,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Multilingual — wide coverage, less accurate per language';
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  String get popup_ctx_edit_start => 'Edit sentence';
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -17918,6 +17921,12 @@ class _StringsAr extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -29405,6 +29414,12 @@ class _StringsDe extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -40946,6 +40961,12 @@ class _StringsEs extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -52520,6 +52541,12 @@ class _StringsFr extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -63898,6 +63925,12 @@ class _StringsId extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -75367,6 +75400,12 @@ class _StringsIt extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -86218,6 +86257,12 @@ class _StringsJa extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -97079,6 +97124,12 @@ class _StringsKo extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -108506,6 +108557,12 @@ class _StringsNl extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -119986,6 +120043,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -131443,6 +131506,12 @@ class _StringsRu extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -142701,6 +142770,12 @@ class _StringsTh extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -154074,6 +154149,12 @@ class _StringsTr extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -165417,6 +165498,12 @@ class _StringsVi extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 // Path: <root>
@@ -175825,6 +175912,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       '总耗时 ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => '编辑句子';
+  @override
+  String get popup_ctx_edit_confirm => '确认修改';
+  @override
+  String get popup_ctx_edit_cancel => '放弃修改';
 }
 
 // Path: <root>
@@ -186360,6 +186453,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String audiobook_transcribe_elapsed_total({required Object elapsed}) =>
       'Total time ${elapsed}';
+  @override
+  String get popup_ctx_edit_start => 'Edit sentence';
+  @override
+  String get popup_ctx_edit_confirm => 'Confirm edit';
+  @override
+  String get popup_ctx_edit_cancel => 'Discard edit';
 }
 
 /// Flat map(s) containing all translations.
@@ -196211,6 +196310,12 @@ extension on _StringsEn {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -206057,6 +206162,12 @@ extension on _StringsAr {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -215948,6 +216059,12 @@ extension on _StringsDe {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -225830,6 +225947,12 @@ extension on _StringsEs {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -235721,6 +235844,12 @@ extension on _StringsFr {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -245583,6 +245712,12 @@ extension on _StringsId {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -255467,6 +255602,12 @@ extension on _StringsIt {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -265278,6 +265419,12 @@ extension on _StringsJa {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -275093,6 +275240,12 @@ extension on _StringsKo {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -284970,6 +285123,12 @@ extension on _StringsNl {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -294842,6 +295001,12 @@ extension on _StringsPtBr {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -304721,6 +304886,12 @@ extension on _StringsRu {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -314572,6 +314743,12 @@ extension on _StringsTh {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -324438,6 +324615,12 @@ extension on _StringsTr {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -334298,6 +334481,12 @@ extension on _StringsVi {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }
@@ -344069,6 +344258,12 @@ extension on _StringsZhCn {
         return '通用模型 · 语言覆盖广，单语言精度不如专用模型';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => '总耗时 ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return '编辑句子';
+      case 'popup_ctx_edit_confirm':
+        return '确认修改';
+      case 'popup_ctx_edit_cancel':
+        return '放弃修改';
       default:
         return null;
     }
@@ -353858,6 +354053,12 @@ extension on _StringsZhHk {
         return 'Multilingual — wide coverage, less accurate per language';
       case 'audiobook_transcribe_elapsed_total':
         return ({required Object elapsed}) => 'Total time ${elapsed}';
+      case 'popup_ctx_edit_start':
+        return 'Edit sentence';
+      case 'popup_ctx_edit_confirm':
+        return 'Confirm edit';
+      case 'popup_ctx_edit_cancel':
+        return 'Discard edit';
       default:
         return null;
     }

--- a/fushi/lib/i18n/strings.i18n.json
+++ b/fushi/lib/i18n/strings.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_ar.i18n.json
+++ b/fushi/lib/i18n/strings_ar.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_de.i18n.json
+++ b/fushi/lib/i18n/strings_de.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_es.i18n.json
+++ b/fushi/lib/i18n/strings_es.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_fr.i18n.json
+++ b/fushi/lib/i18n/strings_fr.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_id.i18n.json
+++ b/fushi/lib/i18n/strings_id.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_it.i18n.json
+++ b/fushi/lib/i18n/strings_it.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_ja.i18n.json
+++ b/fushi/lib/i18n/strings_ja.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_ko.i18n.json
+++ b/fushi/lib/i18n/strings_ko.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_nl.i18n.json
+++ b/fushi/lib/i18n/strings_nl.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_pt-BR.i18n.json
+++ b/fushi/lib/i18n/strings_pt-BR.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_ru.i18n.json
+++ b/fushi/lib/i18n/strings_ru.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_th.i18n.json
+++ b/fushi/lib/i18n/strings_th.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_tr.i18n.json
+++ b/fushi/lib/i18n/strings_tr.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_vi.i18n.json
+++ b/fushi/lib/i18n/strings_vi.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/i18n/strings_zh-CN.i18n.json
+++ b/fushi/lib/i18n/strings_zh-CN.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} 毫秒",
   "audiobook_transcribe_model_scope_dedicated": "专用模型 · 这门语言识别最准",
   "audiobook_transcribe_model_scope_multilingual": "通用模型 · 语言覆盖广，单语言精度不如专用模型",
-  "audiobook_transcribe_elapsed_total": "总耗时 $elapsed"
+  "audiobook_transcribe_elapsed_total": "总耗时 $elapsed",
+  "popup_ctx_edit_start": "编辑句子",
+  "popup_ctx_edit_confirm": "确认修改",
+  "popup_ctx_edit_cancel": "放弃修改"
 }

--- a/fushi/lib/i18n/strings_zh-HK.i18n.json
+++ b/fushi/lib/i18n/strings_zh-HK.i18n.json
@@ -4774,5 +4774,8 @@
   "mining_audio_pad_readout": "${ms} ms",
   "audiobook_transcribe_model_scope_dedicated": "Dedicated — most accurate for this language",
   "audiobook_transcribe_model_scope_multilingual": "Multilingual — wide coverage, less accurate per language",
-  "audiobook_transcribe_elapsed_total": "Total time $elapsed"
+  "audiobook_transcribe_elapsed_total": "Total time $elapsed",
+  "popup_ctx_edit_start": "Edit sentence",
+  "popup_ctx_edit_confirm": "Confirm edit",
+  "popup_ctx_edit_cancel": "Discard edit"
 }

--- a/fushi/lib/src/media/audiobook/mining_sentence_draft.dart
+++ b/fushi/lib/src/media/audiobook/mining_sentence_draft.dart
@@ -1,19 +1,45 @@
 import 'package:fushi_audio/fushi_audio.dart';
 
+/// 「选择句子上下文」对话框里可被手改文本的三种槽位。
+///
+/// 用来在 UI ↔ 宿主 ↔ 草稿之间指明「改的是哪一句」，避免各层用裸字符串
+/// （'prev'/'current'/'next'）互相比较。[SentenceContextSlot.current] 的 index 恒为 0
+/// （当前句只有一句，且不在草稿列表里，见 [MiningSentenceDraft.currentSentenceEdit]）。
+enum SentenceContextSlot { prev, current, next }
+
 /// 单句草稿条目：一次查词时累积的「这一句」+ 可选句子音频区间。
 ///
 /// [sentence] 永远是宿主裁好的整句文本（reader `getSentenceContext`）。
 /// [audioRange] 只有有声书/歌词模式才有值，纯阅读时为 null。多句合并制卡时由
 /// [MiningSentenceDraft] 把各条 [audioRange] 收敛成首句起→末句止的合并区间；跨章/
 /// 跨音频文件无法合并时退化为「只合文本」（[mergeMiningAudioRanges] 返回 null）。
+///
+/// [editedSentence] 是用户在「选择句子上下文」对话框里手改后的文本（未改为 null）。
+/// **只改卡片文本、不改音频身份**——与 galgame hook 制卡的 `sentenceOverride` 同一
+/// 纪律：[audioRange] 恒为宿主按原句算出的区间，手改错别字/删旁白不该让试听与写卡
+/// 的音频区间跟着漂。
 class MiningDraftSentence {
   const MiningDraftSentence({
     required this.sentence,
     this.audioRange,
+    this.editedSentence,
   });
 
   final String sentence;
   final AudioPlaybackRange? audioRange;
+
+  /// 用户手改后的文本；null = 没改过，用 [sentence]。
+  final String? editedSentence;
+
+  /// 参与合成/预览的实际文本（改过用改后的，没改用原句）。
+  String get effectiveSentence => editedSentence ?? sentence;
+
+  /// 换一份手改文本（保留原句与音频区间）。[edited] 传 null 还原成原句。
+  MiningDraftSentence withEditedSentence(String? edited) => MiningDraftSentence(
+        sentence: sentence,
+        audioRange: audioRange,
+        editedSentence: edited,
+      );
 }
 
 /// 会话级「查词窗口多句合一制卡」草稿缓冲（TODO-393 句子上下文再设计）。
@@ -38,6 +64,27 @@ class MiningSentenceDraft {
   List<MiningDraftSentence> _prev = const <MiningDraftSentence>[];
   List<MiningDraftSentence> _next = const <MiningDraftSentence>[];
 
+  /// 上下文句的手改文本表：**键是原句（trim 后）**，不是下标。
+  ///
+  /// 为什么不用下标：[setContext] 是整体替换，宿主按新句数重新解析一遍上下文，
+  /// 「前加一句」会把已有的前文句整体后移一位——用下标记编辑，用户改完一句再点
+  /// 一次「＋」，改动就贴到了别的句子上。原句文本在加减句数时不变，故用它做键，
+  /// 编辑能稳定跟着那一句走。代价：同一段里出现两遍的完全相同的句子会被一起改，
+  /// 这在语义上也说得通（同样的原句改成同样的新句），故不额外做去重。
+  final Map<String, String> _contextEdits = <String, String>{};
+
+  /// 当前句的手改文本（未改为 null）。当前句不在 [_prev]/[_next] 里——它由宿主在
+  /// 制卡瞬间现取（reader 的 `currentSentence.text` / 视频的 `_lastLookupSentence`），
+  /// 故必须在草稿里单独收口，不能去改 `MediaSource.currentSentence`（那是全局态，
+  /// 会连带污染收藏句、落库快照与音频高亮）。
+  String? _currentEdit;
+
+  /// 当前句的手改文本；null = 没改过。
+  String? get currentSentenceEdit => _currentEdit;
+
+  /// 是否有任何手改（上下文句或当前句）。
+  bool get hasEdits => _contextEdits.isNotEmpty || _currentEdit != null;
+
   /// 当前已选的「上 N 句」（紧挨当前句之前，按阅读顺序：最靠前的句在 [0]）。
   List<MiningDraftSentence> get prevSentences =>
       List<MiningDraftSentence>.unmodifiable(_prev);
@@ -61,27 +108,79 @@ class MiningSentenceDraft {
   }) {
     _prev = <MiningDraftSentence>[
       for (final MiningDraftSentence e in prev)
-        if (e.sentence.trim().isNotEmpty) e,
+        if (e.sentence.trim().isNotEmpty) _withStoredEdit(e),
     ];
     _next = <MiningDraftSentence>[
       for (final MiningDraftSentence e in next)
-        if (e.sentence.trim().isNotEmpty) e,
+        if (e.sentence.trim().isNotEmpty) _withStoredEdit(e),
     ];
   }
 
-  /// 清空草稿（制卡成功、换词查询或关闭弹窗栈后调用）。
+  /// 宿主重新解析出来的条目贴回已有的手改文本（见 [_contextEdits] 的键选择说明）。
+  /// 调用方传进来的条目若自带 [MiningDraftSentence.editedSentence]，以表里的为准，
+  /// 表里没有才保留自带的。
+  MiningDraftSentence _withStoredEdit(MiningDraftSentence entry) {
+    final String? stored = _contextEdits[entry.sentence.trim()];
+    if (stored == null) return entry;
+    return entry.withEditedSentence(stored);
+  }
+
+  /// 用户在「选择句子上下文」对话框里手改某一句的文本。
+  ///
+  /// [slot] 指明改的是前文 / 当前句 / 后文；[index] 是该方向列表里的下标
+  /// （[SentenceContextSlot.current] 忽略 index）。[text] 与原句相同（trim 后）或为
+  /// 空白时**还原**成原句而不是写入空句——空句会被 [joinMinedSentences] 丢掉，等于
+  /// 用编辑框当删除键，那是「−」按钮的事。
+  ///
+  /// 返回是否落地（false = 下标越界，草稿未变）。**只改文本，不动音频区间**。
+  bool editSentence({
+    required SentenceContextSlot slot,
+    required int index,
+    required String text,
+  }) {
+    final String trimmed = text.trim();
+    if (slot == SentenceContextSlot.current) {
+      _currentEdit = trimmed.isEmpty ? null : trimmed;
+      return true;
+    }
+    final bool prevDir = slot == SentenceContextSlot.prev;
+    final List<MiningDraftSentence> list = prevDir ? _prev : _next;
+    if (index < 0 || index >= list.length) return false;
+    final MiningDraftSentence entry = list[index];
+    final String key = entry.sentence.trim();
+    final bool restore = trimmed.isEmpty || trimmed == key;
+    if (restore) {
+      _contextEdits.remove(key);
+    } else {
+      _contextEdits[key] = trimmed;
+    }
+    final List<MiningDraftSentence> updated =
+        List<MiningDraftSentence>.of(list);
+    updated[index] = entry.withEditedSentence(restore ? null : trimmed);
+    if (prevDir) {
+      _prev = updated;
+    } else {
+      _next = updated;
+    }
+    return true;
+  }
+
+  /// 清空草稿（制卡成功、换词查询或关闭弹窗栈后调用）。手改文本一并丢弃——
+  /// 换了词条/换了句子，上一句的改写没有任何意义。
   void clear() {
     _prev = const <MiningDraftSentence>[];
     _next = const <MiningDraftSentence>[];
+    _contextEdits.clear();
+    _currentEdit = null;
   }
 
   /// 把「上 N 句 + 当前句 + 下 N 句」按阅读顺序合成最终 sentence 字段文本。
   /// [currentSentence] 是制卡时弹窗里正查的那一句（夹在上下文中间）。
   String composeText(String currentSentence) {
     final List<String> all = <String>[
-      for (final MiningDraftSentence entry in _prev) entry.sentence,
-      currentSentence,
-      for (final MiningDraftSentence entry in _next) entry.sentence,
+      for (final MiningDraftSentence entry in _prev) entry.effectiveSentence,
+      _currentEdit ?? currentSentence,
+      for (final MiningDraftSentence entry in _next) entry.effectiveSentence,
     ];
     return joinMinedSentences(all);
   }
@@ -115,15 +214,19 @@ Map<String, Object?> buildSentenceContextPreview({
   int? currentOffset,
 }) {
   final List<String> prev = <String>[
-    for (final MiningDraftSentence e in draft.prevSentences) e.sentence,
+    for (final MiningDraftSentence e in draft.prevSentences) e.effectiveSentence,
   ];
   final List<String> next = <String>[
-    for (final MiningDraftSentence e in draft.nextSentences) e.sentence,
+    for (final MiningDraftSentence e in draft.nextSentences) e.effectiveSentence,
   ];
+  // 当前句被手改过就吐改后的文本，并把 offset 置空：偏移是按**原句**算的，套到改后
+  // 的文本上会把高亮划在错的位置；置空后消费方回退 indexOf（弹窗侧与卡片渲染
+  // `_sentenceValue` 同一容错），命中不了就整句不高亮，比划错强。
+  final String? edited = draft.currentSentenceEdit;
   return <String, Object?>{
     'prev': prev,
-    'current': current,
-    'currentOffset': currentOffset,
+    'current': edited ?? current,
+    'currentOffset': edited == null ? currentOffset : null,
     'next': next,
     'total': prev.length + next.length,
   };

--- a/fushi/lib/src/pages/base_source_page.dart
+++ b/fushi/lib/src/pages/base_source_page.dart
@@ -11,6 +11,8 @@ import 'package:fushi_anki/fushi_anki.dart' show AnkiOpenWordOutcome;
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/anki/anki_mined_card_action_sheet.dart';
 import 'package:fushi/src/lookup/effective_lookup_size.dart';
+import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart'
+    show SentenceContextSlot;
 import 'package:fushi/src/models/module_id.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_controller.dart';
 import 'package:fushi/src/pages/implementations/dictionary_popup_input_bridge.dart';
@@ -1078,6 +1080,11 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
           matched: matched,
           fetchPreview: onSentenceContextPreviewFromDraft,
           setContext: onSetSentenceContextToDraft,
+          // 「手改某一句文本」：只改这次会写进卡片的**文本**，不动该句的音频区间/
+          // 身份（改完照样是同一句、同一段音频）。门控与其余草稿回调同判据
+          // （本入口只在 sentenceDraftEnabled 时才挂上，这里再按
+          // [supportsSentenceDraft] 兜一层）；不支持的表面传 null，对话框不渲染编辑入口。
+          editSentence: supportsSentenceDraft ? onEditSentenceContextText : null,
           // BUG-2196 ②：只有真的能出声的表面才给试听按钮。
           previewAudio: supportsSentenceAudioPreview ? onPreviewSentenceAudio : null,
           stopAudioPreview:
@@ -1168,6 +1175,19 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
   @protected
   Future<Map<String, Object?>> onSentenceContextPreviewFromDraft() async =>
       const <String, Object?>{};
+
+  /// 「制卡前调整·选择句子上下文」里**手改某一句文本**：把 [slot]（上文/当前/下文）
+  /// 第 [index] 句的文本改成 [text]，写回本表面会话级制卡草稿。
+  ///
+  /// 只改**会写进卡片的那段文本**，不动该句的音频区间与身份——改错别字 / 补主语 /
+  /// 去掉说话人名之后，仍是同一句、同一段音频，试听与压制结果不变。
+  /// 默认 no-op（[supportsSentenceDraft] 为 false 时不会被调用）。reader/视频覆写。
+  @protected
+  Future<void> onEditSentenceContextText(
+    SentenceContextSlot slot,
+    int index,
+    String text,
+  ) async {}
 
   /// BUG-2196 ②：试听**这次制卡真正会写进卡片的那段音频**。
   ///

--- a/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/fushi/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -11,6 +11,8 @@ import 'package:fushi_anki/fushi_anki.dart';
 import 'package:fushi/src/anki/anki_view_model.dart';
 import 'package:fushi/src/anki/anki_mined_card_action_sheet.dart';
 import 'package:fushi/src/lookup/effective_lookup_size.dart';
+import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart'
+    show SentenceContextSlot;
 import 'package:fushi/src/pages/base_source_page.dart'
     show lookupHighlightCharCount;
 import 'package:fushi/src/pages/implementations/dictionary_popup_controller.dart';
@@ -163,6 +165,16 @@ mixin DictionaryPageMixin {
   Future<Map<String, Object?>> Function()?
       get onSentenceContextPreviewToDraft => null;
 
+  /// 「制卡前调整·选择句子上下文」里**手改某一句文本**（视频/首页查词车道）：把 [slot]
+  /// （上文/当前/下文）第 index 句的文本改成给定文本，写回本表面会话级制卡草稿。
+  ///
+  /// 只改**会写进卡片的那段文本**，不动该句的音频/画面区间与身份——改完仍是同一条
+  /// cue、同一段时间窗，GIF 与句子音频的裁法完全不变。默认 null = 不支持（纯查词页
+  /// 无草稿），对话框据此不渲染编辑入口。视频页覆写返回非空闭包。与 reader 车道
+  /// （[BaseSourcePageState.onEditSentenceContextText]）对称。
+  Future<void> Function(SentenceContextSlot slot, int index, String text)?
+      get onEditSentenceContextText => null;
+
   /// BUG-797 / BUG-1040：有多少个「必须盖住查词弹窗」的 Flutter 对话框正开着。
   ///
   /// 查词弹窗是**原生平台视图**（桌面 WebView2 / Android platform view），靠 airspace 永远
@@ -219,6 +231,9 @@ mixin DictionaryPageMixin {
           matched: matched,
           fetchPreview: preview,
           setContext: setter,
+          // 手改某一句文本：只改这次会写进卡片的**文本**，cue 的时间窗（音频/画面
+          // 身份）原样保留。宿主没接就传 null，对话框不渲染编辑入口。
+          editSentence: onEditSentenceContextText,
           onConfirm: () =>
               webViewKey.currentState?.mineEntryByIndex(entryIndex),
         ),

--- a/fushi/lib/src/pages/implementations/reader_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/reader_fushi_page.dart
@@ -3778,6 +3778,19 @@ $liveConfigJs
     return _miningDraft.length;
   }
 
+  /// 「选择句子上下文」对话框里手改某一句文本：只把草稿里 [slot] 第 [index] 句的
+  /// **文本**换成 [text]，音频区间（该句从哪儿到哪儿、属哪个音频文件）原样保留——
+  /// 用户改的是会写进卡片的那行字（错别字、补主语、去掉说话人名），不是这句是哪句。
+  /// 故这里直接转调草稿模型，不重新跑 DOM 取句、也不重算区间。
+  @override
+  Future<void> onEditSentenceContextText(
+    SentenceContextSlot slot,
+    int index,
+    String text,
+  ) async {
+    _miningDraft.editSentence(slot: slot, index: index, text: text);
+  }
+
   /// TODO-382 / TODO-393：弹窗点「清空已加句子」清掉本次查词的上下文选择（回到只制
   /// 当前句），回传清空后的句数（恒 0）。给用户一个明确、可见的撤销入口。
   @override

--- a/fushi/lib/src/pages/implementations/sentence_context_dialog.dart
+++ b/fushi/lib/src/pages/implementations/sentence_context_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:fushi/src/pages/fushi_page_placeholders.dart';
 import 'package:fushi/utils.dart';
 
@@ -12,13 +13,15 @@ import 'package:fushi/utils.dart';
 /// 改为真正的 Flutter 顶层对话框（[showAppDialog]），主题/焦点与 app 一致，句子框不再受
 /// 弹窗表面约束。
 ///
-/// 纯 UI + 三个注入回调，不持有任何宿主状态：
+/// 纯 UI + 注入回调，不持有任何宿主状态：
 ///   * [fetchPreview]：拉当前草稿的真实上下文预览（宿主 `onSentenceContextPreview*`，
 ///     结构 `{prev:[str], current:str, currentOffset:int?, next:[str], total:int}`）。
 ///   * [setContext]：把「上 prev 句 / 下 next 句」整体设进宿主草稿（`onSetSentenceContextToDraft`），
 ///     返回上下文句总数。**整体替换**语义（非累积）。
 ///   * [onConfirm]：确认制卡——回该词条的查词弹窗制卡按钮
 ///     （`DictionaryPopupWebViewState.mineEntryByIndex`，复用全部制卡/查重/覆写逻辑）。
+///   * [editSentence]（可选）：把某一句手改后的文本写回草稿。每张句子卡右上角一个编辑
+///     按钮 → 就地变输入框 → 卡内「确认修改」落地，最后仍由底部「确认制卡」收尾。
 class SentenceContextDialog extends StatefulWidget {
   const SentenceContextDialog({
     super.key,
@@ -26,6 +29,7 @@ class SentenceContextDialog extends StatefulWidget {
     required this.fetchPreview,
     required this.setContext,
     required this.onConfirm,
+    this.editSentence,
     this.previewAudio,
     this.stopAudioPreview,
   });
@@ -41,6 +45,17 @@ class SentenceContextDialog extends StatefulWidget {
 
   /// 确认制卡（回该词条 WebView 制卡按钮）。
   final VoidCallback onConfirm;
+
+  /// 把某一句手改后的文本写回宿主草稿（`MiningSentenceDraft.editSentence`）。
+  ///
+  /// 用户报「加个编辑按钮 → 进入编辑状态 → 最终确认」：每张句子卡（前文各句 / 当前句 /
+  /// 后文各句）都能就地改文本，改完点卡内的「确认修改」落回草稿，再由 `composeText`
+  /// 带进卡片。**只改卡片文本、不改音频身份**——音频区间仍是宿主按原句算出来的，
+  /// 试听与写卡的音频不随手改漂移。
+  ///
+  /// null = 该表面不支持编辑（不渲染任何编辑按钮），与 [previewAudio] 同一处置。
+  final Future<void> Function(SentenceContextSlot slot, int index, String text)?
+      editSentence;
 
   /// BUG-2196 ②：试听**这次制卡真正会写进卡片的那段音频**（不是「当前句的 cue」——
   /// 写进卡的区间还合并了在这个对话框里加减出来的上下文句，并带首尾留白与 A/V
@@ -78,10 +93,32 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
   bool _prevAtMax = false;
   bool _nextAtMax = false;
 
+  // 当前处于编辑态的那一句（null = 没有任何一句在编辑）。同一时刻只允许一句可编辑：
+  // 多句同时开输入框会让「确认」指向不明，也会把矮窗里的句子预览挤没。
+  SentenceContextSlot? _editSlot;
+  int _editIndex = 0;
+  TextEditingController? _editController;
+
+  /// 是否有一句正在编辑。编辑态下 ±上下文 / 试听 / 确认制卡 / 关闭全部禁用——
+  /// 用户的心智是「进入编辑状态 → 改 → 确认」，中途让他能点走或改句数，改到一半的
+  /// 文本要么丢要么贴错句（±会让宿主整体重解析上下文）。
+  bool get _editing => _editSlot != null;
+
+  /// 外层控件（±上下文 / 试听 / 取消 / 确认制卡 / 关闭）是否该禁用：正在跟宿主
+  /// 通信，或有一句正在编辑。编辑器自身的两颗按钮只看 [_busy]，否则一进编辑态就
+  /// 把「确认修改」自己锁死了。
+  bool get _locked => _busy || _editing;
+
   @override
   void initState() {
     super.initState();
     _refresh(initial: true);
+  }
+
+  @override
+  void dispose() {
+    _editController?.dispose();
+    super.dispose();
   }
 
   static List<String> _stringList(Object? v) => v is List
@@ -192,6 +229,48 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
     if (mounted) setState(() => _previewing = false);
   }
 
+  /// 进入某一句的编辑态：把该句当前文本灌进输入框。
+  void _startEdit(SentenceContextSlot slot, int index, String text) {
+    if (_busy || _editing) return;
+    _editController?.dispose();
+    setState(() {
+      _editSlot = slot;
+      _editIndex = index;
+      _editController = TextEditingController(text: text)
+        ..selection = TextSelection.collapsed(offset: text.length);
+    });
+  }
+
+  /// 退出编辑态（不落地）。
+  void _cancelEdit() {
+    if (!_editing) return;
+    _editController?.dispose();
+    setState(() {
+      _editSlot = null;
+      _editIndex = 0;
+      _editController = null;
+    });
+  }
+
+  /// 确认修改：写回宿主草稿，再重新拉一次预览（宿主是唯一真值——它可能把空白句
+  /// 还原成原句，UI 不自作主张地把输入框里的文本直接当成结果显示）。
+  Future<void> _commitEdit() async {
+    final SentenceContextSlot? slot = _editSlot;
+    final Future<void> Function(SentenceContextSlot, int, String)? edit =
+        widget.editSentence;
+    if (slot == null || edit == null) return;
+    final String text = _editController?.text ?? '';
+    final int index = _editIndex;
+    _cancelEdit();
+    setState(() => _busy = true);
+    try {
+      await edit(slot, index, text);
+      await _refresh();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
   /// 当前句里把查到的词高亮：offset 命中优先（offset 处正好是 matched），失配回退
   /// indexOf，再失配整句无高亮——与旧 popup.js `buildHighlightedCurrentText` 同容错。
   Widget _highlightedCurrent(ThemeData theme) {
@@ -237,13 +316,74 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
     );
   }
 
+  /// 句子卡右上角的「编辑」按钮。收到最小尺寸（28）+ compact 密度：它挂在 labelSmall
+  /// 那一行上，默认 48 的命中框会把每张卡都顶高一截，矮窗里几张卡就把句子挤出屏。
+  Widget _editButton(SentenceContextSlot slot, int index, String text) =>
+      IconButton(
+        tooltip: t.popup_ctx_edit_start,
+        visualDensity: VisualDensity.compact,
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+        onPressed:
+            _busy || _editing ? null : () => _startEdit(slot, index, text),
+        icon: const Icon(Icons.edit_outlined, size: 16),
+      );
+
+  /// 编辑态的卡内容：多行输入框 + 「放弃修改 / 确认修改」。
+  ///
+  /// 确认按钮独立于底部的「确认制卡」：用户要的是「先确认这一句改完了」，改完还能继续
+  /// 加减上下文、再改别的句子，最后才按底部主按钮制卡。
+  Widget _editor(ThemeData theme) => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          TextField(
+            controller: _editController,
+            autofocus: true,
+            minLines: 2,
+            maxLines: null,
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.newline,
+            style: theme.textTheme.bodyMedium,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding: EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            alignment: WrapAlignment.end,
+            spacing: 8,
+            runSpacing: 8,
+            children: <Widget>[
+              TextButton(
+                onPressed: _busy ? null : _cancelEdit,
+                child: Text(t.popup_ctx_edit_cancel),
+              ),
+              FilledButton(
+                onPressed: _busy ? null : () => unawaited(_commitEdit()),
+                child: Text(t.popup_ctx_edit_confirm),
+              ),
+            ],
+          ),
+        ],
+      );
+
   Widget _box(
     ThemeData theme, {
     required String label,
     required Widget child,
+    required SentenceContextSlot slot,
+    required String editText,
+    int index = 0,
     bool current = false,
+    bool editable = true,
   }) {
     final ColorScheme scheme = theme.colorScheme;
+    // 这一张卡是不是正被编辑：编辑态换成输入框，且不再走下面的缩略/降透明层
+    // （改文本时该看清楚它，不该比别的卡更淡）。
+    final bool editingThis = _editSlot == slot && _editIndex == index;
     final FushiDesignTokens tokens = FushiDesignTokens.of(context);
     // 走共享 MD3 卡片外壳（FushiCard）而非裸 Container+BoxDecoration：
     // 当前句用更高一档的容器令牌 surfaces.search + primary 描边区分，上/下句用
@@ -258,17 +398,26 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(
-            label,
-            style: theme.textTheme.labelSmall
-                ?.copyWith(color: scheme.onSurfaceVariant),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.labelSmall
+                      ?.copyWith(color: scheme.onSurfaceVariant),
+                ),
+              ),
+              // 编辑入口只在宿主真的能落地编辑时出现（editSentence == null 整颗不渲染）。
+              if (editable && widget.editSentence != null && !editingThis)
+                _editButton(slot, index, editText),
+            ],
           ),
           const SizedBox(height: 4),
-          child,
+          if (editingThis) _editor(theme) else child,
         ],
       ),
     );
-    if (current) return card;
+    if (current || editingThis) return card;
     // 非当前句略缩略淡，做出「当前句浮在上下文之上」的层次（Niratan 卡叠效果）。
     return Opacity(
       opacity: 0.82,
@@ -294,13 +443,31 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
     ThemeData theme, {
     required String label,
     required List<String> sentences,
+    required SentenceContextSlot slot,
   }) {
     if (sentences.isEmpty) {
-      return <Widget>[_box(theme, label: label, child: _emptyText(theme))];
+      // 「(无)」卡没有可改的句子——不给编辑入口（改一句不存在的句子没有落点）。
+      return <Widget>[
+        _box(
+          theme,
+          label: label,
+          slot: slot,
+          editText: '',
+          editable: false,
+          child: _emptyText(theme),
+        ),
+      ];
     }
     return <Widget>[
-      for (final String s in sentences)
-        _box(theme, label: label, child: _sentenceText(theme, s)),
+      for (int i = 0; i < sentences.length; i++)
+        _box(
+          theme,
+          label: label,
+          slot: slot,
+          index: i,
+          editText: sentences[i],
+          child: _sentenceText(theme, sentences[i]),
+        ),
     ];
   }
 
@@ -331,14 +498,26 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
 
     // 一句一卡：前文各句 → 当前句（高亮卡）→ 后文各句，卡间统一 6px 留白。
     final List<Widget> cards = <Widget>[
-      ..._directionCards(theme, label: t.popup_ctx_box_prev, sentences: _prev),
+      ..._directionCards(
+        theme,
+        label: t.popup_ctx_box_prev,
+        sentences: _prev,
+        slot: SentenceContextSlot.prev,
+      ),
       _box(
         theme,
         label: t.popup_ctx_box_current,
+        slot: SentenceContextSlot.current,
+        editText: _current,
         current: true,
         child: _highlightedCurrent(theme),
       ),
-      ..._directionCards(theme, label: t.popup_ctx_box_next, sentences: _next),
+      ..._directionCards(
+        theme,
+        label: t.popup_ctx_box_next,
+        sentences: _next,
+        slot: SentenceContextSlot.next,
+      ),
     ];
     final List<Widget> spacedCards = <Widget>[];
     for (int i = 0; i < cards.length; i++) {
@@ -377,7 +556,7 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
           ),
           IconButton(
             tooltip: t.popup_ctx_cancel,
-            onPressed: _busy ? null : _cancel,
+            onPressed: _locked ? null : _cancel,
             icon: const Icon(Icons.close, size: 20),
           ),
         ],
@@ -416,14 +595,14 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
                             _adjustButton(
                               icon: Icons.remove,
                               label: t.popup_ctx_prev_minus,
-                              onPressed: _busy || _prev.isEmpty
+                              onPressed: _locked || _prev.isEmpty
                                   ? null
                                   : () => _adjust(prevDir: true, plus: false),
                             ),
                             _adjustButton(
                               icon: Icons.add,
                               label: t.popup_ctx_prev_plus,
-                              onPressed: _busy || _prevAtMax
+                              onPressed: _locked || _prevAtMax
                                   ? null
                                   : () => _adjust(prevDir: true, plus: true),
                             ),
@@ -440,14 +619,14 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
                             _adjustButton(
                               icon: Icons.remove,
                               label: t.popup_ctx_next_minus,
-                              onPressed: _busy || _next.isEmpty
+                              onPressed: _locked || _next.isEmpty
                                   ? null
                                   : () => _adjust(prevDir: false, plus: false),
                             ),
                             _adjustButton(
                               icon: Icons.add,
                               label: t.popup_ctx_next_plus,
-                              onPressed: _busy || _nextAtMax
+                              onPressed: _locked || _nextAtMax
                                   ? null
                                   : () => _adjust(prevDir: false, plus: true),
                             ),
@@ -465,7 +644,7 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
         // 的表面才有这个按钮（previewAudio == null 时整颗不渲染）。
         if (widget.previewAudio != null)
           TextButton.icon(
-            onPressed: _busy ? null : _togglePreview,
+            onPressed: _locked ? null : _togglePreview,
             icon: Icon(
               _previewing ? Icons.stop_rounded : Icons.play_arrow_rounded,
             ),
@@ -474,12 +653,12 @@ class _SentenceContextDialogState extends State<SentenceContextDialog>
             ),
           ),
         TextButton(
-          onPressed: _busy ? null : _cancel,
+          onPressed: _locked ? null : _cancel,
           child: Text(t.popup_ctx_cancel),
         ),
         FilledButton(
           autofocus: true,
-          onPressed: _busy ? null : _confirm,
+          onPressed: _locked ? null : _confirm,
           child: Text(t.popup_ctx_confirm),
         ),
       ],

--- a/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi/lookup_mining.part.dart
@@ -79,6 +79,17 @@ extension _VideoLookupMining on _VideoFushiPageState {
     return _miningDraft.length;
   }
 
+  /// 手改草稿里某一句的文本（[DictionaryPageMixin.onEditSentenceContextText] 的私有
+  /// 目标）。**只改文本，不动区间**：这句仍是原来那条 cue、仍是同一段时间窗，GIF 与
+  /// 句子音频的裁法一字不改，改的只是最终写进卡片 sentence 字段的那行字。
+  Future<void> _editSentenceContextText(
+    SentenceContextSlot slot,
+    int index,
+    String text,
+  ) async {
+    _miningDraft.editSentence(slot: slot, index: index, text: text);
+  }
+
   Future<int> _clearSentenceDraft() async {
     _miningDraft.clear();
     return _miningDraft.length;

--- a/fushi/lib/src/pages/implementations/video_fushi_page.dart
+++ b/fushi/lib/src/pages/implementations/video_fushi_page.dart
@@ -1620,6 +1620,13 @@ class _VideoFushiPageState extends ConsumerState<VideoFushiPage>
   Future<int> Function(int prevCount, int nextCount)?
   get onSetSentenceContextToDraft => _setSentenceContextToDraft;
 
+  /// 「选择句子上下文」对话框里手改某一句文本（视频车道）：只把草稿里那一句的**文本**
+  /// 换掉，cue 的时间窗（音频/画面身份）原样保留——用户改的是会写进卡片的那行字
+  /// （字幕错字、去掉说话人名），不是这句对应视频里的哪一段。
+  @override
+  Future<void> Function(SentenceContextSlot slot, int index, String text)?
+      get onEditSentenceContextText => _editSentenceContextText;
+
   /// TODO-382「+句」可撤销（视频车道）：弹窗点「清空已加句子」清掉本会话累积的全部草稿
   /// 句，回传清空后的句数（恒 0）。不动字幕列表「选入词卡」的 cue 选择集（两套独立机制）。
   @override

--- a/fushi/test/media/audiobook/mining_sentence_draft_test.dart
+++ b/fushi/test/media/audiobook/mining_sentence_draft_test.dart
@@ -278,4 +278,221 @@ void main() {
       expect(p['total'], isA<int>());
     });
   });
+
+  group('MiningSentenceDraft.editSentence (user-edited sentence text)', () {
+    MiningDraftSentence s(String text, {int? file, int? start, int? end}) =>
+        MiningDraftSentence(
+          sentence: text,
+          audioRange: file == null
+              ? null
+              : AudioPlaybackRange(
+                  audioFileIndex: file,
+                  startMs: start ?? 0,
+                  endMs: end ?? 0,
+                ),
+        );
+
+    MiningSentenceDraft draftWith({
+      List<String> prev = const <String>[],
+      List<String> next = const <String>[],
+    }) =>
+        MiningSentenceDraft()
+          ..setContext(
+            prev: <MiningDraftSentence>[for (final String p in prev) s(p)],
+            next: <MiningDraftSentence>[for (final String n in next) s(n)],
+          );
+
+    test('editing a context sentence feeds composeText, original text kept',
+        () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      expect(
+        draft.editSentence(
+          slot: SentenceContextSlot.prev,
+          index: 0,
+          text: '前一（改）。',
+        ),
+        isTrue,
+      );
+      expect(draft.composeText('現在。'), '前一（改）。\n現在。');
+      // 原句仍在，供「还原」与重解析后贴回编辑用。
+      expect(draft.prevSentences.single.sentence, '前一。');
+      expect(draft.prevSentences.single.editedSentence, '前一（改）。');
+      expect(draft.prevSentences.single.effectiveSentence, '前一（改）。');
+    });
+
+    test('editing the current sentence overrides it in composeText', () {
+      final MiningSentenceDraft draft = draftWith(next: <String>['後一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '現在（改）。',
+      );
+      expect(draft.currentSentenceEdit, '現在（改）。');
+      expect(draft.composeText('現在。'), '現在（改）。\n後一。');
+    });
+
+    test('edits survive setContext re-resolution (keyed by original text)', () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '前一（改）。',
+      );
+      // 用户接着点「前加一句」：宿主整体重解析，前文变成两句，已改的那句后移一位。
+      draft.setContext(
+        prev: <MiningDraftSentence>[s('前二。'), s('前一。')],
+      );
+      expect(draft.prevSentences[1].effectiveSentence, '前一（改）。');
+      expect(draft.prevSentences[0].effectiveSentence, '前二。');
+      expect(draft.composeText('現在。'), '前二。\n前一（改）。\n現在。');
+    });
+
+    test('blank text restores the original instead of writing an empty line',
+        () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '前一（改）。',
+      );
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '   ',
+      );
+      expect(draft.prevSentences.single.editedSentence, isNull);
+      expect(draft.composeText('現在。'), '前一。\n現在。');
+      expect(draft.hasEdits, isFalse);
+    });
+
+    test('editing back to the original text clears the edit', () {
+      final MiningSentenceDraft draft = draftWith(next: <String>['後一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.next,
+        index: 0,
+        text: '後一（改）。',
+      );
+      expect(draft.hasEdits, isTrue);
+      draft.editSentence(
+        slot: SentenceContextSlot.next,
+        index: 0,
+        text: '後一。',
+      );
+      expect(draft.hasEdits, isFalse);
+      expect(draft.nextSentences.single.editedSentence, isNull);
+    });
+
+    test('blank current edit clears the override', () {
+      final MiningSentenceDraft draft = MiningSentenceDraft();
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '現在（改）。',
+      );
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '',
+      );
+      expect(draft.currentSentenceEdit, isNull);
+      expect(draft.composeText('現在。'), '現在。');
+    });
+
+    test('out-of-range index is a no-op and reports false', () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      expect(
+        draft.editSentence(
+          slot: SentenceContextSlot.prev,
+          index: 3,
+          text: 'x',
+        ),
+        isFalse,
+      );
+      expect(draft.hasEdits, isFalse);
+      expect(draft.composeText('現在。'), '前一。\n現在。');
+    });
+
+    test('editing text never moves the audio range (mirrors sentenceOverride)',
+        () {
+      final MiningSentenceDraft draft = MiningSentenceDraft()
+        ..setContext(
+          prev: <MiningDraftSentence>[
+            s('前一。', file: 0, start: 100, end: 200),
+          ],
+          next: <MiningDraftSentence>[
+            s('後一。', file: 0, start: 500, end: 900),
+          ],
+        );
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '前一（大改，长度完全不同）。',
+      );
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '現在（改）。',
+      );
+      final AudioPlaybackRange? merged = draft.composeAudioRange(
+        range(0, 250, 400),
+      );
+      expect(merged, isNotNull);
+      expect(merged!.startMs, 100);
+      expect(merged.endMs, 900);
+      expect(draft.prevSentences.single.audioRange?.startMs, 100);
+    });
+
+    test('clear() drops edits along with the context', () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '前一（改）。',
+      );
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '現在（改）。',
+      );
+      draft.clear();
+      expect(draft.hasEdits, isFalse);
+      expect(draft.currentSentenceEdit, isNull);
+      expect(draft.composeText('現在。'), '現在。');
+      // 换词后重新出现同一句原文，不该带回上一个词条的改写。
+      draft.setContext(prev: <MiningDraftSentence>[s('前一。')]);
+      expect(draft.prevSentences.single.effectiveSentence, '前一。');
+    });
+
+    test('preview exposes edited text and drops the stale current offset', () {
+      final MiningSentenceDraft draft = draftWith(prev: <String>['前一。']);
+      draft.editSentence(
+        slot: SentenceContextSlot.prev,
+        index: 0,
+        text: '前一（改）。',
+      );
+      Map<String, Object?> p = buildSentenceContextPreview(
+        draft: draft,
+        current: '現在。',
+        currentOffset: 2,
+      );
+      expect(p['prev'], <String>['前一（改）。']);
+      // 当前句没改：offset 照旧有效。
+      expect(p['current'], '現在。');
+      expect(p['currentOffset'], 2);
+
+      draft.editSentence(
+        slot: SentenceContextSlot.current,
+        index: 0,
+        text: '現在（改）。',
+      );
+      p = buildSentenceContextPreview(
+        draft: draft,
+        current: '現在。',
+        currentOffset: 2,
+      );
+      expect(p['current'], '現在（改）。');
+      // 偏移是按原句算的，套到改后的文本上会把高亮划错位置 → 必须置空。
+      expect(p['currentOffset'], isNull);
+    });
+  });
 }

--- a/fushi/test/pages/sentence_context_dialog_widget_test.dart
+++ b/fushi/test/pages/sentence_context_dialog_widget_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fushi/i18n/strings.g.dart';
+import 'package:fushi/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:fushi/src/pages/implementations/sentence_context_dialog.dart';
 
 /// BUG-763/766：「制卡·选择句子上下文」原生顶层对话框（[SentenceContextDialog]）行为测试。
@@ -11,18 +12,27 @@ void main() {
   late int stubNext;
   late List<List<int>> setCalls; // 记录 (prev,next) 调用
   late int confirmCalls;
+  // 手改句子文本：记录 (slot,index,text) 调用，并把改动落进桩，让下一次 preview
+  // 像真宿主那样吐出改后的文本。
+  late List<List<Object>> editCalls;
+  late Map<int, String> prevEdits;
+  late Map<int, String> nextEdits;
+  late String? currentEdit;
+  // 该表面是否支持编辑（false = 宿主没接回调，编辑入口整颗不该渲染）。
+  late bool supportsEdit;
 
   Map<String, Object?> preview() {
     final List<String> prev = <String>[
-      for (int i = 0; i < stubPrev; i++) '前文$i。',
+      for (int i = 0; i < stubPrev; i++) prevEdits[i] ?? '前文$i。',
     ];
     final List<String> next = <String>[
-      for (int i = 0; i < stubNext; i++) '后文$i。',
+      for (int i = 0; i < stubNext; i++) nextEdits[i] ?? '后文$i。',
     ];
     return <String, Object?>{
       'prev': prev,
-      'current': '俺に対する同情。',
-      'currentOffset': 2, // 「対する」在偏移 2
+      'current': currentEdit ?? '俺に対する同情。',
+      // 当前句被手改后偏移失效（宿主置空，见 buildSentenceContextPreview）。
+      'currentOffset': currentEdit == null ? 2 : null, // 「対する」在偏移 2
       'next': next,
       'total': prev.length + next.length,
     };
@@ -46,6 +56,19 @@ void main() {
                     return p + n;
                   },
                   onConfirm: () => confirmCalls++,
+                  editSentence: supportsEdit
+                      ? (SentenceContextSlot slot, int index,
+                          String text) async {
+                          editCalls.add(<Object>[slot, index, text]);
+                          if (slot == SentenceContextSlot.prev) {
+                            prevEdits[index] = text;
+                          } else if (slot == SentenceContextSlot.next) {
+                            nextEdits[index] = text;
+                          } else {
+                            currentEdit = text;
+                          }
+                        }
+                      : null,
                 ),
               ),
               child: const Text('open'),
@@ -61,7 +84,17 @@ void main() {
     stubNext = 0;
     setCalls = <List<int>>[];
     confirmCalls = 0;
+    editCalls = <List<Object>>[];
+    prevEdits = <int, String>{};
+    nextEdits = <int, String>{};
+    currentEdit = null;
+    supportsEdit = true;
   });
+
+  // 用 IconButton finder（不是 byTooltip）：byTooltip 命中的是 RawTooltip 包装层，
+  // 拿不到 IconButton.onPressed 判禁用。
+  Finder editButtons() =>
+      find.widgetWithIcon(IconButton, Icons.edit_outlined);
 
   Future<void> open(WidgetTester tester) async {
     // 放大测试视口，保证对话框全部按钮在屏可点（默认 800x600 会把按钮区挤出屏）。
@@ -128,5 +161,144 @@ void main() {
         reason: '取消必须调 setContext 还原到打开时的快照 (prev=1, next=1)');
     expect(find.text(t.popup_ctx_modal_title), findsNothing);
     expect(confirmCalls, 0);
+  });
+
+  testWidgets('宿主没接编辑回调时一个编辑入口都不渲染', (WidgetTester tester) async {
+    supportsEdit = false;
+    stubPrev = 1;
+    await open(tester);
+    expect(editButtons(), findsNothing);
+    expect(find.byIcon(Icons.edit_outlined), findsNothing);
+  });
+
+  testWidgets('每张有句子的卡各一个编辑按钮，「(无)」空卡没有', (WidgetTester tester) async {
+    stubPrev = 2; // 前文两句 + 当前句 = 3 个入口；后文是「(无)」卡，不给入口。
+    await open(tester);
+    expect(editButtons(), findsNWidgets(3));
+    expect(find.text(t.popup_ctx_box_empty), findsOneWidget);
+  });
+
+  testWidgets('编辑前文某句：改文本 → 确认修改 → 落回宿主并显示改后文本',
+      (WidgetTester tester) async {
+    stubPrev = 2;
+    await open(tester);
+    // 第 0 个入口 = 前文第 0 句。
+    await tester.tap(editButtons().first);
+    await tester.pumpAndSettle();
+    expect(find.byType(TextField), findsOneWidget);
+    // 进入编辑态时输入框里就是那一句的原文。
+    expect(find.widgetWithText(TextField, '前文0。'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), '前文0（改）。');
+    await tester.tap(find.text(t.popup_ctx_edit_confirm));
+    await tester.pumpAndSettle();
+
+    expect(editCalls, hasLength(1));
+    expect(editCalls.single[0], SentenceContextSlot.prev);
+    expect(editCalls.single[1], 0);
+    expect(editCalls.single[2], '前文0（改）。');
+    // 退出编辑态，卡上显示宿主吐回来的新文本；另一句没被动。
+    expect(find.byType(TextField), findsNothing);
+    expect(find.textContaining('前文0（改）。'), findsOneWidget);
+    expect(find.textContaining('前文1。'), findsOneWidget);
+  });
+
+  testWidgets('编辑当前句：slot=current，改后整句重画（旧偏移作废不再高亮原位）',
+      (WidgetTester tester) async {
+    await open(tester);
+    await tester.tap(editButtons().first); // 无上下文时唯一入口 = 当前句
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '書き換えた文。');
+    await tester.tap(find.text(t.popup_ctx_edit_confirm));
+    await tester.pumpAndSettle();
+
+    expect(editCalls.single[0], SentenceContextSlot.current);
+    expect(editCalls.single[2], '書き換えた文。');
+    final Finder rich = find.byWidgetPredicate(
+      (Widget w) =>
+          w is RichText &&
+          w.text is TextSpan &&
+          (w.text as TextSpan).toPlainText().contains('書き換えた文。'),
+    );
+    expect(rich, findsWidgets);
+  });
+
+  testWidgets('放弃修改：不落回宿主，退出编辑态，原文不变', (WidgetTester tester) async {
+    stubPrev = 1;
+    await open(tester);
+    await tester.tap(editButtons().first);
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '不要这个改动。');
+    await tester.tap(find.text(t.popup_ctx_edit_cancel));
+    await tester.pumpAndSettle();
+
+    expect(editCalls, isEmpty);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.textContaining('前文0。'), findsOneWidget);
+    expect(find.textContaining('不要这个改动。'), findsNothing);
+  });
+
+  testWidgets('编辑态下 ±上下文 / 试听 / 取消 / 确认制卡 全部禁用',
+      (WidgetTester tester) async {
+    stubPrev = 1;
+    await open(tester);
+    await tester.tap(editButtons().first);
+    await tester.pumpAndSettle();
+
+    // ±上下文四颗（此时前文有 1 句，「前退一句」本来是可点的）。
+    for (final String label in <String>[
+      t.popup_ctx_prev_minus,
+      t.popup_ctx_prev_plus,
+      t.popup_ctx_next_plus,
+    ]) {
+      final OutlinedButton b =
+          tester.widget(find.widgetWithText(OutlinedButton, label));
+      expect(b.onPressed, isNull, reason: '编辑态下「$label」必须禁用');
+    }
+    // 底部主/次按钮。
+    expect(
+      tester.widget<FilledButton>(find.widgetWithText(
+        FilledButton,
+        t.popup_ctx_confirm,
+      )).onPressed,
+      isNull,
+      reason: '编辑态下「确认制卡」必须禁用——改到一半不该被制卡带走',
+    );
+    expect(
+      tester.widget<TextButton>(find.widgetWithText(
+        TextButton,
+        t.popup_ctx_cancel,
+      )).onPressed,
+      isNull,
+    );
+    // 编辑器自己的两颗按钮反过来必须是活的。
+    expect(
+      tester.widget<FilledButton>(find.widgetWithText(
+        FilledButton,
+        t.popup_ctx_edit_confirm,
+      )).onPressed,
+      isNotNull,
+    );
+    // 同时只允许一句在编辑：其余卡的编辑入口也被禁。
+    for (final Widget w in tester.widgetList(editButtons())) {
+      expect((w as IconButton).onPressed, isNull);
+    }
+  });
+
+  testWidgets('改完一句还能接着加上下文，改动跟着那一句不丢',
+      (WidgetTester tester) async {
+    stubPrev = 1;
+    await open(tester);
+    await tester.tap(editButtons().first);
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), '前文0（改）。');
+    await tester.tap(find.text(t.popup_ctx_edit_confirm));
+    await tester.pumpAndSettle();
+    // 编辑落地后 ±按钮重新可点。
+    await tester.tap(find.widgetWithText(OutlinedButton, t.popup_ctx_next_plus));
+    await tester.pumpAndSettle();
+    expect(setCalls, contains(equals(<int>[1, 1])));
+    expect(find.textContaining('前文0（改）。'), findsOneWidget);
+    expect(find.textContaining('后文0。'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 做什么

「制卡前调整 · 选择句子上下文」对话框支持**逐句手改文本**：每张句子卡（前文各句 / 当前句 / 后文各句）右上角一个编辑按钮 → 就地变多行输入框 → 卡内「确认修改 / 放弃修改」，最后仍由底部「确认制卡」收尾。

| 常态 | 编辑态 | 确认后 |
|---|---|---|
| 每张卡右上角编辑入口 | 输入框 + 确认/放弃；其余控件全部禁用 | 回到只读、显示改后文本、高亮仍命中 |

- 编辑态下 ±上下文 / 试听 / 取消 / 确认制卡全部禁用，同一时刻只允许一句在编辑——避免改到一半被制卡带走，或被 ± 的整体重解析冲掉。
- 「(无)」空卡不给入口；宿主没接回调的表面（纯查词页）一个按钮都不渲染。

## 怎么做

- **编辑收口在草稿层 `MiningSentenceDraft`**：上下文句走 `MiningDraftSentence.editedSentence`，当前句（不在草稿列表里、制卡瞬间由宿主现取）走 `currentSentenceEdit` override。`composeText` 是 reader 与视频两条车道唯一汇聚点，改这里两条车道自动一起生效；没有去改 `MediaSource.currentSentence`（全局态，会污染收藏句 / 落库快照 / 音频高亮）。
- **编辑表以原句文本为键，不是下标**：`setContext` 是整体替换语义，改完一句再点「前加一句」已有句会整体移位，用下标记编辑会贴到别的句子上。
- **只改写进卡片的文本，不动音频区间**（对齐 galgame `sentenceOverride` 的纪律）。
- 当前句改过后预览把 `currentOffset` 置空、回退 indexOf；Anki 侧 `_sentenceValue` 本就有 substring 校验会回退 `replaceFirst`，制卡路径不动。
- 空白文本 = 还原原句，不写空句（删句是「−」按钮的事）。
- 宿主接线：reader 车道 `BaseSourcePageState.onEditSentenceContextText`（reader 覆写），视频/首页车道 `DictionaryPageMixin.onEditSentenceContextText` getter（视频页覆写）；不碰 popup.js / 任何 JS 契约。
- i18n 新增 3 个 key（`popup_ctx_edit_start` / `_confirm` / `_cancel`），走 `i18n_sync --add`；非中英 15 种语言暂回落英文。

## 验证

- `flutter analyze` 全量 No issues found（含 test）。
- 定向 168 条全绿：对话框 4 个 suite + 模态守卫 + 草稿层 + `mining_clip_span` + MD3 静态 + i18n 完整性。
- 目录枚举型守卫整批 367 tests 全过。
- 新增测试 17 条：草稿层 10（编辑落地 / 空白还原 / 改回原文清除 / 加减句后不丢 / 越界 / 音频区间不动 / clear / 预览偏移置空），对话框 widget 7（无回调不渲染 / 空卡无入口 / 三种 slot / 放弃修改 / 编辑态禁用矩阵 / 改完继续加句）。
- widget test 真实像素预览过三态布局（手机宽度 420dp），没有溢出。

https://claude.ai/code/session_01FhQPg2pk8Qdkxbg1Z4TCA8
