### PR TITLE
feat(browser-extension): 视频上的字幕覆盖层可按住拖动挪位，位置按视频分数坐标记住

### DIFF
--- a/fushi/assets/browser_extension/options.css
+++ b/fushi/assets/browser_extension/options.css
@@ -134,6 +134,9 @@ summary:focus-visible {
 
 .setting-row:first-child { border-top: 0; }
 
+/* 不是开关、只带一颗按钮的行：整行不该显示成可点的手形。 */
+.setting-row-static { cursor: default; }
+
 .setting-row:hover .setting-copy strong { color: var(--primary-strong); }
 
 .setting-copy {

--- a/fushi/assets/browser_extension/options.html
+++ b/fushi/assets/browser_extension/options.html
@@ -114,6 +114,14 @@
               </span>
               <span class="switch"><input id="subtitleOverlayEnabled" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <div class="setting-row setting-row-static">
+              <span class="setting-copy">
+                <strong>字幕位置</strong>
+                <small>在视频上按住字幕拖动即可挪到任意位置，位置按视频画面比例记住（全屏、缩放窗口、换视频都跟随）；
+                  点一下仍是查词。</small>
+              </span>
+              <button class="text-button" id="resetSubtitleOverlayPosition" type="button">重置位置</button>
+            </div>
             <label class="setting-row" for="subtitleDragDropEnabled">
               <span class="setting-copy">
                 <strong>允许拖放字幕文件</strong>

--- a/fushi/assets/browser_extension/options.js
+++ b/fushi/assets/browser_extension/options.js
@@ -232,6 +232,13 @@ on('reset', 'click', async () => {
   await refreshConnection(true);
 });
 
+// 覆盖层位置：拖过的位置存 subtitleOverlayPosition（视频分数坐标）；删键即回默认（居中、底锚 88%），
+// 已打开的视频页经 storage.onChanged 立刻重摆。
+on('resetSubtitleOverlayPosition', 'click', async () => {
+  await chrome.storage.local.remove('subtitleOverlayPosition');
+  toast('字幕位置已重置');
+});
+
 on('showToken', 'click', () => {
   const token = $('token');
   const visible = token.type === 'text';

--- a/fushi/assets/browser_extension/subtitle-panel.js
+++ b/fushi/assets/browser_extension/subtitle-panel.js
@@ -42,8 +42,20 @@
     // 预取进 store 了，只是渲染侧默认不用（站点自带轨不叠加，避免双份字幕）。
     // replaceNativeActive = 本轮判定「替代确实生效中」，推给 content.js 决定藏不藏原生。
     replaceNative: false, replaceNativeActive: false,
+    // 覆盖层位置：用户拖过后存 {x, y}，都是**视频矩形的分数**（x = 水平中心、y = 底边锚点），
+    // 不存像素——全屏/退全屏/窗口缩放/换清晰度时视频盒会变，分数坐标让字幕在画面里的相对
+    // 位置不变。null = 没拖过，走默认（居中、底锚 88%）。
+    overlayPos: null,
+    // 进行中的拖拽会话（null = 没在拖）；overlayDragMoved 记「刚才那次按下确实拖动了」，
+    // 用来吞掉松手后浏览器合成的那一次 click——否则每次拖完都会顺手查一次词。
+    overlayDrag: null, overlayDragMoved: false,
   };
   var EXT_PREFIX = '外挂:';
+  var OVERLAY_POS_KEY = 'subtitleOverlayPosition';
+  var OVERLAY_POS_DEFAULT = { x: 0.5, y: 0.88 };
+  // 按下后位移小于这个值仍算点击（查词），超过才进入拖动；与 content.js Shift 悬停的
+  // 4px 限流同量级，略放宽以免手指/鼠标微抖把查词变成挪字幕。
+  var OVERLAY_DRAG_THRESHOLD = 6;
 
   // 键名保留旧名以兼容既有用户设置，语义已是启用原生 Side Panel 字幕能力。
   var SETTING_KEY = 'netflixSubtitlePanel';
@@ -58,6 +70,7 @@
     } catch (_) { cb(false); }
   }
   function teardownAll() {
+    endOverlayDrag(false);
     hideSubtitleOverlay();
     hideDropHint();
     // 面板整体被关掉时替代模式也随之失效（replaceNativeEffective 已含 st.enabled），
@@ -202,8 +215,20 @@
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     st.replaceNative = c.subtitleReplaceNative === true;
+    st.overlayPos = normalizeOverlayPos(c[OVERLAY_POS_KEY]);
     if (!st.overlayEnabled) hideSubtitleOverlay();
+    // 位置变了（另一标签页拖过 / options 页重置）立刻重摆，不等下一个 200ms tick。
+    else if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
     syncNativeSubtitleReplacement();
+  }
+
+  // 存储里的位置只认「两个有限数、都落在 [0,1]」的形状；坏值（旧版本写错、手改 storage）
+  // 一律当没拖过——绝不能把 NaN 写进 style.left 让字幕直接消失。
+  function normalizeOverlayPos(v) {
+    if (!v || typeof v !== 'object') return null;
+    var x = Number(v.x), y = Number(v.y);
+    if (!isFinite(x) || !isFinite(y)) return null;
+    return { x: Math.min(1, Math.max(0, x)), y: Math.min(1, Math.max(0, y)) };
   }
 
   // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
@@ -216,6 +241,7 @@
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
       subtitleReplaceNative: st.replaceNative,
+      subtitleOverlayPosition: st.overlayPos,
     };
   }
 
@@ -224,6 +250,7 @@
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleOverlayAutoLookup',
       'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
+      OVERLAY_POS_KEY,
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -283,8 +310,11 @@
       var el = document.createElement('div');
       el.id = 'fushi-subtitle-overlay';
       el.setAttribute('data-theme', resolveTheme());
+      el.addEventListener('pointerdown', overlayPointerDown);
       el.addEventListener('click', function (e) {
         e.stopPropagation();
+        // 刚拖完字幕松手：这次 click 是拖动的尾巴，不是查词。
+        if (st.overlayDragMoved) { st.overlayDragMoved = false; return; }
         var cue = st.overlayCue;
         if (cue && typeof window.fushiLookupAtPoint === 'function') {
           window.fushiLookupAtPoint(e.clientX, e.clientY, {
@@ -301,6 +331,8 @@
       el.addEventListener('mousemove', function (e) {
         if (!st.overlayAutoLookup || !st.overlayCue ||
             typeof window.fushiLookupAtPoint !== 'function') return;
+        // 拖动中指针在字幕上划过的每个词都不该被自动查——那是在挪字幕，不是在读。
+        if (st.overlayDrag && st.overlayDrag.moved) return;
         if (Math.abs(e.clientX - st.autoLookupLastX) < 4 &&
             Math.abs(e.clientY - st.autoLookupLastY) < 4) return;
         st.autoLookupLastX = e.clientX;
@@ -365,19 +397,115 @@
     el.setAttribute('data-theme', resolveTheme());
     if (typeof window.fushiRenderCueText === 'function') window.fushiRenderCueText(el, cue);
     else el.textContent = cue.text;
-    // 中心恒定贴视频（拖拽跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
-    // 视频中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
+    placeOverlay(el, rect, currentOverlayPos());
+    applyOverlayBlur(el);
+  }
+
+  // 本刻应生效的位置：拖动中用会话里的实时值（tick 每 200ms 重摆也不会把字幕拽回原位），
+  // 否则用持久化的用户位置，没拖过走默认。
+  function currentOverlayPos() {
+    if (st.overlayDrag && st.overlayDrag.pos) return st.overlayDrag.pos;
+    return st.overlayPos || OVERLAY_POS_DEFAULT;
+  }
+
+  // 把分数坐标落成像素。x 是水平中心、y 是底边锚点（CSS transform 是 translate(-50%,-100%)）。
+  function placeOverlay(el, rect, pos) {
+    // 中心贴视频（抽屉拖动跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
+    // 中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
     // 抽屉 → 近侧即屏缘，行宽约等视频盒，永不探进抽屉盖画面（60% 上限保证最窄视频区也 ≥40% 屏）。
+    // 用户把字幕拖向屏缘时同一条规则让行宽收窄折行，永远不出视口。
     var vv = window.innerWidth || (rect.left + rect.right);
-    var cx = rect.left + rect.width / 2;
+    var cx = rect.left + rect.width * pos.x;
     var halfToEdge = Math.max(0, Math.min(cx, vv - cx));
     var maxW = Math.max(200, Math.min(vv * 0.94, (halfToEdge - 6) * 2));
     el.style.left = cx + 'px';
-    // 底边锚定（CSS transform 是 -100%）：文本块从这条线**往上**长。旧版中心锚 84% 时，
-    // 非全屏矮视频（~200px 高）会垂出视频底缘压住进度条——底锚后任何视频高度都出不了界。
-    el.style.top = (rect.top + rect.height * 0.88) + 'px';
+    // 底边锚定：文本块从这条线**往上**长。旧版中心锚 84% 时，非全屏矮视频（~200px 高）会垂出
+    // 视频底缘压住进度条——底锚后任何视频高度都出不了界。
+    el.style.top = (rect.top + rect.height * pos.y) + 'px';
     el.style.maxWidth = Math.round(maxW) + 'px';
-    applyOverlayBlur(el);
+  }
+
+  // 把拖到的像素点夹回视频盒内再换算成分数：中心至少离视频左右缘 8px；底边锚不低于视频底缘、
+  // 不高于「文本块整个还在视频里」的那条线（块高未知/为 0 时退化为不高于视频顶缘）。
+  function overlayPosFromPoint(el, rect, cx, by) {
+    var pad = Math.min(8, rect.width / 2);
+    cx = Math.min(rect.right - pad, Math.max(rect.left + pad, cx));
+    var h = el && typeof el.offsetHeight === 'number' ? el.offsetHeight : 0;
+    var minBy = rect.top + Math.min(h, rect.height);
+    by = Math.min(rect.bottom, Math.max(minBy, by));
+    return { x: (cx - rect.left) / rect.width, y: (by - rect.top) / rect.height };
+  }
+
+  // ── 覆盖层拖拽：按住字幕拖动即挪位；松手按视频分数坐标持久化，点击（位移 < 阈值）仍是查词 ──
+  // 监听挂 window 而不只靠 setPointerCapture：老内核上 capture 静默失败过（见 mobile-drawer.js），
+  // 挂 window 全程收得到 move/up；capture 仍尝试一下，多一层保险。
+  function overlayPointerDown(e) {
+    if (e.button !== undefined && e.button !== null && e.button !== 0) return;
+    if (st.overlayDrag) endOverlayDrag(false);
+    st.overlayDragMoved = false;
+    var from = st.overlayPos || OVERLAY_POS_DEFAULT;
+    st.overlayDrag = {
+      id: e.pointerId, x0: e.clientX, y0: e.clientY,
+      from: from, pos: null, moved: false,
+    };
+    window.addEventListener('pointermove', overlayPointerMove);
+    window.addEventListener('pointerup', overlayPointerUp);
+    window.addEventListener('pointercancel', overlayPointerCancel);
+    try { if (st.overlayEl) st.overlayEl.setPointerCapture(e.pointerId); } catch (_) {}
+    // 不 preventDefault：让点击/取词的默认链路照常；过阈值进入拖动后才接管。
+  }
+  function overlayPointerMove(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    var dx = e.clientX - d.x0, dy = e.clientY - d.y0;
+    if (!d.moved) {
+      if (dx * dx + dy * dy < OVERLAY_DRAG_THRESHOLD * OVERLAY_DRAG_THRESHOLD) return;
+      d.moved = true;
+      if (st.overlayEl) st.overlayEl.setAttribute('data-dragging', '');
+      // 过阈值前浏览器可能已经拉出一小段文字选区（覆盖层 user-select:text），拖动一开始就清掉。
+      try { window.getSelection().removeAllRanges(); } catch (_) {}
+    }
+    var video = videoEl();
+    if (!video || typeof video.getBoundingClientRect !== 'function') return;
+    var rect = video.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return;
+    d.pos = overlayPosFromPoint(st.overlayEl, rect,
+      rect.left + rect.width * d.from.x + dx, rect.top + rect.height * d.from.y + dy);
+    if (st.overlayEl && st.overlayCue) placeOverlay(st.overlayEl, rect, d.pos);
+    try { e.preventDefault(); } catch (_) {}
+  }
+  function overlayPointerUp(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    endOverlayDrag(true);
+  }
+  function overlayPointerCancel(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    endOverlayDrag(false);
+  }
+  // commit=true：把会话位置写成用户位置并持久化；false（取消/面板关闭）：丢弃、回到原位。
+  function endOverlayDrag(commit) {
+    var d = st.overlayDrag;
+    if (!d) return;
+    st.overlayDrag = null;
+    window.removeEventListener('pointermove', overlayPointerMove);
+    window.removeEventListener('pointerup', overlayPointerUp);
+    window.removeEventListener('pointercancel', overlayPointerCancel);
+    if (st.overlayEl) {
+      try { st.overlayEl.removeAttribute('data-dragging'); } catch (_) {}
+    }
+    if (!d.moved) return;
+    // 真拖过：紧随其后的那次合成 click 要吞掉（不查词）。下一次 pointerdown 会清这个标记，
+    // 所以拖出界没产生 click 也不会误吞后面无关的点击。
+    st.overlayDragMoved = true;
+    if (commit && d.pos) {
+      st.overlayPos = d.pos;
+      var patch = {};
+      patch[OVERLAY_POS_KEY] = d.pos;
+      try { chrome.storage.local.set(patch); } catch (_) {}
+    }
+    if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
   }
 
   function firstCueAfter(ms) {
@@ -833,6 +961,7 @@
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
         'subtitleOverlayAutoLookup',
         'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
+        OVERLAY_POS_KEY,
       ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }

--- a/fushi/assets/browser_extension/vendor/content.css
+++ b/fushi/assets/browser_extension/vendor/content.css
@@ -2155,12 +2155,16 @@
     opacity: 0.6;
 }
 
-/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词。 */
+/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词；
+   按住拖动可挪位（subtitle-panel.js，位置按视频分数坐标记住）。 */
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    /* top 给的是底边锚点（JS 默认写 88% 处，用户拖过则是记住的分数）：-100% 让文字向上长，
+       短视频不溢出视频下缘。 */
     transform: translate(-50%, -100%);
+    /* 触屏拖字幕时不让浏览器把手势抢去滚页面/缩放：覆盖层压在视频上，本就不该从这里滚页。 */
+    touch-action: none;
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -2173,6 +2177,12 @@
     white-space: pre-wrap;
     user-select: text;
     cursor: text;
+}
+
+/* 拖动中：抓手光标 + 禁选区（否则移动指针会同时拉出一条文字选区）。 */
+#fushi-subtitle-overlay[data-dragging] {
+    cursor: grabbing;
+    user-select: none;
 }
 
 /* 覆盖层里的振假名：与字幕列表同一套取向——读音在正文上方、不参与选择/取词。 */

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -13,7 +13,7 @@ Anki 能力——一切经本机 Fushi 桌面 App 内置的 yomitan API server�
 | `content.js` | 隔离 | Shift 悬停查词、查词暂停、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样兜底 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
 | `nested-popup-host.js` | 隔离 | 嵌套父子栈、子 iframe 定位、按层桥接、异步结果归属；只关闭根层时恢复视频 |
 | `nested-popup.html/js` | 扩展 iframe | 每层独立的共享词典 renderer、选区、制卡和滚动状态；经专用 MessageChannel 与宿主通信 |
-| `subtitle-panel.js` | 隔离 | 字幕轨状态控制器 + 视频覆盖层 + 外挂字幕安装 + 全轨时轴偏移 + 快捷键执行端；不渲染网页列表 |
+| `subtitle-panel.js` | 隔离 | 字幕轨状态控制器 + 视频覆盖层（可按住拖动挪位，位置按视频分数坐标存 `subtitleOverlayPosition`，点击仍查词）+ 外挂字幕安装 + 全轨时轴偏移 + 快捷键执行端；不渲染网页列表 |
 | `side-panel.html/js/css` | 扩展页 | 浏览器原生 Side Panel 字幕列表；侧边栏内取词，默认把词交给宿主页用页面弹窗渲染（见「侧边栏查词跨出面板」），经 tabs 消息读取轨道并执行跳转/制卡/偏移，不把字幕列表注入网页 |
 | `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；每个动作独立开关，动作交 subtitle-panel 执行 |
 | `touch-lookup.js` | 隔离 | 触屏点按/长按查词：单指点正文=查词（默认开）、长按≈0.5s=查词（默认关）；复用 content.js 的 `fushiLookupAtPoint`，零新增查词链路，只认 touch 主指针，绝不影响鼠标行为 |

--- a/tools/browser-extension/options.css
+++ b/tools/browser-extension/options.css
@@ -134,6 +134,9 @@ summary:focus-visible {
 
 .setting-row:first-child { border-top: 0; }
 
+/* 不是开关、只带一颗按钮的行：整行不该显示成可点的手形。 */
+.setting-row-static { cursor: default; }
+
 .setting-row:hover .setting-copy strong { color: var(--primary-strong); }
 
 .setting-copy {

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -114,6 +114,14 @@
               </span>
               <span class="switch"><input id="subtitleOverlayEnabled" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
+            <div class="setting-row setting-row-static">
+              <span class="setting-copy">
+                <strong>字幕位置</strong>
+                <small>在视频上按住字幕拖动即可挪到任意位置，位置按视频画面比例记住（全屏、缩放窗口、换视频都跟随）；
+                  点一下仍是查词。</small>
+              </span>
+              <button class="text-button" id="resetSubtitleOverlayPosition" type="button">重置位置</button>
+            </div>
             <label class="setting-row" for="subtitleDragDropEnabled">
               <span class="setting-copy">
                 <strong>允许拖放字幕文件</strong>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -232,6 +232,13 @@ on('reset', 'click', async () => {
   await refreshConnection(true);
 });
 
+// 覆盖层位置：拖过的位置存 subtitleOverlayPosition（视频分数坐标）；删键即回默认（居中、底锚 88%），
+// 已打开的视频页经 storage.onChanged 立刻重摆。
+on('resetSubtitleOverlayPosition', 'click', async () => {
+  await chrome.storage.local.remove('subtitleOverlayPosition');
+  toast('字幕位置已重置');
+});
+
 on('showToken', 'click', () => {
   const token = $('token');
   const visible = token.type === 'text';

--- a/tools/browser-extension/scripts/content-css-overlay.css
+++ b/tools/browser-extension/scripts/content-css-overlay.css
@@ -126,12 +126,16 @@
     opacity: 0.6;
 }
 
-/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词。 */
+/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词；
+   按住拖动可挪位（subtitle-panel.js，位置按视频分数坐标记住）。 */
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    /* top 给的是底边锚点（JS 默认写 88% 处，用户拖过则是记住的分数）：-100% 让文字向上长，
+       短视频不溢出视频下缘。 */
     transform: translate(-50%, -100%);
+    /* 触屏拖字幕时不让浏览器把手势抢去滚页面/缩放：覆盖层压在视频上，本就不该从这里滚页。 */
+    touch-action: none;
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -144,6 +148,12 @@
     white-space: pre-wrap;
     user-select: text;
     cursor: text;
+}
+
+/* 拖动中：抓手光标 + 禁选区（否则移动指针会同时拉出一条文字选区）。 */
+#fushi-subtitle-overlay[data-dragging] {
+    cursor: grabbing;
+    user-select: none;
 }
 
 /* 覆盖层里的振假名：与字幕列表同一套取向——读音在正文上方、不参与选择/取词。 */

--- a/tools/browser-extension/subtitle-overlay-drag.test.js
+++ b/tools/browser-extension/subtitle-overlay-drag.test.js
@@ -1,0 +1,411 @@
+// 视频上的自绘字幕覆盖层可拖动（用户诉求：字幕挡住画面/进度条时能挪开，像 asbplayer 那样）。
+//
+// 本测试在受控 vm 里真加载 content.js + subtitle-panel.js，向覆盖层派发 pointer 事件，钉住：
+//   ① 没拖过：居中、底边锚 88%（旧行为一字不改）。
+//   ② 位移小于阈值只是点击 → 仍走 fushiLookupAtPoint 查词，位置不变、不写存储。
+//   ③ 过阈值 → 覆盖层跟手；松手按**视频矩形的分数坐标**写 chrome.storage.local.subtitleOverlayPosition，
+//      紧随其后的合成 click 被吞掉（不查词），再下一次点击照常查词。
+//   ④ 位置是分数：视频盒变化（全屏/缩放）后按新盒重算，字幕留在画面里的同一相对位置；
+//      每 200ms 的 tick 重摆也不把拖动中的字幕拽回原位。
+//   ⑤ 拖出视频盒被夹回盒内；pointercancel 丢弃本次拖动回到原位；options 页删键即回默认。
+//   ⑥ 存储里的坏值当没拖过，绝不把 NaN 写进 style。
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const CONTENT = path.join(__dirname, 'content.js');
+const ADAPTERS = path.join(__dirname, 'subtitle-adapters.js');
+const PROVIDERS = path.join(__dirname, 'subtitle-providers.js');
+const PANEL = path.join(__dirname, 'subtitle-panel.js');
+const POPUP_SIZE = path.join(__dirname, 'popup-size.js');
+const DICT_MEDIA = path.join(__dirname, 'vendor', 'dict-media.js');
+const OVERLAY_ID = 'fushi-subtitle-overlay';
+const POS_KEY = 'subtitleOverlayPosition';
+
+function makeEl(tag) {
+  const listeners = Object.create(null);
+  const attrs = Object.create(null);
+  const el = {
+    tagName: (tag || 'div').toUpperCase(),
+    _id: '',
+    className: '',
+    textContent: '',
+    style: { cssText: '', setProperty() {}, getPropertyValue: () => '' },
+    dataset: {},
+    children: [],
+    parentNode: null,
+    offsetHeight: 40,
+    setAttribute(k, v) { if (k === 'id') el._id = v; attrs[k] = String(v); },
+    removeAttribute(k) { delete attrs[k]; },
+    getAttribute(k) { return k in attrs ? attrs[k] : null; },
+    hasAttribute(k) { return k in attrs; },
+    classList: { add() {}, remove() {}, toggle() {} },
+    addEventListener(type, fn) { (listeners[type] = listeners[type] || []).push(fn); },
+    removeEventListener(type, fn) {
+      const l = listeners[type] || [];
+      const i = l.indexOf(fn);
+      if (i >= 0) l.splice(i, 1);
+    },
+    dispatch(type, ev) {
+      const e = Object.assign({
+        type, stopPropagation() {}, preventDefault() {}, stopImmediatePropagation() {},
+      }, ev || {});
+      for (const fn of (listeners[type] || []).slice()) fn(e);
+      return e;
+    },
+    setPointerCapture() {},
+    appendChild(child) { child.parentNode = el; el.children.push(child); return child; },
+    removeChild(child) {
+      const i = el.children.indexOf(child);
+      if (i >= 0) el.children.splice(i, 1);
+      child.parentNode = null;
+      return child;
+    },
+    remove() { if (el.parentNode) el.parentNode.removeChild(el); },
+    contains(x) { return x === el || el.children.some((c) => c.contains && c.contains(x)); },
+    getBoundingClientRect() {
+      return { x: 0, y: 0, left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    },
+  };
+  Object.defineProperty(el, 'id', { get: () => el._id, set: (v) => { el._id = v; } });
+  return el;
+}
+
+function findById(root, id) {
+  if (root._id === id) return root;
+  for (const c of root.children) {
+    const hit = findById(c, id);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function rectOf(left, top, width, height) {
+  return { x: left, y: top, left, top, right: left + width, bottom: top + height, width, height };
+}
+
+// 建一个装好 content.js + subtitle-panel.js 的世界；覆盖层用「全轨覆盖层」偏好打开，
+// 这样站点检测轨也画覆盖层，不必走外挂文件导入。
+function loadWorld(prefs) {
+  const head = makeEl('head');
+  const body = makeEl('body');
+  const html = makeEl('html');
+  html.appendChild(head);
+  html.appendChild(body);
+  const stored = Object.assign(
+    { netflixSubtitlePanel: true, subtitleOverlayAllTracks: true }, prefs || {});
+  const changeListeners = [];
+  const intervals = [];
+  const winListeners = Object.create(null);
+  const lookups = [];
+  const video = {
+    currentTime: 0, paused: false, playbackRate: 1, textTracks: [],
+    rect: rectOf(100, 50, 1280, 720),
+    getBoundingClientRect() { return video.rect; },
+  };
+
+  const sandbox = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout: () => 0,
+    clearTimeout() {},
+    setInterval: (fn, ms) => { intervals.push({ fn, ms }); return intervals.length; },
+    clearInterval() {},
+    requestAnimationFrame: () => 0,
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    URL,
+    Node: { TEXT_NODE: 3, ELEMENT_NODE: 1 },
+    location: {
+      hostname: 'www.youtube.com',
+      href: 'https://www.youtube.com/watch?v=abc123',
+      pathname: '/watch',
+      search: '?v=abc123',
+    },
+  };
+  sandbox.document = {
+    documentElement: html,
+    head,
+    body,
+    fullscreenElement: null,
+    addEventListener() {},
+    getElementById: (id) => findById(html, id),
+    querySelector: (sel) => (sel === 'video' ? video : null),
+    querySelectorAll: () => [],
+    createElement: (tag) => makeEl(tag),
+    createTreeWalker: () => ({ nextNode: () => null }),
+  };
+  sandbox.chrome = {
+    runtime: {
+      id: 'test-ext-id',
+      getURL: (rel) => `chrome-extension://test-ext-id/${rel}`,
+      lastError: null,
+      onMessage: { addListener() {} },
+      sendMessage() {},
+    },
+    storage: {
+      local: {
+        // 同步 thenable：偏好在加载期就读好（理由见 subtitle-replace-native.test.js）。
+        get: (keys, cb) => {
+          const out = {};
+          for (const k of [].concat(keys)) if (k in stored) out[k] = stored[k];
+          if (cb) { cb(out); return undefined; }
+          return { then: (fn) => { fn(out); return { catch() {} }; }, catch() {} };
+        },
+        set: (patch, cb) => {
+          const changes = {};
+          for (const k of Object.keys(patch)) {
+            changes[k] = { oldValue: stored[k], newValue: patch[k] };
+            stored[k] = patch[k];
+          }
+          // 真实 chrome：本页写 storage 也会收到自己的 onChanged。
+          for (const fn of changeListeners) fn(changes, 'local');
+          if (cb) cb();
+          return Promise.resolve();
+        },
+        remove: (keys) => {
+          const changes = {};
+          for (const k of [].concat(keys)) {
+            changes[k] = { oldValue: stored[k] };
+            delete stored[k];
+          }
+          for (const fn of changeListeners) fn(changes, 'local');
+          return Promise.resolve();
+        },
+      },
+      onChanged: { addListener: (fn) => changeListeners.push(fn) },
+    },
+  };
+  sandbox.window = {
+    addEventListener(type, fn) { (winListeners[type] = winListeners[type] || []).push(fn); },
+    removeEventListener(type, fn) {
+      const l = winListeners[type] || [];
+      const i = l.indexOf(fn);
+      if (i >= 0) l.splice(i, 1);
+    },
+    postMessage() {},
+    innerWidth: 1600,
+    innerHeight: 900,
+    matchMedia: () => ({ matches: false }),
+    getSelection: () => ({ removeAllRanges() {} }),
+    fushiSelection: {
+      getCharacterAtPoint: () => null,
+      selectFromPosition: () => '',
+      clearSelection() {},
+    },
+  };
+  sandbox.window.window = sandbox.window;
+  sandbox.self = sandbox.window;
+  sandbox.globalThis = sandbox;
+  sandbox.navigator = { clipboard: { writeText: () => Promise.resolve() } };
+
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(DICT_MEDIA, 'utf8'), sandbox, { filename: 'vendor/dict-media.js' });
+  vm.runInContext(fs.readFileSync(POPUP_SIZE, 'utf8'), sandbox, { filename: 'popup-size.js' });
+  vm.runInContext(fs.readFileSync(ADAPTERS, 'utf8'), sandbox, { filename: 'subtitle-adapters.js' });
+  vm.runInContext(fs.readFileSync(PROVIDERS, 'utf8'), sandbox, { filename: 'subtitle-providers.js' });
+  vm.runInContext(fs.readFileSync(CONTENT, 'utf8'), sandbox, { filename: 'content.js' });
+  vm.runInContext(fs.readFileSync(PANEL, 'utf8'), sandbox, { filename: 'subtitle-panel.js' });
+  // 覆盖层点击走 window.fushiLookupAtPoint；桩掉它以观察「有没有查词」。
+  sandbox.window.fushiLookupAtPoint = (x, y, cue) => { lookups.push({ x, y, cue }); };
+
+  const tick = () => { for (const it of intervals) if (it.ms === 200) it.fn(); };
+  const overlayEl = () => findById(html, OVERLAY_ID);
+  const setTrack = (lang, cues) => {
+    const key = 'yt-abc123|' + lang;
+    sandbox.window.fushiEpisodeCues[key] = cues;
+    sandbox.window.fushiSubtitlePanelOnCues(key);
+  };
+  // 真实浏览器：pointerdown 在元素上，move/up 由 window 监听（面板挂在 window 上）。
+  const winDispatch = (type, ev) => {
+    const e = Object.assign({ type, preventDefault() {}, stopPropagation() {} }, ev || {});
+    for (const fn of (winListeners[type] || []).slice()) fn(e);
+  };
+  const drag = (from, to, opts) => {
+    const el = overlayEl();
+    const id = (opts && opts.pointerId) || 7;
+    el.dispatch('pointerdown', { pointerId: id, button: 0, clientX: from.x, clientY: from.y });
+    winDispatch('pointermove', { pointerId: id, clientX: to.x, clientY: to.y });
+    if (opts && opts.cancel) winDispatch('pointercancel', { pointerId: id });
+    else winDispatch('pointerup', { pointerId: id, clientX: to.x, clientY: to.y });
+    // 浏览器在 pointerup 后合成 click（capture 时目标就是覆盖层本身）。
+    const target = overlayEl() || el;
+    target.dispatch('click', { clientX: to.x, clientY: to.y });
+  };
+  const geom = () => {
+    const el = overlayEl();
+    return { left: parseFloat(el.style.left), top: parseFloat(el.style.top) };
+  };
+  return { sandbox, stored, tick, overlayEl, setTrack, video, drag, geom, lookups, winListeners };
+}
+
+const CUES = [
+  { startMs: 0, endMs: 3000, text: '君の名は' },
+  { startMs: 3000, endMs: 6000, text: '大丈夫だ' },
+];
+
+test('没拖过：居中、底边锚 88%（旧默认不变）', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  const el = w.overlayEl();
+  assert.ok(el, '全轨覆盖层开着，站点轨也要画覆盖层');
+  assert.deepStrictEqual(w.geom(), { left: 100 + 640, top: 50 + 720 * 0.88 });
+  assert.strictEqual(w.stored[POS_KEY], undefined, '没拖过不写存储');
+});
+
+test('位移小于阈值 = 点击：照常查词，位置不变、不写存储', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  w.drag({ x: 740, y: 680 }, { x: 743, y: 682 });
+  assert.strictEqual(w.lookups.length, 1, '微抖动仍是点击，必须查词');
+  assert.strictEqual(w.lookups[0].cue.text, CUES[0].text);
+  assert.deepStrictEqual(w.geom(), { left: 740, top: 683.6 });
+  assert.strictEqual(w.stored[POS_KEY], undefined);
+  assert.ok(!w.overlayEl().hasAttribute('data-dragging'));
+});
+
+test('过阈值 = 拖动：跟手、按视频分数坐标持久化、吞掉尾随 click；下一次点击照常查词', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  // 从默认点 (740, 683.6) 拖到左上 200px / 300px。
+  w.drag({ x: 740, y: 683.6 }, { x: 540, y: 383.6 });
+  assert.strictEqual(w.lookups.length, 0, '拖完松手的 click 不是查词');
+  const g = w.geom();
+  assert.ok(Math.abs(g.left - 540) < 1e-6 && Math.abs(g.top - 383.6) < 1e-6, '覆盖层跟手落在松手处');
+  const pos = w.stored[POS_KEY];
+  assert.ok(pos, '松手必须持久化');
+  assert.ok(Math.abs(pos.x - (540 - 100) / 1280) < 1e-9, 'x 是视频宽的分数');
+  assert.ok(Math.abs(pos.y - (383.6 - 50) / 720) < 1e-9, 'y 是视频高的分数');
+  assert.ok(!w.overlayEl().hasAttribute('data-dragging'), '松手后拖动态样式要撤');
+  // tick 重摆不会拽回默认位。
+  w.tick();
+  assert.ok(Math.abs(w.geom().left - 540) < 1e-6);
+  // 之后的普通点击又是查词。
+  w.overlayEl().dispatch('click', { clientX: 540, clientY: 380 });
+  assert.strictEqual(w.lookups.length, 1, '拖动只吞自己那一次 click');
+});
+
+test('位置是分数：视频盒变化（全屏/缩放）后按新盒重算，留在画面同一相对位置', () => {
+  const w = loadWorld({ [POS_KEY]: { x: 0.25, y: 0.5 } });
+  w.setTrack('ja', CUES);
+  w.tick();
+  assert.deepStrictEqual(w.geom(), { left: 100 + 1280 * 0.25, top: 50 + 720 * 0.5 });
+  w.video.rect = rectOf(0, 0, 1600, 900); // 全屏
+  w.tick();
+  assert.deepStrictEqual(w.geom(), { left: 400, top: 450 });
+});
+
+test('拖动中 tick 重摆用会话里的实时位置，不把字幕拽回原位', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  const el = w.overlayEl();
+  el.dispatch('pointerdown', { pointerId: 3, button: 0, clientX: 740, clientY: 683.6 });
+  const move = (x, y) => {
+    for (const fn of (w.winListeners.pointermove || []).slice()) {
+      fn({ type: 'pointermove', pointerId: 3, clientX: x, clientY: y, preventDefault() {} });
+    }
+  };
+  move(640, 583.6);
+  assert.ok(el.hasAttribute('data-dragging'), '过阈值后进入拖动态');
+  assert.ok(Math.abs(w.geom().left - 640) < 1e-6);
+  w.tick();
+  assert.ok(Math.abs(w.geom().left - 640) < 1e-6, 'tick 不得把拖动中的字幕拽回默认位');
+  assert.ok(Math.abs(w.geom().top - 583.6) < 1e-6);
+  assert.strictEqual(w.stored[POS_KEY], undefined, '没松手不写存储');
+});
+
+test('拖出视频盒被夹回盒内（中心离左右缘 ≥8px，底锚在视频底缘与「块整个在视频里」之间）', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  w.drag({ x: 740, y: 683.6 }, { x: -500, y: 2000 });
+  const pos = w.stored[POS_KEY];
+  assert.ok(Math.abs(pos.x - 8 / 1280) < 1e-9, 'x 夹到左缘 +8px');
+  assert.strictEqual(pos.y, 1, 'y 夹到视频底缘');
+  const w2 = loadWorld();
+  w2.setTrack('ja', CUES);
+  w2.tick();
+  w2.drag({ x: 740, y: 683.6 }, { x: 5000, y: -5000 });
+  const pos2 = w2.stored[POS_KEY];
+  assert.ok(Math.abs(pos2.x - (1280 - 8) / 1280) < 1e-9, 'x 夹到右缘 -8px');
+  // 块高 40px（桩的 offsetHeight）：底锚最高只能到视频顶 +40，文本块不出画面上缘。
+  assert.ok(Math.abs(pos2.y - 40 / 720) < 1e-9, 'y 夹到「块整个还在视频里」');
+});
+
+test('pointercancel 丢弃本次拖动回到原位，且不写存储、不吞下一次点击的查词', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  w.drag({ x: 740, y: 683.6 }, { x: 540, y: 383.6 }, { cancel: true });
+  assert.strictEqual(w.stored[POS_KEY], undefined);
+  assert.deepStrictEqual(w.geom(), { left: 740, top: 683.6 }, '取消后回默认位');
+  assert.strictEqual(w.lookups.length, 0, '取消后紧随的合成 click 同样不查词（那次按下确实拖过）');
+  w.overlayEl().dispatch('click', { clientX: 740, clientY: 680 });
+  assert.strictEqual(w.lookups.length, 1);
+});
+
+test('options 页「重置位置」删键 → 已打开的视频页立刻回默认', () => {
+  const w = loadWorld({ [POS_KEY]: { x: 0.25, y: 0.5 } });
+  w.setTrack('ja', CUES);
+  w.tick();
+  assert.deepStrictEqual(w.geom(), { left: 420, top: 410 });
+  w.sandbox.chrome.storage.local.remove(POS_KEY);
+  assert.deepStrictEqual(w.geom(), { left: 740, top: 683.6 }, '不等 tick 就重摆');
+});
+
+test('另一标签页拖过（storage.onChanged 带新位置）→ 本页同步跟随', () => {
+  const w = loadWorld();
+  w.setTrack('ja', CUES);
+  w.tick();
+  w.sandbox.chrome.storage.local.set({ [POS_KEY]: { x: 0.5, y: 0.2 } });
+  assert.deepStrictEqual(w.geom(), { left: 740, top: 50 + 720 * 0.2 });
+});
+
+test('存储里的坏值当没拖过：不把 NaN 写进 style', () => {
+  for (const bad of [{ x: 'a', y: 0.5 }, { x: NaN, y: 0.1 }, 'nope', 42, null, { x: 5, y: -3 }]) {
+    const w = loadWorld({ [POS_KEY]: bad });
+    w.setTrack('ja', CUES);
+    w.tick();
+    const g = w.geom();
+    assert.ok(Number.isFinite(g.left) && Number.isFinite(g.top), `坏值 ${JSON.stringify(bad)} 不得产出 NaN`);
+  }
+  // 越界的数值被夹进 [0,1]，而不是丢弃。
+  const w = loadWorld({ [POS_KEY]: { x: 5, y: -3 } });
+  w.setTrack('ja', CUES);
+  w.tick();
+  assert.deepStrictEqual(w.geom(), { left: 100 + 1280, top: 50 });
+});
+
+test('拖动中不触发悬浮字幕自动查词', () => {
+  const w = loadWorld({ subtitleOverlayAutoLookup: true });
+  w.setTrack('ja', CUES);
+  w.tick();
+  const el = w.overlayEl();
+  el.dispatch('mousemove', { clientX: 700, clientY: 680 });
+  assert.strictEqual(w.lookups.length, 1, '未拖动时悬停自动查词照常');
+  el.dispatch('pointerdown', { pointerId: 9, button: 0, clientX: 740, clientY: 683.6 });
+  for (const fn of (w.winListeners.pointermove || []).slice()) {
+    fn({ type: 'pointermove', pointerId: 9, clientX: 640, clientY: 583.6, preventDefault() {} });
+  }
+  el.dispatch('mousemove', { clientX: 600, clientY: 560 });
+  assert.strictEqual(w.lookups.length, 1, '拖动中划过的词不查');
+});
+
+test('CSS：拖动态抓手 + 禁选区、覆盖层 touch-action:none（触屏拖字幕不被滚页抢走）', () => {
+  const css = fs.readFileSync(path.join(__dirname, 'vendor', 'content.css'), 'utf8');
+  assert.match(css, /#fushi-subtitle-overlay\[data-dragging\]\s*\{[^}]*cursor:\s*grabbing/);
+  assert.match(css, /#fushi-subtitle-overlay\[data-dragging\]\s*\{[^}]*user-select:\s*none/);
+  assert.match(css, /#fushi-subtitle-overlay\s*\{[^}]*touch-action:\s*none/);
+});
+
+test('options 页有「重置位置」按钮且 options.js 删的是同一把键', () => {
+  const html = fs.readFileSync(path.join(__dirname, 'options.html'), 'utf8');
+  const js = fs.readFileSync(path.join(__dirname, 'options.js'), 'utf8');
+  assert.match(html, /id="resetSubtitleOverlayPosition"/);
+  assert.match(js, /on\('resetSubtitleOverlayPosition',\s*'click'/);
+  assert.match(js, /chrome\.storage\.local\.remove\('subtitleOverlayPosition'\)/);
+});

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -42,8 +42,20 @@
     // 预取进 store 了，只是渲染侧默认不用（站点自带轨不叠加，避免双份字幕）。
     // replaceNativeActive = 本轮判定「替代确实生效中」，推给 content.js 决定藏不藏原生。
     replaceNative: false, replaceNativeActive: false,
+    // 覆盖层位置：用户拖过后存 {x, y}，都是**视频矩形的分数**（x = 水平中心、y = 底边锚点），
+    // 不存像素——全屏/退全屏/窗口缩放/换清晰度时视频盒会变，分数坐标让字幕在画面里的相对
+    // 位置不变。null = 没拖过，走默认（居中、底锚 88%）。
+    overlayPos: null,
+    // 进行中的拖拽会话（null = 没在拖）；overlayDragMoved 记「刚才那次按下确实拖动了」，
+    // 用来吞掉松手后浏览器合成的那一次 click——否则每次拖完都会顺手查一次词。
+    overlayDrag: null, overlayDragMoved: false,
   };
   var EXT_PREFIX = '外挂:';
+  var OVERLAY_POS_KEY = 'subtitleOverlayPosition';
+  var OVERLAY_POS_DEFAULT = { x: 0.5, y: 0.88 };
+  // 按下后位移小于这个值仍算点击（查词），超过才进入拖动；与 content.js Shift 悬停的
+  // 4px 限流同量级，略放宽以免手指/鼠标微抖把查词变成挪字幕。
+  var OVERLAY_DRAG_THRESHOLD = 6;
 
   // 键名保留旧名以兼容既有用户设置，语义已是启用原生 Side Panel 字幕能力。
   var SETTING_KEY = 'netflixSubtitlePanel';
@@ -58,6 +70,7 @@
     } catch (_) { cb(false); }
   }
   function teardownAll() {
+    endOverlayDrag(false);
     hideSubtitleOverlay();
     hideDropHint();
     // 面板整体被关掉时替代模式也随之失效（replaceNativeEffective 已含 st.enabled），
@@ -202,8 +215,20 @@
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     st.replaceNative = c.subtitleReplaceNative === true;
+    st.overlayPos = normalizeOverlayPos(c[OVERLAY_POS_KEY]);
     if (!st.overlayEnabled) hideSubtitleOverlay();
+    // 位置变了（另一标签页拖过 / options 页重置）立刻重摆，不等下一个 200ms tick。
+    else if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
     syncNativeSubtitleReplacement();
+  }
+
+  // 存储里的位置只认「两个有限数、都落在 [0,1]」的形状；坏值（旧版本写错、手改 storage）
+  // 一律当没拖过——绝不能把 NaN 写进 style.left 让字幕直接消失。
+  function normalizeOverlayPos(v) {
+    if (!v || typeof v !== 'object') return null;
+    var x = Number(v.x), y = Number(v.y);
+    if (!isFinite(x) || !isFinite(y)) return null;
+    return { x: Math.min(1, Math.max(0, x)), y: Math.min(1, Math.max(0, y)) };
   }
 
   // 当前偏好快照（快捷键 toggle 用：改一个键、其余保持现值，绝不把用户已关的项刷回默认）。
@@ -216,6 +241,7 @@
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
       subtitleReplaceNative: st.replaceNative,
+      subtitleOverlayPosition: st.overlayPos,
     };
   }
 
@@ -224,6 +250,7 @@
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
       'subtitleOverlayAutoLookup',
       'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
+      OVERLAY_POS_KEY,
     ];
     try {
       var p = chrome.storage.local.get(keys);
@@ -283,8 +310,11 @@
       var el = document.createElement('div');
       el.id = 'fushi-subtitle-overlay';
       el.setAttribute('data-theme', resolveTheme());
+      el.addEventListener('pointerdown', overlayPointerDown);
       el.addEventListener('click', function (e) {
         e.stopPropagation();
+        // 刚拖完字幕松手：这次 click 是拖动的尾巴，不是查词。
+        if (st.overlayDragMoved) { st.overlayDragMoved = false; return; }
         var cue = st.overlayCue;
         if (cue && typeof window.fushiLookupAtPoint === 'function') {
           window.fushiLookupAtPoint(e.clientX, e.clientY, {
@@ -301,6 +331,8 @@
       el.addEventListener('mousemove', function (e) {
         if (!st.overlayAutoLookup || !st.overlayCue ||
             typeof window.fushiLookupAtPoint !== 'function') return;
+        // 拖动中指针在字幕上划过的每个词都不该被自动查——那是在挪字幕，不是在读。
+        if (st.overlayDrag && st.overlayDrag.moved) return;
         if (Math.abs(e.clientX - st.autoLookupLastX) < 4 &&
             Math.abs(e.clientY - st.autoLookupLastY) < 4) return;
         st.autoLookupLastX = e.clientX;
@@ -365,19 +397,115 @@
     el.setAttribute('data-theme', resolveTheme());
     if (typeof window.fushiRenderCueText === 'function') window.fushiRenderCueText(el, cue);
     else el.textContent = cue.text;
-    // 中心恒定贴视频（拖拽跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
-    // 视频中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
+    placeOverlay(el, rect, currentOverlayPos());
+    applyOverlayBlur(el);
+  }
+
+  // 本刻应生效的位置：拖动中用会话里的实时值（tick 每 200ms 重摆也不会把字幕拽回原位），
+  // 否则用持久化的用户位置，没拖过走默认。
+  function currentOverlayPos() {
+    if (st.overlayDrag && st.overlayDrag.pos) return st.overlayDrag.pos;
+    return st.overlayPos || OVERLAY_POS_DEFAULT;
+  }
+
+  // 把分数坐标落成像素。x 是水平中心、y 是底边锚点（CSS transform 是 translate(-50%,-100%)）。
+  function placeOverlay(el, rect, pos) {
+    // 中心贴视频（抽屉拖动跟随的关键；上一版把中心夹到视口中央，就是「字幕不跟拖拉」的病根）；行宽从
+    // 中心向两侧屏缘撑开、被较近一侧屏缘夹住：非全屏小播放器左右空 → 撑到近满屏不折行；全屏开
     // 抽屉 → 近侧即屏缘，行宽约等视频盒，永不探进抽屉盖画面（60% 上限保证最窄视频区也 ≥40% 屏）。
+    // 用户把字幕拖向屏缘时同一条规则让行宽收窄折行，永远不出视口。
     var vv = window.innerWidth || (rect.left + rect.right);
-    var cx = rect.left + rect.width / 2;
+    var cx = rect.left + rect.width * pos.x;
     var halfToEdge = Math.max(0, Math.min(cx, vv - cx));
     var maxW = Math.max(200, Math.min(vv * 0.94, (halfToEdge - 6) * 2));
     el.style.left = cx + 'px';
-    // 底边锚定（CSS transform 是 -100%）：文本块从这条线**往上**长。旧版中心锚 84% 时，
-    // 非全屏矮视频（~200px 高）会垂出视频底缘压住进度条——底锚后任何视频高度都出不了界。
-    el.style.top = (rect.top + rect.height * 0.88) + 'px';
+    // 底边锚定：文本块从这条线**往上**长。旧版中心锚 84% 时，非全屏矮视频（~200px 高）会垂出
+    // 视频底缘压住进度条——底锚后任何视频高度都出不了界。
+    el.style.top = (rect.top + rect.height * pos.y) + 'px';
     el.style.maxWidth = Math.round(maxW) + 'px';
-    applyOverlayBlur(el);
+  }
+
+  // 把拖到的像素点夹回视频盒内再换算成分数：中心至少离视频左右缘 8px；底边锚不低于视频底缘、
+  // 不高于「文本块整个还在视频里」的那条线（块高未知/为 0 时退化为不高于视频顶缘）。
+  function overlayPosFromPoint(el, rect, cx, by) {
+    var pad = Math.min(8, rect.width / 2);
+    cx = Math.min(rect.right - pad, Math.max(rect.left + pad, cx));
+    var h = el && typeof el.offsetHeight === 'number' ? el.offsetHeight : 0;
+    var minBy = rect.top + Math.min(h, rect.height);
+    by = Math.min(rect.bottom, Math.max(minBy, by));
+    return { x: (cx - rect.left) / rect.width, y: (by - rect.top) / rect.height };
+  }
+
+  // ── 覆盖层拖拽：按住字幕拖动即挪位；松手按视频分数坐标持久化，点击（位移 < 阈值）仍是查词 ──
+  // 监听挂 window 而不只靠 setPointerCapture：老内核上 capture 静默失败过（见 mobile-drawer.js），
+  // 挂 window 全程收得到 move/up；capture 仍尝试一下，多一层保险。
+  function overlayPointerDown(e) {
+    if (e.button !== undefined && e.button !== null && e.button !== 0) return;
+    if (st.overlayDrag) endOverlayDrag(false);
+    st.overlayDragMoved = false;
+    var from = st.overlayPos || OVERLAY_POS_DEFAULT;
+    st.overlayDrag = {
+      id: e.pointerId, x0: e.clientX, y0: e.clientY,
+      from: from, pos: null, moved: false,
+    };
+    window.addEventListener('pointermove', overlayPointerMove);
+    window.addEventListener('pointerup', overlayPointerUp);
+    window.addEventListener('pointercancel', overlayPointerCancel);
+    try { if (st.overlayEl) st.overlayEl.setPointerCapture(e.pointerId); } catch (_) {}
+    // 不 preventDefault：让点击/取词的默认链路照常；过阈值进入拖动后才接管。
+  }
+  function overlayPointerMove(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    var dx = e.clientX - d.x0, dy = e.clientY - d.y0;
+    if (!d.moved) {
+      if (dx * dx + dy * dy < OVERLAY_DRAG_THRESHOLD * OVERLAY_DRAG_THRESHOLD) return;
+      d.moved = true;
+      if (st.overlayEl) st.overlayEl.setAttribute('data-dragging', '');
+      // 过阈值前浏览器可能已经拉出一小段文字选区（覆盖层 user-select:text），拖动一开始就清掉。
+      try { window.getSelection().removeAllRanges(); } catch (_) {}
+    }
+    var video = videoEl();
+    if (!video || typeof video.getBoundingClientRect !== 'function') return;
+    var rect = video.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) return;
+    d.pos = overlayPosFromPoint(st.overlayEl, rect,
+      rect.left + rect.width * d.from.x + dx, rect.top + rect.height * d.from.y + dy);
+    if (st.overlayEl && st.overlayCue) placeOverlay(st.overlayEl, rect, d.pos);
+    try { e.preventDefault(); } catch (_) {}
+  }
+  function overlayPointerUp(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    endOverlayDrag(true);
+  }
+  function overlayPointerCancel(e) {
+    var d = st.overlayDrag;
+    if (!d || e.pointerId !== d.id) return;
+    endOverlayDrag(false);
+  }
+  // commit=true：把会话位置写成用户位置并持久化；false（取消/面板关闭）：丢弃、回到原位。
+  function endOverlayDrag(commit) {
+    var d = st.overlayDrag;
+    if (!d) return;
+    st.overlayDrag = null;
+    window.removeEventListener('pointermove', overlayPointerMove);
+    window.removeEventListener('pointerup', overlayPointerUp);
+    window.removeEventListener('pointercancel', overlayPointerCancel);
+    if (st.overlayEl) {
+      try { st.overlayEl.removeAttribute('data-dragging'); } catch (_) {}
+    }
+    if (!d.moved) return;
+    // 真拖过：紧随其后的那次合成 click 要吞掉（不查词）。下一次 pointerdown 会清这个标记，
+    // 所以拖出界没产生 click 也不会误吞后面无关的点击。
+    st.overlayDragMoved = true;
+    if (commit && d.pos) {
+      st.overlayPos = d.pos;
+      var patch = {};
+      patch[OVERLAY_POS_KEY] = d.pos;
+      try { chrome.storage.local.set(patch); } catch (_) {}
+    }
+    if (st.overlayCue) updateSubtitleOverlay(st.overlayCue);
   }
 
   function firstCueAfter(ms) {
@@ -833,6 +961,7 @@
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
         'subtitleOverlayAutoLookup',
         'subtitleOverlayBlur', 'subtitleOverlayAllTracks', 'subtitleReplaceNative',
+        OVERLAY_POS_KEY,
       ];
       for (var i = 0; i < keys.length; i++) {
         if (changes[keys[i]]) { prefs[keys[i]] = changes[keys[i]].newValue; changed = true; }

--- a/tools/browser-extension/vendor/content.css
+++ b/tools/browser-extension/vendor/content.css
@@ -2155,12 +2155,16 @@
     opacity: 0.6;
 }
 
-/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词。 */
+/* 用户外挂字幕：只显示当前外挂轨，不复制站点原生字幕。按 video rect 动态定位，文本仍可点击查词；
+   按住拖动可挪位（subtitle-panel.js，位置按视频分数坐标记住）。 */
 #fushi-subtitle-overlay {
     position: fixed;
     z-index: 2147483637;
-    /* top 给的是底边锚点（JS 写 88% 处）：-100% 让文字向上长，短视频不溢出视频下缘。 */
+    /* top 给的是底边锚点（JS 默认写 88% 处，用户拖过则是记住的分数）：-100% 让文字向上长，
+       短视频不溢出视频下缘。 */
     transform: translate(-50%, -100%);
+    /* 触屏拖字幕时不让浏览器把手势抢去滚页面/缩放：覆盖层压在视频上，本就不该从这里滚页。 */
+    touch-action: none;
     padding: 6px 12px 7px;
     border-radius: 8px;
     color: #f7f8f2;
@@ -2173,6 +2177,12 @@
     white-space: pre-wrap;
     user-select: text;
     cursor: text;
+}
+
+/* 拖动中：抓手光标 + 禁选区（否则移动指针会同时拉出一条文字选区）。 */
+#fushi-subtitle-overlay[data-dragging] {
+    cursor: grabbing;
+    user-select: none;
 }
 
 /* 覆盖层里的振假名：与字幕列表同一套取向——读音在正文上方、不参与选择/取词。 */


### PR DESCRIPTION
## 动机

扩展在视频上自绘的字幕覆盖层（`#fushi-subtitle-overlay`）位置写死在「水平居中、底边锚 88%」。字幕挡住画面/进度条/站点 UI 时用户无法挪开——asbplayer 的字幕是可以拖的，这里补齐。

## 改动

- **`subtitle-panel.js`**：覆盖层加 pointer 拖拽
  - 过 6px 阈值才算拖动；位移小于阈值仍是点击 → 照常 `fushiLookupAtPoint` 查词
  - 松手把位置以**视频矩形的分数坐标** `{x, y}`（x = 水平中心、y = 底边锚点）持久化到 `chrome.storage.local.subtitleOverlayPosition`；不存像素——全屏/退全屏/窗口缩放/换视频时按新视频盒重算，字幕留在画面里的同一相对位置
  - 拖完松手后浏览器合成的那次 `click` 被吞掉（不查词）；下一次 pointerdown 清标记，拖出界没产生 click 也不会误吞后续点击
  - 拖出视频盒夹回盒内（中心离左右缘 ≥ 8px；底锚在视频底缘与「文本块整个还在视频里」之间）；`pointercancel` 丢弃本次回原位
  - 拖动中每 200ms 的 tick 重摆用会话里的实时位置，不会把字幕拽回原位；悬浮字幕自动查词在拖动中不触发
  - `storage.onChanged` 让另一标签页拖过 / options 重置后本页立刻重摆；存储坏值一律当没拖过（不把 NaN 写进 style）
  - 监听挂 `window` 而不只靠 `setPointerCapture`（老内核 capture 静默失败的教训见 `mobile-drawer.js`）
- **CSS**（`scripts/content-css-overlay.css` → 重新生成两处 `vendor/content.css`）：拖动态 `cursor: grabbing` + `user-select: none`；覆盖层 `touch-action: none`（触屏拖字幕不被滚页/缩放手势抢走）
- **options 页**：「在视频上显示外挂字幕」下新增「字幕位置 → 重置位置」按钮（删键即回默认）
- **README** 文件地图更新；`fushi/assets/browser_extension/` 镜像已同步

## 验证

- 新增 `subtitle-overlay-drag.test.js`（13 条，vm 真加载 `content.js` + `subtitle-panel.js` 派发 pointer 事件）：默认位不变 / 阈值内点击仍查词 / 拖动跟手 + 分数持久化 + 吞尾随 click / 视频盒变化后按分数重算 / 拖动中 tick 不拽回 / 出界夹回 / cancel 回原位 / 重置与跨标签页跟随 / 坏值不产 NaN / 拖动中不自动查词 / CSS 与 options 接线
- `node --test`（扩展目录全量）543/543 绿
- `node scripts/sync-mirrors.mjs --check` / `generate-content-css.mjs --check` 一致
- `flutter test test/build/browser_extension_*_guard_test.dart` 5 个守卫 116 条绿

https://claude.ai/code/session_018K6KF7AsgZQiNkXAdCy4Ls
