### PR TITLE
fix(manga): series page AppBar login button (BUG-2497)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 2294 条。点号进各自文件。
+> 共 2295 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-2497](bugs/BUG-2497-manga-series-login-entry.md) | ✅ | ✅ | manga-series-login-entry |
 | [BUG-2485](bugs/BUG-2485-jellyfin-link-opens-services-root.md) | ✅ | ✅ | jellyfin-link-opens-services-root |
 | [BUG-2484](bugs/BUG-2484-manga-percent-filename.md) | ✅ | ✅ | 漫画页文件名含裸百分号时翻页/选字/制卡全抛 Illegal percent encoding |
 | [BUG-2482](bugs/BUG-2482-webkit-line-box-contain-zero-height-lines.md) | ✅ | ✅ | WebKit 上 BUG-2472 的 line-box-contain 把嵌套 inline / 空行行盒压成零高：目录列叠印、空行消失 |

--- a/docs/bugs/BUG-2497-manga-series-login-entry.md
+++ b/docs/bugs/BUG-2497-manga-series-login-entry.md
@@ -1,0 +1,6 @@
+## BUG-2497 · manga-series-login-entry
+- **报告**：2026-09-13（用户：截图 BookWalker Japan 作品页，「这个怎么登录，这里应该有登录按钮」）
+- **真实性**：✅ 真 bug（入口缺失）。登录流程本身存在（BUG-2479），但作品页 `fushi/lib/src/media/manga/library/manga_series_page.dart` 的 `FushiPageScaffold.actions` 只有收藏 / 刷新；登录只能从 ① 点一条锁章 → 弹窗「登录」（`_promptLockedChapter`）或 ② 漫画源管理页每行的 🔑 图标（`manga_sources_page.dart` `_loginTargetFor`）进入。用户看到「锁」的这一页反而没有入口。
+- **[x] ① 已修复** — 抽 `_loginTarget` getter（与锁章弹窗共用同一判据 `is OnlineMangaLoginCapable`），AppBar 加 `manga_series_login` IconButton 复用 `_loginToSource`（登录成功后自动 `_refreshFromSource` 刷锁位）。Aidoku / 互联对端适配器不实现该接口，按钮自然不出现。
+- **[x] ② 已加自动化测试** — `fushi/test/media/manga/manga_series_page_locked_chapter_test.dart`：登录适配器 → AppBar 有按钮且可点；普通适配器 → 无按钮。
+- **备注**：

--- a/fushi/lib/src/media/manga/library/manga_series_page.dart
+++ b/fushi/lib/src/media/manga/library/manga_series_page.dart
@@ -489,12 +489,7 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
   /// 返回 true = 继续入队下载。选「登录」时登录完自动刷新章节列表（锁位跟着
   /// 变），本次不入队。
   Future<bool> _promptLockedChapter(OnlineMangaChapter chapter) async {
-    final OnlineMangaLibraryEntry? entry = _entry;
-    final OnlineMangaLoginTarget? login = switch (_adapter) {
-      OnlineMangaLoginCapable(:final loginTarget) when entry != null =>
-        loginTarget(entry),
-      _ => null,
-    };
+    final OnlineMangaLoginTarget? login = _loginTarget;
     if (!mounted) return false;
     final _LockedChapterChoice? choice =
         await showAppDialog<_LockedChapterChoice>(
@@ -540,6 +535,17 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
       case null:
         return false;
     }
+  }
+
+  /// 当前条目所属源的登录目标；适配器没这条流程（Aidoku / 互联对端）或源不接受
+  /// 浏览器登录时为 null——AppBar 的登录按钮与锁章弹窗的「登录」项共用这一判据。
+  OnlineMangaLoginTarget? get _loginTarget {
+    final OnlineMangaLibraryEntry? entry = _entry;
+    return switch (_adapter) {
+      OnlineMangaLoginCapable(:final loginTarget) when entry != null =>
+        loginTarget(entry),
+      _ => null,
+    };
   }
 
   Future<void> _loginToSource(OnlineMangaLoginTarget target) async {
@@ -1159,10 +1165,22 @@ class _MangaSeriesPageState extends ConsumerState<MangaSeriesPage> {
     final OnlineMangaLibraryEntry? entry = _entry;
     final String title = entry?.series.title ?? _row?.title ?? t.manga_library;
     final bool canSubscribe = entry != null && _row != null && _service != null;
+    final OnlineMangaLoginTarget? login = _loginTarget;
     return FushiPageScaffold(
       title: title,
       subtitle: _subtitle(),
       actions: <Widget>[
+        // 源站要登录才给锁章（BUG-2497）：入口放在用户看到「锁」的这一页，
+        // 不必先点一条锁章再从弹窗里找。
+        if (login != null)
+          IconButton(
+            key: const ValueKey<String>('manga_series_login'),
+            tooltip: t.mihon_source_login,
+            onPressed: _busy || _refreshing
+                ? null
+                : () => unawaited(_loginToSource(login)),
+            icon: const Icon(Icons.login),
+          ),
         if (canSubscribe)
           IconButton(
             key: const ValueKey<String>('manga_series_subscribe'),

--- a/fushi/test/media/manga/manga_series_page_locked_chapter_test.dart
+++ b/fushi/test/media/manga/manga_series_page_locked_chapter_test.dart
@@ -201,6 +201,9 @@ void main() {
   const ValueKey<String> loginKey = ValueKey<String>(
     'manga_chapter_locked_login',
   );
+  const ValueKey<String> appBarLoginKey = ValueKey<String>(
+    'manga_series_login',
+  );
 
   Future<String> openPage(
     WidgetTester tester,
@@ -257,6 +260,25 @@ void main() {
       await _settle(tester);
       expect(find.byKey(dialogKey), findsOneWidget);
       expect(find.byKey(loginKey), findsOneWidget);
+    });
+  });
+
+  // BUG-2497：登录入口要在作品页 AppBar 上直接可见，不能只藏在锁章弹窗里。
+  testWidgets('适配器给得出登录目标 → AppBar 有「登录」按钮', (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await openPage(tester, _LoginAdapter());
+      expect(find.byKey(appBarLoginKey), findsOneWidget);
+      expect(
+        tester.widget<IconButton>(find.byKey(appBarLoginKey)).onPressed,
+        isNotNull,
+      );
+    });
+  });
+
+  testWidgets('适配器不给登录目标 → AppBar 没有「登录」按钮', (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await openPage(tester, _FakeAdapter());
+      expect(find.byKey(appBarLoginKey), findsNothing);
     });
   });
 


### PR DESCRIPTION
## 背景

用户在 BookWalker Japan 作品页看到章节带锁，问「怎么登录，这里应该有登录按钮」。登录流程（BUG-2479）本身存在，但作品页 AppBar 只有收藏 / 刷新，登录只能从 ① 点一条锁章 → 弹窗「登录」，② 漫画源管理页每行 🔑 图标进入——用户看到「锁」的这一页反而没有入口。

## 改动

- `manga_series_page.dart`：抽 `_loginTarget` getter（与锁章弹窗共用 `is OnlineMangaLoginCapable` 判据），AppBar 加 `manga_series_login` 按钮，复用 `_loginToSource`（登录成功后自动刷章节锁位）。Aidoku / 互联对端不实现该接口，按钮不出现。
- 测试 `manga_series_page_locked_chapter_test.dart` 加两条：登录适配器 → 按钮存在且可点；普通适配器 → 无按钮。
- `docs/bugs/BUG-2497-manga-series-login-entry.md` + 索引。

## 验证

- `flutter analyze` 两个改动文件：No issues。
- `flutter test test/media/manga/manga_series_page_locked_chapter_test.dart`：exit 0，7/7。
- 相邻 `manga_series_page_{download_first,local_ocr_entry,phase_c}_test.dart`：exit 0，9/9。
- 未做真机点击验证（登录 WebView 流程本身未改，只是多了一个入口）。

https://claude.ai/code/session_0127NL1ucmcrX1e71GxCf4r8
